### PR TITLE
perf(formatter): optimize `FormatElement::Token` printing

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -118,9 +118,8 @@ impl Document<'_> {
                         // propagate their expansion.
                         false
                     }
-                    FormatElement::Token { text } | FormatElement::Text { text, .. } => {
-                        text.contains('\n')
-                    }
+                    // `FormatElement::Token` cannot contain line breaks
+                    FormatElement::Text { text, .. } => text.contains('\n'),
                     FormatElement::LocatedTokenText { slice, .. } => slice.contains('\n'),
                     FormatElement::ExpandParent
                     | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -240,13 +240,15 @@ impl FormatElements for FormatElement<'_> {
             FormatElement::ExpandParent => true,
             FormatElement::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
             FormatElement::Line(line_mode) => line_mode.will_break(),
-            FormatElement::Token { text } | FormatElement::Text { text } => text.contains('\n'),
+            FormatElement::Text { text } => text.contains('\n'),
             FormatElement::LocatedTokenText { slice, .. } => slice.contains('\n'),
             FormatElement::Interned(interned) => interned.will_break(),
             // Traverse into the most flat version because the content is guaranteed to expand when even
             // the most flat version contains some content that forces a break.
             FormatElement::BestFitting(best_fitting) => best_fitting.most_flat().will_break(),
-            FormatElement::LineSuffixBoundary
+            // `FormatElement::Token` cannot contain line breaks
+            FormatElement::Token { .. }
+            | FormatElement::LineSuffixBoundary
             | FormatElement::Space
             | FormatElement::Tag(_)
             | FormatElement::HardSpace => false,


### PR DESCRIPTION
`FormatElement::Token` is ASCII-only and does not contain line breaks or tab characters, so we can skip the `\n` check and simplify the logic of getting `FormatElement::Token` length 