### PR TITLE
test(linter/plugins): fix test snapshots on Windows

### DIFF
--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -21,6 +21,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: filename error: Cannot access `context.filename` in `createOnce`
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x create-once-plugin(always-run): before hook: filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
@@ -28,12 +34,6 @@
    `----
 
   x create-once-plugin(always-run): after hook: filename: <fixture>/files/1.js
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): createOnce: filename: Cannot access `context.filename` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -57,31 +57,31 @@
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: options: Cannot access `context.options` in `createOnce`
+  x create-once-plugin(always-run): createOnce: options error: Cannot access `context.options` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: physicalFilename: Cannot access `context.physicalFilename` in `createOnce`
+  x create-once-plugin(always-run): createOnce: physicalFilename error: Cannot access `context.physicalFilename` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: report: Cannot report errors in `createOnce`
+  x create-once-plugin(always-run): createOnce: report error: Cannot report errors in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: settings: Cannot access `context.settings` in `createOnce`
+  x create-once-plugin(always-run): createOnce: settings error: Cannot access `context.settings` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: sourceCode: Cannot access `context.sourceCode` in `createOnce`
+  x create-once-plugin(always-run): createOnce: sourceCode error: Cannot access `context.sourceCode` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -159,6 +159,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: filename error: Cannot access `context.filename` in `createOnce`
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
   x create-once-plugin(always-run): before hook: filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
@@ -166,12 +172,6 @@
    `----
 
   x create-once-plugin(always-run): after hook: filename: <fixture>/files/2.js
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): createOnce: filename: Cannot access `context.filename` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -195,31 +195,31 @@
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: options: Cannot access `context.options` in `createOnce`
+  x create-once-plugin(always-run): createOnce: options error: Cannot access `context.options` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: physicalFilename: Cannot access `context.physicalFilename` in `createOnce`
+  x create-once-plugin(always-run): createOnce: physicalFilename error: Cannot access `context.physicalFilename` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: report: Cannot report errors in `createOnce`
+  x create-once-plugin(always-run): createOnce: report error: Cannot report errors in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: settings: Cannot access `context.settings` in `createOnce`
+  x create-once-plugin(always-run): createOnce: settings error: Cannot access `context.settings` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
    `----
 
-  x create-once-plugin(always-run): createOnce: sourceCode: Cannot access `context.sourceCode` in `createOnce`
+  x create-once-plugin(always-run): createOnce: sourceCode error: Cannot access `context.sourceCode` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
    : ^

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -37,12 +37,15 @@ const alwaysRunRule: Rule = {
         context.report({ message: `createOnce: call count: ${createOnceCallCount}`, node: SPAN });
         context.report({ message: `createOnce: this === rule: ${topLevelThis === alwaysRunRule}`, node: SPAN });
         context.report({ message: `createOnce: id: ${id}`, node: SPAN });
-        context.report({ message: `createOnce: filename: ${filenameError?.message}`, node: SPAN });
-        context.report({ message: `createOnce: physicalFilename: ${physicalFilenameError?.message}`, node: SPAN });
-        context.report({ message: `createOnce: options: ${optionsError?.message}`, node: SPAN });
-        context.report({ message: `createOnce: sourceCode: ${sourceCodeError?.message}`, node: SPAN });
-        context.report({ message: `createOnce: settings: ${settingsError?.message}`, node: SPAN });
-        context.report({ message: `createOnce: report: ${reportError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: filename error: ${filenameError?.message}`, node: SPAN });
+        context.report({
+          message: `createOnce: physicalFilename error: ${physicalFilenameError?.message}`,
+          node: SPAN,
+        });
+        context.report({ message: `createOnce: options error: ${optionsError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: sourceCode error: ${sourceCodeError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: settings error: ${settingsError?.message}`, node: SPAN });
+        context.report({ message: `createOnce: report error: ${reportError?.message}`, node: SPAN });
 
         context.report({ message: `before hook: id: ${context.id}`, node: SPAN });
         context.report({ message: `before hook: filename: ${context.filename}`, node: SPAN });

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -62,9 +62,12 @@ export async function testFixtureWithCommand(options: TestFixtureOptions): Promi
 
 // Regexp to match paths in output.
 // Matches `/path/to/oxc`, `/path/to/oxc/`, `/path/to/oxc/whatever`,
-// when preceded by whitespace or `(`, and followed by whitespace or `)`.
-// @ts-expect-error `RegExp.escape` is new in NodeJS v24
-const PATH_REGEXP = new RegExp(`(?<=^|\\s|\\()${RegExp.escape(REPO_ROOT_PATH)}(/[^\\s\\)]*)?(?=$|\\s|\\))`, 'g');
+// when preceded by whitespace, `(`, or a quote, and followed by whitespace, `)`, or a quote.
+const PATH_REGEXP = new RegExp(
+  // @ts-expect-error `RegExp.escape` is new in NodeJS v24
+  `(?<=^|[\\s\\('"\`])${RegExp.escape(REPO_ROOT_PATH)}(${RegExp.escape(pathSep)}[^\\s\\)'"\`]*)?(?=$|[\\s\\)'"\`])`,
+  'g',
+);
 
 // Regexp to match lines of form `whatever      plugin/rule` in ESLint output.
 const ESLINT_REGEXP = /^(.*?)\s+([A-Za-z0-9_-]+\/[A-Za-z0-9_-]+)$/;


### PR DESCRIPTION
Follow-on after #15424. Fix the snapshots on Windows. I missed one slash!

Also, convert paths wrapped in quotes e.g. `file path: '/path/to/oxc/apps/oxlint/test/fixtures/blah/files/foo.js'`.

I've had to hack one fixture (`createOnce`) to get diagnostics to be printed in same order on all platforms. Otherwise they get printed out of order on Windows: https://github.com/oxc-project/oxc/actions/runs/19180329507/job/54835252163?pr=15451#step:8:419.

Presumably this is because on Windows the file path `D:\...` is sorted after `Cannot access`, whereas on Mac/Linux, file path `/` is sorted before `Cannot access`. However, I'm unclear why the prefixes `before hook:`, `after hook:` etc aren't included in sorting. If they were, this problem wouldn't arise.