### PR TITLE
docs(transformer): clarify `jsx.pure` option would affect JSX elements

### DIFF
--- a/crates/oxc_transformer/src/jsx/options.rs
+++ b/crates/oxc_transformer/src/jsx/options.rs
@@ -61,7 +61,7 @@ pub struct JsxOptions {
 
     /// Enables `@babel/plugin-transform-react-pure-annotations`.
     ///
-    /// It will mark top-level React method calls as pure for tree shaking.
+    /// It will mark JSX elements and top-level React method calls as pure for tree shaking.
     ///
     /// Defaults to `true`.
     #[serde(default = "default_as_true")]

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -211,7 +211,7 @@ export interface JsxOptions {
   /**
    * Enables `@babel/plugin-transform-react-pure-annotations`.
    *
-   * It will mark top-level React method calls as pure for tree shaking.
+   * It will mark JSX elements and top-level React method calls as pure for tree shaking.
    *
    * @see {@link https://babeljs.io/docs/en/babel-plugin-transform-react-pure-annotations}
    *

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -535,7 +535,7 @@ pub struct JsxOptions {
 
     /// Enables `@babel/plugin-transform-react-pure-annotations`.
     ///
-    /// It will mark top-level React method calls as pure for tree shaking.
+    /// It will mark JSX elements and top-level React method calls as pure for tree shaking.
     ///
     /// @see {@link https://babeljs.io/docs/en/babel-plugin-transform-react-pure-annotations}
     ///


### PR DESCRIPTION
Update the doc comment as `jsx.pure` option also affects JSX elements.
https://github.com/oxc-project/oxc/blob/b1d3e005def3fe1899e77d2ace0c0584c9b22f80/crates/oxc_transformer/src/jsx/jsx_impl.rs#L779

I'll update the docs after this PR is merged.
