### PR TITLE
refactor(ast_tools): improve error message in `field_by_name`

### DIFF
--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -113,10 +113,9 @@ impl StructDef {
     /// Panics if struct does not have a field called `name`.
     pub fn field_by_name(&self, name: &str) -> &FieldDef {
         self.fields.iter().find(|field| field.name() == name).unwrap_or_else(|| {
-            panic!(
-                "failed to find field {name}. Available fields {}",
-                self.fields.iter().map(FieldDef::name).join(", ")
-            )
+            let struct_name = self.name();
+            let fields = self.fields.iter().map(FieldDef::name).join(", ");
+            panic!("Failed to find field `{name}` in struct `{struct_name}`. Available fields: {fields}.");
         })
     }
 }


### PR DESCRIPTION
Follow-on after #14853. Include struct name in the error message.