### PR TITLE
refactor(various): use `size_of` and `align_of` from prelude

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -213,7 +213,7 @@ unsafe fn offset_from<T>(p: *const T, origin: *const T) -> isize
 where
     T: Sized,
 {
-    let pointee_size = mem::size_of::<T>();
+    let pointee_size = size_of::<T>();
     assert!(0 < pointee_size && pointee_size <= isize::max_value() as usize);
 
     // This is the same sequence that Clang emits for pointer subtraction.
@@ -363,7 +363,7 @@ where
 /// on an empty Vec, it will not allocate memory. Similarly, if you store zero-sized
 /// types inside a `Vec`, it will not allocate space for them. *Note that in this case
 /// the `Vec` may not report a [`capacity`] of 0*. `Vec` will allocate if and only
-/// if <code>[`mem::size_of::<T>`]\() * capacity() > 0</code>. In general, `Vec`'s allocation
+/// if <code>[`size_of::<T>`]\() * capacity() > 0</code>. In general, `Vec`'s allocation
 /// details are very subtle &mdash; if you intend to allocate memory using a `Vec`
 /// and use it for something else (either to pass to unsafe code, or to build your
 /// own memory-backed collection), be sure to deallocate this memory by using
@@ -430,7 +430,7 @@ where
 /// [`Vec::new_in`]: struct.Vec.html#method.new_in
 /// [`shrink_to_fit`]: struct.Vec.html#method.shrink_to_fit
 /// [`capacity`]: struct.Vec.html#method.capacity
-/// [`mem::size_of::<T>`]: https://doc.rust-lang.org/std/mem/fn.size_of.html
+/// [`size_of::<T>`]: https://doc.rust-lang.org/std/mem/fn.size_of.html
 /// [`len`]: struct.Vec.html#method.len
 /// [`push`]: struct.Vec.html#method.push
 /// [`insert`]: struct.Vec.html#method.insert
@@ -2127,7 +2127,7 @@ impl<'a, T: 'a, A: Alloc> IntoIterator for Vec<'a, T, A> {
         unsafe {
             let begin = self.as_mut_ptr();
             // assume(!begin.is_null());
-            let end = if mem::size_of::<T>() == 0 {
+            let end = if size_of::<T>() == 0 {
                 arith_offset(begin as *const i8, self.len_u32() as isize) as *const T
             } else {
                 begin.add(self.len_usize()) as *const T
@@ -2475,7 +2475,7 @@ impl<'a, T: 'a> Iterator for IntoIter<'a, T> {
         unsafe {
             if std::ptr::eq(self.ptr, self.end) {
                 None
-            } else if mem::size_of::<T>() == 0 {
+            } else if size_of::<T>() == 0 {
                 // purposefully don't use 'ptr.offset' because for
                 // vectors with 0-size elements this would return the
                 // same pointer.
@@ -2494,7 +2494,7 @@ impl<'a, T: 'a> Iterator for IntoIter<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact = if mem::size_of::<T>() == 0 {
+        let exact = if size_of::<T>() == 0 {
             (self.end as usize).wrapping_sub(self.ptr as usize)
         } else {
             unsafe { offset_from(self.end, self.ptr) as usize }
@@ -2514,7 +2514,7 @@ impl<'a, T: 'a> DoubleEndedIterator for IntoIter<'a, T> {
         unsafe {
             if self.end == self.ptr {
                 None
-            } else if mem::size_of::<T>() == 0 {
+            } else if size_of::<T>() == 0 {
                 // See above for why 'ptr.offset' isn't used
                 self.end = arith_offset(self.end as *const i8, -1) as *mut T;
 

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -106,8 +106,6 @@ pub use crate::{
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn size_asserts() {
-    use std::mem::size_of;
-
     use crate::ast;
 
     assert_eq!(size_of::<ast::Statement>(), 16);

--- a/crates/oxc_data_structures/src/stack/common.rs
+++ b/crates/oxc_data_structures/src/stack/common.rs
@@ -26,7 +26,7 @@ pub trait StackCommon<T>: StackCapacity<T> {
     ///
     /// # SAFETY
     /// * `capacity_bytes` must not be 0.
-    /// * `capacity_bytes` must be a multiple of `mem::size_of::<T>()`.
+    /// * `capacity_bytes` must be a multiple of `size_of::<T>()`.
     /// * `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES`.
     #[inline]
     unsafe fn allocate(capacity_bytes: usize) -> (NonNull<T>, NonNull<T>) {
@@ -118,7 +118,7 @@ pub trait StackCommon<T>: StackCapacity<T> {
     ///
     /// # SAFETY
     /// * `capacity_bytes` must not be 0.
-    /// * `capacity_bytes` must be a multiple of `mem::size_of::<T>()`.
+    /// * `capacity_bytes` must be a multiple of `size_of::<T>()`.
     /// * `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES`.
     #[inline]
     unsafe fn layout_for(capacity_bytes: usize) -> Layout {

--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -1,5 +1,4 @@
 use std::{
-    mem::size_of,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -196,7 +195,7 @@ impl<T> NonEmptyStack<T> {
     ///
     /// # SAFETY
     /// * `capacity_bytes` must not be 0.
-    /// * `capacity_bytes` must be a multiple of `mem::size_of::<T>()`.
+    /// * `capacity_bytes` must be a multiple of `size_of::<T>()`.
     /// * `capacity_bytes` must not exceed [`Self::MAX_CAPACITY_BYTES`].
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize, initial_value: T) -> Self {

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -1,5 +1,4 @@
 use std::{
-    mem::size_of,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -170,7 +169,7 @@ impl<T> Stack<T> {
     ///
     /// # SAFETY
     /// * `capacity_bytes` must not be 0.
-    /// * `capacity_bytes` must be a multiple of `mem::size_of::<T>()`.
+    /// * `capacity_bytes` must be a multiple of `size_of::<T>()`.
     /// * `capacity_bytes` must not exceed [`Self::MAX_CAPACITY_BYTES`].
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize) -> Self {

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -20,12 +20,12 @@ use super::{
 const _: () = {
     if cfg!(target_pointer_width = "64") {
         assert!(
-            std::mem::size_of::<FormatElement>() == 40,
+            size_of::<FormatElement>() == 40,
             "`FormatElement` size exceeds 40 bytes, expected 40 bytes in 64-bit platforms"
         );
     } else {
         assert!(
-            std::mem::size_of::<FormatElement>() == 24,
+            size_of::<FormatElement>() == 24,
             "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
         );
     }
@@ -35,12 +35,12 @@ const _: () = {
 const _: () = {
     if cfg!(target_pointer_width = "64") {
         assert!(
-            std::mem::size_of::<FormatElement>() == 24,
+            size_of::<FormatElement>() == 24,
             "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 64-bit platforms"
         );
     } else {
         assert!(
-            std::mem::size_of::<FormatElement>() == 16,
+            size_of::<FormatElement>() == 16,
             "`FormatElement` size exceeds 16 bytes, expected 16 bytes in 32-bit platforms"
         );
     }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -109,7 +109,7 @@ use crate::{
 // 1. `Span`'s `start` and `end` are `u32`s, which limits length to `u32::MAX` bytes.
 // 2. Rust's allocator APIs limit allocations to `isize::MAX`.
 // https://doc.rust-lang.org/std/alloc/struct.Layout.html#method.from_size_align
-pub(crate) const MAX_LEN: usize = if std::mem::size_of::<usize>() >= 8 {
+pub(crate) const MAX_LEN: usize = if size_of::<usize>() >= 8 {
     // 64-bit systems
     u32::MAX as usize
 } else {

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -330,8 +330,6 @@ pub struct NamedReference<'a> {
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn size_asserts() {
-    use std::mem::size_of;
-
     assert!(size_of::<Term>() == 16);
     assert!(size_of::<CharacterClassContents>() == 16);
 }


### PR DESCRIPTION
Pure refactor. `std::mem::size_of` and `std::mem::align_of` are now part of the standard prelude. Shorten code by using them from the prelude, instead of importing from `std::mem`.