### PR TITLE
docs(linter,minifier): always refer as "ES Modules" instead of "ES6 Modules"

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2309,7 +2309,7 @@ pub struct StaticBlock<'a> {
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
-/// ES6 Module Declaration
+/// ES Module Declaration
 ///
 /// An ESM import or export statement.
 ///

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -88,7 +88,7 @@ declare_oxc_lint!(
     ///
     /// The original ESLint rule recognizes `/* exported variableName */`
     /// comments as a way to indicate that a variable is used in another script
-    /// and should not be considered unused. Since ES6 modules are now a TC39
+    /// and should not be considered unused. Since ES modules are now a TC39
     /// standard, Oxlint does not support this feature.
     ///
     /// ### Examples
@@ -183,7 +183,7 @@ declare_oxc_lint!(
     /// ```js
     /// /* exported global_var */
     ///
-    /// // Not respected, use ES6 modules instead.
+    /// // Not respected, use ES modules instead.
     /// var global_var = 42;
     /// ```
     NoUnusedVars,

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -21,7 +21,7 @@ fn no_absolute_path_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoAbsolutePath {
-    /// If set to `true`, dependency paths for ES6-style import statements will be resolved:
+    /// If set to `true`, dependency paths for ES module import statements will be resolved:
     ///
     /// ```js
     /// import foo from '/foo'; // reported

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// AMD (Asynchronous Module Definition) is an older module format
     /// that is less common in modern JavaScript development, especially
-    /// with the widespread use of ES6 modules and CommonJS in Node.js.
+    /// with the widespread use of ES modules and CommonJS in Node.js.
     /// AMD introduces unnecessary complexity and is often considered outdated.
     /// This rule enforces the use of more modern module systems to improve
     /// maintainability and consistency across the codebase.

--- a/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// With both CommonJS' require and the ES6 modules' import syntax,
+    /// With both CommonJS' require and the ES modules' import syntax,
     /// it is possible to import a module but not to use its result.
     /// This can be done explicitly by not assigning the module to a variable.
     /// Doing so can mean either of the following things:

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -12,7 +12,7 @@ use crate::{
 
 fn no_var_requires_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require statement not part of import statement.")
-        .with_help("Use ES6 style imports or import instead.")
+        .with_help("Use ES module imports or `import = require` instead.")
         .with_label(span)
 }
 
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// In other words, the use of forms such as var foo = require("foo") are banned. Instead use ES6 style imports or import foo = require("foo") imports.
+    /// In other words, the use of forms such as var foo = require("foo") are banned. Instead use ES module imports or import foo = require("foo") imports.
     ///
     /// ```typescript
     /// var foo = require('foo');

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -67,7 +67,7 @@ impl std::ops::Deref for TripleSlashReference {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow certain triple slash directives in favor of ES6-style import declarations.
+    /// Disallow certain triple slash directives in favor of ES module import declarations.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/snapshots/typescript_no_var_requires.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_var_requires.snap
@@ -6,77 +6,77 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var foo = require('foo');
    ·           ──────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:13]
  1 │ const foo = require('foo');
    ·             ──────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:11]
  1 │ let foo = require('foo');
    ·           ──────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:17]
  1 │ let foo = trick(require('foo'));
    ·                 ──────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:11]
  1 │ var foo = require?.('foo');
    ·           ────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:13]
  1 │ const foo = require?.('foo');
    ·             ────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:11]
  1 │ let foo = require?.('foo');
    ·           ────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:17]
  1 │ let foo = trick(require?.('foo'));
    ·                 ────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:19]
  1 │ let foo = trick?.(require('foo'));
    ·                   ──────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:13]
  1 │ const foo = require('./foo.json') as Foo;
    ·             ─────────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:1:18]
  1 │ const foo: Foo = require('./foo.json').default;
    ·                  ─────────────────────
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:2:51]
@@ -85,7 +85,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                   ───────────────────
  3 │             configValidator.addSchema(require('./a.json'));
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.
 
   ⚠ typescript-eslint(no-var-requires): Require statement not part of import statement.
    ╭─[no_var_requires.tsx:3:39]
@@ -94,4 +94,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ───────────────────
  4 │         
    ╰────
-  help: Use ES6 style imports or import instead.
+  help: Use ES module imports or `import = require` instead.

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -51,7 +51,7 @@ pub enum Language {
 pub enum ModuleKind {
     /// Regular JS script or CommonJS file
     Script = 0,
-    /// ES6 Module
+    /// ES Module
     Module = 1,
     /// Consider the file a "module" if ESM syntax is present, or else consider it a "script".
     ///

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -129,7 +129,7 @@ export interface MangleOptionsKeepNames {
 export declare function minify(filename: string, sourceText: string, options?: MinifyOptions | undefined | null): MinifyResult
 
 export interface MinifyOptions {
-  /** Use when minifying an ES6 module. */
+  /** Use when minifying an ES module. */
   module?: boolean
   compress?: boolean | CompressOptions
   mangle?: boolean | MangleOptions

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -266,7 +266,7 @@ impl From<&CodegenOptions> for oxc_codegen::CodegenOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct MinifyOptions {
-    /// Use when minifying an ES6 module.
+    /// Use when minifying an ES module.
     pub module: Option<bool>,
 
     pub compress: Option<Either<bool, CompressOptions>>,


### PR DESCRIPTION
Nowadays, we normally call them "ES Modules" instead of "ES6 Modules". I made that consistent through the docs.