### PR TITLE
perf(formatter): memorize text width for `FormatElement::Text`

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -210,10 +210,14 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             let new_element = match element {
                                 // except for static text because source_position is unknown
                                 FormatElement::Token { .. } => element.clone(),
-                                FormatElement::Text { text } => {
+                                FormatElement::Text { text, width } => {
                                     let text = text.cow_replace('"', "\\\"");
                                     FormatElement::Text {
                                         text: f.context().allocator().alloc_str(&text),
+                                        width: TextWidth::from_text(
+                                            &text,
+                                            f.options().indent_width,
+                                        ),
                                     }
                                 }
                                 _ => unreachable!(),

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/import_unit.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/import_unit.rs
@@ -132,7 +132,7 @@ impl SortableImport {
 
         // Strip quotes and params
         let source = match &elements[*source_idx] {
-            FormatElement::Text { text } => *text,
+            FormatElement::Text { text, .. } => *text,
             _ => unreachable!(
                 "`source_idx` must point to either `LocatedTokenText` or `Text` in the `elements`."
             ),

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -65,7 +65,7 @@ impl SourceLine {
         // /* comment */ /* comment */
         // ```
         let is_comment_only = range.clone().all(|idx| match &elements[idx] {
-            FormatElement::Text { text } => text.starts_with("//") || text.starts_with("/*"),
+            FormatElement::Text { text, width } => text.starts_with("//") || text.starts_with("/*"),
             FormatElement::Line(LineMode::Soft | LineMode::SoftOrSpace) | FormatElement::Space => {
                 true
             }

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -496,6 +496,13 @@ impl From<QuoteStyle> for Quote {
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
 pub struct TabWidth(u8);
 
+impl TabWidth {
+    /// Returns the numeric value for this [TabWidth]
+    pub fn value(self) -> u8 {
+        self.0
+    }
+}
+
 impl From<u8> for TabWidth {
     fn from(value: u8) -> Self {
         TabWidth(value)


### PR DESCRIPTION
Back port from https://github.com/astral-sh/ruff/pull/6552