### PR TITLE
fix(linter/plugins, napi/parser): add `parent` field to `FormalParameterRest` and `TSParameterProperty` in TS type defs

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -673,6 +673,7 @@ export interface FormalParameterRest extends Span {
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
   value?: null;
+  parent: Node;
 }
 
 export type FormalParameter = {
@@ -687,6 +688,7 @@ export interface TSParameterProperty extends Span {
   parameter: FormalParameter;
   readonly: boolean;
   static: boolean;
+  parent: Node;
 }
 
 export interface FunctionBody extends Span {

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -261,8 +261,6 @@ export function getScope(node: ESTree.Node): Scope {
       return scope.type === 'function-expression-name' ? scope.childScopes[0] : scope;
     }
 
-    // TODO: `TSParameterProperty` type should have a `parent` property.
-    // @ts-expect-error
     node = node.parent;
   } while (node !== null);
 

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1851,6 +1851,7 @@ pub enum FunctionType {
             optional?: boolean;
             typeAnnotation?: TSTypeAnnotation | null;
             value?: null;
+            parent/* IF !LINTER */?/* END IF */: Node;
         }
     "
 )]
@@ -1886,6 +1887,7 @@ pub struct FormalParameters<'a> {
             parameter: FormalParameter;
             readonly: boolean;
             static: boolean;
+            parent/* IF !LINTER */?/* END IF */: Node;
         }
     "
 )]

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -669,6 +669,7 @@ export interface FormalParameterRest extends Span {
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
   value?: null;
+  parent?: Node;
 }
 
 export type FormalParameter = {
@@ -683,6 +684,7 @@ export interface TSParameterProperty extends Span {
   parameter: FormalParameter;
   readonly: boolean;
   static: boolean;
+  parent?: Node;
 }
 
 export interface FunctionBody extends Span {


### PR DESCRIPTION
Fix TS type defs. Add `parent` property to `FormalParameterRest` and `TSParameterProperty`, which both have their type definitions defined manually.