### PR TITLE
feat(formatter/sort_imports): Add `options.newlinesBetween`

### DIFF
--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), String> {
     let sort_side_effects = args.contains("--sort_side_effects");
     let order = args.opt_value_from_str("--order").unwrap_or(None).unwrap_or(SortOrder::Asc);
     let ignore_case = !args.contains("--no_ignore_case");
+    let newlines_between = !args.contains("--no_newlines_between");
 
     let sort_imports_options = SortImports {
         order,
@@ -26,6 +27,7 @@ fn main() -> Result<(), String> {
         partition_by_comment,
         sort_side_effects,
         ignore_case,
+        newlines_between,
     };
 
     // Read source file

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -173,15 +173,16 @@ impl SortImportsTransform {
                     let preserve_empty_line = self.options.partition_by_newline;
                     let mut prev_group = None;
                     for sortable_import in import_units {
-                        // Check if we need to insert a blank line between different groups
-                        let current_group = sortable_import.get_metadata(prev_elements).group();
-                        if let Some(prev) = prev_group
-                            && prev != current_group
-                        {
-                            // Insert blank line between different groups
-                            next_elements.push(FormatElement::Line(LineMode::Empty));
+                        // Insert blank line between different groups if enabled
+                        if self.options.newlines_between {
+                            let current_group = sortable_import.get_metadata(prev_elements).group();
+                            if let Some(prev) = prev_group
+                                && prev != current_group
+                            {
+                                next_elements.push(FormatElement::Line(LineMode::Empty));
+                            }
+                            prev_group = Some(current_group);
                         }
-                        prev_group = Some(current_group);
 
                         // Output leading lines and import line
                         for line in sortable_import.leading_lines {

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -985,6 +985,12 @@ pub struct SortImports {
     /// Ignore case when sorting.
     /// Default is `true`.
     pub ignore_case: bool,
+    /// Whether to insert blank lines between different import groups.
+    /// - `true`: Insert one blank line between groups (default)
+    /// - `false`: No blank lines between groups
+    ///
+    /// NOTE: Cannot be used together with `partition_by_newline: true`.
+    pub newlines_between: bool,
 }
 
 impl Default for SortImports {
@@ -995,6 +1001,7 @@ impl Default for SortImports {
             sort_side_effects: false,
             order: SortOrder::default(),
             ignore_case: true,
+            newlines_between: true,
         }
     }
 }

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -152,6 +152,8 @@ pub struct SortImportsConfig {
     pub order: Option<SortOrderConfig>,
     #[serde(default = "default_true")]
     pub ignore_case: bool,
+    #[serde(default = "default_true")]
+    pub newlines_between: bool,
 }
 
 fn default_true() -> bool {
@@ -314,6 +316,11 @@ impl Oxfmtrc {
         // Below are our own extensions
 
         if let Some(sort_imports_config) = self.experimental_sort_imports {
+            // `partition_by_newline: true` and `newlines_between` cannot be used together
+            if sort_imports_config.partition_by_newline && sort_imports_config.newlines_between {
+                return Err("Invalid `sortImports` configuration: `partitionByNewline: true` and `newlinesBetween: true` cannot be used together".to_string());
+            }
+
             options.experimental_sort_imports = Some(SortImports {
                 partition_by_newline: sort_imports_config.partition_by_newline,
                 partition_by_comment: sort_imports_config.partition_by_comment,
@@ -322,8 +329,8 @@ impl Oxfmtrc {
                     SortOrderConfig::Asc => SortOrder::Asc,
                     SortOrderConfig::Desc => SortOrder::Desc,
                 }),
-
                 ignore_case: sort_imports_config.ignore_case,
+                newlines_between: sort_imports_config.newlines_between,
             });
         }
 
@@ -348,7 +355,8 @@ mod tests {
             "experimentalSortImports": {
                 "partitionByNewline": true,
                 "order": "desc",
-                "ignoreCase": false
+                "ignoreCase": false,
+                "newlinesBetween": false
             }
         }"#;
 
@@ -365,15 +373,16 @@ mod tests {
         assert!(sort_imports.partition_by_newline);
         assert!(sort_imports.order.is_desc());
         assert!(!sort_imports.ignore_case);
+        assert!(!sort_imports.newlines_between);
     }
 
     #[test]
     fn test_ignore_unknown_fields() {
         let config: Oxfmtrc = serde_json::from_str(
             r#"{
-            "unknownField": "someValue",
-            "anotherUnknown": 123
-        }"#,
+                "unknownField": "someValue",
+                "anotherUnknown": 123
+            }"#,
         )
         .unwrap();
         let options = config.into_format_options().unwrap();
@@ -426,5 +435,65 @@ mod tests {
         let config: Oxfmtrc = serde_json::from_str(r#"{"objectWrap": "always"}"#).unwrap();
         let options = config.into_format_options().unwrap();
         assert_eq!(options.expand, Expand::Always);
+    }
+
+    #[test]
+    fn test_sort_imports_config() {
+        let config: Oxfmtrc = serde_json::from_str(
+            r#"{
+            "experimentalSortImports": {}
+        }"#,
+        )
+        .unwrap();
+        let sort_imports = config.into_format_options().unwrap().experimental_sort_imports.unwrap();
+        assert!(sort_imports.newlines_between);
+        assert!(!sort_imports.partition_by_newline);
+
+        // Test explicit false
+        let config: Oxfmtrc = serde_json::from_str(
+            r#"{
+                "experimentalSortImports": {
+                    "newlinesBetween": false
+                }
+            }"#,
+        )
+        .unwrap();
+        let sort_imports = config.into_format_options().unwrap().experimental_sort_imports.unwrap();
+        assert!(!sort_imports.newlines_between);
+        assert!(!sort_imports.partition_by_newline);
+
+        // Test explicit true
+        let config: Oxfmtrc = serde_json::from_str(
+            r#"{
+                "experimentalSortImports": {
+                    "newlinesBetween": true
+                }
+            }"#,
+        )
+        .unwrap();
+        let sort_imports = config.into_format_options().unwrap().experimental_sort_imports.unwrap();
+        assert!(sort_imports.newlines_between);
+        assert!(!sort_imports.partition_by_newline);
+
+        let config: Oxfmtrc = serde_json::from_str(
+            r#"{
+                "experimentalSortImports": {
+                    "partitionByNewline": true,
+                    "newlinesBetween": false
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(config.into_format_options().is_ok());
+        let config: Oxfmtrc = serde_json::from_str(
+            r#"{
+                "experimentalSortImports": {
+                    "partitionByNewline": true,
+                    "newlinesBetween": true
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(config.into_format_options().is_err_and(|e| e.contains("newlinesBetween")));
     }
 }

--- a/crates/oxc_formatter/tests/ir_transform/_sort-imports-tests.ref.snap
+++ b/crates/oxc_formatter/tests/ir_transform/_sort-imports-tests.ref.snap
@@ -6,52 +6,6 @@ describe("alphabetical", () => {
     order: "asc",
   } as const;
 
-  it("sorts imports without spacing between groups when configured", async () => {
-    await valid({
-      code: dedent`
-          import type { T } from 't'
-          import { a1, a2, a3 } from 'a'
-          import { b1, b2 } from '~/b'
-          import { c1, c2, c3 } from '~/c'
-          import d from '.'
-          import { e1, e2, e3 } from '../../e'
-        `,
-      options: [
-        {
-          ...options,
-          newlinesBetween: "never",
-        },
-      ],
-    });
-
-    await invalid({
-      code: dedent`
-          import d from '.'
-          import { a1, a2, a3 } from 'a'
-          import { c1, c2, c3 } from '~/c'
-
-          import type { T } from 't'
-          import { e1, e2, e3 } from '../../e'
-
-          import { b1, b2 } from '~/b'
-        `,
-      output: dedent`
-          import type { T } from 't'
-          import { a1, a2, a3 } from 'a'
-          import { b1, b2 } from '~/b'
-          import { c1, c2, c3 } from '~/c'
-          import d from '.'
-          import { e1, e2, e3 } from '../../e'
-        `,
-      options: [
-        {
-          ...options,
-          newlinesBetween: "never",
-        },
-      ],
-    });
-  });
-
   it("groups all type imports together when specific type groups not configured", async () => {
     await valid({
       options: [
@@ -518,35 +472,6 @@ describe("alphabetical", () => {
           import 'b.css';
           import 'a.css';
         `,
-    });
-  });
-
-  it.each([
-    ["removes newlines with never option", "never"],
-    ["removes newlines with 0 option", 0],
-  ])("%s", async (_description, newlinesBetween) => {
-    await invalid({
-      code: dedent`
-            import { A } from 'a'
-
-
-           import y from '~/y'
-          import z from '~/z'
-
-              import b from '~/b'
-        `,
-      output: dedent`
-            import { A } from 'a'
-           import b from '~/b'
-          import y from '~/y'
-              import z from '~/z'
-        `,
-      options: [
-        {
-          ...options,
-          newlinesBetween,
-        },
-      ],
     });
   });
 
@@ -1703,70 +1628,6 @@ describe("alphabetical", () => {
         {
           ...options,
           partitionByComment: "^Part",
-        },
-      ],
-    });
-  });
-
-  it("prioritizes dependencies over newline-based partitions", async () => {
-    await invalid({
-      options: [
-        {
-          ...options,
-          newlinesBetween: "ignore",
-          partitionByNewLine: true,
-        },
-      ],
-      output: dedent`
-          import aImport from "b";
-
-          import a = aImport.a1.a2;
-        `,
-      code: dedent`
-          import a = aImport.a1.a2;
-
-          import aImport from "b";
-        `,
-    });
-  });
-
-  it("prioritizes content separation over dependencies", async () => {
-    await invalid({
-      output: dedent`
-          import f = fImport.f1.f2;
-
-          import yImport from "z";
-
-          import y = yImport.y1.y2;
-
-          export { something } from "something";
-
-          import aImport from "b";
-
-          import a = aImport.a1.a2;
-
-          import fImport from "g";
-        `,
-      code: dedent`
-          import f = fImport.f1.f2;
-
-          import y = yImport.y1.y2;
-
-          import yImport from "z";
-
-          export { something } from "something";
-
-          import a = aImport.a1.a2;
-
-          import aImport from "b";
-
-          import fImport from "g";
-        `,
-      options: [
-        {
-          ...options,
-          newlinesBetween: "ignore",
-          partitionByNewLine: true,
         },
       ],
     });

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -1115,3 +1115,93 @@ import { t } from "t";
 "#,
     );
 }
+
+#[test]
+fn should_support_newlines_between_option() {
+    // Test newlines_between: false (no blank lines between groups)
+    assert_format(
+        r#"
+import d from ".";
+import { a1, a2, a3 } from "a";
+import { c1, c2, c3 } from "~/c";
+
+import type { T } from "t";
+import { e1, e2, e3 } from "../../e";
+
+import { b1, b2 } from "~/b";
+"#,
+        &FormatOptions {
+            experimental_sort_imports: Some(SortImports {
+                newlines_between: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        r#"
+import type { T } from "t";
+import { a1, a2, a3 } from "a";
+import { b1, b2 } from "~/b";
+import { c1, c2, c3 } from "~/c";
+import d from ".";
+import { e1, e2, e3 } from "../../e";
+"#,
+    );
+
+    // Test newlines_between: true (one blank line between groups - default)
+    assert_format(
+        r#"
+import d from ".";
+import { a1, a2, a3 } from "a";
+import { c1, c2, c3 } from "~/c";
+
+import type { T } from "t";
+import { e1, e2, e3 } from "../../e";
+
+import { b1, b2 } from "~/b";
+"#,
+        &FormatOptions {
+            experimental_sort_imports: Some(SortImports {
+                newlines_between: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        r#"
+import type { T } from "t";
+
+import { a1, a2, a3 } from "a";
+
+import { b1, b2 } from "~/b";
+import { c1, c2, c3 } from "~/c";
+
+import d from ".";
+import { e1, e2, e3 } from "../../e";
+"#,
+    );
+
+    // Test newlines_between: false removes multiple consecutive blank lines
+    assert_format(
+        r#"
+import { A } from "a";
+
+
+import y from "~/y";
+import z from "~/z";
+
+import b from "~/b";
+"#,
+        &FormatOptions {
+            experimental_sort_imports: Some(SortImports {
+                newlines_between: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        r#"
+import { A } from "a";
+import b from "~/b";
+import y from "~/y";
+import z from "~/z";
+"#,
+    );
+}

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -226,6 +226,10 @@ expression: json
           "default": true,
           "type": "boolean"
         },
+        "newlinesBetween": {
+          "default": true,
+          "type": "boolean"
+        },
         "order": {
           "anyOf": [
             {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -521,6 +521,7 @@ impl Oxc {
                 sort_side_effects: sort_imports_config.sort_side_effects.unwrap_or(false),
                 order,
                 ignore_case: sort_imports_config.ignore_case.unwrap_or(true),
+                newlines_between: sort_imports_config.newlines_between.unwrap_or(true),
             });
         }
 

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -163,4 +163,6 @@ pub struct OxcSortImportsOptions {
     pub order: Option<String>,
     /// Ignore case when sorting (default: true)
     pub ignore_case: Option<bool>,
+    /// Add newlines between import groups (default: true)
+    pub newlines_between: Option<bool>,
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -222,6 +222,10 @@
           "default": true,
           "type": "boolean"
         },
+        "newlinesBetween": {
+          "default": true,
+          "type": "boolean"
+        },
         "order": {
           "anyOf": [
             {


### PR DESCRIPTION
Part of #14253 

Implement `options.newlinseBetween`.

> https://perfectionist.dev/rules/sort-imports#newlinesbetween

Original implementation for this is `type: number | 'ignore'default: 1`.

However, our printer does not allow to insert multiple empty lines.

https://github.com/oxc-project/oxc/blob/e061ae3883dab0864bbe3803fa3d76248a7c2e43/crates/oxc_formatter/src/formatter/printer/mod.rs#L129

So, we only support as `bool` for now.
