### PR TITLE
feat(parser): show allowed modifiers in invalid modifier error messages

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -96,6 +96,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::ABSTRACT,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
 
@@ -226,6 +227,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             &modifiers,
             ModifierFlags::all() - ModifierFlags::EXPORT,
+            false,
             diagnostics::cannot_appear_on_class_elements,
         );
 
@@ -292,7 +294,10 @@ impl<'a> ParserImpl<'a> {
                             ));
                         }
                     }
-                    _ => self.error(diagnostics::cannot_appear_on_an_index_signature(modifier)),
+                    _ => self.error(diagnostics::cannot_appear_on_an_index_signature(
+                        modifier,
+                        Some(ModifierFlags::READONLY | ModifierFlags::STATIC),
+                    )),
                 }
             }
 
@@ -336,6 +341,7 @@ impl<'a> ParserImpl<'a> {
                     self.verify_modifiers(
                         modifiers,
                         ModifierFlags::all() - ModifierFlags::ACCESSIBILITY,
+                        false,
                         diagnostics::accessibility_modifier_on_private_property,
                     );
                 }
@@ -382,6 +388,7 @@ impl<'a> ParserImpl<'a> {
                 | ModifierFlags::STATIC
                 | ModifierFlags::ABSTRACT
                 | ModifierFlags::OVERRIDE,
+            true,
             diagnostics::accessor_modifier,
         );
         self.ast.class_element_accessor_property(
@@ -430,6 +437,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::all() - ModifierFlags::ASYNC - ModifierFlags::DECLARE,
+            false,
             diagnostics::modifier_cannot_be_used_here,
         );
         ClassElement::MethodDefinition(method_definition)
@@ -505,12 +513,28 @@ impl<'a> ParserImpl<'a> {
             for modifier in modifiers.iter() {
                 match modifier.kind {
                     ModifierKind::Declare => {
-                        self.error(diagnostics::cannot_appear_on_class_elements(modifier));
+                        self.error(diagnostics::cannot_appear_on_class_elements(
+                            modifier,
+                            Some(
+                                ModifierFlags::ACCESSIBILITY
+                                    | ModifierFlags::STATIC
+                                    | ModifierFlags::ABSTRACT
+                                    | ModifierFlags::OVERRIDE
+                                    | ModifierFlags::ASYNC,
+                            ),
+                        ));
                     }
                     ModifierKind::Readonly => {
                         self.error(
                             diagnostics::modifier_only_on_property_declaration_or_index_signature(
                                 modifier,
+                                Some(
+                                    ModifierFlags::ACCESSIBILITY
+                                        | ModifierFlags::STATIC
+                                        | ModifierFlags::ABSTRACT
+                                        | ModifierFlags::OVERRIDE
+                                        | ModifierFlags::ASYNC,
+                                ),
                             ),
                         );
                     }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -81,12 +81,14 @@ impl<'a> ParserImpl<'a> {
             self.verify_modifiers(
                 &modifiers,
                 allowed_modifiers,
+                true,
                 diagnostics::cannot_appear_on_a_parameter,
             );
         } else {
             self.verify_modifiers(
                 &modifiers,
                 ModifierFlags::empty(),
+                true,
                 diagnostics::parameter_modifiers_in_ts,
             );
         }
@@ -170,6 +172,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::ASYNC,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
 

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -68,6 +68,7 @@ impl<'a> ParserImpl<'a> {
             self.verify_modifiers(
                 &modifiers,
                 ModifierFlags::ASYNC,
+                true,
                 diagnostics::modifier_cannot_be_used_here,
             );
             let method = self.parse_method(
@@ -89,6 +90,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             &modifiers,
             ModifierFlags::empty(),
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
 
@@ -210,6 +212,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::empty(),
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
         self.ast.alloc_object_property(

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -39,6 +39,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::CONST,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
         self.ast.declaration_ts_enum(
@@ -172,6 +173,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
 
@@ -200,6 +202,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
         if let Some((implements_kw_span, _)) = implements {
@@ -253,6 +256,7 @@ impl<'a> ParserImpl<'a> {
             self.verify_modifiers(
                 &modifiers,
                 ModifierFlags::READONLY,
+                true,
                 diagnostics::cannot_appear_on_an_index_signature,
             );
             return TSSignature::TSIndexSignature(
@@ -263,6 +267,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             &modifiers,
             ModifierFlags::READONLY,
+            true,
             diagnostics::cannot_appear_on_a_type_member,
         );
 
@@ -396,6 +401,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE,
+            true,
             diagnostics::modifier_cannot_be_used_here,
         );
         self.ast.alloc_ts_module_declaration(
@@ -440,6 +446,7 @@ impl<'a> ParserImpl<'a> {
                 self.verify_modifiers(
                     modifiers,
                     ModifierFlags::DECLARE,
+                    true,
                     diagnostics::modifier_cannot_be_used_here,
                 );
                 let decl = self.parse_variable_declaration(

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -190,6 +190,7 @@ impl<'a> ParserImpl<'a> {
         self.verify_modifiers(
             &modifiers,
             ModifierFlags::IN | ModifierFlags::OUT | ModifierFlags::CONST,
+            false, // `in` and `out` are only allowed on a type parameter of a class, interface or type alias
             diagnostics::cannot_appear_on_a_type_parameter,
         );
 
@@ -1198,7 +1199,7 @@ impl<'a> ParserImpl<'a> {
                 if modifier.kind == ModifierKind::Readonly {
                     self.error(
                         diagnostics::modifier_only_on_property_declaration_or_index_signature(
-                            modifier,
+                            modifier, None,
                         ),
                     );
                 }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -5593,12 +5593,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ ({ async a });
    ·    ─────
    ╰────
+  help: No modifiers are allowed here.
 
   × 'async' modifier cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/5/input.js:1:4]
  1 │ ({ async a: function () {} });
    ·    ─────
    ╰────
+  help: No modifiers are allowed here.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/6/input.js:1:15]
@@ -12463,6 +12465,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  5 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × Function implementation is missing or not immediately following the declaration.
    ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/input.js:2:3]
@@ -12495,6 +12498,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  5 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × Function implementation is missing or not immediately following the declaration.
    ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/input.js:2:3]
@@ -12918,6 +12922,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  3 │   private accessor #p: any;
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(18010): An accessibility modifier cannot be used with a private identifier.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/accessor-invalid/input.ts:3:3]
@@ -12944,6 +12949,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ·   ────────
  10 │ }
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(1092): Type parameters cannot appear on a constructor declaration
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-type-parameters/input.ts:2:14]
@@ -13010,6 +13016,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/declare-new-line-abstract/input.ts:1:8]
@@ -13124,6 +13131,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  7 │   declare *f() {}
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1031): 'declare' modifier cannot appear on class elements of this kind.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:7:3]
@@ -13132,6 +13140,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  8 │   protected *g() {}
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/generator-method-with-modifiers/input.ts:5:13]
@@ -13163,6 +13172,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·     ────────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × The keyword 'private' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifier-name-parameters/input.ts:2:15]
@@ -13195,6 +13205,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  3 │   declare [key: string]: string;
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'declare' modifier cannot appear on an index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:3:3]
@@ -13203,6 +13214,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  4 │   private [key: string]: string;
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'private' modifier cannot appear on an index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:4:3]
@@ -13211,6 +13223,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  5 │   public [key: string]: string;
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'public' modifier cannot appear on an index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:5:3]
@@ -13219,6 +13232,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  6 │   protected [key: string]: string;
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'protected' modifier cannot appear on an index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:6:3]
@@ -13227,6 +13241,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ─────────
  7 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'override' modifier cannot appear on an index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-override-errors/input.ts:3:3]
@@ -13235,6 +13250,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  4 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × Expected `;` but found `Identifier`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-async-error/input.js:3:12]
@@ -13260,6 +13276,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  4 │   declare *f?() { }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1031): 'declare' modifier cannot appear on class elements of this kind.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:4:3]
@@ -13268,6 +13285,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  5 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1245): Method 'd?.d' cannot have an implementation because it is marked abstract.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:8:14]
@@ -13284,6 +13302,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ·   ────────
  10 │   declare *[f?.f]?() { }
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1031): 'declare' modifier cannot appear on class elements of this kind.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:10:3]
@@ -13292,6 +13311,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ·   ───────
  11 │ }
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/optional-generator-method-with-invalid-modifiers/input.ts:2:13]
@@ -13316,6 +13336,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ────────
  4 │         public pu: number,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:4:9]
@@ -13324,6 +13345,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ──────
  5 │         protected po?,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'protected' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:5:9]
@@ -13332,6 +13354,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ─────────
  6 │         private pi?: number,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:6:9]
@@ -13340,6 +13363,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ───────
  7 │         public readonly pur,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:9]
@@ -13348,6 +13372,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ──────
  8 │         // Also works on AssignmentPattern
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:16]
@@ -13356,6 +13381,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                ────────
  8 │         // Also works on AssignmentPattern
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:9:9]
@@ -13364,6 +13390,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ·         ────────
  10 │         public y?: number = 0) {}
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:10:9]
@@ -13372,6 +13399,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ·         ──────
  11 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:9]
@@ -13584,6 +13612,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  3 │   public pu: number,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:3:3]
@@ -13592,6 +13621,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  4 │   protected po?,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'protected' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:4:3]
@@ -13600,6 +13630,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ─────────
  5 │   private pi?: number,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:5:3]
@@ -13608,6 +13639,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  6 │   public readonly pur,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:3]
@@ -13616,6 +13648,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  7 │   readonly x = 0,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:10]
@@ -13624,6 +13657,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·          ────────
  7 │   readonly x = 0,
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:7:3]
@@ -13632,6 +13666,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  8 │   public y?: number = 0
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:8:3]
@@ -13640,6 +13675,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  9 │ ) {}
    ╰────
+  help: No modifiers are allowed here.
 
   × A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:3]
@@ -13707,6 +13743,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    · ────────
  2 │   foo: string;
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/declare-new-line/input.ts:1:8]
@@ -13722,6 +13759,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·        ────────
  2 │ 
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/export-default/input.ts:1:26]
@@ -13829,6 +13867,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  3 │   public b();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'public' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:3:3]
@@ -13837,6 +13876,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  4 │   protected c();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'protected' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:4:3]
@@ -13845,6 +13885,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ─────────
  5 │   static d();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'static' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:5:3]
@@ -13853,6 +13894,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  6 │   declare e();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'declare' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:6:3]
@@ -13861,6 +13903,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  7 │   abstract f();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'abstract' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:7:3]
@@ -13869,6 +13912,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  8 │   readonly g();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method/input.ts:8:3]
@@ -13885,6 +13929,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  3 │   public b();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'public' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:3:3]
@@ -13893,6 +13938,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  4 │   protected c();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'protected' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:4:3]
@@ -13901,6 +13947,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ─────────
  5 │   static d();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'static' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:5:3]
@@ -13909,6 +13956,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  6 │   declare e();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'declare' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:6:3]
@@ -13917,6 +13965,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  7 │   abstract f();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'abstract' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:7:3]
@@ -13925,6 +13974,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  8 │   readonly g();
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-method-babel-7/input.ts:8:3]
@@ -13941,6 +13991,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  3 │   public b;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'public' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts:3:3]
@@ -13949,6 +14000,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  4 │   protected c;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'protected' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts:4:3]
@@ -13957,6 +14009,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ─────────
  5 │   static d;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'static' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts:5:3]
@@ -13965,6 +14018,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ──────
  6 │   declare e;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'declare' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts:6:3]
@@ -13973,6 +14027,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ───────
  7 │   abstract f;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'abstract' modifier cannot appear on a type member.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-modifiers-property/input.ts:7:3]
@@ -13981,6 +14036,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ────────
  8 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × Expected `(` but found `:`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-set-properties/input.ts:2:10]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -300,6 +300,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'async' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-10.ts:2:2]
@@ -308,6 +309,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ─────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'const' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-11.ts:2:2]
@@ -316,6 +318,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ─────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'const' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-12.ts:2:2]
@@ -324,6 +327,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ─────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'const' modifier cannot appear on an index signature.
    ╭─[misc/fail/oxc-11713-13.ts:2:3]
@@ -332,6 +336,7 @@ Negative Passed: 107/107 (100.00%)
    ·   ─────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'const' modifier cannot appear on an index signature.
    ╭─[misc/fail/oxc-11713-14.ts:2:2]
@@ -340,6 +345,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ─────
  3 │ } = {};
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'declare' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-15.ts:2:2]
@@ -348,6 +354,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'declare' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-16.ts:2:2]
@@ -356,6 +363,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'default' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-17.ts:2:2]
@@ -364,6 +372,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'default' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-18.ts:2:2]
@@ -372,6 +381,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'default' modifier cannot appear on an index signature.
    ╭─[misc/fail/oxc-11713-19.ts:2:2]
@@ -380,6 +390,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'static' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-2.ts:2:2]
@@ -388,6 +399,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ──────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'default' modifier cannot appear on an index signature.
    ╭─[misc/fail/oxc-11713-20.ts:2:2]
@@ -396,6 +408,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ───────
  3 │ } = {};
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'export' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-21.ts:2:2]
@@ -404,6 +417,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ──────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'export' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-22.ts:2:2]
@@ -412,6 +426,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ──────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[misc/fail/oxc-11713-23.ts:2:3]
@@ -428,6 +443,7 @@ Negative Passed: 107/107 (100.00%)
    ·   ───────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1024): 'readonly' modifier can only appear on a property declaration or index signature.
    ╭─[misc/fail/oxc-11713-25.ts:2:3]
@@ -436,24 +452,28 @@ Negative Passed: 107/107 (100.00%)
    ·   ────────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-26.ts:1:14]
  1 │ function foo(readonly parameter) {}
    ·              ────────
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-27.ts:1:20]
  1 │ class Foo { method(readonly parameter) {} }
    ·                    ────────
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[misc/fail/oxc-11713-3.ts:1:14]
  1 │ function foo(private parameter) {}
    ·              ───────
    ╰────
+  help: No modifiers are allowed here.
 
   × 'declare' modifier cannot be used here.
    ╭─[misc/fail/oxc-11713-4.ts:2:2]
@@ -470,6 +490,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'abstract' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-6.ts:2:2]
@@ -478,6 +499,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'accessor' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-7.ts:2:2]
@@ -486,6 +508,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'accessor' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-8.ts:2:2]
@@ -494,6 +517,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'async' modifier cannot appear on a type member.
    ╭─[misc/fail/oxc-11713-9.ts:2:2]
@@ -502,6 +526,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ─────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1098): Type parameter list cannot be empty.
    ╭─[misc/fail/oxc-11789-1.ts:1:12]
@@ -3174,6 +3199,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ────────
  3 │ 
    ╰────
+  help: Only 'async' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
    ╭─[misc/fail/oxc-3948.ts:5:5]
@@ -3182,6 +3208,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ──────
  6 │ 
    ╰────
+  help: Only 'async' modifier is allowed here.
 
   × 'readonly' modifier cannot be used here.
    ╭─[misc/fail/oxc-3948.ts:5:12]
@@ -3190,6 +3217,7 @@ Negative Passed: 107/107 (100.00%)
    ·            ────────
  6 │ 
    ╰────
+  help: Only 'async' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
    ╭─[misc/fail/oxc-3948.ts:8:5]
@@ -3198,6 +3226,7 @@ Negative Passed: 107/107 (100.00%)
    ·     ──────
  9 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(8037): Type assertion expressions can only be used in TypeScript files.
    ╭─[misc/fail/oxc-4111-1.js:1:1]

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -18998,6 +18998,7 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ·   ─────
  19 │ })
     ╰────
+  help: No modifiers are allowed here.
 
   × Expected `:` but found `Identifier`
     ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-method-formals-body-duplicate.js:18:18]
@@ -19557,6 +19558,7 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
  36 │ ({async async});
     ·   ─────
     ╰────
+  help: No modifiers are allowed here.
 
   × Expected `(` but found `}`
     ╭─[test262/test/language/expressions/object/prop-def-invalid-star-prefix.js:22:8]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -4441,6 +4441,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ var v = (public x: string) => { };
    ·          ──────
    ╰────
+  help: No modifiers are allowed here.
 
   × Constructor implementation is missing.
    ╭─[typescript/tests/cases/compiler/ClassDeclaration10.ts:2:4]
@@ -4594,6 +4595,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  3 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList13.ts:2:10]
@@ -4602,6 +4604,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·          ──────
  3 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList4.ts:1:12]
@@ -4609,6 +4612,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  2 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList5.ts:1:16]
@@ -4616,6 +4620,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                ──────
  2 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/ParameterList6.ts:2:19]
@@ -4624,6 +4629,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                   ──────
  3 │   }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(2369): A parameter property is only allowed in a constructor implementation.
    ╭─[typescript/tests/cases/compiler/ParameterList7.ts:2:14]
@@ -4704,6 +4710,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·           ──────
  3 │     static set X(public v2) { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/accessorParameterAccessibilityModifier.ts:3:18]
@@ -4712,6 +4719,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                  ──────
  4 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × A 'set' accessor cannot have an initializer.
    ╭─[typescript/tests/cases/compiler/accessorWithInitializer.ts:2:10]
@@ -6687,6 +6695,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                  ──────
  3 │     }
    ╰────
+  help: Allowed modifiers are: private, protected, public, readonly, override
 
   × TS(1090): 'static' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/constructorArgsErrors2.ts:2:25]
@@ -6695,6 +6704,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                         ──────
  3 │     }
    ╰────
+  help: Allowed modifiers are: private, protected, public, readonly, override
 
   × TS(1028): Accessibility modifier already seen.
    ╭─[typescript/tests/cases/compiler/constructorArgsErrors3.ts:2:25]
@@ -6721,6 +6731,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                  ──────
  3 │     }
    ╰────
+  help: Allowed modifiers are: private, protected, public, readonly, override
 
   × Multiple constructor implementations are not allowed.
    ╭─[typescript/tests/cases/compiler/constructorOverloads1.ts:4:5]
@@ -6977,6 +6988,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  4 │ default class {}
    · ───────
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × A class name is required.
    ╭─[typescript/tests/cases/compiler/defaultKeywordWithoutExport1.ts:3:1]
@@ -8009,6 +8021,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  3 │     export export function f() { }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:3:12]
@@ -8025,6 +8038,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  4 │ 
    ╰────
+  help: Allowed modifiers are: declare, async
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:5:12]
@@ -8049,6 +8063,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                ──────
  7 │         export export interface I { }
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:7:16]
@@ -8065,6 +8080,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                ──────
  8 │     }  
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'export' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:5:12]
@@ -8073,6 +8089,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  6 │         export export class C { }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:12:12]
@@ -8089,6 +8106,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·            ──────
  13 │     export export function f()
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:13:12]
@@ -8105,6 +8123,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·            ──────
  14 │ 
     ╰────
+  help: Allowed modifiers are: declare, async
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:15:12]
@@ -8129,6 +8148,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                ──────
  17 │         export export interface I { }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:17:16]
@@ -8145,6 +8165,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                ──────
  18 │     }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'export' modifier cannot be used here.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:15:12]
@@ -8153,6 +8174,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·            ──────
  16 │         export export class C { }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts:2:16]
@@ -8525,6 +8547,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  5 │ }
    ╰────
+  help: Allowed modifiers are: declare, async
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/genericCallWithoutArgs.ts:4:18]
@@ -9150,6 +9173,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ class C { constructor(public x) { }}
    ·                       ──────
    ╰────
+  help: No modifiers are allowed here.
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/jsFileCompilationReturnTypeSyntaxOfFunction.ts:1:13]
@@ -9988,6 +10012,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                ───────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, readonly, override
 
   × 'public' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/modifiersInObjectLiterals.ts:2:2]
@@ -9996,6 +10021,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  3 │     private bar: 'nay',
    ╰────
+  help: No modifiers are allowed here.
 
   × 'private' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/modifiersInObjectLiterals.ts:3:2]
@@ -10004,6 +10030,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  4 │     protected baz: 'oh my',
    ╰────
+  help: No modifiers are allowed here.
 
   × 'protected' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/modifiersInObjectLiterals.ts:4:2]
@@ -10012,6 +10039,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ─────────
  5 │     abstract noWay: 'yes'   
    ╰────
+  help: No modifiers are allowed here.
 
   × 'abstract' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/modifiersInObjectLiterals.ts:5:2]
@@ -10020,6 +10048,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ────────
  6 │ };
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1071): 'public' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/compiler/modifiersOnInterfaceIndexSignature1.ts:2:3]
@@ -10028,6 +10057,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·   ──────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × Identifier `Kettle` has already been declared
     ╭─[typescript/tests/cases/compiler/moduleDuplicateIdentifiers.ts:20:14]
@@ -10575,12 +10605,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ var v = { public foo() { } }
    ·           ──────
    ╰────
+  help: Only 'async' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
    ╭─[typescript/tests/cases/compiler/objectLiteralMemberWithModifiers2.ts:1:11]
  1 │ var v = { public get foo() { } }
    ·           ──────
    ╰────
+  help: No modifiers are allowed here.
 
   × Expected `,` or `}` but found `?`
    ╭─[typescript/tests/cases/compiler/objectLiteralMemberWithQuestionMark1.ts:1:14]
@@ -11020,6 +11052,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·         ──────
  3 │     }
    ╰────
+  help: No modifiers are allowed here.
 
   × Expected `,` or `)` but found `:`
    ╭─[typescript/tests/cases/compiler/parametersSyntaxErrorNoCrash1.ts:3:28]
@@ -11598,6 +11631,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ────────
  4 │     set x(readonly value: number) {}
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:4:8]
@@ -11606,6 +11640,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·           ────────
  5 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'readonly' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:6:2]
@@ -11614,6 +11649,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·  ────────
  7 │ // OK to use `readonly` as a name
    ╰────
+  help: No modifiers are allowed here.
 
   × Identifier `bar` has already been declared
    ╭─[typescript/tests/cases/compiler/reassignStaticProp.ts:3:12]
@@ -14313,6 +14349,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × Constructor can't be an async method
    ╭─[typescript/tests/cases/conformance/async/es5/asyncConstructor_es5.ts:2:9]
@@ -14328,6 +14365,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │   Value
    ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es5/asyncGetter_es5.ts:2:3]
@@ -14343,6 +14381,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es5/asyncModule_es5.ts:1:1]
@@ -14350,6 +14389,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es5/asyncSetter_es5.ts:2:3]
@@ -14447,6 +14487,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × Constructor can't be an async method
    ╭─[typescript/tests/cases/conformance/async/es6/asyncConstructor_es6.ts:2:9]
@@ -14462,6 +14503,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │   Value
    ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es6/asyncGetter_es6.ts:2:3]
@@ -14477,6 +14519,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es6/asyncModule_es6.ts:1:1]
@@ -14484,6 +14527,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'async' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/async/es6/asyncSetter_es6.ts:2:3]
@@ -14829,6 +14873,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ abstract interface I {}
    · ────────
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × Identifier `C` has already been declared
    ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAndVariableWithSameName.ts:1:7]
@@ -15240,6 +15285,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ────────
  4 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(2369): A parameter property is only allowed in a constructor implementation.
    ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:2:14]
@@ -15317,6 +15363,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  5 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'private' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts:8:5]
@@ -15325,6 +15372,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  9 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'private' modifier cannot appear on an index signature.
     ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts:12:5]
@@ -15333,6 +15381,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  13 │ }
     ╰────
+  help: Allowed modifiers are: static, readonly
 
   × Expected `]` but found `:`
    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts:4:15]
@@ -15350,6 +15399,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  5 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'public' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts:8:5]
@@ -15358,6 +15408,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  9 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'public' modifier cannot appear on an index signature.
     ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts:12:5]
@@ -15366,6 +15417,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  13 │ }
     ╰────
+  help: Allowed modifiers are: static, readonly
 
   × Expected `;` but found `.`
     ╭─[typescript/tests/cases/conformance/classes/members/accessibility/privateInstanceMemberAccessibility.ts:12:12]
@@ -16209,6 +16261,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ────────
  12 │     declare #whatMethod()                      // Error
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(1031): 'declare' modifier cannot appear on class elements of this kind.
     ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:12:5]
@@ -16217,6 +16270,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  13 │     async #asyncMethod() { return 1; }         //OK
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × TS(18010): An accessibility modifier cannot be used with a private identifier.
     ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:17:5]
@@ -16459,6 +16513,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ────────
  4 │     declare accessor c: any;
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:4:5]
@@ -16467,6 +16522,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  5 │     accessor public d: any;
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(1276): An 'accessor' property cannot be declared optional.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:14:15]
@@ -16484,6 +16540,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·              ────────
  16 │     accessor declare n: any;
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(1243): 'accessor' modifier cannot be used with 'declare' modifier.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:16:14]
@@ -16492,6 +16549,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·              ───────
  17 │ }
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override
 
   × TS(1070): 'accessor' modifier cannot appear on a type member.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:24:5]
@@ -16500,6 +16558,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ────────
  25 │ }
     ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:27:1]
@@ -16508,6 +16567,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  28 │ accessor interface I2 {}
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:28:1]
@@ -16516,6 +16576,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  29 │ accessor namespace N1 {}
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:29:1]
@@ -16524,6 +16585,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  30 │ accessor enum E1 {}
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:30:1]
@@ -16532,6 +16594,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  31 │ accessor var V1: any;
     ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:31:1]
@@ -16540,6 +16603,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  32 │ accessor type T1 = never;
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:32:1]
@@ -16548,6 +16612,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  33 │ accessor function F1() {}
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'accessor' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:33:1]
@@ -16556,6 +16621,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     · ────────
  34 │ accessor import "x";
     ╰────
+  help: Allowed modifiers are: declare, async
 
   × Unexpected token
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts:34:17]
@@ -16585,6 +16651,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  16 │     declare nonce: any; // ok, even though it's not in the base
     ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × Function implementation is missing or not immediately following the declaration.
    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionOverloadMixingStaticAndInstance.ts:3:12]
@@ -16749,6 +16816,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  13 │     static [s: number]: 42 | 233;
     ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'static' modifier cannot appear on an index signature.
     ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature4.ts:13:5]
@@ -16757,6 +16825,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  14 │ }
     ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'static' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature5.ts:7:5]
@@ -16765,6 +16834,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  8 │     static readonly [s: number]: 42 | 233
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1071): 'static' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature5.ts:8:5]
@@ -16773,6 +16843,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  9 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
     ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:69:10]
@@ -20344,6 +20415,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │ export @dec default class C3 {}
    ·             ───────
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'default' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-exportModifier.ts:2:13]
@@ -20351,6 +20423,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │ export @dec default class C3 {}
    ·             ───────
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × TS(1249): A decorator can only decorate a method implementation, not an overload.
    ╭─[typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticAbstract.ts:6:5]
@@ -21646,6 +21719,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  4 │     private b: any;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'private' modifier cannot appear on a type member.
    ╭─[typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithAccessibilityModifiers.ts:4:5]
@@ -21654,6 +21728,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  5 │     protected c: any;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'protected' modifier cannot appear on a type member.
    ╭─[typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithAccessibilityModifiers.ts:5:5]
@@ -21662,6 +21737,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ─────────
  6 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts:5:10]
@@ -21700,6 +21776,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  5 │ 
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'public' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:6:5]
@@ -21708,6 +21785,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  7 │         id: number;
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'public' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:12:5]
@@ -21716,6 +21794,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  13 │     public interface I { id: number }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'public' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:13:5]
@@ -21724,6 +21803,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  14 │ 
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:15:5]
@@ -21732,6 +21812,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  16 │ }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'public' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:19:5]
@@ -21740,6 +21821,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  20 │         class A { s: string }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:25:5]
@@ -21748,6 +21830,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  26 │ }
     ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:29:5]
@@ -21756,6 +21839,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  30 │ 
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:31:5]
@@ -21764,6 +21848,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  32 │         id: number;
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:37:5]
@@ -21772,6 +21857,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  38 │     private interface I { id: number }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:38:5]
@@ -21780,6 +21866,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  39 │ 
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:40:5]
@@ -21788,6 +21875,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  41 │ }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:44:5]
@@ -21796,6 +21884,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  45 │         class A { s: string }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:50:5]
@@ -21804,6 +21893,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  51 │ }
     ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:55:5]
@@ -21812,6 +21902,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  56 │ 
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:57:5]
@@ -21820,6 +21911,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  58 │         id: number;
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:63:5]
@@ -21828,6 +21920,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  64 │     static interface I { id: number }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:64:5]
@@ -21836,6 +21929,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  65 │ 
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:66:5]
@@ -21844,6 +21938,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  67 │ }
     ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:70:5]
@@ -21852,6 +21947,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  71 │         class A { s: string }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithStatementsOfEveryKind.ts:76:5]
@@ -21860,6 +21956,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  77 │ }
     ╰────
+  help: Allowed modifiers are: declare, const
 
   × 'public' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:4:5]
@@ -21868,6 +21965,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  5 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'public' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:8:5]
@@ -21876,6 +21974,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  9 │ }
    ╰────
+  help: Allowed modifiers are: declare, async
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:12:5]
@@ -21884,6 +21983,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  13 │ }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'static' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:16:5]
@@ -21892,6 +21992,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ──────
  17 │ }
     ╰────
+  help: Allowed modifiers are: declare, async
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:20:5]
@@ -21900,6 +22001,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  21 │ }
     ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'private' modifier cannot be used here.
     ╭─[typescript/tests/cases/conformance/internalModules/moduleBody/invalidModuleWithVarStatements.ts:25:5]
@@ -21908,6 +22010,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  26 │ }
     ╰────
+  help: Allowed modifiers are: declare, async
 
   × Identifier `Point` has already been declared
    ╭─[typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidInstantiatedModule.ts:2:18]
@@ -22445,6 +22548,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ────────
  9 │     baz(): void;
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'override' modifier cannot appear on a type member.
     ╭─[typescript/tests/cases/conformance/override/override9.ts:10:5]
@@ -22453,6 +22557,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ────────
  11 │ }
     ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1090): 'override' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/override/overrideParameterProperty.ts:25:5]
@@ -22461,6 +22566,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ────────
  26 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × Cannot use `await` as an identifier in an async context
    ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.classMethods.es2018.ts:2:15]
@@ -22571,6 +22677,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·   ──────
  3 │ };
    ╰────
+  help: No modifiers are allowed here.
 
   × A 'get' accessor must not have any formal parameters.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors7.ts:1:18]
@@ -22598,6 +22705,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ var v = (public x: string) => { };
    ·          ──────
    ╰────
+  help: No modifiers are allowed here.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts:1:19]
@@ -23426,6 +23534,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ──────
  3 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserPublicBreak1.ts:1:7]
@@ -23684,6 +23793,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·    ──────
  3 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1071): 'private' modifier cannot appear on an index signature.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration8.ts:2:4]
@@ -23692,6 +23802,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·    ───────
  3 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × TS(1031): 'export' modifier cannot appear on class elements of this kind.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration9.ts:2:4]
@@ -23708,6 +23819,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·    ──────
  3 │ }
    ╰────
+  help: Allowed modifiers are: static, readonly
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature1.ts:2:4]
@@ -23808,6 +23920,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ──────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × 'static' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration4.ts:1:1]
@@ -23815,6 +23928,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ──────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration6.ts:1:8]
@@ -23829,6 +23943,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·        ──────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(2414): Interface name cannot be 'string'
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration8.ts:1:11]
@@ -23887,6 +24002,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  3 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × A 'set' accessor cannot have an initializer.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts:2:11]
@@ -23955,6 +24071,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  3 │ }
    ╰────
+  help: Allowed modifiers are: private, protected, public, static, abstract, override, async
 
   × Identifier `public` has already been declared
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclarationAmbiguities1.ts:2:3]
@@ -24103,6 +24220,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·          ──────
  3 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × A required parameter cannot follow an optional parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList3.ts:2:9]
@@ -24118,6 +24236,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·            ──────
  2 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList5.ts:1:16]
@@ -24125,6 +24244,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                ──────
  2 │ }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList6.ts:2:19]
@@ -24133,6 +24253,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                   ──────
  3 │   }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(2369): A parameter property is only allowed in a constructor implementation.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList7.ts:2:14]
@@ -24189,6 +24310,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────────
  2 │ }
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × 'protected' modifier cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected2.ts:1:1]
@@ -24196,6 +24318,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    · ─────────
  2 │ }
    ╰────
+  help: Only 'declare' modifier is allowed here.
 
   × TS(1028): Accessibility modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected4.ts:2:13]
@@ -24335,6 +24458,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·        ──────
  2 │   public Bar() {
    ╰────
+  help: Allowed modifiers are: declare, abstract
 
   × The keyword 'static' is reserved
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331.ts:2:18]
@@ -25256,6 +25380,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ var v = { public get [e]() { } };
    ·           ──────
    ╰────
+  help: No modifiers are allowed here.
 
   × Expected `;` but found `Identifier`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement2.ts:1:13]
@@ -26682,6 +26807,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  5 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'private' modifier cannot appear on a type member.
    ╭─[typescript/tests/cases/conformance/types/namedTypes/interfaceWithPrivateMember.ts:8:5]
@@ -26690,6 +26816,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ───────
  9 │ }
    ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1070): 'private' modifier cannot appear on a type member.
     ╭─[typescript/tests/cases/conformance/types/namedTypes/interfaceWithPrivateMember.ts:12:5]
@@ -26698,6 +26825,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·     ───────
  13 │ }
     ╰────
+  help: Only 'readonly' modifier is allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:3:14]
@@ -26706,6 +26834,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·              ──────
  4 │ var f = function foo(public x, private y) { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:3:24]
@@ -26714,6 +26843,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                        ───────
  4 │ var f = function foo(public x, private y) { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:4:22]
@@ -26722,6 +26852,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                      ──────
  5 │ var f2 = function (public x, private y) { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:4:32]
@@ -26730,6 +26861,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                                ───────
  5 │ var f2 = function (public x, private y) { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:5:20]
@@ -26738,6 +26870,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                    ──────
  6 │ var f3 = (x, private y) => { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:5:30]
@@ -26746,6 +26879,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                              ───────
  6 │ var f3 = (x, private y) => { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:6:14]
@@ -26754,6 +26888,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·              ───────
  7 │ var f4 = <T>(public x: T, y: T) => { }
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:7:14]
@@ -26762,6 +26897,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·              ──────
  8 │ 
    ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:9:15]
@@ -26770,6 +26906,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·               ───────
  10 │ var f5 = function foo(private x: string, public y: number) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:9:34]
@@ -26778,6 +26915,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                                  ──────
  10 │ var f5 = function foo(private x: string, public y: number) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:10:23]
@@ -26786,6 +26924,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                       ───────
  11 │ var f6 = function (private x: string, public y: number) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:10:42]
@@ -26794,6 +26933,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                                          ──────
  11 │ var f6 = function (private x: string, public y: number) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:11:20]
@@ -26802,6 +26942,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                    ───────
  12 │ var f7 = (private x: string, public y: number) => { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:11:39]
@@ -26810,6 +26951,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                                       ──────
  12 │ var f7 = (private x: string, public y: number) => { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:12:11]
@@ -26818,6 +26960,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·           ───────
  13 │ var f8 = <T>(private x: T, public y: T) => { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:12:30]
@@ -26826,6 +26969,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                              ──────
  13 │ var f8 = <T>(private x: T, public y: T) => { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:13:14]
@@ -26834,6 +26978,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·              ───────
  14 │ 
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:13:28]
@@ -26842,6 +26987,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                            ──────
  14 │ 
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:16:9]
@@ -26850,6 +26996,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·         ──────
  17 │     foo2(public x: number, private y: string) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:16:19]
@@ -26858,6 +27005,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                   ───────
  17 │     foo2(public x: number, private y: string) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:17:10]
@@ -26866,6 +27014,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  18 │     foo3<T>(public x: T, private y: T) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:17:28]
@@ -26874,6 +27023,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                            ───────
  18 │     foo3<T>(public x: T, private y: T) { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:18:13]
@@ -26882,6 +27032,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·             ──────
  19 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:18:26]
@@ -26890,6 +27041,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                          ───────
  19 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:22:6]
@@ -26898,6 +27050,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·      ───────
  23 │     (private x: string, public y: number);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:22:17]
@@ -26906,6 +27059,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                 ──────
  23 │     (private x: string, public y: number);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:23:6]
@@ -26914,6 +27068,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·      ───────
  24 │     foo(private x, public y);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:23:25]
@@ -26922,6 +27077,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                         ──────
  24 │     foo(private x, public y);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:24:9]
@@ -26930,6 +27086,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·         ───────
  25 │     foo(public x: number, y: string);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:24:20]
@@ -26938,6 +27095,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                    ──────
  25 │     foo(public x: number, y: string);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:25:9]
@@ -26946,6 +27104,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·         ──────
  26 │     foo3<T>(x: T, private y: T);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:26:19]
@@ -26954,6 +27113,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                   ───────
  27 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:30:9]
@@ -26962,6 +27122,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·         ──────
  31 │     foo2(private x: number, public y: string);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:30:19]
@@ -26970,6 +27131,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                   ───────
  31 │     foo2(private x: number, public y: string);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:31:10]
@@ -26978,6 +27140,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  32 │ };
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:31:29]
@@ -26986,6 +27149,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                             ──────
  32 │ };
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:35:9]
@@ -26994,6 +27158,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·         ──────
  36 │     a: function foo(x: number, private y: string) { },
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:36:32]
@@ -27002,6 +27167,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                                ───────
  37 │     b: <T>(public x: T, private y: T) => { }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:37:12]
@@ -27010,6 +27176,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·            ──────
  38 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters.ts:37:25]
@@ -27018,6 +27185,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·                         ───────
  38 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × Identifier `x` has already been declared
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters.ts:6:11]
@@ -27185,6 +27353,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  17 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:20:10]
@@ -27193,6 +27362,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  21 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:24:10]
@@ -27201,6 +27371,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  25 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:28:10]
@@ -27209,6 +27380,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  29 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:19:10]
@@ -27217,6 +27389,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  20 │     new (public x);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:20:10]
@@ -27225,6 +27398,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  21 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:24:10]
@@ -27233,6 +27407,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  25 │     new (private x);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:25:10]
@@ -27241,6 +27416,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  26 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:29:10]
@@ -27249,6 +27425,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  30 │     new (public y);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:30:10]
@@ -27257,6 +27434,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ──────
  31 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:34:10]
@@ -27265,6 +27443,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  35 │     new (private y);
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(1090): 'private' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:35:10]
@@ -27273,6 +27452,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ·          ───────
  36 │ }
     ╰────
+  help: No modifiers are allowed here.
 
   × TS(2369): A parameter property is only allowed in a constructor implementation.
    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2.ts:4:17]

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1467,6 +1467,8 @@ rebuilt        : ["x"]
     :   ^^^^^^^^
  15 | }
     `----
+  help: Allowed modifiers are: private, protected, public, static, abstract,
+        override
 
 
 * class/accessor-allowDeclareFields-true/input.ts
@@ -1490,6 +1492,8 @@ rebuilt        : ["x"]
     :   ^^^^^^^^
  15 | }
     `----
+  help: Allowed modifiers are: private, protected, public, static, abstract,
+        override
 
 
 * class/head/input.ts


### PR DESCRIPTION
Add allowed modifiers for that context so that it's easier to understand what is wrong.