### PR TITLE
refactor(linter/plugins): use `Record` types

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -121,7 +121,7 @@ export const SOURCE_CODE = Object.freeze({
   },
 
   // Get visitor keys to traverse this AST.
-  get visitorKeys(): { [key: string]: string[] } {
+  get visitorKeys(): Record<string, string[]> {
     return visitorKeys;
   },
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -14,7 +14,7 @@ interface TestOptions {
   // Supply a different name when there are multiple tests for a single fixture.
   snapshotName?: string;
   // Function to get extra data to include in the snapshot
-  getExtraSnapshotData?: (dirPath: string) => Promise<{ [key: string]: string }>;
+  getExtraSnapshotData?: (dirPath: string) => Promise<Record<string, string>>;
 
   /**
    * Override the `files` directory within the fixture to lint.

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -21,7 +21,7 @@ interface TestFixtureOptions {
   // Name of the snapshot file
   snapshotName: string;
   // Function to get extra data to include in the snapshot
-  getExtraSnapshotData?: (dirPath: string) => Promise<{ [key: string]: string }>;
+  getExtraSnapshotData?: (dirPath: string) => Promise<Record<string, string>>;
 }
 
 /**


### PR DESCRIPTION
Pure refactor. We were using a mix of `{ [key: string]: T }` and `Record<string, T>`. Standardize on `Record`.