### PR TITLE
test(linter/plugins): improve reliability of replacing paths in output

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -40,6 +40,7 @@ async function testFixture(fixtureName: string, options?: TestOptions): Promise<
     fixtureName,
     snapshotName: options?.snapshotName ?? 'output',
     getExtraSnapshotData: options?.getExtraSnapshotData,
+    isESLint: false,
   });
 }
 

--- a/apps/oxlint/test/eslint-compat.test.ts
+++ b/apps/oxlint/test/eslint-compat.test.ts
@@ -14,6 +14,7 @@ async function testFixture(fixtureName: string): Promise<void> {
     args: [],
     fixtureName,
     snapshotName: 'eslint',
+    isESLint: true,
   });
 }
 

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -3,21 +3,45 @@
 
 # stdout
 ```
+  x context-plugin(log-context): cwd: <fixture>
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x context-plugin(log-context): filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x context-plugin(log-context): physicalFilename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x context-plugin(log-context): id: context-plugin/log-context
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
    `----
 
-  x context-plugin(log-context): filename: files/1.js
-   ,-[files/1.js:1:1]
- 1 | let x;
+  x context-plugin(log-context): cwd: <fixture>
+   ,-[files/2.js:1:1]
+ 1 | let y;
    : ^
    `----
 
-  x context-plugin(log-context): physicalFilename: files/1.js
-   ,-[files/1.js:1:1]
- 1 | let x;
+  x context-plugin(log-context): filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
+  x context-plugin(log-context): physicalFilename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
    : ^
    `----
 
@@ -27,19 +51,7 @@
    : ^
    `----
 
-  x context-plugin(log-context): filename: files/2.js
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x context-plugin(log-context): physicalFilename: files/2.js
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-Found 0 warnings and 6 errors.
+Found 0 warnings and 8 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -12,36 +12,12 @@ const SPAN: Node = {
   },
 };
 
-const DIR_PATH_LEN = import.meta.dirname.length + 1;
-
-const relativePath = sep === '/'
-  ? (path: string) => path.slice(DIR_PATH_LEN)
-  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
-
 const rule: Rule = {
   create(context) {
-    context.report({
-      message: `id: ${context.id}`,
-      node: SPAN,
-    });
-
-    context.report({
-      message: `filename: ${relativePath(context.filename)}`,
-      node: SPAN,
-    });
-
-    context.report({
-      message: `physicalFilename: ${relativePath(context.physicalFilename)}`,
-      node: SPAN,
-    });
-
-    if (context.cwd.length === 0) {
-      context.report({ message: 'cwd.length === 0', node: SPAN });
-    }
-
-    if (context.cwd !== process.cwd()) {
-      context.report({ message: 'cwd !== process.cwd()', node: SPAN });
-    }
+    context.report({ message: `id: ${context.id}`, node: SPAN });
+    context.report({ message: `filename: ${context.filename}`, node: SPAN });
+    context.report({ message: `physicalFilename: ${context.physicalFilename}`, node: SPAN });
+    context.report({ message: `cwd: ${context.cwd}`, node: SPAN });
 
     if (this !== rule) context.report({ message: 'this !== rule', node: SPAN });
 

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-  x create-once-plugin(after-only): after hook: filename: files/1.js
+  x create-once-plugin(after-only): after hook: filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -21,19 +21,19 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): before hook: filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): after hook: filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: filename: Cannot access `context.filename` in `createOnce`
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: filename: files/1.js
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: filename: files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -93,7 +93,7 @@
    : ^
    `----
 
-  x create-once-plugin(before-only): before hook: filename: files/1.js
+  x create-once-plugin(before-only): before hook: filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -105,7 +105,7 @@
    : ^
    `----
 
-  x create-once-plugin(skip-run): before hook: filename: files/1.js
+  x create-once-plugin(skip-run): before hook: filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -117,31 +117,31 @@
    : ^
    `----
 
-  x create-once-plugin(after-only): ident visit fn "x": filename: files/1.js
+  x create-once-plugin(after-only): ident visit fn "x": filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let x;
    :     ^
    `----
 
-  x create-once-plugin(always-run): ident visit fn "x": filename: files/1.js
+  x create-once-plugin(always-run): ident visit fn "x": filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let x;
    :     ^
    `----
 
-  x create-once-plugin(before-only): ident visit fn "x": filename: files/1.js
+  x create-once-plugin(before-only): ident visit fn "x": filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let x;
    :     ^
    `----
 
-  x create-once-plugin(no-hooks): ident visit fn "x": filename: files/1.js
+  x create-once-plugin(no-hooks): ident visit fn "x": filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let x;
    :     ^
    `----
 
-  x create-once-plugin(after-only): after hook: filename: files/2.js
+  x create-once-plugin(after-only): after hook: filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -159,19 +159,19 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): before hook: filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): after hook: filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: filename: Cannot access `context.filename` in `createOnce`
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: filename: files/2.js
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: filename: files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -231,7 +231,7 @@
    : ^
    `----
 
-  x create-once-plugin(before-only): before hook: filename: files/2.js
+  x create-once-plugin(before-only): before hook: filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -243,7 +243,7 @@
    : ^
    `----
 
-  x create-once-plugin(skip-run): before hook: filename: files/2.js
+  x create-once-plugin(skip-run): before hook: filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -255,25 +255,25 @@
    : ^
    `----
 
-  x create-once-plugin(after-only): ident visit fn "y": filename: files/2.js
+  x create-once-plugin(after-only): ident visit fn "y": filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let y;
    :     ^
    `----
 
-  x create-once-plugin(always-run): ident visit fn "y": filename: files/2.js
+  x create-once-plugin(always-run): ident visit fn "y": filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let y;
    :     ^
    `----
 
-  x create-once-plugin(before-only): ident visit fn "y": filename: files/2.js
+  x create-once-plugin(before-only): ident visit fn "y": filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let y;
    :     ^
    `----
 
-  x create-once-plugin(no-hooks): ident visit fn "y": filename: files/2.js
+  x create-once-plugin(no-hooks): ident visit fn "y": filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let y;
    :     ^

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -12,12 +12,6 @@ const SPAN: Node = {
   },
 };
 
-const DIR_PATH_LEN = import.meta.dirname.length + 1;
-
-const relativePath = sep === '/'
-  ? (path: string) => path.slice(DIR_PATH_LEN)
-  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
-
 let createOnceCallCount = 0;
 
 const alwaysRunRule: Rule = {
@@ -50,17 +44,17 @@ const alwaysRunRule: Rule = {
         context.report({ message: `createOnce: report: ${reportError?.message}`, node: SPAN });
 
         context.report({ message: `before hook: id: ${context.id}`, node: SPAN });
-        context.report({ message: `before hook: filename: ${relativePath(context.filename)}`, node: SPAN });
+        context.report({ message: `before hook: filename: ${context.filename}`, node: SPAN });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}": filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}": filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({ message: `after hook: id: ${context.id}`, node: SPAN });
-        context.report({ message: `after hook: filename: ${relativePath(context.filename)}`, node: SPAN });
+        context.report({ message: `after hook: filename: ${context.filename}`, node: SPAN });
       },
     };
   },
@@ -71,7 +65,7 @@ const skipRunRule: Rule = {
     return {
       before() {
         context.report({ message: `before hook: id: ${context.id}`, node: SPAN });
-        context.report({ message: `before hook: filename: ${relativePath(context.filename)}`, node: SPAN });
+        context.report({ message: `before hook: filename: ${context.filename}`, node: SPAN });
         // Skip running this rule
         return false;
       },
@@ -90,11 +84,11 @@ const beforeOnlyRule: Rule = {
     return {
       before() {
         context.report({ message: `before hook: id: ${context.id}`, node: SPAN });
-        context.report({ message: `before hook: filename: ${relativePath(context.filename)}`, node: SPAN });
+        context.report({ message: `before hook: filename: ${context.filename}`, node: SPAN });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}": filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}": filename: ${context.filename}`,
           node,
         });
       },
@@ -107,13 +101,13 @@ const afterOnlyRule: Rule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}": filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}": filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({ message: `after hook: id: ${context.id}`, node: SPAN });
-        context.report({ message: `after hook: filename: ${relativePath(context.filename)}`, node: SPAN });
+        context.report({ message: `after hook: filename: ${context.filename}`, node: SPAN });
       },
     };
   },
@@ -138,7 +132,7 @@ const noHooksRule: Rule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}": filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}": filename: ${context.filename}`,
           node,
         });
       },

--- a/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_import_error/output.snap.md
@@ -7,7 +7,7 @@ Failed to parse configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: whoops!
-  |     at <root>/apps/oxlint/test/fixtures/custom_plugin_import_error/plugin.ts:1:7
+  |     at <fixture>/plugin.ts:1:7
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/output.snap.md
@@ -4,9 +4,9 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Whoops!
-  |     at after (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.ts:13:19)
+  |     at after (<fixture>/plugin.ts:13:19)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/output.snap.md
@@ -4,9 +4,9 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Whoops!
-  |     at before (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.ts:12:19)
+  |     at before (<fixture>/plugin.ts:12:19)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/output.snap.md
@@ -7,7 +7,7 @@ Failed to parse configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: Whoops!
-  |     at Object.createOnce (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.ts:10:15)
+  |     at Object.createOnce (<fixture>/plugin.ts:10:15)
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/output.snap.md
@@ -4,9 +4,9 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Whoops!
-  |     at Object.create (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.ts:10:15)
+  |     at Object.create (<fixture>/plugin.ts:10:15)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/output.snap.md
@@ -4,10 +4,10 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Whoops!
-  |     at Object.fix (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.ts:16:23)
-  |     at Identifier (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.ts:12:21)
+  |     at Object.fix (<fixture>/plugin.ts:16:23)
+  |     at Identifier (<fixture>/plugin.ts:12:21)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/output.snap.md
@@ -4,9 +4,9 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Whoops!
-  |     at Identifier (<root>/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.ts:12:19)
+  |     at Identifier (<fixture>/plugin.ts:12:19)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.

--- a/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/eslint.snap.md
@@ -3,97 +3,97 @@
 
 # stdout
 ```
-<root>/apps/oxlint/test/fixtures/definePlugin/files/1.js
+<fixture>/files/1.js
   0:1  error  create body:
-this === rule: true                                                define-plugin-plugin/create
+this === rule: true                                         define-plugin-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/1.js  define-plugin-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-plugin/create-once-before-false
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/1.js                                    define-plugin-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once
   0:1  error  after hook:
-filename: files/1.js                                                define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/1.js                                                define-plugin-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-plugin/create
+filename: <fixture>/files/1.js                              define-plugin-plugin/create
   1:5  error  ident visit fn "a":
 identNum: 1
-filename: files/1.js                            define-plugin-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-before-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-after-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-no-hooks
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-plugin/create
+filename: <fixture>/files/1.js                              define-plugin-plugin/create
   1:8  error  ident visit fn "b":
 identNum: 2
-filename: files/1.js                            define-plugin-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-before-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-after-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-plugin-plugin/create-once-no-hooks
 
-<root>/apps/oxlint/test/fixtures/definePlugin/files/2.js
+<fixture>/files/2.js
   0:1  error  create body:
-this === rule: true                                                define-plugin-plugin/create
+this === rule: true                                         define-plugin-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/2.js  define-plugin-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/2.js                                    define-plugin-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-false
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-plugin/create
+filename: <fixture>/files/2.js                              define-plugin-plugin/create
   1:5  error  ident visit fn "c":
 identNum: 1
-filename: files/2.js                            define-plugin-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-false
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-no-hooks
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-plugin/create
+filename: <fixture>/files/2.js                              define-plugin-plugin/create
   1:8  error  ident visit fn "d":
 identNum: 2
-filename: files/2.js                            define-plugin-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-false
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-before-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-after-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-plugin-plugin/create-once-no-hooks
 
 ✖ 39 problems (39 errors, 0 warnings)
 ```

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -13,7 +13,7 @@
   x define-plugin-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
@@ -21,35 +21,35 @@
 
   x define-plugin-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-plugin(create-once-after-only): after hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-plugin(create-once-before-false): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-plugin(create-once-before-only): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-plugin(create): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
@@ -57,35 +57,35 @@
 
   x define-plugin-plugin(create-once): ident visit fn "a":
   | identNum: 1
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-after-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-before-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-no-hooks): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-plugin(create): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -93,28 +93,28 @@
 
   x define-plugin-plugin(create-once): ident visit fn "b":
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-after-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-before-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-no-hooks): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -130,7 +130,7 @@
   x define-plugin-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
@@ -138,42 +138,42 @@
 
   x define-plugin-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-plugin(create-once-after-only): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-plugin(create-once-before-false): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-plugin(create-once-before-false): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-plugin(create-once-before-only): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-plugin(create): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
@@ -181,42 +181,42 @@
 
   x define-plugin-plugin(create-once): ident visit fn "c":
   | identNum: 1
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-after-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-before-false): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-before-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-plugin(create-once-no-hooks): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-plugin(create): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
@@ -224,35 +224,35 @@
 
   x define-plugin-plugin(create-once): ident visit fn "d":
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-after-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-before-false): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-before-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-plugin(create-once-no-hooks): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -13,12 +13,6 @@ const SPAN: Node = {
   },
 };
 
-const DIR_PATH_LEN = import.meta.dirname.length + 1;
-
-const relativePath = sep === '/'
-  ? (path: string) => path.slice(DIR_PATH_LEN)
-  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
-
 const createRule: Rule = {
   create(context) {
     context.report({ message: `create body:\nthis === rule: ${this === createRule}`, node: SPAN });
@@ -26,7 +20,7 @@ const createRule: Rule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\nfilename: ${context.filename}`,
           node,
         });
       },
@@ -45,7 +39,8 @@ const createOnceRule: Rule = {
 
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
-    let fileNum = 0, identNum: number;
+    let fileNum = 0,
+      identNum: number;
     // Note: Files are processed in unpredictable order, so `files/1.js` may be `fileNum` 1 or 2.
     // Therefore, collect all visits and check them in `after` hook of the 2nd file.
     const visits: { fileNum: number; identNum: number }[] = [];
@@ -60,10 +55,11 @@ const createOnceRule: Rule = {
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n' +
+          message:
+            'before hook:\n' +
             `createOnce call count: ${createOnceCallCount}\n` +
             `this === rule: ${topLevelThis === createOnceRule}\n` +
-            `filename: ${relativePath(context.filename)}`,
+            `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -72,17 +68,13 @@ const createOnceRule: Rule = {
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -114,8 +106,7 @@ const createOnceBeforeFalseRule: Rule = {
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -124,15 +115,13 @@ const createOnceBeforeFalseRule: Rule = {
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -147,15 +136,13 @@ const createOnceBeforeOnlyRule: Rule = {
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
@@ -168,15 +155,13 @@ const createOnceAfterOnlyRule: Rule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -190,15 +175,13 @@ const createOnceHooksOnlyRule: Rule = {
       // Neither hook should be called, because no AST node visitor functions
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -211,8 +194,7 @@ const createOnceNoHooksRule: Rule = {
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/eslint.snap.md
@@ -3,97 +3,97 @@
 
 # stdout
 ```
-<root>/apps/oxlint/test/fixtures/definePlugin_and_defineRule/files/1.js
+<fixture>/files/1.js
   0:1  error  create body:
-this === rule: true                                                define-plugin-and-rule-plugin/create
+this === rule: true                                         define-plugin-and-rule-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/1.js  define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-before-false
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/1.js                                               define-plugin-and-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/1.js                                    define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/1.js                                                define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/1.js                                                define-plugin-and-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create
   1:5  error  ident visit fn "a":
 identNum: 1
-filename: files/1.js                            define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create
   1:8  error  ident visit fn "b":
 identNum: 2
-filename: files/1.js                            define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-plugin-and-rule-plugin/create-once-no-hooks
 
-<root>/apps/oxlint/test/fixtures/definePlugin_and_defineRule/files/2.js
+<fixture>/files/2.js
   0:1  error  create body:
-this === rule: true                                                define-plugin-and-rule-plugin/create
+this === rule: true                                         define-plugin-and-rule-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/2.js  define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/2.js                                               define-plugin-and-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/2.js                                    define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-false
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/2.js                                                define-plugin-and-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create
   1:5  error  ident visit fn "c":
 identNum: 1
-filename: files/2.js                            define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-false
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create
   1:8  error  ident visit fn "d":
 identNum: 2
-filename: files/2.js                            define-plugin-and-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-false
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-plugin-and-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-plugin-and-rule-plugin/create-once-no-hooks
 
 ✖ 39 problems (39 errors, 0 warnings)
 ```

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -13,7 +13,7 @@
   x define-plugin-and-rule-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
@@ -21,35 +21,35 @@
 
   x define-plugin-and-rule-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): after hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-false): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
@@ -57,35 +57,35 @@
 
   x define-plugin-and-rule-plugin(create-once): ident visit fn "a":
   | identNum: 1
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-no-hooks): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -93,28 +93,28 @@
 
   x define-plugin-and-rule-plugin(create-once): ident visit fn "b":
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-no-hooks): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -130,7 +130,7 @@
   x define-plugin-and-rule-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
@@ -138,42 +138,42 @@
 
   x define-plugin-and-rule-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-false): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-false): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-plugin-and-rule-plugin(create): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
@@ -181,42 +181,42 @@
 
   x define-plugin-and-rule-plugin(create-once): ident visit fn "c":
   | identNum: 1
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-false): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-no-hooks): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-plugin-and-rule-plugin(create): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
@@ -224,35 +224,35 @@
 
   x define-plugin-and-rule-plugin(create-once): ident visit fn "d":
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-after-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-false): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-before-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-plugin-and-rule-plugin(create-once-no-hooks): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -13,12 +13,6 @@ const SPAN: Node = {
   },
 };
 
-const DIR_PATH_LEN = import.meta.dirname.length + 1;
-
-const relativePath = sep === '/'
-  ? (path: string) => path.slice(DIR_PATH_LEN)
-  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
-
 const createRule = defineRule({
   create(context) {
     context.report({ message: `create body:\nthis === rule: ${this === createRule}`, node: SPAN });
@@ -26,7 +20,7 @@ const createRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\nfilename: ${context.filename}`,
           node,
         });
       },
@@ -44,7 +38,8 @@ const createOnceRule = defineRule({
 
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
-    let fileNum = 0, identNum: number;
+    let fileNum = 0,
+      identNum: number;
     // Note: Files are processed in unpredictable order, so `files/1.js` may be `fileNum` 1 or 2.
     // Therefore, collect all visits and check them in `after` hook of the 2nd file.
     const visits: { fileNum: number; identNum: number }[] = [];
@@ -59,10 +54,11 @@ const createOnceRule = defineRule({
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n' +
+          message:
+            'before hook:\n' +
             `createOnce call count: ${createOnceCallCount}\n` +
             `this === rule: ${topLevelThis === createOnceRule}\n` +
-            `filename: ${relativePath(context.filename)}`,
+            `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -71,17 +67,13 @@ const createOnceRule = defineRule({
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -113,8 +105,7 @@ const createOnceBeforeFalseRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -123,15 +114,13 @@ const createOnceBeforeFalseRule = defineRule({
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -146,15 +135,13 @@ const createOnceBeforeOnlyRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
@@ -167,15 +154,13 @@ const createOnceAfterOnlyRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -189,15 +174,13 @@ const createOnceHooksOnlyRule = defineRule({
       // Neither hook should be called, because no AST node visitor functions
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -210,8 +193,7 @@ const createOnceNoHooksRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },

--- a/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/eslint.snap.md
@@ -3,97 +3,97 @@
 
 # stdout
 ```
-<root>/apps/oxlint/test/fixtures/defineRule/files/1.js
+<fixture>/files/1.js
   0:1  error  create body:
-this === rule: true                                                define-rule-plugin/create
+this === rule: true                                         define-rule-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/1.js  define-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/1.js                                               define-rule-plugin/create-once-before-false
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/1.js                                               define-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/1.js                                               define-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/1.js                                    define-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/1.js                                                define-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/1.js                                                define-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-rule-plugin/create
+filename: <fixture>/files/1.js                              define-rule-plugin/create
   1:5  error  ident visit fn "a":
 identNum: 1
-filename: files/1.js                            define-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "a":
-filename: files/1.js                                        define-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-rule-plugin/create
+filename: <fixture>/files/1.js                              define-rule-plugin/create
   1:8  error  ident visit fn "b":
 identNum: 2
-filename: files/1.js                            define-rule-plugin/create-once
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-rule-plugin/create-once-before-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-rule-plugin/create-once-after-only
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "b":
-filename: files/1.js                                        define-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/1.js                              define-rule-plugin/create-once-no-hooks
 
-<root>/apps/oxlint/test/fixtures/defineRule/files/2.js
+<fixture>/files/2.js
   0:1  error  create body:
-this === rule: true                                                define-rule-plugin/create
+this === rule: true                                         define-rule-plugin/create
   0:1  error  before hook:
 createOnce call count: 1
 this === rule: true
-filename: files/2.js  define-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once
   0:1  error  before hook:
-filename: files/2.js                                               define-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-false
   0:1  error  before hook:
-filename: files/2.js                                               define-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-only
   0:1  error  before hook:
-filename: files/2.js                                               define-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-hooks-only
   0:1  error  after hook:
 identNum: 2
-filename: files/2.js                                    define-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once
   0:1  error  after hook:
-filename: files/2.js                                                define-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-false
   0:1  error  after hook:
-filename: files/2.js                                                define-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-after-only
   0:1  error  after hook:
-filename: files/2.js                                                define-rule-plugin/create-once-hooks-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-hooks-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-rule-plugin/create
+filename: <fixture>/files/2.js                              define-rule-plugin/create
   1:5  error  ident visit fn "c":
 identNum: 1
-filename: files/2.js                            define-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-false
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-after-only
   1:5  error  ident visit fn "c":
-filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-no-hooks
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-rule-plugin/create
+filename: <fixture>/files/2.js                              define-rule-plugin/create
   1:8  error  ident visit fn "d":
 identNum: 2
-filename: files/2.js                            define-rule-plugin/create-once
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-rule-plugin/create-once-before-false
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-false
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-rule-plugin/create-once-before-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-before-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-rule-plugin/create-once-after-only
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-after-only
   1:8  error  ident visit fn "d":
-filename: files/2.js                                        define-rule-plugin/create-once-no-hooks
+filename: <fixture>/files/2.js                              define-rule-plugin/create-once-no-hooks
 
 ✖ 39 problems (39 errors, 0 warnings)
 ```

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -13,7 +13,7 @@
   x define-rule-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
@@ -21,35 +21,35 @@
 
   x define-rule-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-rule-plugin(create-once-after-only): after hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-rule-plugin(create-once-before-false): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-rule-plugin(create-once-before-only): before hook:
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
   x define-rule-plugin(create): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
@@ -57,35 +57,35 @@
 
   x define-rule-plugin(create-once): ident visit fn "a":
   | identNum: 1
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-rule-plugin(create-once-after-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-rule-plugin(create-once-before-only): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-rule-plugin(create-once-no-hooks): ident visit fn "a":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
  1 | let a, b;
    :     ^
    `----
 
   x define-rule-plugin(create): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -93,28 +93,28 @@
 
   x define-rule-plugin(create-once): ident visit fn "b":
   | identNum: 2
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-rule-plugin(create-once-after-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-rule-plugin(create-once-before-only): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
    `----
 
   x define-rule-plugin(create-once-no-hooks): ident visit fn "b":
-  | filename: files/1.js
+  | filename: <fixture>/files/1.js
    ,-[files/1.js:1:8]
  1 | let a, b;
    :        ^
@@ -130,7 +130,7 @@
   x define-rule-plugin(create-once): before hook:
   | createOnce call count: 1
   | this === rule: true
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
@@ -138,42 +138,42 @@
 
   x define-rule-plugin(create-once): after hook:
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-rule-plugin(create-once-after-only): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-rule-plugin(create-once-before-false): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-rule-plugin(create-once-before-false): after hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-rule-plugin(create-once-before-only): before hook:
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
   x define-rule-plugin(create): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
@@ -181,42 +181,42 @@
 
   x define-rule-plugin(create-once): ident visit fn "c":
   | identNum: 1
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-rule-plugin(create-once-after-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-rule-plugin(create-once-before-false): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-rule-plugin(create-once-before-only): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-rule-plugin(create-once-no-hooks): ident visit fn "c":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
  1 | let c, d;
    :     ^
    `----
 
   x define-rule-plugin(create): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
@@ -224,35 +224,35 @@
 
   x define-rule-plugin(create-once): ident visit fn "d":
   | identNum: 2
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-rule-plugin(create-once-after-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-rule-plugin(create-once-before-false): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-rule-plugin(create-once-before-only): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^
    `----
 
   x define-rule-plugin(create-once-no-hooks): ident visit fn "d":
-  | filename: files/2.js
+  | filename: <fixture>/files/2.js
    ,-[files/2.js:1:8]
  1 | let c, d;
    :        ^

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -13,12 +13,6 @@ const SPAN: Node = {
   },
 };
 
-const DIR_PATH_LEN = import.meta.dirname.length + 1;
-
-const relativePath = sep === '/'
-  ? (path: string) => path.slice(DIR_PATH_LEN)
-  : (path: string) => path.slice(DIR_PATH_LEN).replace(/\\/g, '/');
-
 const createRule = defineRule({
   create(context) {
     context.report({ message: `create body:\nthis === rule: ${this === createRule}`, node: SPAN });
@@ -26,7 +20,7 @@ const createRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\nfilename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\nfilename: ${context.filename}`,
           node,
         });
       },
@@ -44,7 +38,8 @@ const createOnceRule = defineRule({
 
     // `fileNum` should be different for each file.
     // `identNum` should start at 1 for each file.
-    let fileNum = 0, identNum: number;
+    let fileNum = 0,
+      identNum: number;
     // Note: Files are processed in unpredictable order, so `files/1.js` may be `fileNum` 1 or 2.
     // Therefore, collect all visits and check them in `after` hook of the 2nd file.
     const visits: { fileNum: number; identNum: number }[] = [];
@@ -59,10 +54,11 @@ const createOnceRule = defineRule({
         identNum = 0;
 
         context.report({
-          message: 'before hook:\n' +
+          message:
+            'before hook:\n' +
             `createOnce call count: ${createOnceCallCount}\n` +
             `this === rule: ${topLevelThis === createOnceRule}\n` +
-            `filename: ${relativePath(context.filename)}`,
+            `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -71,17 +67,13 @@ const createOnceRule = defineRule({
         visits.push({ fileNum, identNum });
 
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `identNum: ${identNum}\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `identNum: ${identNum}\n` + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -113,8 +105,7 @@ const createOnceBeforeFalseRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
 
@@ -123,15 +114,13 @@ const createOnceBeforeFalseRule = defineRule({
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -146,15 +135,13 @@ const createOnceBeforeOnlyRule = defineRule({
     return {
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
@@ -167,15 +154,13 @@ const createOnceAfterOnlyRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -189,15 +174,13 @@ const createOnceHooksOnlyRule = defineRule({
       // Neither hook should be called, because no AST node visitor functions
       before() {
         context.report({
-          message: 'before hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'before hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
       after() {
         context.report({
-          message: 'after hook:\n' +
-            `filename: ${relativePath(context.filename)}`,
+          message: 'after hook:\n' + `filename: ${context.filename}`,
           node: SPAN,
         });
       },
@@ -210,8 +193,7 @@ const createOnceNoHooksRule = defineRule({
     return {
       Identifier(node) {
         context.report({
-          message: `ident visit fn "${node.name}":\n` +
-            `filename: ${relativePath(context.filename)}`,
+          message: `ident visit fn "${node.name}":\n` + `filename: ${context.filename}`,
           node,
         });
       },

--- a/apps/oxlint/test/fixtures/message_id_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_error/output.snap.md
@@ -4,9 +4,9 @@
 # stdout
 ```
   x Error running JS plugin.
-  | File path: <root>/apps/oxlint/test/fixtures/message_id_error/files/index.js
+  | File path: <fixture>/files/index.js
   | Error: Unknown messageId 'unknownMessage'. Available `messageIds`: 'validMessage'
-  |     at DebuggerStatement (<root>/apps/oxlint/test/fixtures/message_id_error/plugin.ts:18:21)
+  |     at DebuggerStatement (<fixture>/plugin.ts:18:21)
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file using X threads.


### PR DESCRIPTION
When replacing absolute paths in fixture snapshots, replace paths anywhere in the output, rather than only in certain specified patterns.

Additionally, introduce `<fixtures>` and `<fixture>` replacements to shorten paths in snapshots.

```diff
- File path: <root>/apps/oxlint/test/fixtures/fixture_name/files/1.js
+ File path: <fixture>/files/1.js
- File path: <root>/apps/oxlint/test/fixtures
+ File path: <fixtures>
```

This allows removing the `relativePath` helper function from some test plugins, outputting paths (e.g. `cwd`) anywhere, and generally will avoid problems with snapshots being system-dependent, and dependent on directory layout of fixtures.

Also, amend ESLint `stdout` output in snapshots to align all rule names, to reduce churn in snapshots, and avoid mismatches between local and CI (presumably due to differences in terminal width).

```diff
- filename: <fixture>/files/1.js                              define-plugin-plugin/create-once
- filename: <fixture>/files/long_filename.js                              define-plugin-plugin/create-once
- filename: <fixture>/files/very_long_filename.js                              define-plugin-plugin/create-once
+ filename: <fixture>/files/1.js                                 define-plugin-plugin/create-once
+ filename: <fixture>/files/long_filename.js                     define-plugin-plugin/create-once
+ filename: <fixture>/files/very_long_filename.js                define-plugin-plugin/create-once
```