### PR TITLE
perf(formatter): check the `Text` to see whether it has multiple lines based on its width

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -119,7 +119,7 @@ impl Document<'_> {
                         false
                     }
                     // `FormatElement::Token` cannot contain line breaks
-                    FormatElement::Text { text, .. } => text.contains('\n'),
+                    FormatElement::Text { text, width } => width.is_multiline(),
                     FormatElement::ExpandParent
                     | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
                     _ => false,


### PR DESCRIPTION
I forgot to change this in #15372

<img width="1291" height="386" alt="image" src="https://github.com/user-attachments/assets/db7c21f2-81e4-433a-8dae-a69813528af8" />