### PR TITLE
refactor(language_server): tools `Builder::new` method should accept `serde_json::Value`

### DIFF
--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -31,7 +31,16 @@ pub struct ServerLinterBuilder {
 }
 
 impl ServerLinterBuilder {
-    pub fn new(root_uri: Uri, options: LSPLintOptions) -> Self {
+    pub fn new(root_uri: Uri, options: serde_json::Value) -> Self {
+        let options = match serde_json::from_value::<LSPLintOptions>(options) {
+            Ok(opts) => opts,
+            Err(e) => {
+                warn!(
+                    "Failed to deserialize LSPLintOptions from JSON: {e}. Falling back to default options."
+                );
+                LSPLintOptions::default()
+            }
+        };
         Self { root_uri, options }
     }
 


### PR DESCRIPTION
> This PR refactors the language server's initialization and configuration handling by moving JSON deserialization from the caller to the builder constructors. The ServerFormatterBuilder now handles its own experimental flag check and returns Option<ServerFormatter> instead of requiring external conditional logic.