### PR TITLE
fix(linter/plugins): block access to `context.settings` in `createOnce`

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -56,7 +56,7 @@ let cwd: string | null = null;
 export let setupContextForFile: (context: Context, ruleIndex: number, filePath: string) => void;
 
 // Settings for current file. Set before linting a file by `setSettingsForFile`.
-let settings: Record<string, unknown> = {};
+let settings: Record<string, unknown> = null;
 
 /**
  * Updates the settings record for the file.
@@ -164,6 +164,7 @@ export class Context {
   }
 
   get settings() {
+    getInternal(this, 'access `context.settings`');
     return settings;
   }
 

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -75,6 +75,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: settings: Cannot access `context.settings` in `createOnce`
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: sourceCode: Cannot access `context.sourceCode` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
@@ -207,6 +213,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: settings: Cannot access `context.settings` in `createOnce`
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: sourceCode: Cannot access `context.sourceCode` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
@@ -267,7 +279,7 @@
    :     ^
    `----
 
-Found 0 warnings and 44 errors.
+Found 0 warnings and 46 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -34,6 +34,7 @@ const alwaysRunRule: Rule = {
     const physicalFilenameError = tryCatch(() => context.physicalFilename);
     const optionsError = tryCatch(() => context.options);
     const sourceCodeError = tryCatch(() => context.sourceCode);
+    const settingsError = tryCatch(() => context.settings);
     const reportError = tryCatch(() => context.report({ message: 'oh no', node: SPAN }));
 
     return {
@@ -45,6 +46,7 @@ const alwaysRunRule: Rule = {
         context.report({ message: `createOnce: physicalFilename: ${physicalFilenameError?.message}`, node: SPAN });
         context.report({ message: `createOnce: options: ${optionsError?.message}`, node: SPAN });
         context.report({ message: `createOnce: sourceCode: ${sourceCodeError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: settings: ${settingsError?.message}`, node: SPAN });
         context.report({ message: `createOnce: report: ${reportError?.message}`, node: SPAN });
 
         context.report({ message: `before hook: id: ${context.id}`, node: SPAN });


### PR DESCRIPTION
Follow-on after #14724. Prevent accessing `context.settings` in `createOnce`. Settings are per-file, so they shouldn't be available in `createOnce`.