### PR TITLE
docs(linter/import/named): update "ES7" comment in examples

### DIFF
--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -57,7 +57,7 @@ declare_oxc_lint!(
     /// // ./baz.js
     /// import { notFoo } from './foo'
     ///
-    /// // ES7 proposal
+    /// // re-export
     /// export { notFoo as defNotBar } from './foo'
     ///
     /// // will follow 'jsnext:main', if available
@@ -69,7 +69,7 @@ declare_oxc_lint!(
     /// // ./bar.js
     /// import { foo } from './foo'
     ///
-    /// // ES7 proposal
+    /// // re-export
     /// export { foo as bar } from './foo'
     ///
     /// // node_modules without jsnext:main are not analyzed by default


### PR DESCRIPTION
In https://github.com/import-js/eslint-plugin-import/pull/131, ES7 is linked to https://github.com/leebyron/ecmascript-more-export-from. This proposal is not standardized yet and is not relevant to these examples.