### PR TITLE
refactor(allocator, formatter): use `std` crate over `core`

### DIFF
--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -23,9 +23,11 @@
 #![allow(unstable_name_collisions)]
 #![allow(dead_code)]
 
-use core::alloc::Layout;
-use core::cmp;
-use core::ptr::{self, NonNull};
+use std::{
+    alloc::Layout,
+    cmp,
+    ptr::{self, NonNull},
+};
 
 use crate::alloc::Alloc;
 
@@ -676,7 +678,7 @@ impl<'a, T> RawVec<'a, T> {
         use crate::boxed::Box;
 
         // NOTE: not calling `cap()` here; actually using the real `cap` field!
-        let slice = core::slice::from_raw_parts_mut(self.ptr(), self.cap);
+        let slice = std::slice::from_raw_parts_mut(self.ptr(), self.cap);
         let output: Box<'a, [T]> = Box::from_raw(slice);
         mem::forget(self);
         output
@@ -839,7 +841,7 @@ impl<T, A: Alloc> RawVec<'_, T, A> {
 #[inline]
 fn alloc_guard(alloc_size: usize) -> Result<(), AllocError> {
     if size_of::<usize>() < 8 {
-        if alloc_size > ::core::isize::MAX as usize {
+        if alloc_size > isize::MAX as usize {
             return Err(AllocError::CapacityOverflow);
         }
     } else if alloc_size > u32::MAX as usize {

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -1,5 +1,5 @@
-use core::fmt;
 use std::{
+    fmt,
     mem::{transmute, transmute_copy},
     ops::Deref,
 };

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -125,7 +125,7 @@ impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
                 }
 
                 // Early return if the parent isn't a `TSSatisfiesExpression` or `TSAsExpression`
-                if core::ptr::eq(self.parent, parent) {
+                if ptr::eq(self.parent, parent) {
                     return false;
                 }
 

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -1,5 +1,8 @@
-use std::iter::{FusedIterator, Peekable};
-use std::str::Chars;
+use std::{
+    iter::{FusedIterator, Peekable},
+    mem,
+    str::Chars,
+};
 
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
@@ -215,7 +218,7 @@ impl PartialEq for JsxChild<'_, '_> {
         match (self, other) {
             (Self::Word(l0), Self::Word(r0)) => l0 == r0,
             (Self::NonText(_), Self::NonText(_)) => false, // Never equal by structural comparison
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+            _ => mem::discriminant(self) == mem::discriminant(other),
         }
     }
 }


### PR DESCRIPTION
Pure refactor. Oxc is not no-std, and we use `std` crate everywhere. But a few references to `core` crate existed. Improve consistency by using `std` instead.