### PR TITLE
ci(oxlint,oxfmt): Fix smoke test running shell

### DIFF
--- a/.github/workflows/release_oxfmt.yml
+++ b/.github/workflows/release_oxfmt.yml
@@ -221,6 +221,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
+            is-windows: true
           - os: ubuntu-latest
           - os: ubuntu-latest
             container: node:18-alpine # musl
@@ -228,14 +229,19 @@ jobs:
     name: Smoke Test ${{ matrix.os }} ${{ matrix.container }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    defaults:
-      run:
-        shell: bash
     steps:
-      - name: Test
+      - run: touch test.js
+
+      - name: Test (Unix)
+        if: ${{ !matrix.is-windows }}
         env:
           OXFMT_VERSION: ${{ needs.check.outputs.version }}
         run: |
-          touch test.js
           ldd --version || true
           npx oxfmt@${OXFMT_VERSION} ./test.js
+
+      - name: Test (Windows)
+        if: ${{ matrix.is-windows }}
+        env:
+          OXFMT_VERSION: ${{ needs.check.outputs.version }}
+        run: npx oxfmt@$env:OXFMT_VERSION ./test.js

--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -234,6 +234,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
+            is-windows: true
           - os: ubuntu-latest
           - os: ubuntu-latest
             container: node:18-alpine # musl
@@ -241,17 +242,22 @@ jobs:
     name: Smoke Test ${{ matrix.os }} ${{ matrix.container }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    defaults:
-      run:
-        shell: bash
     steps:
-      - name: Test
+      - run: touch test.js
+
+      - name: Test (Unix)
+        if: ${{ !matrix.is-windows }}
         env:
           OXLINT_VERSION: ${{ needs.check.outputs.version}}
         run: |
-          touch test.js
           ldd --version || true
           npx oxlint@${OXLINT_VERSION} ./test.js
+
+      - name: Test (Windows)
+        if: ${{ matrix.is-windows }}
+        env:
+          OXLINT_VERSION: ${{ needs.check.outputs.version}}
+        run: npx oxlint@$env:OXLINT_VERSION ./test.js
 
   bump:
     needs: [check, publish, smoke]


### PR DESCRIPTION
Previously...

- Smoke tests on Windows suddenly started failing
  - This was because `npx oxlint@${VER}` should be `npx oxlint@$env:VER` on Windows
- Tried to fix this by using `bash` by default
- But `bash` does not exist on Alpine 👈🏻 Current status
- Fixed by using the default shell again, but splitting the Windows job