### PR TITLE
fix(linter/plugins): make `parent` fields in TS type defs non-optional

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -10,7 +10,7 @@ export interface Program extends Span {
   sourceType: ModuleKind;
   hashbang: Hashbang | null;
   comments: Comment[];
-  parent?: null;
+  parent: null;
 }
 
 export type Expression =
@@ -62,7 +62,7 @@ export interface IdentifierName extends Span {
   name: string;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface IdentifierReference extends Span {
@@ -71,7 +71,7 @@ export interface IdentifierReference extends Span {
   name: string;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BindingIdentifier extends Span {
@@ -80,7 +80,7 @@ export interface BindingIdentifier extends Span {
   name: string;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface LabelIdentifier extends Span {
@@ -89,18 +89,18 @@ export interface LabelIdentifier extends Span {
   name: string;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ThisExpression extends Span {
   type: 'ThisExpression';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ArrayExpression extends Span {
   type: 'ArrayExpression';
   elements: Array<ArrayExpressionElement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ArrayExpressionElement = SpreadElement | null | Expression;
@@ -108,7 +108,7 @@ export type ArrayExpressionElement = SpreadElement | null | Expression;
 export interface ObjectExpression extends Span {
   type: 'ObjectExpression';
   properties: Array<ObjectPropertyKind>;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ObjectPropertyKind = ObjectProperty | SpreadElement;
@@ -122,7 +122,7 @@ export interface ObjectProperty extends Span {
   shorthand: boolean;
   computed: boolean;
   optional?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export type PropertyKey = IdentifierName | PrivateIdentifier | Expression;
@@ -133,7 +133,7 @@ export interface TemplateLiteral extends Span {
   type: 'TemplateLiteral';
   quasis: Array<TemplateElement>;
   expressions: Array<Expression>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TaggedTemplateExpression extends Span {
@@ -141,14 +141,14 @@ export interface TaggedTemplateExpression extends Span {
   tag: Expression;
   typeArguments?: TSTypeParameterInstantiation | null;
   quasi: TemplateLiteral;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TemplateElement extends Span {
   type: 'TemplateElement';
   value: TemplateElementValue;
   tail: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TemplateElementValue {
@@ -164,7 +164,7 @@ export interface ComputedMemberExpression extends Span {
   property: Expression;
   optional: boolean;
   computed: true;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface StaticMemberExpression extends Span {
@@ -173,7 +173,7 @@ export interface StaticMemberExpression extends Span {
   property: IdentifierName;
   optional: boolean;
   computed: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface PrivateFieldExpression extends Span {
@@ -182,7 +182,7 @@ export interface PrivateFieldExpression extends Span {
   property: PrivateIdentifier;
   optional: boolean;
   computed: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface CallExpression extends Span {
@@ -191,7 +191,7 @@ export interface CallExpression extends Span {
   typeArguments?: TSTypeParameterInstantiation | null;
   arguments: Array<Argument>;
   optional: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface NewExpression extends Span {
@@ -199,20 +199,20 @@ export interface NewExpression extends Span {
   callee: Expression;
   typeArguments?: TSTypeParameterInstantiation | null;
   arguments: Array<Argument>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface MetaProperty extends Span {
   type: 'MetaProperty';
   meta: IdentifierName;
   property: IdentifierName;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface SpreadElement extends Span {
   type: 'SpreadElement';
   argument: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export type Argument = SpreadElement | Expression;
@@ -222,7 +222,7 @@ export interface UpdateExpression extends Span {
   operator: UpdateOperator;
   prefix: boolean;
   argument: SimpleAssignmentTarget;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface UnaryExpression extends Span {
@@ -230,7 +230,7 @@ export interface UnaryExpression extends Span {
   operator: UnaryOperator;
   argument: Expression;
   prefix: true;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BinaryExpression extends Span {
@@ -238,7 +238,7 @@ export interface BinaryExpression extends Span {
   left: Expression;
   operator: BinaryOperator;
   right: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface PrivateInExpression extends Span {
@@ -246,7 +246,7 @@ export interface PrivateInExpression extends Span {
   left: PrivateIdentifier;
   operator: 'in';
   right: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface LogicalExpression extends Span {
@@ -254,7 +254,7 @@ export interface LogicalExpression extends Span {
   left: Expression;
   operator: LogicalOperator;
   right: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ConditionalExpression extends Span {
@@ -262,7 +262,7 @@ export interface ConditionalExpression extends Span {
   test: Expression;
   consequent: Expression;
   alternate: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface AssignmentExpression extends Span {
@@ -270,7 +270,7 @@ export interface AssignmentExpression extends Span {
   operator: AssignmentOperator;
   left: AssignmentTarget;
   right: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export type AssignmentTarget = SimpleAssignmentTarget | AssignmentTargetPattern;
@@ -291,7 +291,7 @@ export interface ArrayAssignmentTarget extends Span {
   elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ObjectAssignmentTarget extends Span {
@@ -300,7 +300,7 @@ export interface ObjectAssignmentTarget extends Span {
   properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface AssignmentTargetRest extends Span {
@@ -310,7 +310,7 @@ export interface AssignmentTargetRest extends Span {
   optional?: false;
   typeAnnotation?: null;
   value?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | AssignmentTarget;
@@ -322,7 +322,7 @@ export interface AssignmentTargetWithDefault extends Span {
   right: Expression;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty;
@@ -336,7 +336,7 @@ export interface AssignmentTargetPropertyIdentifier extends Span {
   shorthand: true;
   computed: false;
   optional?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface AssignmentTargetPropertyProperty extends Span {
@@ -348,30 +348,30 @@ export interface AssignmentTargetPropertyProperty extends Span {
   shorthand: false;
   computed: boolean;
   optional?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface SequenceExpression extends Span {
   type: 'SequenceExpression';
   expressions: Array<Expression>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface Super extends Span {
   type: 'Super';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface AwaitExpression extends Span {
   type: 'AwaitExpression';
   argument: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ChainExpression extends Span {
   type: 'ChainExpression';
   expression: ChainElement;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ChainElement = CallExpression | TSNonNullExpression | MemberExpression;
@@ -379,7 +379,7 @@ export type ChainElement = CallExpression | TSNonNullExpression | MemberExpressi
 export interface ParenthesizedExpression extends Span {
   type: 'ParenthesizedExpression';
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export type Statement =
@@ -408,19 +408,19 @@ export interface Directive extends Span {
   type: 'ExpressionStatement';
   expression: StringLiteral;
   directive: string;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface Hashbang extends Span {
   type: 'Hashbang';
   value: string;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BlockStatement extends Span {
   type: 'BlockStatement';
   body: Array<Statement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export type Declaration =
@@ -438,7 +438,7 @@ export interface VariableDeclaration extends Span {
   kind: VariableDeclarationKind;
   declarations: Array<VariableDeclarator>;
   declare?: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export type VariableDeclarationKind = 'var' | 'let' | 'const' | 'using' | 'await using';
@@ -448,19 +448,19 @@ export interface VariableDeclarator extends Span {
   id: BindingPattern;
   init: Expression | null;
   definite?: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface EmptyStatement extends Span {
   type: 'EmptyStatement';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ExpressionStatement extends Span {
   type: 'ExpressionStatement';
   expression: Expression;
   directive?: string | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface IfStatement extends Span {
@@ -468,21 +468,21 @@ export interface IfStatement extends Span {
   test: Expression;
   consequent: Statement;
   alternate: Statement | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface DoWhileStatement extends Span {
   type: 'DoWhileStatement';
   body: Statement;
   test: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface WhileStatement extends Span {
   type: 'WhileStatement';
   test: Expression;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ForStatement extends Span {
@@ -491,7 +491,7 @@ export interface ForStatement extends Span {
   test: Expression | null;
   update: Expression | null;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ForStatementInit = VariableDeclaration | Expression;
@@ -501,7 +501,7 @@ export interface ForInStatement extends Span {
   left: ForStatementLeft;
   right: Expression;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ForStatementLeft = VariableDeclaration | AssignmentTarget;
@@ -512,59 +512,59 @@ export interface ForOfStatement extends Span {
   left: ForStatementLeft;
   right: Expression;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ContinueStatement extends Span {
   type: 'ContinueStatement';
   label: LabelIdentifier | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BreakStatement extends Span {
   type: 'BreakStatement';
   label: LabelIdentifier | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ReturnStatement extends Span {
   type: 'ReturnStatement';
   argument: Expression | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface WithStatement extends Span {
   type: 'WithStatement';
   object: Expression;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface SwitchStatement extends Span {
   type: 'SwitchStatement';
   discriminant: Expression;
   cases: Array<SwitchCase>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface SwitchCase extends Span {
   type: 'SwitchCase';
   test: Expression | null;
   consequent: Array<Statement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface LabeledStatement extends Span {
   type: 'LabeledStatement';
   label: LabelIdentifier;
   body: Statement;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ThrowStatement extends Span {
   type: 'ThrowStatement';
   argument: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TryStatement extends Span {
@@ -572,19 +572,19 @@ export interface TryStatement extends Span {
   block: BlockStatement;
   handler: CatchClause | null;
   finalizer: BlockStatement | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface CatchClause extends Span {
   type: 'CatchClause';
   param: BindingPattern | null;
   body: BlockStatement;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface DebuggerStatement extends Span {
   type: 'DebuggerStatement';
-  parent?: Node;
+  parent: Node;
 }
 
 export type BindingPattern = {
@@ -601,7 +601,7 @@ export interface AssignmentPattern extends Span {
   right: Expression;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ObjectPattern extends Span {
@@ -610,7 +610,7 @@ export interface ObjectPattern extends Span {
   properties: Array<BindingProperty | BindingRestElement>;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BindingProperty extends Span {
@@ -622,7 +622,7 @@ export interface BindingProperty extends Span {
   shorthand: boolean;
   computed: boolean;
   optional?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ArrayPattern extends Span {
@@ -631,7 +631,7 @@ export interface ArrayPattern extends Span {
   elements: Array<BindingPattern | BindingRestElement | null>;
   optional?: false;
   typeAnnotation?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BindingRestElement extends Span {
@@ -641,7 +641,7 @@ export interface BindingRestElement extends Span {
   optional?: false;
   typeAnnotation?: null;
   value?: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface Function extends Span {
@@ -655,7 +655,7 @@ export interface Function extends Span {
   returnType?: TSTypeAnnotation | null;
   body: FunctionBody | null;
   expression: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
@@ -692,7 +692,7 @@ export interface TSParameterProperty extends Span {
 export interface FunctionBody extends Span {
   type: 'BlockStatement';
   body: Array<Directive | Statement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ArrowFunctionExpression extends Span {
@@ -705,14 +705,14 @@ export interface ArrowFunctionExpression extends Span {
   body: FunctionBody | Expression;
   id: null;
   generator: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface YieldExpression extends Span {
   type: 'YieldExpression';
   delegate: boolean;
   argument: Expression | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface Class extends Span {
@@ -726,7 +726,7 @@ export interface Class extends Span {
   body: ClassBody;
   abstract?: boolean;
   declare?: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ClassType = 'ClassDeclaration' | 'ClassExpression';
@@ -734,7 +734,7 @@ export type ClassType = 'ClassDeclaration' | 'ClassExpression';
 export interface ClassBody extends Span {
   type: 'ClassBody';
   body: Array<ClassElement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition | AccessorProperty | TSIndexSignature;
@@ -750,7 +750,7 @@ export interface MethodDefinition extends Span {
   override?: boolean;
   optional?: boolean;
   accessibility?: TSAccessibility | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinition';
@@ -769,7 +769,7 @@ export interface PropertyDefinition extends Span {
   definite?: boolean;
   readonly?: boolean;
   accessibility?: TSAccessibility | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type PropertyDefinitionType = 'PropertyDefinition' | 'TSAbstractPropertyDefinition';
@@ -779,13 +779,13 @@ export type MethodDefinitionKind = 'constructor' | 'method' | 'get' | 'set';
 export interface PrivateIdentifier extends Span {
   type: 'PrivateIdentifier';
   name: string;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface StaticBlock extends Span {
   type: 'StaticBlock';
   body: Array<Statement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ModuleDeclaration =
@@ -812,7 +812,7 @@ export interface AccessorProperty extends Span {
   declare?: false;
   optional?: false;
   readonly?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ImportExpression extends Span {
@@ -820,7 +820,7 @@ export interface ImportExpression extends Span {
   source: Expression;
   options: Expression | null;
   phase: ImportPhase | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ImportDeclaration extends Span {
@@ -830,7 +830,7 @@ export interface ImportDeclaration extends Span {
   phase: ImportPhase | null;
   attributes: Array<ImportAttribute>;
   importKind?: ImportOrExportKind;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ImportPhase = 'source' | 'defer';
@@ -842,26 +842,26 @@ export interface ImportSpecifier extends Span {
   imported: ModuleExportName;
   local: BindingIdentifier;
   importKind?: ImportOrExportKind;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ImportDefaultSpecifier extends Span {
   type: 'ImportDefaultSpecifier';
   local: BindingIdentifier;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ImportNamespaceSpecifier extends Span {
   type: 'ImportNamespaceSpecifier';
   local: BindingIdentifier;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ImportAttribute extends Span {
   type: 'ImportAttribute';
   key: ImportAttributeKey;
   value: StringLiteral;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ImportAttributeKey = IdentifierName | StringLiteral;
@@ -873,14 +873,14 @@ export interface ExportNamedDeclaration extends Span {
   source: StringLiteral | null;
   exportKind?: ImportOrExportKind;
   attributes: Array<ImportAttribute>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ExportDefaultDeclaration extends Span {
   type: 'ExportDefaultDeclaration';
   declaration: ExportDefaultDeclarationKind;
   exportKind?: 'value';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ExportAllDeclaration extends Span {
@@ -889,7 +889,7 @@ export interface ExportAllDeclaration extends Span {
   source: StringLiteral;
   attributes: Array<ImportAttribute>;
   exportKind?: ImportOrExportKind;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface ExportSpecifier extends Span {
@@ -897,7 +897,7 @@ export interface ExportSpecifier extends Span {
   local: ModuleExportName;
   exported: ModuleExportName;
   exportKind?: ImportOrExportKind;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ExportDefaultDeclarationKind = Function | Class | TSInterfaceDeclaration | Expression;
@@ -908,35 +908,35 @@ export interface V8IntrinsicExpression extends Span {
   type: 'V8IntrinsicExpression';
   name: IdentifierName;
   arguments: Array<Argument>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BooleanLiteral extends Span {
   type: 'Literal';
   value: boolean;
   raw: string | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface NullLiteral extends Span {
   type: 'Literal';
   value: null;
   raw: 'null' | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface NumericLiteral extends Span {
   type: 'Literal';
   value: number;
   raw: string | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface StringLiteral extends Span {
   type: 'Literal';
   value: string;
   raw: string | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface BigIntLiteral extends Span {
@@ -944,7 +944,7 @@ export interface BigIntLiteral extends Span {
   value: bigint;
   raw: string | null;
   bigint: string;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface RegExpLiteral extends Span {
@@ -952,7 +952,7 @@ export interface RegExpLiteral extends Span {
   value: RegExp | null;
   raw: string | null;
   regex: { pattern: string; flags: string };
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXElement extends Span {
@@ -960,7 +960,7 @@ export interface JSXElement extends Span {
   openingElement: JSXOpeningElement;
   children: Array<JSXChild>;
   closingElement: JSXClosingElement | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXOpeningElement extends Span {
@@ -969,13 +969,13 @@ export interface JSXOpeningElement extends Span {
   typeArguments?: TSTypeParameterInstantiation | null;
   attributes: Array<JSXAttributeItem>;
   selfClosing: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXClosingElement extends Span {
   type: 'JSXClosingElement';
   name: JSXElementName;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXFragment extends Span {
@@ -983,19 +983,19 @@ export interface JSXFragment extends Span {
   openingFragment: JSXOpeningFragment;
   children: Array<JSXChild>;
   closingFragment: JSXClosingFragment;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXOpeningFragment extends Span {
   type: 'JSXOpeningFragment';
   attributes?: [];
   selfClosing?: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXClosingFragment extends Span {
   type: 'JSXClosingFragment';
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
@@ -1004,14 +1004,14 @@ export interface JSXNamespacedName extends Span {
   type: 'JSXNamespacedName';
   namespace: JSXIdentifier;
   name: JSXIdentifier;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXMemberExpression extends Span {
   type: 'JSXMemberExpression';
   object: JSXMemberExpressionObject;
   property: JSXIdentifier;
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
@@ -1019,14 +1019,14 @@ export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
 export interface JSXExpressionContainer extends Span {
   type: 'JSXExpressionContainer';
   expression: JSXExpression;
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXExpression = JSXEmptyExpression | Expression;
 
 export interface JSXEmptyExpression extends Span {
   type: 'JSXEmptyExpression';
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
@@ -1035,13 +1035,13 @@ export interface JSXAttribute extends Span {
   type: 'JSXAttribute';
   name: JSXAttributeName;
   value: JSXAttributeValue | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXSpreadAttribute extends Span {
   type: 'JSXSpreadAttribute';
   argument: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
@@ -1051,7 +1051,7 @@ export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElem
 export interface JSXIdentifier extends Span {
   type: 'JSXIdentifier';
   name: string;
-  parent?: Node;
+  parent: Node;
 }
 
 export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
@@ -1059,14 +1059,14 @@ export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContain
 export interface JSXSpreadChild extends Span {
   type: 'JSXSpreadChild';
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSXText extends Span {
   type: 'JSXText';
   value: string;
   raw: string | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSThisParameter extends Span {
@@ -1075,7 +1075,7 @@ export interface TSThisParameter extends Span {
   name: 'this';
   optional: false;
   typeAnnotation: TSTypeAnnotation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSEnumDeclaration extends Span {
@@ -1084,13 +1084,13 @@ export interface TSEnumDeclaration extends Span {
   body: TSEnumBody;
   const: boolean;
   declare: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSEnumBody extends Span {
   type: 'TSEnumBody';
   members: Array<TSEnumMember>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSEnumMember extends Span {
@@ -1098,7 +1098,7 @@ export interface TSEnumMember extends Span {
   id: TSEnumMemberName;
   initializer: Expression | null;
   computed: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
@@ -1106,13 +1106,13 @@ export type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
 export interface TSTypeAnnotation extends Span {
   type: 'TSTypeAnnotation';
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSLiteralType extends Span {
   type: 'TSLiteralType';
   literal: TSLiteral;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSLiteral =
@@ -1168,32 +1168,32 @@ export interface TSConditionalType extends Span {
   extendsType: TSType;
   trueType: TSType;
   falseType: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSUnionType extends Span {
   type: 'TSUnionType';
   types: Array<TSType>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSIntersectionType extends Span {
   type: 'TSIntersectionType';
   types: Array<TSType>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSParenthesizedType extends Span {
   type: 'TSParenthesizedType';
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeOperator extends Span {
   type: 'TSTypeOperator';
   operator: TSTypeOperatorOperator;
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSTypeOperatorOperator = 'keyof' | 'unique' | 'readonly';
@@ -1201,20 +1201,20 @@ export type TSTypeOperatorOperator = 'keyof' | 'unique' | 'readonly';
 export interface TSArrayType extends Span {
   type: 'TSArrayType';
   elementType: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSIndexedAccessType extends Span {
   type: 'TSIndexedAccessType';
   objectType: TSType;
   indexType: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTupleType extends Span {
   type: 'TSTupleType';
   elementTypes: Array<TSTupleElement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNamedTupleMember extends Span {
@@ -1222,98 +1222,98 @@ export interface TSNamedTupleMember extends Span {
   label: IdentifierName;
   elementType: TSTupleElement;
   optional: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSOptionalType extends Span {
   type: 'TSOptionalType';
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSRestType extends Span {
   type: 'TSRestType';
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSTupleElement = TSOptionalType | TSRestType | TSType;
 
 export interface TSAnyKeyword extends Span {
   type: 'TSAnyKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSStringKeyword extends Span {
   type: 'TSStringKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSBooleanKeyword extends Span {
   type: 'TSBooleanKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNumberKeyword extends Span {
   type: 'TSNumberKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNeverKeyword extends Span {
   type: 'TSNeverKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSIntrinsicKeyword extends Span {
   type: 'TSIntrinsicKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSUnknownKeyword extends Span {
   type: 'TSUnknownKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNullKeyword extends Span {
   type: 'TSNullKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSUndefinedKeyword extends Span {
   type: 'TSUndefinedKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSVoidKeyword extends Span {
   type: 'TSVoidKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSSymbolKeyword extends Span {
   type: 'TSSymbolKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSThisType extends Span {
   type: 'TSThisType';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSObjectKeyword extends Span {
   type: 'TSObjectKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSBigIntKeyword extends Span {
   type: 'TSBigIntKeyword';
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeReference extends Span {
   type: 'TSTypeReference';
   typeName: TSTypeName;
   typeArguments: TSTypeParameterInstantiation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSTypeName = IdentifierReference | TSQualifiedName | ThisExpression;
@@ -1322,13 +1322,13 @@ export interface TSQualifiedName extends Span {
   type: 'TSQualifiedName';
   left: TSTypeName;
   right: IdentifierName;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeParameterInstantiation extends Span {
   type: 'TSTypeParameterInstantiation';
   params: Array<TSType>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeParameter extends Span {
@@ -1339,13 +1339,13 @@ export interface TSTypeParameter extends Span {
   in: boolean;
   out: boolean;
   const: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeParameterDeclaration extends Span {
   type: 'TSTypeParameterDeclaration';
   params: Array<TSTypeParameter>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeAliasDeclaration extends Span {
@@ -1354,7 +1354,7 @@ export interface TSTypeAliasDeclaration extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   typeAnnotation: TSType;
   declare: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSAccessibility = 'private' | 'protected' | 'public';
@@ -1363,7 +1363,7 @@ export interface TSClassImplements extends Span {
   type: 'TSClassImplements';
   expression: IdentifierReference | ThisExpression | MemberExpression;
   typeArguments: TSTypeParameterInstantiation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSInterfaceDeclaration extends Span {
@@ -1373,13 +1373,13 @@ export interface TSInterfaceDeclaration extends Span {
   extends: Array<TSInterfaceHeritage>;
   body: TSInterfaceBody;
   declare: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSInterfaceBody extends Span {
   type: 'TSInterfaceBody';
   body: Array<TSSignature>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSPropertySignature extends Span {
@@ -1391,7 +1391,7 @@ export interface TSPropertySignature extends Span {
   typeAnnotation: TSTypeAnnotation | null;
   accessibility: null;
   static: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSSignature =
@@ -1408,7 +1408,7 @@ export interface TSIndexSignature extends Span {
   readonly: boolean;
   static: boolean;
   accessibility: null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSCallSignatureDeclaration extends Span {
@@ -1416,7 +1416,7 @@ export interface TSCallSignatureDeclaration extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSMethodSignatureKind = 'method' | 'get' | 'set';
@@ -1433,7 +1433,7 @@ export interface TSMethodSignature extends Span {
   accessibility: null;
   readonly: false;
   static: false;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSConstructSignatureDeclaration extends Span {
@@ -1441,7 +1441,7 @@ export interface TSConstructSignatureDeclaration extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSIndexSignatureName extends Span {
@@ -1450,14 +1450,14 @@ export interface TSIndexSignatureName extends Span {
   name: string;
   optional: false;
   typeAnnotation: TSTypeAnnotation;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSInterfaceHeritage extends Span {
   type: 'TSInterfaceHeritage';
   expression: Expression;
   typeArguments: TSTypeParameterInstantiation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypePredicate extends Span {
@@ -1465,7 +1465,7 @@ export interface TSTypePredicate extends Span {
   parameterName: TSTypePredicateName;
   asserts: boolean;
   typeAnnotation: TSTypeAnnotation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSTypePredicateName = IdentifierName | TSThisType;
@@ -1477,7 +1477,7 @@ export interface TSModuleDeclaration extends Span {
   kind: TSModuleDeclarationKind;
   declare: boolean;
   global: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSModuleDeclarationKind = 'global' | 'module' | 'namespace';
@@ -1485,26 +1485,26 @@ export type TSModuleDeclarationKind = 'global' | 'module' | 'namespace';
 export interface TSModuleBlock extends Span {
   type: 'TSModuleBlock';
   body: Array<Directive | Statement>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeLiteral extends Span {
   type: 'TSTypeLiteral';
   members: Array<TSSignature>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSInferType extends Span {
   type: 'TSInferType';
   typeParameter: TSTypeParameter;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeQuery extends Span {
   type: 'TSTypeQuery';
   exprName: TSTypeQueryExprName;
   typeArguments: TSTypeParameterInstantiation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSTypeQueryExprName = TSImportType | TSTypeName;
@@ -1515,7 +1515,7 @@ export interface TSImportType extends Span {
   options: ObjectExpression | null;
   qualifier: TSImportTypeQualifier | null;
   typeArguments: TSTypeParameterInstantiation | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSImportTypeQualifier = IdentifierName | TSImportTypeQualifiedName;
@@ -1524,7 +1524,7 @@ export interface TSImportTypeQualifiedName extends Span {
   type: 'TSQualifiedName';
   left: TSImportTypeQualifier;
   right: IdentifierName;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSFunctionType extends Span {
@@ -1532,7 +1532,7 @@ export interface TSFunctionType extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSConstructorType extends Span {
@@ -1541,7 +1541,7 @@ export interface TSConstructorType extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSMappedType extends Span {
@@ -1552,7 +1552,7 @@ export interface TSMappedType extends Span {
   typeAnnotation: TSType | null;
   optional: TSMappedTypeModifierOperator | false;
   readonly: TSMappedTypeModifierOperator | null;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSMappedTypeModifierOperator = true | '+' | '-';
@@ -1561,28 +1561,28 @@ export interface TSTemplateLiteralType extends Span {
   type: 'TSTemplateLiteralType';
   quasis: Array<TemplateElement>;
   types: Array<TSType>;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSAsExpression extends Span {
   type: 'TSAsExpression';
   expression: Expression;
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSSatisfiesExpression extends Span {
   type: 'TSSatisfiesExpression';
   expression: Expression;
   typeAnnotation: TSType;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSTypeAssertion extends Span {
   type: 'TSTypeAssertion';
   typeAnnotation: TSType;
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSImportEqualsDeclaration extends Span {
@@ -1590,7 +1590,7 @@ export interface TSImportEqualsDeclaration extends Span {
   id: BindingIdentifier;
   moduleReference: TSModuleReference;
   importKind: ImportOrExportKind;
-  parent?: Node;
+  parent: Node;
 }
 
 export type TSModuleReference = TSExternalModuleReference | TSTypeName;
@@ -1598,38 +1598,38 @@ export type TSModuleReference = TSExternalModuleReference | TSTypeName;
 export interface TSExternalModuleReference extends Span {
   type: 'TSExternalModuleReference';
   expression: StringLiteral;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNonNullExpression extends Span {
   type: 'TSNonNullExpression';
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface Decorator extends Span {
   type: 'Decorator';
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSExportAssignment extends Span {
   type: 'TSExportAssignment';
   expression: Expression;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSNamespaceExportDeclaration extends Span {
   type: 'TSNamespaceExportDeclaration';
   id: IdentifierName;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface TSInstantiationExpression extends Span {
   type: 'TSInstantiationExpression';
   expression: Expression;
   typeArguments: TSTypeParameterInstantiation;
-  parent?: Node;
+  parent: Node;
 }
 
 export type ImportOrExportKind = 'value' | 'type';
@@ -1638,19 +1638,19 @@ export interface JSDocNullableType extends Span {
   type: 'TSJSDocNullableType';
   typeAnnotation: TSType;
   postfix: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSDocNonNullableType extends Span {
   type: 'TSJSDocNonNullableType';
   typeAnnotation: TSType;
   postfix: boolean;
-  parent?: Node;
+  parent: Node;
 }
 
 export interface JSDocUnknownType extends Span {
   type: 'TSJSDocUnknownType';
-  parent?: Node;
+  parent: Node;
 }
 
 export type AssignmentOperator =

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -261,7 +261,6 @@ export function getScope(node: ESTree.Node): Scope {
       return scope.type === 'function-expression-name' ? scope.childScopes[0] : scope;
     }
 
-    // TODO: AST nodes' `parent` property should not be optional.
     // TODO: `TSParameterProperty` type should have a `parent` property.
     // @ts-expect-error
     node = node.parent;

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -27,10 +27,15 @@ impl Generator for TypescriptGenerator {
     /// Generate Typescript type definitions for all AST types.
     fn generate_many(&self, schema: &Schema, codegen: &Codegen) -> Vec<Output> {
         let code = generate_ts_type_defs(schema, codegen);
+
+        let standard_code = amend_standard_types(&code);
         let oxlint_code = amend_oxlint_types(&code);
 
         vec![
-            Output::Javascript { path: TYPESCRIPT_DEFINITIONS_PATH.to_string(), code },
+            Output::Javascript {
+                path: TYPESCRIPT_DEFINITIONS_PATH.to_string(),
+                code: standard_code,
+            },
             Output::Javascript {
                 path: format!("{OXLINT_APP_PATH}/src-js/generated/types.d.ts"),
                 code: oxlint_code,
@@ -170,7 +175,7 @@ fn generate_ts_type_def_for_struct(
 
     if !struct_def.estree.no_type {
         let parent_type = if struct_def.id == program_type_id { "null" } else { "Node" };
-        write_it!(fields_str, "\n\tparent?: {parent_type};");
+        write_it!(fields_str, "\n\tparent/* IF !LINTER */?/* END IF */: {parent_type};");
     }
 
     let ts_def = if extends.is_empty() {
@@ -452,6 +457,13 @@ fn get_single_field<'s>(struct_def: &'s StructDef, schema: &Schema) -> Option<&'
     }
 }
 
+/// Amend version of types for usages other than Oxlint.
+fn amend_standard_types(code: &str) -> String {
+    // Remove comments on parent fields
+    #[expect(clippy::disallowed_methods)]
+    code.replace("/* IF !LINTER */?/* END IF */", "?")
+}
+
 /// Amend version of types for Oxlint.
 fn amend_oxlint_types(code: &str) -> String {
     // Remove `export interface Span`, and instead import local version of same interface,
@@ -472,6 +484,10 @@ fn amend_oxlint_types(code: &str) -> String {
     const HASHBANG_FIELD: &str = "hashbang: Hashbang | null;";
     let index = code.find(HASHBANG_FIELD).unwrap();
     code.insert_str(index + HASHBANG_FIELD.len(), "comments: Comment[];");
+
+    // Make `parent` fields non-optional
+    #[expect(clippy::disallowed_methods)]
+    let mut code = code.replace("/* IF !LINTER */?/* END IF */", "");
 
     #[rustfmt::skip]
     code.insert_str(0, "


### PR DESCRIPTION
Fix TS type defs for AST types in linter. Make `parent` property non-optional on all node types.