### PR TITLE
perf(linter/plugins): remove `Arc`s

### DIFF
--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -1,10 +1,10 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use serde::Deserialize;
 
 use oxc_allocator::Allocator;
 
-pub type ExternalLinterLoadPluginCb = Arc<
+pub type ExternalLinterLoadPluginCb = Box<
     dyn Fn(
             String,
             Option<String>,
@@ -13,7 +13,7 @@ pub type ExternalLinterLoadPluginCb = Arc<
         + Sync,
 >;
 
-pub type ExternalLinterLintFileCb = Arc<
+pub type ExternalLinterLintFileCb = Box<
     dyn Fn(String, Vec<u32>, String, &Allocator) -> Result<Vec<LintFileResult>, String>
         + Sync
         + Send,
@@ -47,7 +47,6 @@ pub struct JsFix {
     pub text: String,
 }
 
-#[derive(Clone)]
 pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -94,7 +94,7 @@ fn size_asserts() {
     assert_eq!(size_of::<RuleEnum>(), 16);
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[expect(clippy::struct_field_names)]
 pub struct Linter {
     options: LintOptions,


### PR DESCRIPTION
Remove 2 levels of `Arc`s from `ExternalLinter`.

1. Make wrapped callback functions `Box<dyn Fn>` instead of `Arc<dyn Fn>`.
2. Avoid wrapping `ThreadsafeFunction`s in `Arc`. The closures take ownership of them anyway. In `wrap_load_plugin`, make the inner closure borrow the `ThreadsafeFunction` from the outer closure.

The first of these (and possibly the 2nd too) was prevented previously by `#[derive(Clone)]` on `Linter`. `Linter` doesn't appear to need to be cloned, so remove that derive.
