### PR TITLE
docs(linter/no-this-before-super): correct "Why is this bad?" section

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -30,8 +30,8 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Getters should always return a value.
-    /// If they don't, it's probably a mistake.
+    /// In the constructor of derived classes, if `this`/`super` are used before `super()` calls,
+    /// it raises a ReferenceError.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
The description was of "eslint/getter-return" instead. 