### PR TITLE
refactor(linter/plugins): move settings-related code into separate file

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -1,13 +1,13 @@
 import { getFixes } from './fix.js';
 import { getOffsetFromLineColumn } from './location.js';
 import { SOURCE_CODE } from './source_code.js';
+import { settings, initSettings } from './settings.js';
 
 import type { Fix, FixFn } from './fix.ts';
 import type { SourceCode } from './source_code.ts';
 import type { Location, Ranged } from './types.ts';
 
-const { hasOwn, keys: ObjectKeys } = Object,
-  { isArray } = Array;
+const { hasOwn, keys: ObjectKeys } = Object;
 
 // Diagnostic in form passed by user to `Context#report()`
 export type Diagnostic = DiagnosticWithNode | DiagnosticWithLoc;
@@ -54,32 +54,6 @@ let cwd: string | null = null;
  * @param filePath - Absolute path of file being linted
  */
 export let setupContextForFile: (context: Context, ruleIndex: number, filePath: string) => void;
-
-// Settings for current file.
-// `settingsJSON` is set before linting a file by `setSettingsForFile`.
-// `settings` is deserialized from `settingsJSON` lazily upon first access.
-let settingsJSON: string | null = null;
-let settings: Record<string, unknown> | null = null;
-
-/**
- * Updates the settings for the file.
- *
- * TODO(perf): Settings are de/serialized once per file to accommodate folder level settings,
- * even if the settings haven't changed.
- *
- * @param settingsJSONInput - Settings for the file as JSON
- */
-export function setSettingsForFile(settingsJSONInput: string) {
-  settingsJSON = settingsJSONInput;
-}
-
-/**
- * Reset settings.
- */
-export function resetSettings() {
-  settings = null;
-  settingsJSON = null;
-}
 
 // Internal data within `Context` that don't want to expose to plugins.
 // Stored as `#internal` property of `Context`.
@@ -172,15 +146,7 @@ export class Context {
 
   get settings() {
     getInternal(this, 'access `context.settings`');
-
-    // Lazily deserialize settings from JSON
-    if (settings === null) {
-      // Deep freeze the settings object, to prevent any mutation of the settings from plugins.
-      // If there's a use case for mutation, we can relax this restriction.
-      settings = JSON.parse(settingsJSON);
-      deepFreezeSettings(settings);
-    }
-
+    if (settings === null) initSettings();
     return settings;
   }
 
@@ -319,26 +285,4 @@ function resolveMessageFromMessageId(messageId: string, internal: InternalContex
   }
 
   return messages[messageId];
-}
-
-/**
- * Deep freeze the settings object, recursively freezing all nested objects and arrays.
- * This prevents any mutation of the settings from plugins.
- * @param obj - The object to deep freeze
- */
-function deepFreezeSettings(obj: unknown): undefined {
-  if (obj === null || typeof obj !== 'object') return;
-
-  if (isArray(obj)) {
-    for (let i = 0, len = obj.length; i < len; i++) {
-      deepFreezeSettings(obj[i]);
-    }
-  } else {
-    // We don't need to handle symbol properties or circular references because settings are deserialized from JSON
-    for (const key in obj) {
-      deepFreezeSettings((obj as unknown as Record<string, unknown>)[key]);
-    }
-  }
-
-  Object.freeze(obj);
 }

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -1,5 +1,6 @@
-import { diagnostics, setSettingsForFile, resetSettings, setupContextForFile } from './context.js';
+import { diagnostics, setupContextForFile } from './context.js';
 import { registeredRules } from './load.js';
+import { setSettingsForFile, resetSettings } from './settings.js';
 import { ast, initAst, resetSourceAndAst, setupSourceForFile } from './source_code.js';
 import { assertIs, getErrorMessage } from './utils.js';
 import { addVisitorToCompiled, compiledVisitor, finalizeCompiledVisitor, initCompiledVisitor } from './visitor.js';

--- a/apps/oxlint/src-js/plugins/settings.ts
+++ b/apps/oxlint/src-js/plugins/settings.ts
@@ -1,0 +1,61 @@
+/*
+ * Methods related to settings.
+ */
+
+const { isArray } = Array;
+
+// Settings for current file.
+// `settingsJSON` is set before linting a file by `setSettingsForFile`.
+// `settings` is deserialized from `settingsJSON` lazily upon first access.
+let settingsJSON: string | null = null;
+export let settings: Record<string, unknown> | null = null;
+
+/**
+ * Updates the settings for the file.
+ *
+ * TODO(perf): Settings are deserialized once per file to accommodate folder level settings,
+ * even if the settings haven't changed.
+ *
+ * @param settingsJSONInput - Settings for the file as JSON
+ */
+export function setSettingsForFile(settingsJSONInput: string) {
+  settingsJSON = settingsJSONInput;
+}
+
+/**
+ * Deserialize settings from JSON.
+ */
+export function initSettings() {
+  settings = JSON.parse(settingsJSON);
+  deepFreezeSettings(settings);
+}
+
+/**
+ * Reset settings.
+ */
+export function resetSettings() {
+  settings = null;
+  settingsJSON = null;
+}
+
+/**
+ * Deep freeze the settings object, recursively freezing all nested objects and arrays.
+ * This prevents any mutation of the settings from plugins.
+ * @param obj - The object to deep freeze
+ */
+function deepFreezeSettings(obj: unknown): undefined {
+  if (obj === null || typeof obj !== 'object') return;
+
+  if (isArray(obj)) {
+    for (let i = 0, len = obj.length; i < len; i++) {
+      deepFreezeSettings(obj[i]);
+    }
+  } else {
+    // We don't need to handle symbol properties or circular references because settings are deserialized from JSON
+    for (const key in obj) {
+      deepFreezeSettings((obj as unknown as Record<string, unknown>)[key]);
+    }
+  }
+
+  Object.freeze(obj);
+}


### PR DESCRIPTION
Pure refactor. Move this code into a separate file to keep it grouped together.