### PR TITLE
perf(linter/plugins): lazily deserialize settings JSON

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -1,4 +1,4 @@
-import { diagnostics, setSettingsForFile, setupContextForFile } from './context.js';
+import { diagnostics, setSettingsForFile, resetSettings, setupContextForFile } from './context.js';
 import { registeredRules } from './load.js';
 import { ast, initAst, resetSourceAndAst, setupSourceForFile } from './source_code.js';
 import { assertIs, getErrorMessage } from './utils.js';
@@ -181,6 +181,7 @@ function lintFileImpl(
     afterHooks.length = 0;
   }
 
-  // Reset source and AST, to free memory
+  // Reset source, AST, and settings, to free memory
   resetSourceAndAst();
+  resetSettings();
 }


### PR DESCRIPTION
Follow-on after #14724. Deserialize and deep freeze settings lazily on demand. These operations are not so expensive, but if settings object is large, they're not so cheap either. So avoid that work unless `context.settings` is accessed.

A better eventual solution will be to send all settings objects over to JS in one go after parsing all configs, rather than again and again for every file, but this is a simple optimization to get a bit of gain in the meantime.
