### PR TITLE
fix(linter/plugins): Return empty object for unimplemented parserServices

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -127,7 +127,7 @@ export const SOURCE_CODE = Object.freeze({
 
   // Get parser services for the file.
   get parserServices(): { [key: string]: unknown } {
-    throw new Error('`sourceCode.parserServices` not implemented yet'); // TODO
+    return {}; // TODO
   },
 
   // Get source text as array of lines, split according to specification's definition of line breaks.

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -254,4 +254,8 @@ describe('oxlint CLI', () => {
   it('should support UTF16 characters in source code and comments with correct spans', async () => {
     await testFixture('unicode-comments');
   });
+
+  it('should return empty object for `parserServices` without throwing', async () => {
+    await testFixture('parser_services');
+  });
 });

--- a/apps/oxlint/test/fixtures/parser_services/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/parser_services/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "parser-services-plugin/check-parser-services": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/parser_services/files/index.js
+++ b/apps/oxlint/test/fixtures/parser_services/files/index.js
@@ -1,0 +1,2 @@
+// Simple file to test parserServices access
+console.log('testing parserServices');

--- a/apps/oxlint/test/fixtures/parser_services/output.snap.md
+++ b/apps/oxlint/test/fixtures/parser_services/output.snap.md
@@ -1,0 +1,14 @@
+# Exit code
+0
+
+# stdout
+```
+Found 0 warnings and 0 errors.
+Finished in Xms on 1 file using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/parser_services/output.snap.md
+++ b/apps/oxlint/test/fixtures/parser_services/output.snap.md
@@ -1,9 +1,16 @@
 # Exit code
-0
+1
 
 # stdout
 ```
-Found 0 warnings and 0 errors.
+  x parser-services-plugin(check-parser-services): typeof context.sourceCode.parserServices: object
+   ,-[files/index.js:1:1]
+ 1 | // Simple file to test parserServices access
+   : ^
+ 2 | console.log('testing parserServices');
+   `----
+
+Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -1,0 +1,19 @@
+import type { Plugin } from '../../../dist/index.js';
+
+const plugin: Plugin = {
+  meta: {
+    name: 'parser-services-plugin',
+  },
+  rules: {
+    'check-parser-services': {
+      create(context) {
+        if (typeof context.sourceCode.parserServices?.defineTemplateBodyVisitor === 'function') {
+        }
+
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -1,4 +1,14 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin, Node } from '../../../dist/index.js';
+
+const SPAN: Node = {
+  start: 0,
+  end: 0,
+  range: [0, 0],
+  loc: {
+    start: { line: 0, column: 0 },
+    end: { line: 0, column: 0 },
+  },
+};
 
 const plugin: Plugin = {
   meta: {
@@ -7,9 +17,10 @@ const plugin: Plugin = {
   rules: {
     'check-parser-services': {
       create(context) {
-        if (typeof context.sourceCode.parserServices?.defineTemplateBodyVisitor === 'function') {
-          // Intentionally left empty: test access pattern without errors.
-        }
+        context.report({
+          message: `typeof context.sourceCode.parserServices: ${typeof context.sourceCode.parserServices}`,
+          node: SPAN,
+        });
 
         return {};
       },

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -8,6 +8,7 @@ const plugin: Plugin = {
     'check-parser-services': {
       create(context) {
         if (typeof context.sourceCode.parserServices?.defineTemplateBodyVisitor === 'function') {
+          // Intentionally left empty: test access pattern without errors.
         }
 
         return {};

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -73,7 +73,7 @@ function normalizeStdout(stdout: string): string {
 
   // Remove timing and thread count info which can vary between runs
   lines[lines.length - 1] = lines[lines.length - 1].replace(
-    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?)(?: with \d+ rules)? using \d+ threads.$/,
+    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?) using \d+ threads.$/,
     'Finished in Xms on $1 file$2 using X threads.',
   );
 

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -73,7 +73,7 @@ function normalizeStdout(stdout: string): string {
 
   // Remove timing and thread count info which can vary between runs
   lines[lines.length - 1] = lines[lines.length - 1].replace(
-    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?) using \d+ threads.$/,
+    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?)(?: with \d+ rules)? using \d+ threads.$/,
     'Finished in Xms on $1 file$2 using X threads.',
   );
 


### PR DESCRIPTION
## Summary

- Changed `sourceCode.parserServices` from throwing an error to returning an empty object `{}`
- Aligns with ESLint specification for parsers that don't implement parser services
- Prevents crashes in ESLint plugins such as `eslint-plugin-better-tailwindcss`.

## Motivation

According to the [ESLint custom parser documentation](https://eslint.org/docs/latest/extend/custom-parsers#parseforeslint-return-object):

> services can contain any parser-dependent services (such as type checkers for nodes). The value of the services property is available to rules as context.sourceCode.parserServices. **Default is an empty object.**

The current implementation throws an error when `parserServices` is accessed, which breaks plugins that use defensive checks like:

```typescript
if(typeof ctx.sourceCode.parserServices?.defineTemplateBodyVisitor === "function"){
  // ...
}
```

Plugin authors defensively handle:
- ✅ `parserServices` being undefined
- ✅ `defineTemplateBodyVisitor` not existing
- ❌ `parserServices` getter throwing an error (unexpected)

## Solution

Return an empty object `{}` for unimplemented parser services, which:
1. Matches ESLint's documented default behavior
2. Allows plugins' defensive checks to work correctly
3. Provides correct semantics for "not implemented"

## Test Plan

- Existing tests should continue to pass
- Plugins using defensive checks like the example above will no longer crash

## Related

Fixes the compatibility issue with plugins like [eslint-plugin-better-tailwindcss](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/a90cc3f547098a4293d7b0b7998bf6774f717cd2/src/utils/rule.ts#L140)
