### PR TITLE
perf(linter/plugins): use single object for `parserServices`

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -25,6 +25,9 @@ const buffers: (BufferWithArrays | null)[] = [];
 // Array of `after` hooks to run after traversal. This array reused for every file.
 const afterHooks: AfterHook[] = [];
 
+// Default parser services object (empty object).
+const PARSER_SERVICES_DEFAULT: Record<string, unknown> = Object.freeze({});
+
 /**
  * Run rules on a file.
  *
@@ -108,7 +111,8 @@ function lintFileImpl(
   // But... source text and AST can be accessed in body of `create` method, or `before` hook, via `context.sourceCode`.
   // So we pass the buffer to source code module here, so it can decode source text / deserialize AST on demand.
   const hasBOM = false; // TODO: Set this correctly
-  setupSourceForFile(buffer, hasBOM);
+  const parserServices = PARSER_SERVICES_DEFAULT; // TODO: Set this correctly
+  setupSourceForFile(buffer, hasBOM, parserServices);
 
   // Get visitors for this file from all rules
   initCompiledVisitor();

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -40,14 +40,23 @@ export let sourceText: string | null = null;
 let sourceByteLen: number = 0;
 export let ast: Program | null = null;
 
+// Parser services object. Set before linting a file by `setupSourceForFile`.
+let parserServices: Record<string, unknown> | null = null;
+
 /**
  * Set up source for the file about to be linted.
  * @param bufferInput - Buffer containing AST
  * @param hasBOMInput - `true` if file's original source text has Unicode BOM
+ * @param parserServicesInput - Parser services object for the file
  */
-export function setupSourceForFile(bufferInput: BufferWithArrays, hasBOMInput: boolean): void {
+export function setupSourceForFile(
+  bufferInput: BufferWithArrays,
+  hasBOMInput: boolean,
+  parserServicesInput: Record<string, unknown>,
+): void {
   buffer = bufferInput;
   hasBOM = hasBOMInput;
+  parserServices = parserServicesInput;
 }
 
 /**
@@ -82,6 +91,7 @@ export function resetSourceAndAst(): void {
   buffer = null;
   sourceText = null;
   ast = null;
+  parserServices = null;
   resetBuffer();
   resetLines();
   resetScopeManager();
@@ -126,8 +136,8 @@ export const SOURCE_CODE = Object.freeze({
   },
 
   // Get parser services for the file.
-  get parserServices(): { [key: string]: unknown } {
-    return {}; // TODO
+  get parserServices(): Record<string, unknown> {
+    return parserServices;
   },
 
   // Get source text as array of lines, split according to specification's definition of line breaks.


### PR DESCRIPTION
Follow-on after #15364. Re-use a single object for `parserServices`, instead of creating a new object each time. This is better for perf, and also matches ESLint where each access to `sourceCode.parserServices` in a `create` invocation results in the same object.