### PR TITLE
refactor(linter/plugins): rename var

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -74,7 +74,7 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
     Arc::new(
         move |file_path: String,
               rule_ids: Vec<u32>,
-              stringified_settings: String,
+              settings_json: String,
               allocator: &Allocator| {
             let cb = Arc::clone(&cb);
 
@@ -91,7 +91,7 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
 
             // Send data to JS
             let status = cb.call_with_return_value(
-                FnArgs::from((file_path, buffer_id, buffer, rule_ids, stringified_settings)),
+                FnArgs::from((file_path, buffer_id, buffer, rule_ids, settings_json)),
                 ThreadsafeFunctionCallMode::NonBlocking,
                 move |result, _env| {
                     let _ = match &result {

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -448,7 +448,7 @@ impl Linter {
         // for a `RawTransferMetadata`. `end_ptr` is aligned for `RawTransferMetadata`.
         unsafe { metadata_ptr.write(metadata) };
 
-        let stringified_settings: String = match &ctx_host.settings().json {
+        let settings_json = match &ctx_host.settings().json {
             Some(json) => serde_json::to_string(&json).unwrap_or_else(|e| {
                 let path = path.to_string_lossy();
                 let message = format!("Error serializing settings.\nFile path: {path}\n{e}");
@@ -464,7 +464,7 @@ impl Linter {
         let result = (external_linter.lint_file)(
             path.to_str().unwrap().to_string(),
             external_rules.iter().map(|(rule_id, _)| rule_id.raw()).collect(),
-            stringified_settings,
+            settings_json,
             allocator,
         );
         match result {


### PR DESCRIPTION
Tiny refactor. Just rename vars to better describe what they contain.