### PR TITLE
perf(formatter): reuse previous indent stack in `FitsMeasurer`

### DIFF
--- a/crates/oxc_formatter/src/formatter/printer/call_stack.rs
+++ b/crates/oxc_formatter/src/formatter/printer/call_stack.rs
@@ -299,6 +299,10 @@ impl<'print> FitsIndentStack<'print> {
 
         Self { indentions, history_indentions }
     }
+
+    pub(super) fn finish(self) -> (Vec<Indention>, Vec<Indention>) {
+        (self.indentions.into_vec(), self.history_indentions.into_vec())
+    }
 }
 
 impl<'a> IndentStack for FitsIndentStack<'a> {

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -1203,6 +1203,12 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
         let mut stack = self.stack.finish();
         stack.clear();
         self.printer.state.fits_stack = stack;
+
+        let (mut indent_stack, mut history_stack) = self.indent_stack.finish();
+        indent_stack.clear();
+        self.printer.state.fits_indent_stack = indent_stack;
+        history_stack.clear();
+        self.printer.state.fits_stack_tem_indent = history_stack;
     }
 
     fn options(&self) -> &PrinterOptions {


### PR DESCRIPTION
As said in https://github.com/oxc-project/oxc/blob/60848996f81a4d9808a0b5788cc225f10e524971/crates/oxc_formatter/src/formatter/printer/mod.rs#L703-L708

These four stacks should be reused in each FitsMeasurer run to avoid reallocation, but `fits_indent_stack` and `fits_stack_tem_indent are lacking. 


<img width="1268" height="434" alt="image" src="https://github.com/user-attachments/assets/43aeb36e-4c34-4fc9-8786-c45e353386aa" />

