### PR TITLE
refactor(language_server): add `lint_file_on_change` and `lint_file_on_save` beside `lint_file`

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -23,7 +23,6 @@ use crate::{
     code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC,
     commands::{FIX_ALL_COMMAND_ID, FixAllCommandArgs},
     file_system::LSPFileSystem,
-    linter::options::Run,
     options::WorkspaceOption,
     worker::WorkspaceWorker,
 };
@@ -448,11 +447,7 @@ impl LanguageServer for Backend {
             self.file_system.write().await.remove(uri);
         }
 
-        if !worker.should_lint_on_run_type(Run::OnSave).await {
-            return;
-        }
-
-        if let Some(diagnostics) = worker.lint_file(uri, None).await {
+        if let Some(diagnostics) = worker.lint_file_on_save(uri, None).await {
             self.client
                 .publish_diagnostics(
                     uri.clone(),
@@ -480,11 +475,7 @@ impl LanguageServer for Backend {
             self.file_system.write().await.set(uri, content.clone());
         }
 
-        if !worker.should_lint_on_run_type(Run::OnType).await {
-            return;
-        }
-
-        if let Some(diagnostics) = worker.lint_file(uri, content).await {
+        if let Some(diagnostics) = worker.lint_file_on_change(uri, content).await {
             self.client
                 .publish_diagnostics(
                     uri.clone(),

--- a/crates/oxc_language_server/src/options.rs
+++ b/crates/oxc_language_server/src/options.rs
@@ -1,17 +1,6 @@
 use serde::{Deserialize, Serialize};
 use tower_lsp_server::lsp_types::Uri;
 
-use crate::{formatter::options::FormatOptions, linter::options::LintOptions};
-
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Options {
-    #[serde(flatten)]
-    pub lint: LintOptions,
-    #[serde(flatten)]
-    pub format: FormatOptions,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceOption {


### PR DESCRIPTION
> This PR refactors the linter run-time logic by moving the Run mode check from the caller level (should_lint_on_run_type in WorkspaceWorker) to the implementation level within ServerLinter. This simplifies the API and encapsulates the run mode logic closer to where it's used.

And now the Backend & Worker does not know about the tools' configuration (beside the naming, which will be fixed later)