### PR TITLE
refactor(formatter): rename `FormatElement::StaticText` and `FormatElement::DynamicText` to `FormatElement::Token` and `FormatElement::Text`

### DIFF
--- a/crates/oxc_formatter/src/formatter/arguments.rs
+++ b/crates/oxc_formatter/src/formatter/arguments.rs
@@ -69,7 +69,7 @@ impl<'ast> Format<'ast> for Argument<'_, 'ast> {
 ///
 /// # fn main() -> FormatResult<()> {
 /// let formatted = format!(SimpleFormatContext::default(), [
-///     format_args!(text("a"), space(), text("b"))
+///     format_args!(token("a"), space(), token("b"))
 /// ])?;
 ///
 /// assert_eq!("a b", formatted.print()?.as_code());

--- a/crates/oxc_formatter/src/formatter/buffer.rs
+++ b/crates/oxc_formatter/src/formatter/buffer.rs
@@ -29,9 +29,9 @@ pub trait Buffer<'ast> {
     /// let mut state = FormatState::new(SimpleFormatContext::default());
     /// let mut buffer = VecBuffer::new(&mut state);
     ///
-    /// buffer.write_element(FormatElement::StaticText { text: "test"}).unwrap();
+    /// buffer.write_element(FormatElement::Token { text: "test"}).unwrap();
     ///
-    /// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText { text: "test" }]);
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Token { text: "test" }]);
     /// ```
     ///
     fn write_element(&mut self, element: FormatElement<'ast>) -> FormatResult<()>;
@@ -57,9 +57,9 @@ pub trait Buffer<'ast> {
     /// let mut state = FormatState::new(SimpleFormatContext::default());
     /// let mut buffer = VecBuffer::new(&mut state);
     ///
-    /// buffer.write_fmt(format_args!(text("Hello World"))).unwrap();
+    /// buffer.write_fmt(format_args!(token("Hello World"))).unwrap();
     ///
-    /// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText{ text: "Hello World" }]);
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Token{ text: "Hello World" }]);
     /// ```
     fn write_fmt(mut self: &mut Self, arguments: Arguments<'_, 'ast>) -> FormatResult<()> {
         super::write(&mut self, arguments)
@@ -269,7 +269,7 @@ Make sure that you take and restore the snapshot in order and that this snapshot
 ///
 /// impl Format<SimpleFormatContext> for Preamble {
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
-///         write!(f, [text("# heading"), hard_line_break()])
+///         write!(f, [token("# heading"), hard_line_break()])
 ///     }
 /// }
 ///
@@ -280,7 +280,7 @@ Make sure that you take and restore the snapshot in order and that this snapshot
 /// {
 ///     let mut with_preamble = PreambleBuffer::new(&mut buffer, Preamble);
 ///
-///     write!(&mut with_preamble, [text("this text will be on a new line")])?;
+///     write!(&mut with_preamble, [token("this text will be on a new line")])?;
 /// }
 ///
 /// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
@@ -300,7 +300,7 @@ Make sure that you take and restore the snapshot in order and that this snapshot
 ///
 /// impl Format<SimpleFormatContext> for Preamble {
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
-///         write!(f, [text("# heading"), hard_line_break()])
+///         write!(f, [token("# heading"), hard_line_break()])
 ///     }
 /// }
 ///
@@ -447,11 +447,11 @@ where
 ///         write!(
 ///             buffer,
 ///             [
-///                 text("The next soft line or space gets replaced by a space"),
+///                 token("The next soft line or space gets replaced by a space"),
 ///                 soft_line_break_or_space(),
-///                 text("and the line here"),
+///                 token("and the line here"),
 ///                 soft_line_break(),
-///                 text("is removed entirely.")
+///                 token("is removed entirely.")
 ///             ]
 ///         )
 ///     })]
@@ -460,10 +460,10 @@ where
 /// assert_eq!(
 ///     formatted.document().as_ref(),
 ///     &[
-///         FormatElement::StaticText { text: "The next soft line or space gets replaced by a space" },
+///         FormatElement::Token { text: "The next soft line or space gets replaced by a space" },
 ///         FormatElement::Space,
-///         FormatElement::StaticText { text: "and the line here" },
-///         FormatElement::StaticText { text: "is removed entirely." }
+///         FormatElement::Token { text: "and the line here" },
+///         FormatElement::Token { text: "is removed entirely." }
 ///     ]
 /// );
 ///
@@ -674,19 +674,19 @@ pub trait BufferExtensions<'ast>: Buffer<'ast> + Sized {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     let mut recording = f.start_recording();
     ///
-    ///     write!(recording, [text("A")])?;
-    ///     write!(recording, [text("B")])?;
+    ///     write!(recording, [token("A")])?;
+    ///     write!(recording, [token("B")])?;
     ///
-    ///     write!(recording, [format_with(|f| write!(f, [text("C"), text("D")]))])?;
+    ///     write!(recording, [format_with(|f| write!(f, [token("C"), token("D")]))])?;
     ///
     ///     let recorded = recording.stop();
     ///     assert_eq!(
     ///         recorded.deref(),
     ///         &[
-    ///             FormatElement::StaticText{ text: "A" },
-    ///             FormatElement::StaticText{ text: "B" },
-    ///             FormatElement::StaticText{ text: "C" },
-    ///             FormatElement::StaticText{ text: "D" }
+    ///             FormatElement::Token{ text: "A" },
+    ///             FormatElement::Token{ text: "B" },
+    ///             FormatElement::Token{ text: "C" },
+    ///             FormatElement::Token{ text: "D" }
     ///         ]
     ///     );
     ///

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -38,7 +38,7 @@ use crate::{TrailingSeparator, write};
 ///
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
-///     group(&format_args![text("a,"), soft_line_break(), text("b")])
+///     group(&format_args![token("a,"), soft_line_break(), token("b")])
 /// ])?;
 ///
 /// assert_eq!(
@@ -64,9 +64,9 @@ use crate::{TrailingSeparator, write};
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("a long word,"),
+///         token("a long word,"),
 ///         soft_line_break(),
-///         text("so that the group doesn't fit on a single line"),
+///         token("so that the group doesn't fit on a single line"),
 ///     ])
 /// ])?;
 ///
@@ -95,9 +95,9 @@ pub const fn soft_line_break() -> Line {
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("a,"),
+///         token("a,"),
 ///         hard_line_break(),
-///         text("b"),
+///         token("b"),
 ///         hard_line_break()
 ///     ])
 /// ])?;
@@ -127,9 +127,9 @@ pub const fn hard_line_break() -> Line {
 /// let elements = format!(
 ///     SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("a,"),
+///         token("a,"),
 ///         empty_line(),
-///         text("b"),
+///         token("b"),
 ///         empty_line()
 ///     ])
 /// ])?;
@@ -158,9 +158,9 @@ pub const fn empty_line() -> Line {
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("a,"),
+///         token("a,"),
 ///         soft_line_break_or_space(),
-///         text("b"),
+///         token("b"),
 ///     ])
 /// ])?;
 ///
@@ -185,9 +185,9 @@ pub const fn empty_line() -> Line {
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("a long word,"),
+///         token("a long word,"),
 ///         soft_line_break_or_space(),
-///         text("so that the group doesn't fit on a single line"),
+///         token("so that the group doesn't fit on a single line"),
 ///     ])
 /// ])?;
 ///
@@ -226,12 +226,12 @@ impl std::fmt::Debug for Line {
     }
 }
 
-/// Creates a token that gets written as is to the output. Make sure to properly escape the text if
-/// it's user generated (e.g. a string and not a language keyword).
+/// Creates a [`FormatElement::Token`] that gets written as is to the output.
 ///
-/// # Line feeds
-/// Tokens may contain line breaks but they must use the line feeds (`\n`).
-/// The [crate::Printer] converts the line feed characters to the character specified in the [crate::PrinterOptions].
+/// # SAFELY
+///
+/// This function is safe to use only if the provided text contains no line breaks, tab characters,
+/// or other non-ASCII characters.
 ///
 /// # Examples
 ///
@@ -240,7 +240,7 @@ impl std::fmt::Debug for Line {
 /// use biome_formatter::prelude::*;
 ///
 /// # fn main() -> FormatResult<()> {
-/// let elements = format!(SimpleFormatContext::default(), [text("Hello World")])?;
+/// let elements = format!(SimpleFormatContext::default(), [token("Hello World")])?;
 ///
 /// assert_eq!(
 ///     "Hello World",
@@ -259,56 +259,63 @@ impl std::fmt::Debug for Line {
 ///
 /// # fn main() -> FormatResult<()> {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
-/// let elements = format!(SimpleFormatContext::default(), [text("\"Hello\\tWorld\"")])?;
+/// let elements = format!(SimpleFormatContext::default(), [token("\"Hello\\tWorld\"")])?;
 ///
 /// assert_eq!(r#""Hello\tWorld""#, elements.print()?.as_code());
 /// # Ok(())
 /// # }
 /// ```
 #[inline]
-pub fn text(text: &'static str) -> StaticText {
-    debug_assert_no_newlines(text);
-    StaticText { text }
+pub fn token(text: &'static str) -> Token {
+    debug_assert_token_ascii_only_and_no_linebreaks(text);
+    Token { text }
+}
+
+fn debug_assert_token_ascii_only_and_no_linebreaks(text: &str) {
+    debug_assert!(
+        text.as_bytes().iter().all(|&c| c.is_ascii() && !matches!(c, b'\r' | b'\n' | b'\t')),
+        "`FormatElement::Token` can only contain ASCII characters without line breaks or tab characters. Found invalid content: '{text}'"
+    );
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct StaticText {
+pub struct Token {
     text: &'static str,
 }
 
-impl Format<'_> for StaticText {
+impl Format<'_> for Token {
     fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::StaticText { text: self.text })
+        f.write_element(FormatElement::Token { text: self.text })
     }
 }
 
-impl std::fmt::Debug for StaticText {
+impl std::fmt::Debug for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(f, "StaticToken({})", self.text)
+        std::write!(f, "Token({})", self.text)
     }
 }
 
 /// Creates a text from a dynamic string and a range of the input source
-pub fn dynamic_text(text: &str) -> DynamicText<'_> {
+pub fn text(text: &str) -> Text<'_> {
     // FIXME
     // debug_assert_no_newlines(text);
-    DynamicText { text }
+    Text { text }
 }
 
 #[derive(Eq, PartialEq)]
-pub struct DynamicText<'a> {
+pub struct Text<'a> {
     text: &'a str,
 }
 
-impl<'a> Format<'a> for DynamicText<'a> {
+impl<'a> Format<'a> for Text<'a> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        f.write_element(FormatElement::DynamicText { text: self.text })
+        f.write_element(FormatElement::Text { text: self.text })
     }
 }
 
-impl std::fmt::Debug for DynamicText<'_> {
+impl std::fmt::Debug for Text<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(f, "DynamicToken({})", self.text)
+        std::write!(f, "Text({})", self.text)
     }
 }
 
@@ -331,7 +338,7 @@ impl<'a> Format<'a> for SyntaxTokenCowSlice<'a> {
                 // let range = TextRange::at(self.start, text.text_len());
                 // debug_assert_eq!(
                 // *text,
-                // &self.token.text()[range - self.token.text_range().start()],
+                // &self.token.token()[range - self.token.text_range().start()],
                 // "The borrowed string doesn't match the specified token substring. Does the borrowed string belong to this token and range?"
                 // );
 
@@ -343,7 +350,7 @@ impl<'a> Format<'a> for SyntaxTokenCowSlice<'a> {
                     source_position: self.span.start,
                 })
             }
-            Cow::Owned(text) => f.write_element(FormatElement::DynamicText {
+            Cow::Owned(text) => f.write_element(FormatElement::Text {
                 // TODO: Should use arena String to replace Cow::Owned.
                 text: f.context().allocator().alloc_str(text),
             }),
@@ -402,9 +409,9 @@ fn debug_assert_no_newlines(text: &str) {
 ///
 /// fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
-///     text("a"),
-///     line_suffix(&text("c")),
-///     text("b")
+///     token("a"),
+///     line_suffix(&token("c")),
+///     token("b")
 /// ])?;
 ///
 /// assert_eq!(
@@ -453,11 +460,11 @@ impl std::fmt::Debug for LineSuffix<'_, '_> {
 ///
 /// # fn  main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
-///     text("a"),
-///     line_suffix(&text("c")),
-///     text("b"),
+///     token("a"),
+///     line_suffix(&token("c")),
+///     token("b"),
 ///     line_suffix_boundary(),
-///     text("d")
+///     token("d")
 /// ])?;
 ///
 /// assert_eq!(
@@ -517,7 +524,7 @@ impl Format<'_> for LineSuffixBoundary {
 ///         write!(recording, [
 ///             labelled(
 ///                 LabelId::of(MyLabels::Main),
-///                 &text("'I have a label'")
+///                 &token("'I have a label'")
 ///             )
 ///         ])?;
 ///
@@ -526,9 +533,9 @@ impl Format<'_> for LineSuffixBoundary {
 ///         let is_labelled = recorded.first().is_some_and(|element| element.has_label(LabelId::of(MyLabels::Main)));
 ///
 ///         if is_labelled {
-///             write!(f, [text(" has label `Main`")])
+///             write!(f, [token(" has label `Main`")])
 ///         } else {
-///             write!(f, [text(" doesn't have label `Main`")])
+///             write!(f, [token(" doesn't have label `Main`")])
 ///         }
 ///     })]
 /// )?;
@@ -583,7 +590,7 @@ impl std::fmt::Debug for FormatLabelled<'_, '_> {
 ///
 /// # fn main() -> FormatResult<()> {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
-/// let elements = format!(SimpleFormatContext::default(), [text("a"), space(), text("b")])?;
+/// let elements = format!(SimpleFormatContext::default(), [token("a"), space(), token("b")])?;
 ///
 /// assert_eq!("a b", elements.print()?.as_code());
 /// # Ok(())
@@ -612,9 +619,9 @@ pub const fn space() -> Space {
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("nineteen_characters"),
+///         token("nineteen_characters"),
 ///         soft_line_break(),
-///         text("1"),
+///         token("1"),
 ///         hard_space(),
 ///     ])
 /// ])?;
@@ -641,9 +648,9 @@ pub const fn space() -> Space {
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("nineteen_characters"),
+///         token("nineteen_characters"),
 ///         soft_line_break(),
-///         text("1"),
+///         token("1"),
 ///         space(),
 ///     ])
 /// ])?;
@@ -668,8 +675,8 @@ pub const fn hard_space() -> HardSpace {
 /// use biome_formatter::prelude::*;
 ///
 /// # fn main() -> FormatResult<()> {
-/// let elements = format!(SimpleFormatContext::default(), [text("a"), maybe_space(true), text("b")])?;
-/// let nospace = format!(SimpleFormatContext::default(), [text("a"), maybe_space(false), text("b")])?;
+/// let elements = format!(SimpleFormatContext::default(), [token("a"), maybe_space(true), token("b")])?;
+/// let nospace = format!(SimpleFormatContext::default(), [token("a"), maybe_space(false), token("b")])?;
 ///
 /// assert_eq!("a b", elements.print()?.as_code());
 /// assert_eq!("ab", nospace.print()?.as_code());
@@ -714,16 +721,16 @@ impl Format<'_> for HardSpace {
 ///
 /// # fn main() -> FormatResult<()> {
 /// let block = format!(SimpleFormatContext::default(), [
-///     text("switch {"),
+///     token("switch {"),
 ///     block_indent(&format_args![
-///         text("default:"),
+///         token("default:"),
 ///         indent(&format_args![
 ///             // this is where we want to use a
 ///             hard_line_break(),
-///             text("break;"),
+///             token("break;"),
 ///         ])
 ///     ]),
-///     text("}"),
+///     token("}"),
 /// ])?;
 ///
 /// assert_eq!(
@@ -743,12 +750,12 @@ impl Format<'_> for HardSpace {
 /// let block = format!(
 ///     SimpleFormatContext::default(),
 ///     [
-///         text("root"),
+///         token("root"),
 ///         indent(&format_args![align(
 ///             2,
 ///             &format_args![indent(&format_args![
 ///                 hard_line_break(),
-///                 text("should be 3 tabs"),
+///                 token("should be 3 tabs"),
 ///             ])]
 ///         )])
 ///     ]
@@ -802,22 +809,22 @@ impl std::fmt::Debug for Indent<'_, '_> {
 ///
 /// # fn main() -> FormatResult<()> {
 /// let block = format!(SimpleFormatContext::default(), [
-///     text("root"),
+///     token("root"),
 ///     align(2, &format_args![
 ///         hard_line_break(),
-///         text("aligned"),
+///         token("aligned"),
 ///         dedent(&format_args![
 ///             hard_line_break(),
-///             text("not aligned"),
+///             token("not aligned"),
 ///         ]),
 ///         dedent(&indent(&format_args![
 ///             hard_line_break(),
-///             text("Indented, not aligned")
+///             token("Indented, not aligned")
 ///         ]))
 ///     ]),
 ///     dedent(&format_args![
 ///         hard_line_break(),
-///         text("Dedent on root level is a no-op.")
+///         token("Dedent on root level is a no-op.")
 ///     ])
 /// ])?;
 ///
@@ -842,18 +849,18 @@ impl std::fmt::Debug for Indent<'_, '_> {
 ///     let elements = format!(
 ///         context,
 ///         [
-///             text("root"),
+///             token("root"),
 ///             indent(&format_args![
 ///                 hard_line_break(),
-///                 text("Indented"),
+///                 token("Indented"),
 ///                 align(
 ///                     2,
 ///                     &format_args![
 ///                         hard_line_break(),
-///                         text("Indented and aligned"),
+///                         token("Indented and aligned"),
 ///                         dedent(&format_args![
 ///                             hard_line_break(),
-///                             text("Indented, not aligned"),
+///                             token("Indented, not aligned"),
 ///                         ]),
 ///                     ]
 ///                 ),
@@ -862,18 +869,18 @@ impl std::fmt::Debug for Indent<'_, '_> {
 ///                 2,
 ///                 &format_args![
 ///                     hard_line_break(),
-///                     text("Aligned"),
+///                     token("Aligned"),
 ///                     indent(&format_args![
 ///                         hard_line_break(),
-///                         text("Aligned, and indented"),
+///                         token("Aligned, and indented"),
 ///                         dedent(&format_args![
 ///                             hard_line_break(),
-///                             text("aligned, not indented"),
+///                             token("aligned, not indented"),
 ///                         ]),
 ///                     ])
 ///                 ]
 ///             ),
-///             dedent(&format_args![hard_line_break(), text("root level")])
+///             dedent(&format_args![hard_line_break(), token("root level")])
 ///         ]
 ///     )?;
 ///     assert_eq!(
@@ -892,17 +899,17 @@ impl std::fmt::Debug for Indent<'_, '_> {
 /// let block = format!(
 ///     SimpleFormatContext::default(),
 ///     [
-///         text("root"),
+///         token("root"),
 ///         indent(&format_args![align(
 ///             2,
 ///             &format_args![align(
 ///                 2,
 ///                 &format_args![indent(&format_args![
 ///                     hard_line_break(),
-///                     text("should be 4 tabs"),
+///                     token("should be 4 tabs"),
 ///                     dedent(&format_args![
 ///                         hard_line_break(),
-///                         text("should be 1 tab and 4 spaces"),
+///                         token("should be 1 tab and 4 spaces"),
 ///                     ]),
 ///                 ])]
 ///             ),]
@@ -954,23 +961,23 @@ impl std::fmt::Debug for Dedent<'_, '_> {
 ///
 /// # fn main() -> FormatResult<()> {
 /// let block = format!(SimpleFormatContext::default(), [
-///     text("root"),
+///     token("root"),
 ///     indent(&format_args![
 ///         hard_line_break(),
-///         text("indent level 1"),
+///         token("indent level 1"),
 ///         indent(&format_args![
 ///             hard_line_break(),
-///             text("indent level 2"),
+///             token("indent level 2"),
 ///             align(2, &format_args![
 ///                 hard_line_break(),
-///                 text("two space align"),
+///                 token("two space align"),
 ///                 dedent_to_root(&format_args![
 ///                     hard_line_break(),
-///                     text("starts at the beginning of the line")
+///                     token("starts at the beginning of the line")
 ///                 ]),
 ///             ]),
 ///             hard_line_break(),
-///             text("end indent level 2"),
+///             token("end indent level 2"),
 ///         ])
 ///  ]),
 /// ])?;
@@ -1013,24 +1020,24 @@ where
 ///
 /// # fn main() -> FormatResult<()> {
 /// let block = format!(SimpleFormatContext::default(), [
-///     text("a"),
+///     token("a"),
 ///     hard_line_break(),
-///     text("?"),
+///     token("?"),
 ///     space(),
 ///     align(2, &format_args![
-///         text("function () {"),
+///         token("function () {"),
 ///         hard_line_break(),
-///         text("}"),
+///         token("}"),
 ///     ]),
 ///     hard_line_break(),
-///     text(":"),
+///     token(":"),
 ///     space(),
 ///     align(2, &format_args![
-///         text("function () {"),
-///         block_indent(&text("console.log('test');")),
-///         text("}"),
+///         token("function () {"),
+///         block_indent(&token("console.log('test');")),
+///         token("}"),
 ///     ]),
-///     text(";")
+///     token(";")
 /// ])?;
 ///
 /// assert_eq!(
@@ -1064,24 +1071,24 @@ where
 /// });
 ///
 /// let block = format!(context, [
-///     text("a"),
+///     token("a"),
 ///     hard_line_break(),
-///     text("?"),
+///     token("?"),
 ///     space(),
 ///     align(2, &format_args![
-///         text("function () {"),
+///         token("function () {"),
 ///         hard_line_break(),
-///         text("}"),
+///         token("}"),
 ///     ]),
 ///     hard_line_break(),
-///     text(":"),
+///     token(":"),
 ///     space(),
 ///     align(2, &format_args![
-///         text("function () {"),
-///         block_indent(&text("console.log('test');")),
-///         text("}"),
+///         token("function () {"),
+///         block_indent(&token("console.log('test');")),
+///         token("}"),
 ///     ]),
-///     text(";")
+///     token(";")
 /// ])?;
 ///
 /// assert_eq!(
@@ -1147,13 +1154,13 @@ impl std::fmt::Debug for Align<'_, '_> {
 /// let block = format![
 ///     SimpleFormatContext::default(),
 ///     [
-///         text("{"),
+///         token("{"),
 ///         block_indent(&format_args![
-///             text("let a = 10;"),
+///             token("let a = 10;"),
 ///             hard_line_break(),
-///             text("let c = a + 5;"),
+///             token("let c = a + 5;"),
 ///         ]),
-///         text("}"),
+///         token("}"),
 ///     ]
 /// ]?;
 ///
@@ -1189,13 +1196,13 @@ pub fn block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> 
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("'First string',"),
+///             token("'First string',"),
 ///             soft_line_break_or_space(),
-///             text("'second string',"),
+///             token("'second string',"),
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1215,13 +1222,13 @@ pub fn block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> 
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("5,"),
+///             token("5,"),
 ///             soft_line_break_or_space(),
-///             text("10"),
+///             token("10"),
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1257,14 +1264,14 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("{"),
+///         token("{"),
 ///         soft_block_indent_with_maybe_space(&format_args![
-///             text("aPropertyThatExceeds"),
-///             text(":"),
+///             token("aPropertyThatExceeds"),
+///             token(":"),
 ///             space(),
-///             text("'line width'"),
+///             token("'line width'"),
 ///         ], false),
-///         text("}")
+///         token("}")
 ///     ])
 /// ])?;
 ///
@@ -1285,14 +1292,14 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("{"),
+///         token("{"),
 ///         soft_block_indent_with_maybe_space(&format_args![
-///             text("a"),
-///             text(":"),
+///             token("a"),
+///             token(":"),
 ///             space(),
-///             text("5"),
+///             token("5"),
 ///         ], true),
-///         text("}")
+///         token("}")
 ///     ])
 /// ])?;
 ///
@@ -1312,14 +1319,14 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("{"),
+///         token("{"),
 ///         soft_block_indent_with_maybe_space(&format_args![
-///             text("a"),
-///             text(":"),
+///             token("a"),
+///             token(":"),
 ///             space(),
-///             text("5"),
+///             token("5"),
 ///         ], false),
-///         text("}")
+///         token("}")
 ///     ])
 /// ])?;
 ///
@@ -1360,15 +1367,15 @@ pub fn soft_block_indent_with_maybe_space<'ast>(
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("name"),
+///         token("name"),
 ///         space(),
-///         text("="),
+///         token("="),
 ///         soft_line_indent_or_space(&format_args![
-///             text("firstName"),
+///             token("firstName"),
 ///             space(),
-///             text("+"),
+///             token("+"),
 ///             space(),
-///             text("lastName"),
+///             token("lastName"),
 ///         ]),
 ///     ])
 /// ])?;
@@ -1389,10 +1396,10 @@ pub fn soft_block_indent_with_maybe_space<'ast>(
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("a"),
+///         token("a"),
 ///         space(),
-///         text("="),
-///         soft_line_indent_or_space(&text("10")),
+///         token("="),
+///         soft_line_indent_or_space(&token("10")),
 ///     ])
 /// ])?;
 ///
@@ -1427,15 +1434,15 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("name"),
+///         token("name"),
 ///         space(),
-///         text("="),
+///         token("="),
 ///         soft_line_indent_or_hard_space(&format_args![
-///             text("firstName"),
+///             token("firstName"),
 ///             space(),
-///             text("+"),
+///             token("+"),
 ///             space(),
-///             text("lastName"),
+///             token("lastName"),
 ///         ]),
 ///     ])
 /// ])?;
@@ -1456,10 +1463,10 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("a"),
+///         token("a"),
 ///         space(),
-///         text("="),
-///         soft_line_indent_or_hard_space(&text("10")),
+///         token("="),
+///         soft_line_indent_or_hard_space(&token("10")),
 ///     ])
 /// ])?;
 ///
@@ -1484,11 +1491,11 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("value"),
+///         token("value"),
 ///         soft_line_break_or_space(),
-///         text("="),
+///         token("="),
 ///         soft_line_indent_or_hard_space(&format_args![
-///             text("10"),
+///             token("10"),
 ///         ]),
 ///     ])
 /// ])?;
@@ -1589,14 +1596,14 @@ impl std::fmt::Debug for BlockIndent<'_, '_> {
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("{"),
+///         token("{"),
 ///         soft_space_or_block_indent(&format_args![
-///             text("aPropertyThatExceeds"),
-///             text(":"),
+///             token("aPropertyThatExceeds"),
+///             token(":"),
 ///             space(),
-///             text("'line width'"),
+///             token("'line width'"),
 ///         ]),
-///         text("}")
+///         token("}")
 ///     ])
 /// ])?;
 ///
@@ -1616,14 +1623,14 @@ impl std::fmt::Debug for BlockIndent<'_, '_> {
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("{"),
+///         token("{"),
 ///         soft_space_or_block_indent(&format_args![
-///             text("a"),
-///             text(":"),
+///             token("a"),
+///             token(":"),
 ///             space(),
-///             text("5"),
+///             token("5"),
 ///         ]),
-///         text("}")
+///         token("}")
 ///     ])
 /// ])?;
 ///
@@ -1658,15 +1665,15 @@ pub fn soft_space_or_block_indent<'ast>(content: &impl Format<'ast>) -> BlockInd
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("1,"),
+///             token("1,"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
+///             token("3"),
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1691,15 +1698,15 @@ pub fn soft_space_or_block_indent<'ast>(content: &impl Format<'ast>) -> BlockInd
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("'Good morning! How are you today?',"),
+///             token("'Good morning! How are you today?',"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
+///             token("3"),
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1777,16 +1784,16 @@ impl std::fmt::Debug for Group<'_, '_> {
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("'Good morning! How are you today?',"),
+///             token("'Good morning! How are you today?',"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             expand_parent(), // Forces the parent to expand
 ///             soft_line_break_or_space(),
-///             text("3"),
+///             token("3"),
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1831,16 +1838,16 @@ impl Format<'_> for ExpandParent {
 /// # fn main() -> FormatResult<()> {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("1,"),
+///             token("1,"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
-///             if_group_breaks(&text(","))
+///             token("3"),
+///             if_group_breaks(&token(","))
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1866,16 +1873,16 @@ impl Format<'_> for ExpandParent {
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("'A somewhat longer string to force a line break',"),
+///             token("'A somewhat longer string to force a line break',"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
-///             if_group_breaks(&text(","))
+///             token("3"),
+///             if_group_breaks(&token(","))
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1909,16 +1916,16 @@ where
 /// # fn main() -> FormatResult<()> {
 /// let formatted = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("1,"),
+///             token("1,"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
-///             if_group_fits_on_line(&text(","))
+///             token("3"),
+///             if_group_fits_on_line(&token(","))
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -1943,16 +1950,16 @@ where
 ///
 /// let formatted = format!(context, [
 ///     group(&format_args![
-///         text("["),
+///         token("["),
 ///         soft_block_indent(&format_args![
-///             text("'A somewhat longer string to force a line break',"),
+///             token("'A somewhat longer string to force a line break',"),
 ///             soft_line_break_or_space(),
-///             text("2,"),
+///             token("2,"),
 ///             soft_line_break_or_space(),
-///             text("3"),
-///             if_group_fits_on_line(&text(","))
+///             token("3"),
+///             if_group_fits_on_line(&token(","))
 ///         ]),
-///         text("]"),
+///         token("]"),
 ///     ])
 /// ])?;
 ///
@@ -2005,21 +2012,21 @@ impl IfGroupBreaks<'_, '_> {
     ///     write!(f, [
     ///         group(
     ///             &format_args![
-    ///                 text("["),
+    ///                 token("["),
     ///                 soft_block_indent(&format_with(|f| {
     ///                     f.fill()
-    ///                         .entry(&soft_line_break_or_space(), &text("1,"))
-    ///                         .entry(&soft_line_break_or_space(), &text("234568789,"))
-    ///                         .entry(&soft_line_break_or_space(), &text("3456789,"))
+    ///                         .entry(&soft_line_break_or_space(), &token("1,"))
+    ///                         .entry(&soft_line_break_or_space(), &token("234568789,"))
+    ///                         .entry(&soft_line_break_or_space(), &token("3456789,"))
     ///                         .entry(&soft_line_break_or_space(), &format_args!(
-    ///                             text("["),
-    ///                             soft_block_indent(&text("4")),
-    ///                             text("]"),
-    ///                             if_group_breaks(&text(",")).with_group_id(Some(group_id))
+    ///                             token("["),
+    ///                             soft_block_indent(&token("4")),
+    ///                             token("]"),
+    ///                             if_group_breaks(&token(",")).with_group_id(Some(group_id))
     ///                         ))
     ///                     .finish()
     ///                 })),
-    ///                 text("]")
+    ///                 token("]")
     ///             ],
     ///         ).with_group_id(Some(group_id))
     ///     ])
@@ -2073,9 +2080,9 @@ impl std::fmt::Debug for IfGroupBreaks<'_, '_> {
 /// let id = f.group_id("head");
 ///
 /// write!(f, [
-///     group(&text("Head")).with_group_id(Some(id)),
-///     if_group_breaks(&indent(&text("indented"))).with_group_id(Some(id)),
-///     if_group_fits_on_line(&text("indented")).with_group_id(Some(id))
+///     group(&token("Head")).with_group_id(Some(id)),
+///     if_group_breaks(&indent(&token("indented"))).with_group_id(Some(id)),
+///     if_group_fits_on_line(&token("indented")).with_group_id(Some(id))
 /// ])
 ///
 /// # });
@@ -2098,8 +2105,8 @@ impl std::fmt::Debug for IfGroupBreaks<'_, '_> {
 ///     let group_id = f.group_id("header");
 ///
 ///     write!(f, [
-///         group(&text("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
-///         indent_if_group_breaks(&format_args![hard_line_break(), text("a => b")], group_id)
+///         group(&token("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
+///         indent_if_group_breaks(&format_args![hard_line_break(), token("a => b")], group_id)
 ///     ])
 /// });
 ///
@@ -2128,8 +2135,8 @@ impl std::fmt::Debug for IfGroupBreaks<'_, '_> {
 ///     let group_id = f.group_id("header");
 ///
 ///     write!(f, [
-///         group(&text("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
-///         indent_if_group_breaks(&format_args![hard_line_break(), text("a => b")], group_id)
+///         group(&token("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
+///         indent_if_group_breaks(&format_args![hard_line_break(), token("a => b")], group_id)
 ///     ])
 /// });
 ///
@@ -2214,17 +2221,17 @@ impl<T> std::fmt::Debug for FormatWith<T> {
 /// impl Format<SimpleFormatContext> for MyFormat {
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
 ///         write!(f, [
-///             text("("),
+///             token("("),
 ///             block_indent(&format_with(|f| {
 ///                 let separator = space();
 ///                 let mut join = f.join_with(&separator);
 ///
 ///                 for item in &self.items {
-///                     join.entry(&format_with(|f| write!(f, [dynamic_text(item, TextSize::default())])));
+///                     join.entry(&format_with(|f| write!(f, [text(item, TextSize::default())])));
 ///                 }
 ///                 join.finish()
 ///             })),
-///             text(")")
+///             token(")")
 ///         ])
 ///     }
 /// }
@@ -2262,8 +2269,8 @@ where
 ///
 /// struct MyFormat;
 ///
-/// fn generate_values() -> impl Iterator<Item=StaticText> {
-///     vec![text("1"), text("2"), text("3"), text("4")].into_iter()
+/// fn generate_values() -> impl Iterator<Item=Token> {
+///     vec![token("1"), token("2"), token("3"), token("4")].into_iter()
 /// }
 ///
 /// impl Format<SimpleFormatContext> for MyFormat {

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -118,8 +118,9 @@ impl Document<'_> {
                         // propagate their expansion.
                         false
                     }
-                    FormatElement::StaticText { text }
-                    | FormatElement::DynamicText { text, .. } => text.contains('\n'),
+                    FormatElement::Token { text } | FormatElement::Text { text, .. } => {
+                        text.contains('\n')
+                    }
                     FormatElement::LocatedTokenText { slice, .. } => slice.contains('\n'),
                     FormatElement::ExpandParent
                     | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
@@ -186,7 +187,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
         while let Some(element) = iter.next() {
             if !first_element && !in_text && !element.is_end_tag() {
                 // Write a separator between every two elements
-                write!(f, [text(","), soft_line_break_or_space()])?;
+                write!(f, [token(","), soft_line_break_or_space()])?;
             }
 
             first_element = false;
@@ -194,33 +195,33 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
             match element {
                 element @ (FormatElement::Space
                 | FormatElement::HardSpace
-                | FormatElement::StaticText { .. }
-                | FormatElement::DynamicText { .. }
+                | FormatElement::Token { .. }
+                | FormatElement::Text { .. }
                 | FormatElement::LocatedTokenText { .. }) => {
                     if !in_text {
-                        write!(f, [text("\"")])?;
+                        write!(f, [token("\"")])?;
                     }
 
                     in_text = true;
 
                     match element {
                         FormatElement::Space | FormatElement::HardSpace => {
-                            write!(f, [text(" ")])?;
+                            write!(f, [token(" ")])?;
                         }
                         element if element.is_text() => {
                             // escape quotes
                             let new_element = match element {
                                 // except for static text because source_position is unknown
-                                FormatElement::StaticText { .. } => element.clone(),
-                                FormatElement::DynamicText { text } => {
+                                FormatElement::Token { .. } => element.clone(),
+                                FormatElement::Text { text } => {
                                     let text = text.cow_replace('"', "\\\"");
-                                    FormatElement::DynamicText {
+                                    FormatElement::Text {
                                         text: f.context().allocator().alloc_str(&text),
                                     }
                                 }
                                 FormatElement::LocatedTokenText { slice, source_position } => {
                                     let text = slice.cow_replace('"', "\\\"");
-                                    FormatElement::DynamicText {
+                                    FormatElement::Text {
                                         text: f.context().allocator().alloc_str(&text),
                                     }
                                 }
@@ -234,35 +235,35 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                     let is_next_text = iter.peek().is_some_and(|e| e.is_text() || e.is_space());
 
                     if !is_next_text {
-                        write!(f, [text("\"")])?;
+                        write!(f, [token("\"")])?;
                         in_text = false;
                     }
                 }
 
                 FormatElement::Line(mode) => match mode {
                     LineMode::SoftOrSpace => {
-                        write!(f, [text("soft_line_break_or_space")])?;
+                        write!(f, [token("soft_line_break_or_space")])?;
                     }
                     LineMode::Soft => {
-                        write!(f, [text("soft_line_break")])?;
+                        write!(f, [token("soft_line_break")])?;
                     }
                     LineMode::Hard => {
-                        write!(f, [text("hard_line_break")])?;
+                        write!(f, [token("hard_line_break")])?;
                     }
                     LineMode::Empty => {
-                        write!(f, [text("empty_line")])?;
+                        write!(f, [token("empty_line")])?;
                     }
                 },
                 FormatElement::ExpandParent => {
-                    write!(f, [text("expand_parent")])?;
+                    write!(f, [token("expand_parent")])?;
                 }
 
                 FormatElement::LineSuffixBoundary => {
-                    write!(f, [text("line_suffix_boundary")])?;
+                    write!(f, [token("line_suffix_boundary")])?;
                 }
 
                 FormatElement::BestFitting(best_fitting) => {
-                    write!(f, [text("best_fitting([")])?;
+                    write!(f, [token("best_fitting([")])?;
                     f.write_elements([
                         FormatElement::Tag(StartIndent),
                         FormatElement::Line(LineMode::Hard),
@@ -277,7 +278,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         FormatElement::Line(LineMode::Hard),
                     ])?;
 
-                    write!(f, [text("])")])?;
+                    write!(f, [token("])")])?;
                 }
 
                 FormatElement::Interned(interned) => {
@@ -290,7 +291,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             write!(
                                 f,
                                 [
-                                    dynamic_text(
+                                    text(
                                         f.context()
                                             .allocator()
                                             .alloc_str(&std::format!("<interned {index}>"))
@@ -303,7 +304,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         Some(reference) => {
                             write!(
                                 f,
-                                [dynamic_text(
+                                [text(
                                     f.context()
                                         .allocator()
                                         .alloc_str(&std::format!("<ref interned *{reference}>"))
@@ -326,13 +327,13 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                 write!(
                                     f,
                                     [
-                                        text("<END_TAG_WITHOUT_START<"),
-                                        dynamic_text(
+                                        token("<END_TAG_WITHOUT_START<"),
+                                        text(
                                             f.context()
                                                 .allocator()
                                                 .alloc_str(&std::format!("{:?}", tag.kind()))
                                         ),
-                                        text(">>"),
+                                        token(">>"),
                                     ]
                                 )?;
                                 first_element = false;
@@ -343,21 +344,21 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                     f,
                                     [
                                         ContentArrayEnd,
-                                        text(")"),
+                                        token(")"),
                                         soft_line_break_or_space(),
-                                        text("ERROR<START_END_TAG_MISMATCH<start: "),
-                                        dynamic_text(
+                                        token("ERROR<START_END_TAG_MISMATCH<start: "),
+                                        text(
                                             f.context()
                                                 .allocator()
                                                 .alloc_str(&std::format!("{start_kind:?}"))
                                         ),
-                                        text(", end: "),
-                                        dynamic_text(
+                                        token(", end: "),
+                                        text(
                                             f.context()
                                                 .allocator()
                                                 .alloc_str(&std::format!("{:?}", tag.kind()))
                                         ),
-                                        text(">>")
+                                        token(">>")
                                     ]
                                 )?;
                                 first_element = false;
@@ -371,7 +372,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
 
                     match tag {
                         StartIndent => {
-                            write!(f, [text("indent(")])?;
+                            write!(f, [token("indent(")])?;
                         }
 
                         StartDedent(mode) => {
@@ -380,44 +381,42 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                 DedentMode::Root => "dedentRoot",
                             };
 
-                            write!(f, [text(label), text("(")])?;
+                            write!(f, [token(label), token("(")])?;
                         }
 
                         StartAlign(tag::Align(count)) => {
                             write!(
                                 f,
                                 [
-                                    text("align("),
-                                    dynamic_text(
-                                        f.context().allocator().alloc_str(&count.to_string()),
-                                    ),
-                                    text(","),
+                                    token("align("),
+                                    text(f.context().allocator().alloc_str(&count.to_string()),),
+                                    token(","),
                                     space(),
                                 ]
                             )?;
                         }
 
                         StartLineSuffix => {
-                            write!(f, [text("line_suffix(")])?;
+                            write!(f, [token("line_suffix(")])?;
                         }
 
                         StartVerbatim(_) => {
-                            write!(f, [text("verbatim(")])?;
+                            write!(f, [token("verbatim(")])?;
                         }
 
                         StartGroup(group) => {
-                            write!(f, [text("group(")])?;
+                            write!(f, [token("group(")])?;
 
                             if let Some(group_id) = group.id() {
                                 write!(
                                     f,
                                     [
-                                        dynamic_text(
+                                        text(
                                             f.context()
                                                 .allocator()
                                                 .alloc_str(&std::format!("\"{group_id:?}\""))
                                         ),
-                                        text(","),
+                                        token(","),
                                         space(),
                                     ]
                                 )?;
@@ -426,10 +425,10 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             match group.mode() {
                                 GroupMode::Flat => {}
                                 GroupMode::Expand => {
-                                    write!(f, [text("expand: true,"), space()])?;
+                                    write!(f, [token("expand: true,"), space()])?;
                                 }
                                 GroupMode::Propagated => {
-                                    write!(f, [text("expand: propagated,"), space()])?;
+                                    write!(f, [token("expand: propagated,"), space()])?;
                                 }
                             }
                         }
@@ -438,13 +437,13 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             write!(
                                 f,
                                 [
-                                    text("indent_if_group_breaks("),
-                                    dynamic_text(
+                                    token("indent_if_group_breaks("),
+                                    text(
                                         f.context()
                                             .allocator()
                                             .alloc_str(&std::format!("\"{id:?}\"")),
                                     ),
-                                    text(","),
+                                    token(","),
                                     space(),
                                 ]
                             )?;
@@ -453,10 +452,10 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         StartConditionalContent(condition) => {
                             match condition.mode {
                                 PrintMode::Flat => {
-                                    write!(f, [text("if_group_fits_on_line(")])?;
+                                    write!(f, [token("if_group_fits_on_line(")])?;
                                 }
                                 PrintMode::Expanded => {
-                                    write!(f, [text("if_group_breaks(")])?;
+                                    write!(f, [token("if_group_breaks(")])?;
                                 }
                             }
 
@@ -464,12 +463,12 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                 write!(
                                     f,
                                     [
-                                        dynamic_text(
+                                        text(
                                             f.context()
                                                 .allocator()
                                                 .alloc_str(&std::format!("\"{group_id:?}\"")),
                                         ),
-                                        text(","),
+                                        token(","),
                                         space(),
                                     ]
                                 )?;
@@ -480,20 +479,20 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             write!(
                                 f,
                                 [
-                                    text("label("),
-                                    dynamic_text(
+                                    token("label("),
+                                    text(
                                         f.context()
                                             .allocator()
                                             .alloc_str(&std::format!("\"{label_id:?}\"")),
                                     ),
-                                    text(","),
+                                    token(","),
                                     space(),
                                 ]
                             )?;
                         }
 
                         StartFill => {
-                            write!(f, [text("fill(")])?;
+                            write!(f, [token("fill(")])?;
                         }
 
                         StartEntry => {
@@ -511,7 +510,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         | EndLineSuffix
                         | EndDedent(_)
                         | EndVerbatim => {
-                            write!(f, [ContentArrayEnd, text(")")])?;
+                            write!(f, [ContentArrayEnd, token(")")])?;
                         }
                     }
 
@@ -527,9 +526,9 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                 f,
                 [
                     ContentArrayEnd,
-                    text(")"),
+                    token(")"),
                     soft_line_break_or_space(),
-                    dynamic_text(
+                    text(
                         f.context()
                             .allocator()
                             .alloc_str(&std::format!("<START_WITHOUT_END<{top:?}>>"))
@@ -548,7 +547,7 @@ impl<'a> Format<'a> for ContentArrayStart {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         use Tag::{StartGroup, StartIndent};
 
-        write!(f, [text("[")])?;
+        write!(f, [token("[")])?;
 
         f.write_elements([
             FormatElement::Tag(StartGroup(tag::Group::new())),
@@ -569,7 +568,7 @@ impl<'a> Format<'a> for ContentArrayEnd {
             FormatElement::Tag(EndGroup),
         ])?;
 
-        write!(f, [text("]")])
+        write!(f, [token("]")])
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/format_extensions.rs
+++ b/crates/oxc_formatter/src/formatter/format_extensions.rs
@@ -30,7 +30,7 @@ pub trait MemoizeFormat<'a> {
     ///         let value = self.value.get();
     ///         self.value.set(value + 1);
     ///
-    ///         write!(f, [dynamic_text(&std::format!("Formatted {value} times."), TextSize::from(0))])
+    ///         write!(f, [text(&std::format!("Formatted {value} times."), TextSize::from(0))])
     ///     }
     /// }
     ///
@@ -102,9 +102,9 @@ where
     ///         let current = self.value.get();
     ///
     ///         write!(f, [
-    ///             text("Count:"),
+    ///             token("Count:"),
     ///             space(),
-    ///             dynamic_text(&std::format!("{current}"), TextSize::default()),
+    ///             text(&std::format!("{current}"), TextSize::default()),
     ///             hard_line_break()
     ///         ])?;
     ///
@@ -119,9 +119,9 @@ where
     ///     let counter_content = counter.inspect(f)?;
     ///
     ///     if counter_content.will_break() {
-    ///         write!(f, [text("Counter:"), block_indent(&counter)])
+    ///         write!(f, [token("Counter:"), block_indent(&counter)])
     ///     } else {
-    ///         write!(f, [text("Counter:"), counter])
+    ///         write!(f, [token("Counter:"), counter])
     ///     }?;
     ///
     ///     write!(f, [counter])

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -80,11 +80,11 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// # fn main() -> FormatResult<()> {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.join()
-    ///         .entry(&text("a"))
+    ///         .entry(&token("a"))
     ///         .entry(&space())
-    ///         .entry(&text("+"))
+    ///         .entry(&token("+"))
     ///         .entry(&space())
-    ///         .entry(&text("b"))
+    ///         .entry(&token("b"))
     ///         .finish()
     /// })])?;
     ///
@@ -111,11 +111,11 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     ///
     /// # fn main() -> FormatResult<()> {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
-    ///     f.join_with(&format_args!(text(","), space()))
-    ///         .entry(&text("1"))
-    ///         .entry(&text("2"))
-    ///         .entry(&text("3"))
-    ///         .entry(&text("4"))
+    ///     f.join_with(&format_args!(token(","), space()))
+    ///         .entry(&token("1"))
+    ///         .entry(&token("2"))
+    ///         .entry(&token("3"))
+    ///         .entry(&token("4"))
     ///         .finish()
     /// })])?;
     ///
@@ -188,10 +188,10 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// # fn main() -> FormatResult<()> {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.fill()
-    ///         .entry(&soft_line_break_or_space(), &text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-    ///         .entry(&soft_line_break_or_space(), &text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
-    ///         .entry(&soft_line_break_or_space(), &text("cccccccccccccccccccccccccccccc"))
-    ///         .entry(&soft_line_break_or_space(), &text("dddddddddddddddddddddddddddddd"))
+    ///         .entry(&soft_line_break_or_space(), &token("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+    ///         .entry(&soft_line_break_or_space(), &token("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+    ///         .entry(&soft_line_break_or_space(), &token("cccccccccccccccccccccccccccccc"))
+    ///         .entry(&soft_line_break_or_space(), &token("dddddddddddddddddddddddddddddd"))
     ///         .finish()
     /// })])?;
     ///
@@ -209,10 +209,10 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     ///
     /// # fn main() -> FormatResult<()> {
     /// let entries = vec![
-    ///     text("<b>Important: </b>"),
-    ///     text("Please do not commit memory bugs such as segfaults, buffer overflows, etc. otherwise you "),
-    ///     text("<em>will</em>"),
-    ///     text(" be reprimanded")
+    ///     token("<b>Important: </b>"),
+    ///     token("Please do not commit memory bugs such as segfaults, buffer overflows, etc. otherwise you "),
+    ///     token("<em>will</em>"),
+    ///     token(" be reprimanded")
     /// ];
     ///
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {

--- a/crates/oxc_formatter/src/formatter/macros.rs
+++ b/crates/oxc_formatter/src/formatter/macros.rs
@@ -16,7 +16,7 @@
 ///
 /// # fn main() -> FormatResult<()> {
 /// let formatted = format!(SimpleFormatContext::default(), [
-///     format_args!(text("Hello World"))
+///     format_args!(token("Hello World"))
 /// ])?;
 ///
 /// assert_eq!("Hello World", formatted.print()?.as_code());
@@ -52,15 +52,15 @@ macro_rules! format_args {
 /// # fn main() -> FormatResult<()> {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
-/// write!(&mut buffer, [text("Hello"), space()])?;
-/// write!(&mut buffer, [text("World")])?;
+/// write!(&mut buffer, [token("Hello"), space()])?;
+/// write!(&mut buffer, [token("World")])?;
 ///
 /// assert_eq!(
 ///     buffer.into_vec(),
 ///     vec![
-///         FormatElement::StaticText { text: "Hello" },
+///         FormatElement::Token { text: "Hello" },
 ///         FormatElement::Space,
-///         FormatElement::StaticText { text: "World" },
+///         FormatElement::Token { text: "World" },
 ///     ]
 ///  );
 /// #  Ok(())
@@ -90,10 +90,10 @@ macro_rules! write {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
-/// dbg_write!(buffer, [text("Hello")])?;
+/// dbg_write!(buffer, [token("Hello")])?;
 /// // ^-- prints: [src/main.rs:7][0] = StaticToken("Hello")
 ///
-/// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText { text: "Hello" }]);
+/// assert_eq!(buffer.into_vec(), vec![FormatElement::Token { text: "Hello" }]);
 /// # Ok(())
 /// # }
 /// ```
@@ -130,14 +130,14 @@ macro_rules! dbg_write {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::format;
 ///
-/// let formatted = format!(SimpleFormatContext::default(), [text("("), text("a"), text(")")]).unwrap();
+/// let formatted = format!(SimpleFormatContext::default(), [token("("), token("a"), token(")")]).unwrap();
 ///
 /// assert_eq!(
 ///     formatted.into_document(),
 ///     Document::from(vec![
-///         FormatElement::StaticText { text: "(" },
-///         FormatElement::StaticText { text: "a" },
-///         FormatElement::StaticText { text: ")" },
+///         FormatElement::Token { text: "(" },
+///         FormatElement::Token { text: "a" },
+///         FormatElement::Token { text: ")" },
 ///     ])
 /// );
 /// ```
@@ -165,49 +165,49 @@ macro_rules! format {
 /// let formatted = format!(
 ///     SimpleFormatContext::default(),
 ///     [
-///         text("aVeryLongIdentifier"),
+///         token("aVeryLongIdentifier"),
 ///         best_fitting!(
 ///             // Everything fits on a single line
 ///             format_args!(
-///                 text("("),
+///                 token("("),
 ///                 group(&format_args![
-///                     text("["),
+///                     token("["),
 ///                         soft_block_indent(&format_args![
-///                         text("1,"),
+///                         token("1,"),
 ///                         soft_line_break_or_space(),
-///                         text("2,"),
+///                         token("2,"),
 ///                         soft_line_break_or_space(),
-///                         text("3"),
+///                         token("3"),
 ///                     ]),
-///                     text("]")
+///                     token("]")
 ///                 ]),
-///                 text(")")
+///                 token(")")
 ///             ),
 ///
 ///             // Breaks after `[`, but prints all elements on a single line
 ///             format_args!(
-///                 text("("),
-///                 text("["),
-///                 block_indent(&text("1, 2, 3")),
-///                 text("]"),
-///                 text(")"),
+///                 token("("),
+///                 token("["),
+///                 block_indent(&token("1, 2, 3")),
+///                 token("]"),
+///                 token(")"),
 ///             ),
 ///
 ///             // Breaks after `[` and prints each element on a single line
 ///             format_args!(
-///                 text("("),
+///                 token("("),
 ///                 block_indent(&format_args![
-///                     text("["),
+///                     token("["),
 ///                     block_indent(&format_args![
-///                         text("1,"),
+///                         token("1,"),
 ///                         hard_line_break(),
-///                         text("2,"),
+///                         token("2,"),
 ///                         hard_line_break(),
-///                         text("3"),
+///                         token("3"),
 ///                     ]),
-///                     text("]"),
+///                     token("]"),
 ///                 ]),
-///                 text(")")
+///                 token(")")
 ///             )
 ///         )
 ///     ]
@@ -256,38 +256,38 @@ macro_rules! format {
 ///         best_fitting!(
 ///             // Prints the method call on the line but breaks the array.
 ///             format_args!(
-///                 text("expect(a).toMatch("),
+///                 token("expect(a).toMatch("),
 ///                 group(&format_args![
-///                     text("["),
+///                     token("["),
 ///                     soft_block_indent(&format_args![
-///                         text("1,"),
+///                         token("1,"),
 ///                         soft_line_break_or_space(),
-///                         text("2,"),
+///                         token("2,"),
 ///                         soft_line_break_or_space(),
-///                         text("3"),
+///                         token("3"),
 ///                     ]),
-///                     text("]")
+///                     token("]")
 ///                 ]).should_expand(true),
-///                 text(")")
+///                 token(")")
 ///             ),
 ///
 ///             // Breaks after `(`
 ///            format_args!(
-///                 text("expect(a).toMatch("),
+///                 token("expect(a).toMatch("),
 ///                 group(&soft_block_indent(
 ///                     &group(&format_args![
-///                         text("["),
+///                         token("["),
 ///                         soft_block_indent(&format_args![
-///                             text("1,"),
+///                             token("1,"),
 ///                             soft_line_break_or_space(),
-///                             text("2,"),
+///                             token("2,"),
 ///                             soft_line_break_or_space(),
-///                             text("3"),
+///                             token("3"),
 ///                         ]),
-///                         text("]")
+///                         token("]")
 ///                     ]).should_expand(true),
 ///                 )).should_expand(true),
-///                 text(")")
+///                 token(")")
 ///             ),
 ///         )
 ///     ]

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -211,7 +211,7 @@ pub type FormatResult<F> = Result<F, FormatError>;
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
 ///         write!(f, [
 ///             hard_line_break(),
-///             dynamic_text(&self.0, TextSize::from(0)),
+///             text(&self.0, TextSize::from(0)),
 ///             hard_line_break(),
 ///         ])
 ///     }
@@ -280,7 +280,7 @@ impl Format<'_> for () {
 impl Format<'_> for &'static str {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        crate::write!(f, builders::text(self))
+        crate::write!(f, builders::token(self))
     }
 }
 
@@ -309,7 +309,7 @@ impl<C> Default for FormatToken<C> {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
-/// write!(&mut buffer, [format_args!(text("Hello World"))])?;
+/// write!(&mut buffer, [format_args!(token("Hello World"))])?;
 ///
 /// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
 ///
@@ -328,7 +328,7 @@ impl<C> Default for FormatToken<C> {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
-/// write!(&mut buffer, [text("Hello World")])?;
+/// write!(&mut buffer, [token("Hello World")])?;
 ///
 /// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
 ///
@@ -355,7 +355,7 @@ pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> 
 /// use biome_formatter::{format, format_args};
 ///
 /// # fn main() -> FormatResult<()> {
-/// let formatted = format!(SimpleFormatContext::default(), [&format_args!(text("test"))])?;
+/// let formatted = format!(SimpleFormatContext::default(), [&format_args!(token("test"))])?;
 /// assert_eq!("test", formatted.print()?.as_code());
 /// # Ok(())
 /// # }
@@ -368,7 +368,7 @@ pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> 
 /// use biome_formatter::{format};
 ///
 /// # fn main() -> FormatResult<()> {
-/// let formatted = format!(SimpleFormatContext::default(), [text("test")])?;
+/// let formatted = format!(SimpleFormatContext::default(), [token("test")])?;
 /// assert_eq!("test", formatted.print()?.as_code());
 /// # Ok(())
 /// # }

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -471,7 +471,7 @@ impl<'a> Format<'a> for Comment {
 
             // `is_alignable_comment` only returns `true` for multiline comments
             let first_line = lines.next().unwrap();
-            write!(f, [dynamic_text(first_line.trim_end())])?;
+            write!(f, [text(first_line.trim_end())])?;
 
             source_offset += first_line.len() as u32;
 
@@ -480,14 +480,14 @@ impl<'a> Format<'a> for Comment {
                 f,
                 [&format_once(|f| {
                     for line in lines {
-                        write!(f, [hard_line_break(), " ", dynamic_text(line.trim())])?;
+                        write!(f, [hard_line_break(), " ", text(line.trim())])?;
                         source_offset += line.len() as u32;
                     }
                     Ok(())
                 })]
             )
         } else {
-            write!(f, [dynamic_text(source_text)])
+            write!(f, [text(source_text)])
         }
     }
 }

--- a/crates/oxc_formatter/src/formatter/verbatim.rs
+++ b/crates/oxc_formatter/src/formatter/verbatim.rs
@@ -112,7 +112,7 @@
 //             },
 //         );
 //
-//         dynamic_text(
+//         text(
 //             &normalize_newlines(&original_source, LINE_TERMINATORS),
 //             self.node.text_trimmed_range().start(),
 //         )

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/import_unit.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/import_unit.rs
@@ -133,9 +133,9 @@ impl SortableImport {
         // Strip quotes and params
         let source = match &elements[*source_idx] {
             FormatElement::LocatedTokenText { slice, .. } => slice,
-            FormatElement::DynamicText { text } => *text,
+            FormatElement::Text { text } => *text,
             _ => unreachable!(
-                "`source_idx` must point to either `LocatedTokenText` or `DynamicText` in the `elements`."
+                "`source_idx` must point to either `LocatedTokenText` or `Text` in the `elements`."
             ),
         };
         let source = source.trim_matches('"').trim_matches('\'');

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -65,7 +65,7 @@ impl SourceLine {
         // /* comment */ /* comment */
         // ```
         let is_comment_only = range.clone().all(|idx| match &elements[idx] {
-            FormatElement::DynamicText { text } => text.starts_with("//") || text.starts_with("/*"),
+            FormatElement::Text { text } => text.starts_with("//") || text.starts_with("/*"),
             FormatElement::Line(LineMode::Soft | LineMode::SoftOrSpace) | FormatElement::Space => {
                 true
             }
@@ -106,7 +106,7 @@ impl SourceLine {
             }
 
             match element {
-                FormatElement::StaticText { text } => match *text {
+                FormatElement::Token { text } => match *text {
                     "import" => {
                         // Look ahead to determine import type (skip spaces)
                         let mut offset = 1;
@@ -117,14 +117,14 @@ impl SourceLine {
                             }
 
                             match &elements[idx + offset] {
-                                FormatElement::StaticText { text } => match *text {
+                                FormatElement::Token { text } => match *text {
                                     "type" => is_type_import = true,
                                     "*" => has_namespace_specifier = true,
                                     "{" => has_named_specifier = true,
                                     _ => {}
                                 },
                                 FormatElement::LocatedTokenText { .. }
-                                | FormatElement::DynamicText { .. } => {
+                                | FormatElement::Text { .. } => {
                                     has_default_specifier = true;
                                 }
                                 _ => {}
@@ -138,7 +138,7 @@ impl SourceLine {
                     }
                     _ => {}
                 },
-                FormatElement::LocatedTokenText { .. } | FormatElement::DynamicText { .. } => {
+                FormatElement::LocatedTokenText { .. } | FormatElement::Text { .. } => {
                     if source_idx.is_none() {
                         source_idx = Some(idx);
                     }

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -6,7 +6,7 @@ pub use crate::formatter::{
 use crate::{
     formatter::{
         formatter::Formatter,
-        prelude::{if_group_breaks, text},
+        prelude::{if_group_breaks, token},
         printer::PrinterOptions,
     },
     write,
@@ -672,7 +672,7 @@ impl Format<'_> for FormatTrailingCommas {
         }
 
         if matches!(self, FormatTrailingCommas::ES5) || f.options().trailing_commas.is_all() {
-            write!(f, [if_group_breaks(&text(","))])?;
+            write!(f, [if_group_breaks(&token(","))])?;
         }
 
         Ok(())

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -452,9 +452,9 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 write!(
                     f,
                     [
-                        if_group_fits_on_line(&text("(")),
+                        if_group_fits_on_line(&token("(")),
                         format_consequent_with_proper_indentation,
-                        if_group_fits_on_line(&text(")"))
+                        if_group_fits_on_line(&token(")"))
                     ]
                 )
             } else {
@@ -677,9 +677,9 @@ impl<'a> Format<'a> for FormatJsxChainExpression<'a, '_> {
             write!(
                 f,
                 [
-                    if_group_breaks(&text("(")),
+                    if_group_breaks(&token("(")),
                     soft_block_indent(&format_expression),
-                    if_group_breaks(&text(")"))
+                    if_group_breaks(&token(")"))
                 ]
             )
         }

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -143,7 +143,7 @@ impl<'a> Format<'a> for JsxRawSpace {
             QuoteStyle::Single => "{' '}",
         };
 
-        write!(f, [text(jsx_space)])
+        write!(f, [token(jsx_space)])
     }
 }
 
@@ -246,7 +246,7 @@ impl<'a> JsxWord<'a> {
 
 impl<'a> Format<'a> for JsxWord<'a> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [dynamic_text(self.text)])
+        write!(f, [text(self.text)])
     }
 }
 

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -16,7 +16,7 @@ impl FormatSuppressedNode {
 
 impl<'a> Format<'a> for FormatSuppressedNode {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [dynamic_text(f.source_text().text_for(&self.0))]);
+        write!(f, [text(f.source_text().text_for(&self.0))]);
 
         // The suppressed node contains comments that should be marked as printed.
         mark_comments_as_printed_before(self.0.end, f);

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -140,9 +140,9 @@ impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
                                 formatted_signature,
                                 group(&format_args!(indent(&format_args!(
                                     hard_line_break(),
-                                    text("("),
+                                    token("("),
                                     soft_block_indent(&format_body),
-                                    text(")")
+                                    token(")")
                                 ))))
                             ))]
                         )
@@ -153,9 +153,9 @@ impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
                                 formatted_signature,
                                 group(&format_args!(
                                     space(),
-                                    text("("),
+                                    token("("),
                                     soft_block_indent(&format_body),
-                                    text(")")
+                                    token(")")
                                 ))
                             ))]
                         )
@@ -592,18 +592,18 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                         f,
                         [group(&format_args!(indent(&format_args!(
                             hard_line_break(),
-                            text("("),
+                            token("("),
                             soft_block_indent(&format_tail_body),
-                            text(")")
+                            token(")")
                         ))))]
                     )?;
                 } else {
                     write!(
                         f,
                         [group(&format_args!(
-                            text("("),
+                            token("("),
                             soft_block_indent(&format_tail_body),
-                            text(")")
+                            token(")")
                         ))]
                     )?;
                 }
@@ -613,9 +613,9 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                     write!(
                         f,
                         [
-                            if_group_fits_on_line(&text("(")),
+                            if_group_fits_on_line(&token("(")),
                             format_tail_body,
-                            if_group_fits_on_line(&text(")"))
+                            if_group_fits_on_line(&token(")"))
                         ]
                     )?;
                 } else {

--- a/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
@@ -43,7 +43,7 @@ fn format_as_or_satisfies_expression<'a>(
     f: &mut Formatter<'_, 'a>,
 ) -> FormatResult<()> {
     let format_inner = format_with(|f| {
-        write!(f, [expression, space(), text(operation)])?;
+        write!(f, [expression, space(), token(operation)])?;
         write!(f, [space(), type_annotation])
     });
 

--- a/crates/oxc_formatter/src/write/binding_property_list.rs
+++ b/crates/oxc_formatter/src/write/binding_property_list.rs
@@ -6,7 +6,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
     formatter::{
         Buffer, Format, FormatResult, Formatter,
-        prelude::{format_once, soft_line_break_or_space, text},
+        prelude::{format_once, soft_line_break_or_space, token},
         separated::FormatSeparatedIter,
     },
     options::{FormatTrailingCommas, TrailingSeparator},

--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -130,7 +130,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, PropertyDefinition<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, PrivateIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["#", dynamic_text(self.name().as_str())])
+        write!(f, ["#", text(self.name().as_str())])
     }
 }
 
@@ -214,7 +214,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [dynamic_text(self.name().as_str()), self.type_annotation()])
+        write!(f, [text(self.name().as_str()), self.type_annotation()])
     }
 }
 
@@ -419,16 +419,16 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
 
                     if matches!(extends.grand_parent(), AstNodes::AssignmentExpression(_)) {
                         if has_trailing_comments {
-                            write!(f, [text("("), &content, text(")")])
+                            write!(f, [token("("), &content, token(")")])
                         } else {
                             let content = content.memoized();
                             write!(
                                 f,
                                 [
                                     if_group_breaks(&format_args!(
-                                        text("("),
+                                        token("("),
                                         &soft_block_indent(&content),
-                                        text(")"),
+                                        token(")"),
                                     )),
                                     if_group_fits_on_line(&content)
                                 ]

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -264,7 +264,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportAttribute<'a>> {
             if f.options().quote_properties == QuoteProperties::AsNeeded
                 && is_identifier_name(s.value().as_str())
             {
-                dynamic_text(s.value().as_str()).fmt(f)?;
+                text(s.value().as_str()).fmt(f)?;
             } else {
                 s.fmt(f)?;
             }

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -143,7 +143,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
 
                 let format_inner = format_with(|f| {
                     if !needs_parentheses {
-                        write!(f, [if_group_breaks(&text("("))])?;
+                        write!(f, [if_group_breaks(&token("("))])?;
                     }
 
                     write!(
@@ -156,7 +156,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                     )?;
 
                     if !needs_parentheses {
-                        write!(f, [if_group_breaks(&text(")"))])?;
+                        write!(f, [if_group_breaks(&token(")"))])?;
                     }
 
                     Ok(())

--- a/crates/oxc_formatter/src/write/jsx/mod.rs
+++ b/crates/oxc_formatter/src/write/jsx/mod.rs
@@ -337,7 +337,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.name().as_str()))
+        write!(f, text(self.name().as_str()))
     }
 }
 
@@ -365,6 +365,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXText<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.value().as_str()))
+        write!(f, text(self.value().as_str()))
     }
 }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -103,25 +103,25 @@ pub trait FormatWrite<'ast, T = ()> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.name().as_str()))
+        write!(f, text(self.name().as_str()))
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierReference<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.name().as_str()))
+        write!(f, text(self.name().as_str()))
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.name().as_str()))
+        write!(f, text(self.name().as_str()))
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabelIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.name().as_str()))
+        write!(f, text(self.name().as_str()))
     }
 }
 
@@ -296,7 +296,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
         {
             write!(
                 f,
-                [group(&format_args!(text("("), soft_block_indent(self.argument()), text(")")))]
+                [group(&format_args!(token("("), soft_block_indent(self.argument()), token(")")))]
             )
         } else {
             write!(f, self.argument())
@@ -1081,9 +1081,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         write!(
             f,
-            dynamic_text(
-                f.context().allocator().alloc_str(&self.raw().unwrap().cow_to_ascii_lowercase())
-            )
+            text(f.context().allocator().alloc_str(&self.raw().unwrap().cow_to_ascii_lowercase()))
         )
     }
 }
@@ -1097,7 +1095,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, RegExpLiteral<'a>> {
         flags.sort_unstable();
         let flags = flags.iter().collect::<String>();
         let s = StringBuilder::from_strs_array_in([pattern, "/", &flags], f.context().allocator());
-        write!(f, dynamic_text(s.into_str(),))
+        write!(f, text(s.into_str(),))
     }
 }
 
@@ -1523,14 +1521,14 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
         match f.options().semicolons {
             Semicolons::Always => {
                 if self.last {
-                    write!(f, [if_group_breaks(&text(";"))])?;
+                    write!(f, [if_group_breaks(&token(";"))])?;
                 } else {
-                    text(";").fmt(f)?;
+                    token(";").fmt(f)?;
                 }
             }
             Semicolons::AsNeeded => {
                 if !self.last {
-                    write!(f, [if_group_fits_on_line(&text(";"))])?;
+                    write!(f, [if_group_fits_on_line(&token(";"))])?;
                 }
             }
         }
@@ -1738,9 +1736,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAssertion<'a>> {
                     format_args!(
                         format_cast,
                         group(&format_args!(
-                            text("("),
+                            token("("),
                             block_indent(&format_expression),
-                            text(")")
+                            token(")")
                         ))
                     ),
                     format_args!(format_cast, format_expression)

--- a/crates/oxc_formatter/src/write/program.rs
+++ b/crates/oxc_formatter/src/write/program.rs
@@ -32,7 +32,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
             f,
             [
                 // BOM
-                f.source_text().chars().next().is_some_and(|c| c == ZWNBSP).then_some("\u{feff}"),
+                f.source_text()
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c == ZWNBSP)
+                    .then_some(text("\u{feff}")),
                 self.hashbang(),
                 self.directives(),
                 FormatProgramBody(self.body()),
@@ -146,7 +150,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Hashbang<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["#!", dynamic_text(self.value().as_str().trim_end())])?;
+        write!(f, ["#!", text(self.value().as_str().trim_end())])?;
 
         if f.source_text().lines_after(self.span.end) > 1 {
             write!(f, [empty_line()])

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -94,18 +94,18 @@ impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
         if !matches!(argument.as_ref(), Expression::JSXElement(_) | Expression::JSXFragment(_))
             && has_argument_leading_comments(argument, f)
         {
-            write!(f, [text("("), &block_indent(&argument), text(")")])
+            write!(f, [token("("), &block_indent(&argument), token(")")])
         } else if argument.is_binaryish() {
             write!(
                 f,
                 [group(&format_args!(
-                    if_group_breaks(&text("(")),
+                    if_group_breaks(&token("(")),
                     soft_block_indent(&argument),
-                    if_group_breaks(&text(")"))
+                    if_group_breaks(&token(")"))
                 ))]
             )
         } else if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-            write!(f, [group(&format_args!(text("("), soft_block_indent(&argument), text(")")))])
+            write!(f, [group(&format_args!(token("("), soft_block_indent(&argument), token(")")))])
         } else {
             write!(f, argument)
         }

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -69,7 +69,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TemplateElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, dynamic_text(self.value.raw.as_str()))
+        write!(f, text(self.value.raw.as_str()))
     }
 }
 
@@ -565,7 +565,7 @@ struct EachTemplateSeparator;
 
 impl<'a> Format<'a> for EachTemplateSeparator {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [text("|")])
+        write!(f, [token("|")])
     }
 }
 
@@ -655,7 +655,7 @@ impl<'a> Format<'a> for EachTemplateTable<'a> {
 
                 match element {
                     EachTemplateElement::Column(column) => {
-                        let mut text = if current_column != 0
+                        let mut content = if current_column != 0
                             && (!is_last_in_row || !column.text.is_empty())
                         {
                             StringBuilder::from_strs_array_in(
@@ -677,13 +677,13 @@ impl<'a> Format<'a> for EachTemplateTable<'a> {
 
                                 let padding = " ".repeat(column_width.saturating_sub(column.width));
 
-                                text.push_str(&padding);
+                                content.push_str(&padding);
                             }
 
-                            text.push(' ');
+                            content.push(' ');
                         }
 
-                        write!(f, [dynamic_text(text.into_str())])?;
+                        write!(f, [text(content.into_str())])?;
 
                         if !is_last_in_row {
                             write!(f, [EachTemplateSeparator])?;
@@ -746,7 +746,7 @@ fn try_format_embedded_template<'a>(
     let format_content = format_once(|f: &mut Formatter<'_, 'a>| {
         let content = f.context().allocator().alloc_str(&formatted);
         for line in content.split('\n') {
-            write!(f, [dynamic_text(line), hard_line_break()])?;
+            write!(f, [text(line), hard_line_break()])?;
         }
         Ok(())
     });

--- a/crates/oxc_formatter/src/write/union_type.rs
+++ b/crates/oxc_formatter/src/write/union_type.rs
@@ -83,7 +83,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                 if leading_soft_line_break_or_space {
                     write!(f, [soft_line_break_or_space()])?;
                 }
-                write!(f, [text("|"), space()])
+                write!(f, [token("|"), space()])
             });
 
             write!(f, [if_group_breaks(&separator)])?;
@@ -110,11 +110,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                     f,
                     [
                         indent(&format_args!(
-                            if_group_breaks(&format_args!(text("("), soft_line_break())),
+                            if_group_breaks(&format_args!(token("("), soft_line_break())),
                             types
                         )),
                         soft_line_break(),
-                        if_group_breaks(&text(")"))
+                        if_group_breaks(&token(")"))
                     ]
                 )
             } else if should_indent {


### PR DESCRIPTION
Back port https://github.com/astral-sh/ruff/pull/7048
