### PR TITLE
perf(formatter): use `ArenaVec` and `ArenaBox`

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -6,6 +6,7 @@ use Tag::{
     StartDedent, StartEntry, StartFill, StartGroup, StartIndent, StartIndentIfGroupBreaks,
     StartLabelled, StartLineSuffix,
 };
+use oxc_allocator::Vec as ArenaVec;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::identifier::{is_identifier_name, is_line_terminator, is_white_space_single_line};
 
@@ -2549,8 +2550,11 @@ impl<'ast> Format<'ast> for BestFitting<'_, 'ast> {
             buffer.write_fmt(Arguments::from(variant))?;
             buffer.write_element(FormatElement::Tag(EndEntry))?;
 
-            formatted_variants.push(buffer.take_vec().into_boxed_slice());
+            formatted_variants.push(buffer.take_vec().into_bump_slice());
         }
+
+        let formatted_variants =
+            ArenaVec::from_iter_in(formatted_variants, f.context().allocator());
 
         // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,
         // safe to call into the unsafe `from_vec_unchecked` function

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception)]
 
-use oxc_allocator::{Address, Allocator};
+use oxc_allocator::{Address, Allocator, Vec as ArenaVec};
 use oxc_ast::AstKind;
 
 use crate::options::FormatOptions;
@@ -27,7 +27,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
         Self { buffer }
     }
 
-    pub fn allocator(&self) -> &Allocator {
+    pub fn allocator(&self) -> &'ast Allocator {
         self.context().allocator()
     }
 
@@ -244,7 +244,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
 
     pub fn intern_vec(
         &mut self,
-        mut elements: Vec<FormatElement<'ast>>,
+        mut elements: ArenaVec<'ast, FormatElement<'ast>>,
     ) -> Option<FormatElement<'ast>> {
         match elements.len() {
             0 => None,

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use oxc_allocator::Vec as ArenaVec;
+
 use crate::{
     JsLabels,
     formatter::format_element::{
@@ -153,7 +155,7 @@ impl SourceLine {
     pub fn write<'a>(
         &self,
         prev_elements: &[FormatElement<'a>],
-        next_elements: &mut Vec<FormatElement<'a>>,
+        next_elements: &mut ArenaVec<'a, FormatElement<'a>>,
         preserve_empty_line: bool,
     ) {
         match self {

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -103,7 +103,7 @@ impl<'a> Formatter<'a> {
         // Now apply additional transforms if enabled.
         if let Some(sort_imports_options) = experimental_sort_imports {
             let sort_imports = SortImportsTransform::new(sort_imports_options);
-            formatted.apply_transform(|doc| sort_imports.transform(doc));
+            formatted.apply_transform(|doc| sort_imports.transform(doc, self.allocator));
         }
 
         formatted

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -708,7 +708,7 @@ fn write_grouped_arguments<'a>(
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
 
-        buffer.into_vec()
+        buffer.into_vec().into_bump_slice()
     };
 
     // Now reformat the first or last argument if they happen to be a function or arrow function expression.
@@ -808,14 +808,14 @@ fn write_grouped_arguments<'a>(
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
 
-        buffer.into_vec().into_boxed_slice()
+        buffer.into_vec().into_bump_slice()
     };
 
     // If the grouped content breaks, then we can skip the most_flat variant,
     // since we already know that it won't be fitting on a single line.
     let variants = if grouped_breaks {
         write!(f, [expand_parent()])?;
-        vec![middle_variant, most_expanded.into_boxed_slice()]
+        ArenaVec::from_array_in([middle_variant, most_expanded], f.context().allocator())
     } else {
         // Write the most flat variant with the first or last argument grouped.
         let most_flat = {
@@ -845,10 +845,10 @@ fn write_grouped_arguments<'a>(
 
             buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
 
-            buffer.into_vec().into_boxed_slice()
+            buffer.into_vec().into_bump_slice()
         };
 
-        vec![most_flat, middle_variant, most_expanded.into_boxed_slice()]
+        ArenaVec::from_array_in([most_flat, middle_variant, most_expanded], f.context().allocator())
     };
 
     // SAFETY: Safe because variants is guaranteed to contain exactly 3 entries:


### PR DESCRIPTION
This PR aims to replace the Formatter's standard `Vec` and `Box` usages with `ArenaVec` and `ArenaBox` to gain performance, which could reduce the `drop` overhead.

There are three key changes:

1. Change the Document's element from `Vec<FormatElement<'a>>`
```diff
pub struct Document<'a> {
-    elements: Vec<FormatElement<'a>>,
+    elements: &'a [FormatElement<'a>],
}
```

2. Change the `FormatElement::interned`'s argument from `Rc<[FormatElement<'a>]>` to `&'a [FormatElement<'a>]`
```diff
- pub struct Interned<'a>(Rc<[FormatElement<'a>]>);
+ pub struct Interned<'a>(&'a [FormatElement<'a>]);
```

3. Change the `FormatElement::variants`'s variants from `Box<[Box<[FormatElement<'a>]>]>` to `&'a [&'a [FormatElement<'a>]]`
```diff
pub struct BestFittingElement<'a> {
-    variants: Box<[Box<[FormatElement<'a>]>]>,
+    variants: &'a [&'a [FormatElement<'a>]],
}
```

All other changes stem from those mentioned above.

Replacing the `Rc` with `&a` reference approach was suggested and guided by @overlookmotel. Thank you!