### PR TITLE
test(formatter): port printer tests from Biome

### DIFF
--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -65,6 +65,18 @@ impl<'ast> FormatContext<'ast> {
         }
     }
 
+    pub(crate) fn dummy(allocator: &'ast Allocator) -> Self {
+        Self {
+            options: FormatOptions::default(),
+            source_text: SourceText::new(""),
+            source_type: SourceType::default(),
+            comments: Comments::new(SourceText::new(""), &[]),
+            allocator,
+            cached_elements: FxHashMap::default(),
+            embedded_formatter: None,
+        }
+    }
+
     /// Set the embedded formatter for handling embedded languages
     pub fn set_embedded_formatter(&mut self, embedded_formatter: Option<EmbeddedFormatter>) {
         self.embedded_formatter = embedded_formatter;

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -158,19 +158,7 @@ impl<'a> Deref for Document<'a> {
 impl std::fmt::Display for Document<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let allocator = Allocator::default();
-        let source_text = allocator.alloc_str("");
-        let source_type = SourceType::default();
-        let comments: oxc_allocator::Vec<Comment> = oxc_allocator::Vec::new_in(&allocator);
-        let options = FormatOptions {
-            line_width: LineWidth::default(),
-            indent_style: IndentStyle::Space,
-            indent_width: IndentWidth::default(),
-            line_ending: LineEnding::Lf,
-            ..Default::default()
-        };
-        let context =
-            FormatContext::new(source_text, source_type, comments.as_ref(), &allocator, options);
-
+        let context = FormatContext::dummy(&allocator);
         let formatted = format!(context, [self.elements.as_slice()])
             .expect("Formatting not to throw any FormatErrors");
 


### PR DESCRIPTION
Copied from https://github.com/biomejs/biome/blob/ceed34a164cc76406baf617000b8877160f0bcc3/crates/biome_formatter/src/printer/mod.rs#L1389-L1833 and tweaked a little bit to fit our architecture.