### PR TITLE
fix(formatter): correct `FormatElement` size check

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -41,7 +41,7 @@ const _: () = {
     } else {
         assert!(
             std::mem::size_of::<FormatElement>() == 16,
-            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
+            "`FormatElement` size exceeds 16 bytes, expected 16 bytes in 32-bit platforms"
         );
     }
 };

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -36,7 +36,7 @@ const _: () = {
     if cfg!(target_pointer_width = "64") {
         assert!(
             std::mem::size_of::<FormatElement>() == 24,
-            "`FormatElement` size exceeds 32 bytes, expected 32 bytes in 64-bit platforms"
+            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 64-bit platforms"
         );
     } else {
         assert!(

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -18,18 +18,32 @@ use super::{
 
 #[cfg(debug_assertions)]
 const _: () = {
-    assert!(
-        std::mem::size_of::<FormatElement>() == 40,
-        "`FormatElement` size exceeds 40 bytes, expected 40 bytes"
-    );
+    if cfg!(target_pointer_width = "64") {
+        assert!(
+            std::mem::size_of::<FormatElement>() == 40,
+            "`FormatElement` size exceeds 40 bytes, expected 40 bytes in 64-bit platforms"
+        );
+    } else {
+        assert!(
+            std::mem::size_of::<FormatElement>() == 24,
+            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
+        );
+    }
 };
 
 #[cfg(not(debug_assertions))]
 const _: () = {
-    assert!(
-        std::mem::size_of::<FormatElement>() == 24,
-        "`FormatElement` size exceeds 24 bytes, expected 24 bytes"
-    );
+    if cfg!(target_pointer_width = "64") {
+        assert!(
+            std::mem::size_of::<FormatElement>() == 24,
+            "`FormatElement` size exceeds 32 bytes, expected 32 bytes in 64-bit platforms"
+        );
+    } else {
+        assert!(
+            std::mem::size_of::<FormatElement>() == 16,
+            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
+        );
+    }
 };
 
 /// Language agnostic IR for formatting source code.


### PR DESCRIPTION
Fixes https://github.com/oxc-project/playground/actions/runs/19187163966/job/54855957272