### PR TITLE
refactor(language_server):  move restart to `Tool::handle_watched_file_change`  trait method

### DIFF
--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -152,6 +152,10 @@ impl Tool for ServerFormatter {
     }
 
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern> {
+        if !self.should_run {
+            return vec![];
+        }
+
         let options = match serde_json::from_value::<LSPFormatOptions>(options) {
             Ok(opts) => opts,
             Err(e) => {
@@ -162,15 +166,37 @@ impl Tool for ServerFormatter {
             }
         };
 
-        if !self.should_run {
-            return vec![];
-        }
-
         if let Some(config_path) = options.config_path.as_ref() {
             return vec![config_path.clone()];
         }
 
         FORMAT_CONFIG_FILES.iter().map(|file| (*file).to_string()).collect()
+    }
+
+    async fn handle_watched_file_change(
+        &self,
+        _changed_uri: &Uri,
+        root_uri: &Uri,
+        options: serde_json::Value,
+    ) -> ToolRestartChanges<Self> {
+        if !self.should_run {
+            return ToolRestartChanges {
+                tool: None,
+                diagnostic_reports: None,
+                watch_patterns: None,
+            };
+        }
+
+        // TODO: Check if the changed file is actually a config file
+
+        let new_formatter = ServerFormatterBuilder::new(root_uri.clone(), options).build();
+
+        ToolRestartChanges {
+            tool: Some(new_formatter),
+            diagnostic_reports: None,
+            // TODO: update watch patterns if config_path changed
+            watch_patterns: None,
+        }
     }
 }
 

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -24,6 +24,16 @@ pub trait Tool: Sized {
     /// These patterns will be used to watch for file changes relevant to the tool.
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern>;
 
+    /// Handle a watched file change event for the given URI.
+    /// Returns a [ToolRestartChanges] indicating what changes were made for the Tool.
+    /// The Tool should decide whether it needs to restart or take any action based on the URI.
+    async fn handle_watched_file_change(
+        &self,
+        changed_uri: &Uri,
+        root_uri: &Uri,
+        options: serde_json::Value,
+    ) -> ToolRestartChanges<Self>;
+
     /// Check if this tool is responsible for handling the given command.
     fn is_responsible_for_command(&self, _command: &str) -> bool {
         false


### PR DESCRIPTION
Returning `ToolRestartChanges` like `handle_configuration_change` does.
The logic in `WorkspaceWorker/Backend` can be shared later for simplified usage.