### PR TITLE
fix(linter/plugins): replace `Context` class

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -44,6 +44,7 @@
     "execa": "^9.6.0",
     "jiti": "^2.6.0",
     "tsdown": "catalog:",
+    "type-fest": "^5.2.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -1,6 +1,7 @@
 import { assertIs } from './utils.js';
 
-import type { Diagnostic, InternalContext } from './context.ts';
+import type { Diagnostic } from './context.ts';
+import type { RuleAndContext } from './load.ts';
 import type { Range, Ranged } from './types.ts';
 
 const { prototype: ArrayPrototype, from: ArrayFrom } = Array,
@@ -77,12 +78,12 @@ export type Fixer = typeof FIXER;
  * with getters. As we're not managing to be 100% bulletproof anyway, maybe we don't need to be quite so defensive.
  *
  * @param diagnostic - Diagnostic object
- * @param internal - Internal context object
+ * @param ruleAndContext - `RuleAndContext` object, containing rule-specific `isFixable` value
  * @returns Non-empty array of `Fix` objects, or `null` if none
  * @throws {Error} If rule is not marked as fixable but `fix` function returns fixes,
  *   or if `fix` function returns any invalid `Fix` objects
  */
-export function getFixes(diagnostic: Diagnostic, internal: InternalContext): Fix[] | null {
+export function getFixes(diagnostic: Diagnostic, ruleAndContext: RuleAndContext): Fix[] | null {
   // ESLint silently ignores non-function `fix` values, so we do the same
   const { fix } = diagnostic;
   if (typeof fix !== 'function') return null;
@@ -137,7 +138,7 @@ export function getFixes(diagnostic: Diagnostic, internal: InternalContext): Fix
 
   // ESLint does not throw this error if `fix` function returns only falsy values.
   // We've already exited if that is the case, so we're reproducing that behavior.
-  if (internal.isFixable === false) {
+  if (ruleAndContext.isFixable === false) {
     throw new Error('Fixable rules must set the `meta.fixable` property to "code" or "whitespace".');
   }
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -259,4 +259,8 @@ describe('oxlint CLI', () => {
   it('should return empty object for `parserServices` without throwing', async () => {
     await testFixture('parser_services');
   });
+
+  it('wrapping context should work', async () => {
+    await testFixture('context_wrapping');
+  });
 });

--- a/apps/oxlint/test/fixtures/context_wrapping/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/context_wrapping/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "wrapped-context/wrapped-rule": "error",
+    "wrapped-context/wrapped-rule2": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/context_wrapping/files/index.js
+++ b/apps/oxlint/test/fixtures/context_wrapping/files/index.js
@@ -1,0 +1,1 @@
+console.log('Hello, world!');

--- a/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
@@ -1,0 +1,74 @@
+# Exit code
+1
+
+# stdout
+```
+  x wrapped-context(wrapped-rule): wrapped 1: filename: <fixture>/files/index.js
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule): wrapped 1: id: wrapped-context/wrapped-rule
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule): wrapped 1: source text: "console.log('Hello, world!');\n"
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule2): wrapped 2: filename: <fixture>/files/index.js
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule2): wrapped 2: id: wrapped-context/wrapped-rule2
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule2): wrapped 2: source text: "console.log('Hello, world!');\n"
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^
+   `----
+
+  x wrapped-context(wrapped-rule): wrapped 1: Identifier: 'console'
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^^^^^^^
+   `----
+
+  x wrapped-context(wrapped-rule2): wrapped 2: Identifier: 'console'
+   ,-[files/index.js:1:1]
+ 1 | console.log('Hello, world!');
+   : ^^^^^^^
+   `----
+
+  x wrapped-context(wrapped-rule): wrapped 1: Identifier: 'log'
+   ,-[files/index.js:1:9]
+ 1 | console.log('Hello, world!');
+   :         ^^^
+   `----
+
+  x wrapped-context(wrapped-rule2): wrapped 2: Identifier: 'log'
+   ,-[files/index.js:1:9]
+ 1 | console.log('Hello, world!');
+   :         ^^^
+   `----
+
+Found 0 warnings and 10 errors.
+Finished in Xms on 1 file using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
@@ -1,0 +1,62 @@
+import type { Plugin, Rule, Context, Diagnostic, Node } from '../../../dist/index.js';
+
+const SPAN: Node = {
+  start: 0,
+  end: 0,
+  range: [0, 0],
+  loc: {
+    start: { line: 0, column: 0 },
+    end: { line: 0, column: 0 },
+  },
+};
+
+function createWrappedReportFunction(context: Context, prefix: string): (diagnostic: Diagnostic) => void {
+  const { report } = context;
+  return (diagnostic: Diagnostic) => report({ ...diagnostic, message: `${prefix}: ${diagnostic.message}` });
+}
+
+const baseRule: Rule = {
+  create(context) {
+    context.report({ message: `id: ${context.id}`, node: SPAN });
+    context.report({ message: `filename: ${context.filename}`, node: SPAN });
+    context.report({ message: `source text: ${JSON.stringify(context.sourceCode.text)}`, node: SPAN });
+
+    return {
+      Identifier(node) {
+        context.report({ message: `Identifier: '${node.name}'`, node });
+      },
+    };
+  },
+};
+
+const plugin: Plugin = {
+  meta: {
+    name: 'wrapped-context',
+  },
+  rules: {
+    // Two different forms of context wrapping
+    'wrapped-rule': {
+      create(context) {
+        const wrappedContext = Object.create(context, {
+          report: {
+            value: createWrappedReportFunction(context, 'wrapped 1'),
+            writable: false,
+          },
+        });
+
+        return baseRule.create(wrappedContext);
+      },
+    },
+    'wrapped-rule2': {
+      create(context) {
+        const wrappedContext = Object.create(Object.getPrototypeOf(context));
+        Object.assign(wrappedContext, context);
+        wrappedContext.report = createWrappedReportFunction(context, 'wrapped 2');
+
+        return baseRule.create(wrappedContext);
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(@arethetypeswrong/core@0.18.2)(publint@0.3.15)(typescript@5.9.3)
+      type-fest:
+        specifier: ^5.2.0
+        version: 5.2.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3835,6 +3838,10 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -3943,6 +3950,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.2.0:
+    resolution: {integrity: sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==}
+    engines: {node: '>=20'}
 
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
@@ -7689,6 +7700,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.3.0: {}
 
   tar-fs@2.1.4:
@@ -7793,6 +7806,10 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.41.0: {}
+
+  type-fest@5.2.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-rest-client@1.8.11:
     dependencies:


### PR DESCRIPTION
Fix #15325.

Some ESLint rules create a wrapped copy of `context`, in order to patch `report` and pass that wrapped context object to another rule.

Some rules also rely on unspecified details of ESLint's implementation - that `context` is formed of 2 layers - top layer being `RuleContext` (`id`, `report` etc), and bottom layer being `FileContext` (`filename`, `sourceText` etc).

This usage was broken in our implementation because:

1. We collapsed the 2 layers into 1.
2. We used a `Context` class which stored its internal data in a private property. When `context.report` was called with a different `this`, it failed because the private property couldn't be accessed from an object which isn't an instance of the class.

Fix this problem by:

1. Splitting `Context` into 2 layers like ESLint does.
2. Not using classes or private properties.
3. No methods/getters on context objects use `this`.

We now have:

* Separate `Context` object per rule, containing properties related to the rule - a plain object which uses data from closure scope.
* All rule `Context`s inherit from the same singleton `FILE_CONTEXT` object, which provides getters for properties related to the file (same for all rules).

Tests adapted from #15326.