### PR TITLE
refactor(linter/plugins): allow accessing `context.id` in `createOnce`

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -118,7 +118,8 @@ export class Context {
 
   // Getter for full rule name, in form `<plugin>/<rule>`
   get id() {
-    return getInternal(this, 'access `context.id`').id;
+    // Note: We can allow accessing `id` in `createOnce`, as it's not file-specific. So skip `getInternal` call.
+    return this.#internal.id;
   }
 
   // Getter for absolute path of file being linted.

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -39,7 +39,7 @@
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: id: Cannot access `context.id` in `createOnce`
+  x create-once-plugin(always-run): createOnce: id: create-once-plugin/always-run
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -177,7 +177,7 @@
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: id: Cannot access `context.id` in `createOnce`
+  x create-once-plugin(always-run): createOnce: id: create-once-plugin/always-run
    ,-[files/2.js:1:1]
  1 | let y;
    : ^

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -22,8 +22,9 @@ const alwaysRunRule: Rule = {
     // oxlint-disable-next-line typescript-eslint/no-this-alias
     const topLevelThis = this;
 
+    const { id } = context;
+
     // Check that these APIs throw here
-    const idError = tryCatch(() => context.id);
     const filenameError = tryCatch(() => context.filename);
     const physicalFilenameError = tryCatch(() => context.physicalFilename);
     const optionsError = tryCatch(() => context.options);
@@ -35,7 +36,7 @@ const alwaysRunRule: Rule = {
       before() {
         context.report({ message: `createOnce: call count: ${createOnceCallCount}`, node: SPAN });
         context.report({ message: `createOnce: this === rule: ${topLevelThis === alwaysRunRule}`, node: SPAN });
-        context.report({ message: `createOnce: id: ${idError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: id: ${id}`, node: SPAN });
         context.report({ message: `createOnce: filename: ${filenameError?.message}`, node: SPAN });
         context.report({ message: `createOnce: physicalFilename: ${physicalFilenameError?.message}`, node: SPAN });
         context.report({ message: `createOnce: options: ${optionsError?.message}`, node: SPAN });


### PR DESCRIPTION
Previously we blocked accessing `context.id` (rule name) in `createOnce`. There's no need to be so restrictive, as it's a static value, and not file-specific. Relax this restriction.