### PR TITLE
docs(linter): always refer as "ES2015" instead of "ES6"

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -24,14 +24,14 @@ pub struct NoVar;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// ECMAScript 6 allows programmers to create variables with block scope
+    /// ECMAScript 2015 allows programmers to create variables with block scope
     /// instead of function scope using the `let` and `const` keywords.  Block
     /// scope is common in many other programming languages and helps
     /// programmers avoid mistakes.
     ///
     /// ### Why is this bad?
     ///
-    /// Using `var` in an es6 environment triggers this error
+    /// Using `var` in an ES2015 environment triggers this error
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// With JavaScript ES6, a new syntax was added for creating variables from an array index or object property,
+    /// With JavaScript ES2015, a new syntax was added for creating variables from an array index or object property,
     /// called destructuring. This rule enforces usage of destructuring
     /// instead of accessing a property through a member expression.
     ///

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     ///
     /// The parseInt() and Number.parseInt() functions can be used to turn binary, octal, and
     /// hexadecimal strings into integers. As binary, octal, and hexadecimal literals are supported
-    /// in ES6, this rule encourages use of those numeric literals instead of parseInt() or
+    /// in ES2015, this rule encourages use of those numeric literals instead of parseInt() or
     /// Number.parseInt().
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -12,7 +12,7 @@ use crate::{
 
 fn implements_on_classes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`@implements` used on a non-constructor function")
-        .with_help("Add `@class` tag or use ES6 class syntax.")
+        .with_help("Add `@class` tag or use class syntax.")
         .with_label(span)
 }
 
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// Constructor functions should be
-    /// whether marked with `@class`, `@constructs`, or being an ES6 class constructor.
+    /// whether marked with `@class`, `@constructs`, or being a class constructor.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// The rule is intended to prevent the indication of defaults on tags
-    /// where this would be redundant with ES6 default parameters.
+    /// where this would be redundant with ES2015 default parameters.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -8,7 +8,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 fn bad_array_method_on_arguments_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad array method on arguments")
         .with_help(format!(
-            "The 'arguments' object does not have a '{method_name}()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead."
+            "The 'arguments' object does not have a '{method_name}()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead."
         ))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -21,11 +21,11 @@ pub struct NoIsMounted;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule prevents using isMounted in ES6 classes
+    /// This rule prevents using isMounted in classes
     ///
     /// ### Why is this bad?
     ///
-    /// isMounted is an anti-pattern, is not available when using ES6 classes,
+    /// isMounted is an anti-pattern, is not available when using classes,
     /// and it is on its way to being officially deprecated.///
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -11,11 +11,13 @@ use crate::{
 };
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use createClass instead of ES6 class.").with_label(span)
+    OxcDiagnostic::warn("Components should use createClass instead of an ES2015 class.")
+        .with_label(span)
 }
 
 fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use ES6 class instead of createClass.").with_label(span)
+    OxcDiagnostic::warn("Components should use an ES2015 class instead of createClass.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -27,7 +29,7 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// React offers you two ways to create traditional components: using the ES5
-    /// create-react-class module or the new ES6 class system.
+    /// create-react-class module or the new ES2015 class system.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -26,7 +26,7 @@ pub struct RequireRenderReturn;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce ES5 or ES6 class for returning value in render function
+    /// Enforce ES5 or ES2015 class for returning value in render function
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -18,7 +18,7 @@ use crate::{
 
 fn no_this_alias_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
-        .with_help("Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.")
+        .with_help("Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.")
         .with_label(span)
 }
 
@@ -69,7 +69,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Assigning a variable to `this` instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+    /// Assigning a variable to `this` instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
     NoThisAlias,
     typescript,
     correctness,

--- a/crates/oxc_linter/src/snapshots/jsdoc_implements_on_classes.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_implements_on_classes.snap
@@ -8,7 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────
  4 │                    */
    ╰────
-  help: Add `@class` tag or use ES6 class syntax.
+  help: Add `@class` tag or use class syntax.
 
   ⚠ eslint-plugin-jsdoc(implements-on-classes): `@implements` used on a non-constructor function
    ╭─[implements_on_classes.tsx:3:13]
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────
  4 │                    */
    ╰────
-  help: Add `@class` tag or use ES6 class syntax.
+  help: Add `@class` tag or use class syntax.
 
   ⚠ eslint-plugin-jsdoc(implements-on-classes): `@implements` used on a non-constructor function
    ╭─[implements_on_classes.tsx:4:13]
@@ -26,4 +26,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────
  5 │                    */
    ╰────
-  help: Add `@class` tag or use ES6 class syntax.
+  help: Add `@class` tag or use class syntax.

--- a/crates/oxc_linter/src/snapshots/oxc_bad_array_method_on_arguments.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_bad_array_method_on_arguments.snap
@@ -6,228 +6,228 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function fn() {arguments['map'](() => {})}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments[`map`](() => {})}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.at(0)}
    ·                ────────────
    ╰────
-  help: The 'arguments' object does not have a 'at()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'at()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.concat([])}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'concat()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'concat()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.copyWithin(0)}
    ·                ────────────────────
    ╰────
-  help: The 'arguments' object does not have a 'copyWithin()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'copyWithin()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.entries()}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'entries()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'entries()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.every(() => {})}
    ·                ───────────────
    ╰────
-  help: The 'arguments' object does not have a 'every()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'every()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.fill(() => {})}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'fill()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'fill()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.filter(() => {})}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'filter()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'filter()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.find(() => {})}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'find()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'find()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.findIndex(() => {})}
    ·                ───────────────────
    ╰────
-  help: The 'arguments' object does not have a 'findIndex()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'findIndex()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.flat(() => {})}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'flat()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'flat()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.flatMap(() => {})}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'flatMap()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'flatMap()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.forEach(() => {})}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'forEach()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'forEach()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.includes(() => {})}
    ·                ──────────────────
    ╰────
-  help: The 'arguments' object does not have a 'includes()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'includes()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.indexOf(() => {})}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'indexOf()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'indexOf()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.join()}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'join()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'join()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.keys()}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'keys()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'keys()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.lastIndexOf('')}
    ·                ─────────────────────
    ╰────
-  help: The 'arguments' object does not have a 'lastIndexOf()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'lastIndexOf()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.map(() => {})}
    ·                ─────────────
    ╰────
-  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'map()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.pop()}
    ·                ─────────────
    ╰────
-  help: The 'arguments' object does not have a 'pop()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'pop()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.push('')}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'push()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'push()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.reduce(() => {})}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'reduce()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'reduce()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.reduceRight(() => {})}
    ·                ─────────────────────
    ╰────
-  help: The 'arguments' object does not have a 'reduceRight()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'reduceRight()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.reverse()}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'reverse()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'reverse()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.shift()}
    ·                ───────────────
    ╰────
-  help: The 'arguments' object does not have a 'shift()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'shift()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.slice()}
    ·                ───────────────
    ╰────
-  help: The 'arguments' object does not have a 'slice()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'slice()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.some(() => {})}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'some()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'some()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.sort(() => {})}
    ·                ──────────────
    ╰────
-  help: The 'arguments' object does not have a 'sort()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'sort()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.splice(() => {})}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'splice()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'splice()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.unshift()}
    ·                ─────────────────
    ╰────
-  help: The 'arguments' object does not have a 'unshift()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'unshift()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments.values()}
    ·                ────────────────
    ╰────
-  help: The 'arguments' object does not have a 'values()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a 'values()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.
 
   ⚠ oxc(bad-array-method-on-arguments): Bad array method on arguments
    ╭─[bad_array_method_on_arguments.tsx:1:16]
  1 │ function fn() {arguments['@@iterator'](() => {})}
    ·                ───────────────────────
    ╰────
-  help: The 'arguments' object does not have a '@@iterator()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES6 rest parameter instead.
+  help: The 'arguments' object does not have a '@@iterator()' method. If you intended to use an array method, consider converting the 'arguments' object to an array or using an ES2015 rest parameter instead.

--- a/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use ES6 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of createClass.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │               displayName: 'Hello',
    ╰────
 
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use ES6 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of createClass.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │               render: function() {
    ╰────
 
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use createClass instead of ES6 class.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use createClass instead of an ES2015 class.
    ╭─[prefer_es6_class.tsx:2:19]
  1 │ 
  2 │             class Hello extends React.Component {

--- a/crates/oxc_linter/src/snapshots/typescript_no_this_alias.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_this_alias.snap
@@ -6,7 +6,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const self = this;
    ·       ────
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of members of 'this' to local variables.
    ╭─[no_this_alias.tsx:1:7]
@@ -28,14 +28,14 @@ source: crates/oxc_linter/src/tester.rs
  6 │ foo = this
    · ───
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:1:11]
  1 │ let foo; (foo as any) = this
    ·           ───
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:2:17]
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────
  3 │           }
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:2:19]
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────────
  3 │           };
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:3:21]
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────────
  4 │               const asThis: this = this;
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:4:21]
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────────
  5 │ 
    ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
     ╭─[no_this_alias.tsx:12:21]
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                     ────────────────
  13 │               const { act1 } = this;
     ╰────
-  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
 
   ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of members of 'this' to local variables.
     ╭─[no_this_alias.tsx:13:21]


### PR DESCRIPTION
It is now more common to refer ES6 / ES2015 as "ES2015" than "ES6". This PR updates multiple places to use "ES2015" instead of "ES6". It also removes some redundant "ES6" when it is not important anymore in context of those sentences.