### PR TITLE
feat(parser): improve error messages for missing closing parentheses

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -24,9 +24,10 @@ use crate::{
 
 impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_paren_expression(&mut self) -> Expression<'a> {
+        let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);
         let expression = self.parse_expr();
-        self.expect(Kind::RParen);
+        self.expect_closing(Kind::RParen, opening_span);
         expression
     }
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -385,8 +385,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026
   × Expected `)` but found `of`
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-await-using-binding-escaped-of-of/input.mjs:1:29]
  1 │ for await (using \u006ff of of);
-   ·                             ─┬
-   ·                              ╰── `)` expected
+   ·           ┬                 ─┬
+   ·           │                  ╰── `)` expected
+   ·           ╰── Opened here
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-using-binding-escaped-of-of/input.js
@@ -400,8 +401,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026
   × Expected `)` but found `of`
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-using-binding-escaped-of-of/input.js:1:23]
  1 │ for (using o\u0066 of of);
-   ·                       ─┬
-   ·                        ╰── `)` expected
+   ·     ┬                 ─┬
+   ·     │                  ╰── `)` expected
+   ·     ╰── Opened here
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
@@ -3277,8 +3279,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Expected `)` but found `,`
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-expr/input.js:1:16]
  1 │ for (let x of y, z) {}
-   ·                ┬
-   ·                ╰── `)` expected
+   ·     ┬          ┬
+   ·     │          ╰── `)` expected
+   ·     ╰── Opened here
    ╰────
 
   × The left-hand side of a `for...of` statement may not start with `let`
@@ -5823,8 +5826,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Expected `)` but found `;`
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-for-await-expression-init/input.js:1:23]
  1 │ for (await o\u0066 [0];;);
-   ·                       ┬
-   ·                       ╰── `)` expected
+   ·     ┬                 ┬
+   ·     │                 ╰── `)` expected
+   ·     ╰── Opened here
    ╰────
 
   × Async functions can only be declared at the top level or inside a block
@@ -9415,8 +9419,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Expected `)` but found `of`
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-await-using-binding-of-of/input.mjs:1:24]
  1 │ for await (using of of of);
-   ·                        ─┬
-   ·                         ╰── `)` expected
+   ·           ┬            ─┬
+   ·           │             ╰── `)` expected
+   ·           ╰── Opened here
    ╰────
 
   × The left-hand side of a for...in statement cannot be an using declaration.
@@ -9435,8 +9440,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Expected `)` but found `of`
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-binding-of-of/input.js:1:18]
  1 │ for (using of of of);
-   ·                  ─┬
-   ·                   ╰── `)` expected
+   ·     ┬            ─┬
+   ·     │             ╰── `)` expected
+   ·     ╰── Opened here
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -1755,8 +1755,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/asi/S7.9_A6.4_T1.js:19:22]
  18 │ //CHECK#1
  19 │ for(false;false;false;) {
-    ·                      ┬
-    ·                      ╰── `)` expected
+    ·    ┬                 ┬
+    ·    │                 ╰── `)` expected
+    ·    ╰── Opened here
  20 │   break;
     ╰────
 
@@ -33616,8 +33617,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A4.1.js:23:18]
  22 │ //CHECK#1
  23 │ for (var a in arr;1;){
-    ·                  ┬
-    ·                  ╰── `)` expected
+    ·     ┬            ┬
+    ·     │            ╰── `)` expected
+    ·     ╰── Opened here
  24 │     break;
     ╰────
 
@@ -33625,8 +33627,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A4_T1.js:23:14]
  22 │ //CHECK#1
  23 │ for (a in arr;1;){
-    ·              ┬
-    ·              ╰── `)` expected
+    ·     ┬        ┬
+    ·     │        ╰── `)` expected
+    ·     ╰── Opened here
  24 │     break;
     ╰────
 
@@ -33642,8 +33645,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A7.1_T1.js:22:35]
  21 │ //CHECK#1
  22 │ for(var index=0; index<10; index++; index--);
-    ·                                   ┬
-    ·                                   ╰── `)` expected
+    ·    ┬                              ┬
+    ·    │                              ╰── `)` expected
+    ·    ╰── Opened here
  23 │ //
     ╰────
 
@@ -33651,8 +33655,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A7.1_T2.js:22:36]
  21 │ //CHECK#1
  22 │ for(var index=0; index<10; index+=4; index++; index--) ;
-    ·                                    ┬
-    ·                                    ╰── `)` expected
+    ·    ┬                               ┬
+    ·    │                               ╰── `)` expected
+    ·    ╰── Opened here
  23 │ //
     ╰────
 
@@ -33660,8 +33665,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A7_T1.js:22:31]
  21 │ //CHECK#1
  22 │ for(index=0; index<10; index++; index--) ;
-    ·                               ┬
-    ·                               ╰── `)` expected
+    ·    ┬                          ┬
+    ·    │                          ╰── `)` expected
+    ·    ╰── Opened here
  23 │ //
     ╰────
 
@@ -33669,8 +33675,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for/S12.6.3_A7_T2.js:22:32]
  21 │ //CHECK#1
  22 │ for(index=0; index<10; index+=4; index++; index--) ;
-    ·                                ┬
-    ·                                ╰── `)` expected
+    ·    ┬                           ┬
+    ·    │                           ╰── `)` expected
+    ·    ╰── Opened here
  23 │ //
     ╰────
 
@@ -35876,16 +35883,18 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for-of/head-decl-no-expr.js:18:17]
  17 │ 
  18 │ for (let x of [], []) {}
-    ·                 ┬
-    ·                 ╰── `)` expected
+    ·     ┬           ┬
+    ·     │           ╰── `)` expected
+    ·     ╰── Opened here
     ╰────
 
   × Expected `)` but found `,`
     ╭─[test262/test/language/statements/for-of/head-expr-no-expr.js:19:13]
  18 │ var x;
  19 │ for (x of [], []) {}
-    ·             ┬
-    ·             ╰── `)` expected
+    ·     ┬       ┬
+    ·     │       ╰── `)` expected
+    ·     ╰── Opened here
     ╰────
 
   × Identifier `x` has already been declared
@@ -36004,8 +36013,9 @@ Expect to Parse: tasks/coverage/test262/test/annexB/language/expressions/assignm
     ╭─[test262/test/language/statements/for-of/head-var-no-expr.js:18:17]
  17 │ 
  18 │ for (var x of [], []) {}
-    ·                 ┬
-    ·                 ╰── `)` expected
+    ·     ┬           ┬
+    ·     │           ╰── `)` expected
+    ·     ╰── Opened here
     ╰────
 
   × Invalid function declaration

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -9905,8 +9905,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╭─[typescript/tests/cases/compiler/missingCloseParenStatements.ts:2:26]
  1 │ var a1, a2, a3 = 0;
  2 │ if ( a1 && (a2 + a3 > 0) {
-   ·                          ┬
-   ·                          ╰── `)` expected
+   ·    ┬                     ┬
+   ·    │                     ╰── `)` expected
+   ·    ╰── Opened here
  3 │     while( (a2 > 0) && a1
    ╰────
 
@@ -23131,7 +23132,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 
   × Expected `)` but found `}`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement2.ts:4:3]
+ 2 │   f1() {
  3 │     if (a
+   ·        ┬
+   ·        ╰── Opened here
  4 │   }
    ·   ┬
    ·   ╰── `)` expected
@@ -23140,7 +23144,10 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 
   × Expected `)` but found `}`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement3.ts:4:3]
+ 2 │   f1() {
  3 │     if (a.b
+   ·        ┬
+   ·        ╰── Opened here
  4 │   }
    ·   ┬
    ·   ╰── `)` expected


### PR DESCRIPTION
Improves error message for imbalanced tokens for parentheses.

**Before**
```
  × Expected `)` but found `}`
   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement3.ts:4:3]
 3 │     if (a.b
 4 │   }
   ·   ┬
   ·   ╰── `)` expected
 5 │   f2() {
   ╰────
```
**After**
```
  × Expected `)` but found `}`
   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement3.ts:4:3]
 2 │   f1() {
 3 │     if (a.b
   ·        ┬
   ·        ╰── Opened here
 4 │   }
   ·   ┬
   ·   ╰── `)` expected
 5 │   f2() {
   ╰────
```
