### PR TITLE
test(tasks/coverage/typescript): Update `2541-2999` error codes handling

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 8ea03f88
 
 codegen_typescript Summary:
-AST Parsed     : 8827/8827 (100.00%)
-Positive Passed: 8827/8827 (100.00%)
+AST Parsed     : 9649/9649 (100.00%)
+Positive Passed: 9649/9649 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 8ea03f88
 
 estree_typescript Summary:
-AST Parsed     : 8767/8767 (100.00%)
-Positive Passed: 8761/8767 (99.93%)
+AST Parsed     : 9580/9580 (100.00%)
+Positive Passed: 9573/9580 (99.93%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
@@ -12,6 +12,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
+Using declaration cannot appear in the bare case statement.
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
 Using declaration cannot appear in the bare case statement.

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -1,8 +1,8 @@
 commit: 8ea03f88
 
 formatter_typescript Summary:
-AST Parsed     : 8827/8827 (100.00%)
-Positive Passed: 8817/8827 (99.89%)
+AST Parsed     : 9649/9649 (100.00%)
+Positive Passed: 9636/9649 (99.87%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
@@ -11,14 +11,20 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericTypeAsser
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDecorators.ts
 Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
+Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
 Classes may not have a static property named 'prototype'Classes may not have a static property named 'prototype'Classes may not have a static property named 'prototype'Classes may not have a static property named 'prototype'Classes may not have a static property named 'prototype'Classes may not have a static property named 'prototype'
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 The only valid meta property for import is import.meta
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
+
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/letIdentifierInElementAccess01.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
 
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
+Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
 Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.Using declaration cannot appear in the bare case statement.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: 8ea03f88
 
 parser_typescript Summary:
-AST Parsed     : 8825/8827 (99.98%)
-Positive Passed: 8813/8827 (99.84%)
-Negative Passed: 1454/3530 (41.19%)
+AST Parsed     : 9647/9649 (99.98%)
+Positive Passed: 9634/9649 (99.84%)
+Negative Passed: 1453/2708 (53.66%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -16,25 +16,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDecl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/accessorsInAmbientContext.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowImportClausesToMergeWithTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports10.ts
 
@@ -48,8 +32,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientError
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientExportDefaultErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleInAnotherExternalModule.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithRelativeExternalImportDeclaration.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithRelativeModuleName.ts
@@ -58,77 +40,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientGette
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ambientStatement1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIdenticalToItself.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsPropertyNameInJsMode1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsReferenceInObjectLiteral_Js.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/argumentsSpreadRestIterables.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arithAssignTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToEnum.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignToModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatFunctionsWithOptionalArgs.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWithErrorSourceType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToAnyArrayRestParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToObjectAndFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/assignmentToReferenceTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1_1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2_1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentedClassWithPrototypePropertyOnModule.ts
 
@@ -144,27 +64,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/autolift4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitCallExpressionInSyncFunction.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigintAmbientMinimal.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigintIndex.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic1.ts
 
@@ -186,14 +90,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedS
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationStrictES5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationStrictES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads2.ts
@@ -204,33 +100,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverload
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cannotInvokeNewOnIndexExpression.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedAssignmentChecking.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkForObjectTooStrict.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsFiles6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkMergedGlobalUMDSymbol.ts
 
@@ -250,21 +126,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkingObje
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/circularOptionalityRemoval.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithDecorator1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface_not.ts
 
@@ -274,39 +140,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtends
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessibleJs1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessibleJs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsPrimitive.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyAccess.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classUsedBeforeInitializedVariables.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/cloduleTest2.ts
 
@@ -336,25 +174,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/collisionExp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndVar.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commaOperator1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/complicatedGenericRecursiveBaseClassReference.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring1_ES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access.ts
 
@@ -368,8 +196,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constWithNon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads6.ts
@@ -382,19 +208,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTy
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTyping5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaReturnExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement4.ts
 
@@ -402,23 +220,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowA
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/corrupted.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/couldNotSelectGenericOverload.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashRegressionTest.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationParenType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
 
@@ -428,47 +238,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationE
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIndexTypeNotFound.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRelativeModuleError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationFileNoCrashOnExtraExportModifier.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnImport1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorUsedBeforeDeclaration.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/decoratorsOnComputedProperties.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInFunctionExpressions.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInOverloads.ts
 
@@ -484,19 +260,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/definiteAssi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deleteOperator1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deleteReadonlyInStrictNullChecks.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuredLateBoundNameHasCorrectTypes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithExportedName.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringFromUnionSpread.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringTuple.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/destructuringUnspreadableIntoRest.ts
 
@@ -504,19 +270,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/detachedComm
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfFunctionBody2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/didYouMeanStringLiteral.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/didYouMeanSuggestionErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dissallowSymbolAsWeakType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsVisibility1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2023.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst16.ts
 
@@ -525,12 +279,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/downlevelLet
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst19.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateDefaultExport.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
 
@@ -580,12 +328,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateVar
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dynamicImportTrailingComma.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/elidedJSImport1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_isolatedModules.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/emptyThenWarning.ts
@@ -602,8 +344,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumBasics3.
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccess.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumPropertyAccessBeforeInitalisation.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumWithComputedMember.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations1.ts
@@ -614,29 +354,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/erasableSynt
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorCause.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorLocationForInterfaceExtension.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnObjectLiteralType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorSupression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorsOnImportedSymbol.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs3.ts
 
@@ -660,13 +384,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportEqu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportEqualsInterop.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1InEs5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts
 
@@ -682,8 +400,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleEs2015Error.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoNamedExports.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClause.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
@@ -698,27 +414,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esmModeDecla
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/esmNoSynthesizedDefault.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/evalAfter0.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithSpread.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/experimentalDecoratorMetadataUnresolvedTypeObjectInEmit.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace_augment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithExports.ts
 
@@ -758,33 +460,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportEquals
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAndValueWithDuplicatesInImportList.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportStarFromEmptyModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/expressionWithJSDocTypeArguments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendFromAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendPrivateConstructorClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts
 
@@ -798,19 +484,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/externalModu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/findLast.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forInStatement7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardDeclaredCommonTypes01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionAndImportNameConflict.ts
 
@@ -819,28 +495,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionAndI
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionArgShadowing.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionAssignment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall16.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall17.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall18.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCall9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionExpressionShadowedByParams.ts
 
@@ -860,53 +514,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOver
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads19.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads29.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads34.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads37.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads41.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionOverloads5.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithPropError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCallSpecializedToTypeArg.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericChainedCalls.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericConstructInvocationWithNoTypeArg.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionTypedArgumentsAreFixed.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
 
@@ -916,25 +540,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericRecur
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericReduce.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericWithOpenTypeParameters1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/getterMissingReturnError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/gettersAndSetters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersAccessibility.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatEmit1.ts
 
@@ -946,17 +558,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/impliedNodeF
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importAliasInModuleAugmentation.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importAnImport.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclRefereingExternalModuleWithNoResolve.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithClassModifiers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts
 
@@ -964,25 +570,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importDeclarationInModuleDeclaration1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importEqualsError45874.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importInsideModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember10.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember11.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importUsedAsTypeWithErrors.ts
 
@@ -990,27 +586,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importWithTr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/importedModuleAddToGlobal.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/incrementOnTypeParameter.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexAt.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWithInitializer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessImplicitlyAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithFreshObjectLiteral.ts
 
@@ -1018,49 +600,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inexistentPr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferTypePredicates.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inferenceFromGenericClassNoCrash1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingAccessor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/initializedDestructuringAssignmentTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/initializerWithThisPropertyAccess.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/innerAliases.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instanceofOperator.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instanceofWithStructurallyIdenticalTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceAssignmentCompat.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClassWithPrivate1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceMemberValidation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceMergeWithNonGenericTypeArguments.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceNameAsIdentifier.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/interfacedeclWithIndexerErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExportAccessError.ts
 
@@ -1069,10 +623,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAlia
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExportAccessError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExportAccessError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExportAccessError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExportAccessError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExportAccessError.ts
 
@@ -1086,13 +636,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersection
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidReferenceSyntax1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidStaticField.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments1.ts
 
@@ -1101,8 +647,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isLiteral1.t
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportDeclarationType.ts
 
@@ -1113,10 +657,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModu
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsCheckObjectDefineThisNoCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsElementAccessNoContextualTypeCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation2.ts
 
@@ -1132,11 +672,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompil
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationPublicMethodSyntaxOfClass.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFileFunctionParametersAsOptional2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsFunctionWithPrototypeNoErrorTruncationNoCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocCallbackAndType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocFunctionTypeFalsePositive.ts
 
@@ -1146,51 +682,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocInTypeS
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocParameterParsingInfiniteLoop.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocPropertyTagInvalid.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenArrayWrongType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenWrongType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxClassAttributeResolution.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxComponentTypeErrors.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxElementType.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteral.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierWithAbsentParameter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryMissingErrorInsideAClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryNotIdentifierOrQualifiedName2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedNameResolutionError.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedNameWithEs5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryReference.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxImportSourceNonPragmaComment.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/keyofIsLiteralContexualType.ts
 
@@ -1200,11 +702,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lambdaParamT
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lambdaPropSelf.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/largeControlFlowGraph.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/lastPropertyInLiteralWins.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letConstInCaseClauses.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates2.ts
 
@@ -1218,31 +716,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarati
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/longObjectInstantiationChain1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/longObjectInstantiationChain2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/longObjectInstantiationChain3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericWithKnownKeys.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/maxNodeModuleJsDepthDefaultsToZero.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSuggestions.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/memberOverride.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/memberScope.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportInterface.ts
 
@@ -1262,25 +744,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclar
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/metadataImportType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/methodChainError.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/methodInAmbientClass1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateStringsArray.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingDomElement_UsingDomLib.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingDomElements.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingMemberErrorHasShortPath.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/missingPropertiesOfClassExpression.ts
 
@@ -1292,23 +762,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mixinPrivate
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/mixingStaticAndInstanceOverloads.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6ArrayWithOnlyES6ArrayLib.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceWithSameName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAsBaseType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDisallowedExtensions.ts
 
@@ -1330,43 +786,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmen
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInDependency2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleCrashBug1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleExports1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleImport.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleInTypePosition1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleNewExportBug.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleNoneErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/modulePreserve3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleProperty2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsCJS.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsESM.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_unexpected2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVariableArrayIndexer.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithNoValuesAsType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithValuesAsType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleClassPropertyModifiers.ts
 
@@ -1380,37 +808,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleInhe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multivar.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespaceNotMergedWithFunctionDefaultExport.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nanEquality.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowByEquality.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nestedIfStatement.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/newNonReferenceType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
 
@@ -1424,25 +828,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyIndexingSuppressed.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyLoopCrash.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noInferCommonPropertyCheck1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noMappedGetSet.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noRepeatedPropertyNames.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/noSymbolForMergeCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nonExportedElementsOfMergedModules.ts
 
@@ -1452,19 +844,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nonexistentP
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nullKeyword.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 
@@ -1482,13 +864,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalPara
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overload1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadAssignmentCompat.ts
 
@@ -1500,37 +878,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnCo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOnDefaultConstructor1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadsInDifferentContainersDisagreeOnAmbient.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overshifts.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parameterDecoratorsEmitCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parameterNamesInTypeParameterList.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructor3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/paramterDestrcuturingDeclaration.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parenthesizedJSDocCastDoesNotNarrow.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineNumber.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineString.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidation4.ts
 
@@ -1538,15 +894,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidat
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDecorators.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnExportedVariables.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
 
@@ -1554,17 +902,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyTopLe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelAmbientExternalModuleImportWithoutExport.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privateNameWeakMapCollision.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promiseDefinitionTest.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermutations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccess1.ts
 
@@ -1575,8 +915,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAcce
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccess4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccess5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOfReadonlyIndexSignature.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering.ts
 
@@ -1590,31 +928,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pushTypeGetT
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/qualifiedModuleLocals.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quickIntersectionCheckCorrectlyCachesErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quotedModuleNameMustBeAmbient.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceInvalidInput.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceMissingDeclaration.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reboundIdentifierOnImportAlias.ts
 
@@ -1626,35 +942,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBas
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveComplicatedClasses.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/regularExpressionExtendedUnicodeEscapes.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/relativeNamesInClassicResolution.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileInJsFile.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithComputedPropertyName.ts
 
@@ -1670,35 +964,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJso
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModule.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/requiredMappedTypeModifierTrumpsVariance.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnInterfaceImport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImportWithInterface.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restInvalidArgumentType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restParamsWithNonRestParams.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/restUnion3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameter.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/returnValueInSetter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsidePublicMethod2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsideStaticMethod1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsidePublicMethod1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsideStaticMethod1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/scopeCheckStaticInitializer.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/selfReferencesInFunctionParameters.ts
 
@@ -1710,35 +986,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/semicolonsIn
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/setterWithReturn.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-amd.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyUndefined.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchInOverload.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureAsCallbackParameter1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadUnionPropOverride.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 
@@ -1746,35 +994,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticClassM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAccess.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticPropSuper.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticVisibility.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticVisibility2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/strictModeInConstructor.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/super.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/super1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superAccess.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassDeclaration.ts
 
@@ -1788,27 +1022,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superPropert
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInSuperCall01.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/switchAssignmentCompat.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/switchCaseCircularRefeference.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/switchCases.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/switchCasesExpressionTypeMismatch.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule10_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule11.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule12.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule16.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule2.ts
 
@@ -1819,14 +1033,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeTe
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsInTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisBinding.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCallJs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisInModule.ts
 
@@ -1844,41 +1050,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisKeyword.
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisPredicateInObjectLiteral.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tooManyTypeParameters1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxInvokeComponentType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/tsxTypeArgumentPartialDefinitionStillErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts
 
@@ -1888,73 +1066,27 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardCon
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeInterfaceDeclarationsInBlockStatements1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeMatch1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeMatch2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterWithInvalidConstraintType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateInLoop.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveScopedPackageCustomTypeRoot.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithFailedFromTypeRoot.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsTypeLiteralIndex.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeValueConflict1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeValueConflict2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typecheckCommaExpression.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typecheckIfCondition.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofClass.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofExternalModules.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdDependencyComment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdGlobalAugmentationNoCrash.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undeclaredBase.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undeclaredMethod.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
 
@@ -1962,13 +1094,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTyp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionPropertyExistence.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolJs.ts
 
@@ -1976,23 +1104,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/unusedSwitchStatement.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_jsx.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useUnknownInCatchVariables01.ts
 
@@ -2000,27 +1114,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varNameConfl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/variableDeclaratorResolvedDuringContextualTyping.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varianceReferences.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/voidAsNonAmbiguousReturnType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/voidAsOperator.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/widenedTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbient.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbientExternalModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction3_es2017.ts
 
@@ -2032,21 +1136,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration3_es2017.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAliasReturnType_es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction3_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncDeclare_es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration13_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts
 
@@ -2055,8 +1153,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration3_es5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclarationCapturesArguments_es5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
 
@@ -2070,55 +1166,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock23.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/classWithoutExplicitConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorOverloadsAccessibility.ts
 
@@ -2148,13 +1208,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithBaseClassButNoConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingPublicInstance.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember.ts
 
@@ -2174,15 +1228,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadSuperUseDefineForClassFields.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameCircularReference.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclarationMerging.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethod.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassAccessorsShadowing.ts
 
@@ -2190,17 +1236,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassMethodShadowing.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameReadonly.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterNoGetter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticEmitHelpers.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAccess.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethod.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAsync.ts
 
@@ -2220,69 +1256,17 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/m
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessModifiers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorExperimentalDecorators.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorLocals.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redeclaredProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redefinedPararameterProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumNoObjectPrototypePropertyAccess.ts
 
@@ -2296,15 +1280,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFl
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForStatement.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrorsAsync.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts
 
@@ -2332,31 +1308,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorator
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-js.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionErrorInES2015.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES2015.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNestedES20152.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/enums/enumMergingErrors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer6.ts
 
@@ -2377,14 +1337,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2019/gl
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisVarDeclaration.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es5/es5DateAPIs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts
 
@@ -2407,8 +1359,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbo
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty59.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType11.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType13.ts
 
@@ -2498,14 +1448,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/compu
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames35_ES6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES6.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames51_ES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames51_ES6.ts
@@ -2542,17 +1484,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringControlFlow.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringInFunctionType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration1ES5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration1ES5iterable.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts
 
@@ -2566,15 +1502,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringSpread.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts
 
@@ -2588,21 +1516,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destr
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithBindingPattern2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of30.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of39.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration3_es6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportsCannotMerge01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportsCannotMerge02.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportsCannotMerge03.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportsCannotMerge04.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportSpellingSuggestion.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportStar-amd.ts
 
@@ -2616,27 +1532,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modul
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports05.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/readonlyRestParameters.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNoneExistingIdentifier.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadImportHelpers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts
 
@@ -2645,12 +1541,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInDeleteExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInDeleteExpressionES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInSwitchAndCase.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringInSwitchAndCaseES6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext1.ts
 
@@ -2665,12 +1555,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yield
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck18.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck20.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck9.ts
 
@@ -2724,61 +1608,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorStrictMode.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithEveryType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsObjectType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsAnyType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsStringType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callOverload.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/grammarAmbiguities.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolution.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/literals/literals.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterBindingPattern.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterInitializer.2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInParameterBindingPattern.2.ts
 
@@ -2852,49 +1696,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithStringType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithBooleanType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithEnumType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithNumberType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithStringType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithBooleanType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithEnumType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithNumberType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithStringType.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithBooleanType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithEnumType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithNumberType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithStringType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithBooleanType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithEnumType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithNumberType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithStringType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/circularReference.ts
 
@@ -2906,33 +1710,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentAndDeclaration.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectAMD.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectCommonJS.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectSystem.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectUMD.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDefaultClassNameWithObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/importTsBeforeDTs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/importsImplicitlyReadonly.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/initializersInDeclarations.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension8.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault1.ts
 
@@ -2946,15 +1728,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/cjsErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emit.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/packageJsonImportsErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelModuleDeclarationAndFile.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained.ts
 
@@ -2990,13 +1766,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace8.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace9.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/extendsClause.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/filterNamespace_import.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/generic.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
 
@@ -3014,23 +1786,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceMemberAccess.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/renamed.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeOnlyESMImportFromCJS.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typesOnlyExternalModuleStillHasInstance.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd8.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/valuesMergingAcrossModules.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxInternalImportEquals.ts
 
@@ -3044,8 +1806,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/fixSignat
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementationErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementations.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid01.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadErrors.ts
@@ -3058,15 +1818,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing1_es6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes3.ts
 
@@ -3075,8 +1827,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importDef
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferNamespace.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts
 
@@ -3106,8 +1856,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatementsInterfaces.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedClasses.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedEnums.ts
@@ -3118,21 +1866,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedVariables.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/shadowedInternalModule.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidNestedModules.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignPrototypeProperty.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocOptionalParamOrder.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocReturnTag1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocReturnTag2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag1.ts
 
@@ -3153,8 +1893,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/che
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag7.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypeTag2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkOtherObjectAssignProperty.ts
 
@@ -3188,11 +1926,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_noExtends.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_class.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_missingType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImplements_properties.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocOuterTypeParameters1.ts
 
@@ -3222,8 +1956,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsd
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagCast.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag2.ts
@@ -3246,109 +1978,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefTagWrapping.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragma.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarationsLocalTypes.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryLocalTypeGlobalFallback.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryWithFragmentIsError.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxSpreadOverwritesAttributeStrict.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImportPragma.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImport.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImportPragma.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution2.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution4.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution6.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName3.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName7.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution1.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution10.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution6.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution7.tsx
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution8.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnUndefinedStrictNullChecks.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution17.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents2.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent2.tsx
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerConditionsExcludesNode.ts
 
@@ -3361,14 +2005,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleRes
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/nodeModulesAtTypesPriority.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeCache.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTripleSlash5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_allowJs.ts
 
@@ -3390,11 +2026,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allo
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsTopLevelAwait.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/legacyNodeModulesExportsSpecifierGenerationConditions.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModules1.ts
 
@@ -3414,21 +2046,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/node
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportAssignments.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsBlocksTypesVersions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesExportsSourceTs.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesForbidenSyntax.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesGeneratedNameCollisions.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAssertions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesModeDeclarationEmit1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesModeDeclarationEmit2.ts
 
@@ -3455,8 +2079,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/node
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackagePatternExportsExclude.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesPackagePatternExportsTrailers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesResolveJsonModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesSynchronousCallErrors.ts
 
@@ -3492,8 +2114,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression4.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
@@ -3524,8 +2144,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic7.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock2.ts
@@ -3553,12 +2171,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts
 
@@ -3610,21 +2222,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected6.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509534.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509618.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509693.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement4.ts
 
@@ -3670,10 +2268,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode16.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode3-negative.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode6-negative.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts
@@ -3686,8 +2280,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts
@@ -3697,14 +2289,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.2_A1.5_T2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.3_A1.1_T2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserS7.6_A4.2_T1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName4.ts
 
@@ -3716,27 +2300,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/assignmentToVoidZero2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/conflictingCommonJSES2015Exports.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorFunctions.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/expandoOnAlias.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/exportNestedNamespaces2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/importAliasModuleExports.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/jsContainerMergeTsDeclaration3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAliasUnknown.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportDuplicateAlias.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment2.ts
 
@@ -3748,11 +2318,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/mod
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportsAliasLoop2.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSTypeErrors.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeAcrossFiles2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeWithInterfaceMethod.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/requireOfESWithPropertyAccess.ts
 
@@ -3766,13 +2332,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment29.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment36.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPrototypeAssignment2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/salsa/typeLookupInIIFE.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral2.ts
 
@@ -3784,41 +2346,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/e
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerNumericLiteral9.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.2_A1.5_T2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.3_A1.1_T2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.6_A4.2_T1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannertest1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.12.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.13.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.14.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithAsyncIteratorObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithIteratorObject.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/invalidSwitchBreakStatement.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/breakStatements/switchBreakStatements.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatements.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts
 
@@ -3838,41 +2370,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statement
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of35.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of36.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/invalidReturnStatements.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/any/assignAnyToEveryType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowExceptionVariableInCatchClause.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithInstanceof.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithTypePredicate.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/logicalAnd/contextuallyTypeLogicalAnd03.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGeneric.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocalMissing.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeNested.ts
 
@@ -3880,45 +2384,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/imp
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeNonString.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReduction.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReductionStrict.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeAssignment.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements04.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicateNumericIndexers.ts
 
@@ -3926,21 +2406,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/mem
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/indexSignatures1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringAndNumberIndexSignatureToAny.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringNamedNumericProperty.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPrivateConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithProtectedConstructor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPublicConstructor.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAccessProperty.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveNarrow.ts
 
@@ -3960,43 +2428,15 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/obj
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleStringIndexers.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/objectTypeLiteralSyntax2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArity.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArityStrict.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/circularTypeofWithVarOrFunc.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofANonExportedType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofAnExportedType.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofTypeParameter.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument.d.ts
 
@@ -4008,23 +2448,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spe
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNegative.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicate.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicateExact.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadMethods.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonObject1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadTypeVariable.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads05.ts
 
@@ -4044,15 +2468,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thi
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/typeRelationships.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeTupleEnd.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/optionalTupleElements1.ts
 
@@ -4060,23 +2476,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tup
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOfTupleTypes1.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicKeyword.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4.ts
 
@@ -4086,53 +2490,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typesWithDuplicateTypeParameters.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithEnumIndexer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersStringNumericNames.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignedToUndefined.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithUnionTypes01.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/initializersWidened.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeConstructSignatures.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeMembers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReadonly.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts
 
@@ -4142,19 +2512,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun2.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 
@@ -4432,6 +2790,35 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·     ─
  3 │ }
    ╰────
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:41:9]
+ 40 │     case 0:
+ 41 │         await using d20 = { async [Symbol.asyncDispose]() {} };
+    ·         ───────────────────────────────────────────────────────
+ 42 │         break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:45:9]
+ 44 │     case 1:
+ 45 │         await using d21 = { async [Symbol.asyncDispose]() {} };
+    ·         ───────────────────────────────────────────────────────
+ 46 │         break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:52:13]
+ 51 │         case 0:
+ 52 │             await using d22 = { async [Symbol.asyncDispose]() {} };
+    ·             ───────────────────────────────────────────────────────
+ 53 │             break;
+    ╰────
+  help: Wrap this declaration in a block statement
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
 
@@ -25957,33 +24344,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·     ──────────
  7 │ function *gen() {
    ╰────
-
-  × Using declaration cannot appear in the bare case statement.
-    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:41:9]
- 40 │     case 0:
- 41 │         await using d20 = { async [Symbol.asyncDispose]() {} };
-    ·         ───────────────────────────────────────────────────────
- 42 │         break;
-    ╰────
-  help: Wrap this declaration in a block statement
-
-  × Using declaration cannot appear in the bare case statement.
-    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:45:9]
- 44 │     case 1:
- 45 │         await using d21 = { async [Symbol.asyncDispose]() {} };
-    ·         ───────────────────────────────────────────────────────
- 46 │         break;
-    ╰────
-  help: Wrap this declaration in a block statement
-
-  × Using declaration cannot appear in the bare case statement.
-    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts:52:13]
- 51 │         case 0:
- 52 │             await using d22 = { async [Symbol.asyncDispose]() {} };
-    ·             ───────────────────────────────────────────────────────
- 53 │             break;
-    ╰────
-  help: Wrap this declaration in a block statement
 
   × Lexical declaration cannot appear in a single-statement context
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts:5:12]

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 8ea03f88
 
 transformer_typescript Summary:
-AST Parsed     : 8827/8827 (100.00%)
-Positive Passed: 8825/8827 (99.98%)
+AST Parsed     : 9649/9649 (100.00%)
+Positive Passed: 9647/9649 (99.98%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -206,7 +206,193 @@ pub static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "2537", // Type '{ bar: string; }' has no matching index signature for type 'string'.
     "2538", // Type '[]' cannot be used as an index type.
     "2540", // Cannot assign to 'ro' because it is a read-only property.
+    "2542", // Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
+    "2545", // A mixin class must have a constructor with a single rest parameter of type 'any[]'.
+    "2548", // Type 'number' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator.
+    "2550", // Property 'setBigInt64' does not exist on type 'DataView<ArrayBuffer>'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+    "2551", // Property 'fng2' does not exist on type 'typeof A'. Did you mean 'fng'?
+    "2552", // Cannot find name 'tupel'. Did you mean 'tuple'?
+    "2554", // Expected 0 arguments, but got 1.
+    "2555", // Expected at least 1 arguments, but got 0.
+    "2556", // A spread argument must either have a tuple type or be passed to a rest parameter.
+    "2558", // Expected 0 type arguments, but got 1.
+    "2559", // Type 'D' has no properties in common with type 'C'.
+    "2560", // Value of type '() => { timeout: number; }' has no properties in common with type 'Settings'. Did you mean to call it?
+    "2561", // Object literal may only specify known properties, but 'colour' does not exist in type 'CSSProps'. Did you mean to write 'color'?
+    "2563", // The containing function or module body is too large for control flow analysis.
+    "2564", // Property 'b' has no initializer and is not definitely assigned in the constructor.
+    "2565", // Property 'blah2' is used before being assigned.
+    "2571", // Object is of type 'unknown'.
+    "2574", // A rest element type must be an array type.
+    "2575", // No overload expects 2 arguments, but overloads do exist that expect either 1 or 3 arguments.
+    "2576", // Property 'bar' does not exist on type 'C2'. Did you mean to access the static member 'C2.bar' instead?
+    "2577", // Return type annotation circularly references itself.
+    "2578", // Unused '@ts-expect-error' directive.
+    "2580", // Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+    "2581", // Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery`.
+    "2582", // Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
+    "2583", // Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+    "2584", // Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
+    "2585", // 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+    "2589", // Type instantiation is excessively deep and possibly infinite.
+    "2590", // Expression produces a union type that is too complex to represent.
+    "2591", // Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
+    "2595", // 'Foo' can only be imported by using a default import.
+    "2596", // 'Foo' can only be imported by turning on the 'esModuleInterop' flag and using a default import.
+    "2597", // 'Foo' can only be imported by using a 'require' call or by using a default import.
+    "2598", // 'Foo' can only be imported by using a 'require' call or by turning on the 'esModuleInterop' flag and using a default import.
+    "2604", // JSX element type 'BaseComponent' does not have any construct or call signatures.
+    "2607", // JSX element class does not support attributes because it does not have a 'pr' property.
+    "2608", // The global type 'JSX.ElementAttributesProperty' may not have more than one property.
+    "2609", // JSX spread child must be an array type.
+    "2610", // 'a' is defined as an accessor in class 'C1', but is overridden here in 'C2' as an instance property.
+    "2611", // 'p' is defined as a property in class 'A', but is overridden here in 'B' as an accessor.
+    "2613", // Module '"db"' has no default export. Did you mean to use 'import { db } from "db"' instead?
+    "2614", // Module '"es6ImportDefaultBindingFollowedWithNamedImport1_0"' has no exported member 'a'. Did you mean to use 'import a from "es6ImportDefaultBindingFollowedWithNamedImport1_0"' instead?
+    "2615", // Type of property '"each"' circularly references itself in mapped type '{ [P in keyof ListWidget]: undefined extends ListWidget[P] ? never : P; }'.
+    "2616", // 'Foo' can only be imported by using 'import Foo = require("./a")' or a default import.
+    "2617", // 'a' can only be imported by using 'import a = require("./es6ImportNamedImportNoNamedExports_0")' or by turning on the 'esModuleInterop' flag and using a default import.
+    "2628", // Cannot assign to 'A' because it is an enum.
+    "2629", // Cannot assign to 'f' because it is a class.
+    "2630", // Cannot assign to 'foo' because it is a function.
+    "2631", // Cannot assign to 'M' because it is a namespace.
+    "2635", // Type '<N extends string, QR>(queries: { [QK in keyof QR]: any; }) => (state?: { queries: QR; }) => { queries: QR; }' has no signatures for which the type argument list is applicable.
+    "2636", // Type 'Controller<sub-T>' is not assignable to type 'Controller<super-T>' as implied by variance annotation.
+    "2638", // Type '{}' may represent a primitive value, which is not permitted as the right operand of the 'in' operator.
+    "2639", // React components cannot include JSX namespace names
+    "2649", // Cannot augment module 'lib' with value exports because it resolves to a non-module entity.
+    "2650", // Non-abstract class expression is missing implementations for the following members of 'A': 'm1', 'm2', 'm3', 'm4' and 2 more.
+    "2652", // Merged declaration 'Decl' cannot include a default export declaration. Consider adding a separate 'export default Decl' declaration instead.
+    "2653", // Non-abstract class expression does not implement inherited abstract member 'foo' from class 'A'.
+    "2654", // Non-abstract class 'C' is missing implementations for the following members of 'B': 'prop', 'readonlyProp', 'm', 'mismatch'.
+    "2655", // Non-abstract class 'B' is missing implementations for the following members of 'A': 'm1', 'm2', 'm3', 'm4' and 2 more.
+    "2659", // 'super' is only allowed in members of object literal expressions when option 'target' is 'ES2015' or higher.
+    "2661", // Cannot export 'string'. Only local declarations can be exported from a module.
+    "2662", // Cannot find name 'foo'. Did you mean the static member 'C.foo'?
+    "2663", // Cannot find name 'foo'. Did you mean the instance member 'this.foo'?
+    "2664", // Invalid module name in augmentation, module 'ext' cannot be found.
     "2665", // Invalid module name in augmentation. Module 'foo' resolves to an untyped module at '/node_modules/foo/index.js', which cannot be augmented.
+    "2671", // Cannot augment module './file1' because it resolves to a non-module entity.
+    "2673", // Constructor of class 'D' is private and only accessible within the class declaration.
+    "2674", // Constructor of class 'E' is protected and only accessible within the class declaration.
+    "2675", // Cannot extend a class 'BaseC'. Class constructor is marked as private.
+    "2677", // A type predicate's type must be assignable to its parameter's type.
+    "2678", // Type 'Choice.Unknown' is not comparable to type 'Choice.Yes'.
+    "2679", // A function that is called with the 'new' keyword cannot have a 'this' type that is 'void'.
+    "2683", // 'this' implicitly has type 'any' because it does not have a type annotation.
+    "2684", // The 'this' context of type 'EPromise<number, string>' is not assignable to method's 'this' of type 'EPromise<never, string>'.
+    "2686", // 'Puppeteer' refers to a UMD global, but the current file is a module. Consider adding an import instead.
+    "2687", // All declarations of 'x' must have identical modifiers.
+    "2688", // Cannot find type definition file for 'react'.
+    "2689", // Cannot extend an interface 'Base'. Did you mean 'implements'?
+    "2690", // 'K' only refers to a type, but is being used as a value here. Did you mean to use 'P in K'?
+    "2693", // 'I' only refers to a type, but is being used as a value here.
+    "2694", // Namespace 'foo.bar.baz' has no exported member 'bar'.
+    "2695", // Left side of comma operator is unused and has no side effects.
+    "2696", // The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
+    "2698", // Spread types may only be created from object types.
+    "2700", // Rest types may only be created from object types.
+    "2702", // 'db' only refers to a type, but is being used as a namespace here.
+    "2704", // The operand of a 'delete' operator cannot be a read-only property.
+    "2705", // An async function or method in ES5 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
+    "2707", // Generic type 'i09<T, U, V>' requires between 2 and 3 type arguments.
+    "2708", // Cannot use namespace 'M' as a value.
+    "2709", // Cannot use namespace 'M' as a type.
+    "2710", // 'children' are specified twice. The attribute named 'children' will be overwritten.
+    "2712", // A dynamic import call in ES5 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
+    "2713", // Cannot access 'Foo.bar' because 'Foo' is a type, but not a namespace. Did you mean to retrieve the type of the property 'bar' in 'Foo' with 'Foo["bar"]'?
+    "2715", // Abstract property 'prop' in class 'AbstractClass' cannot be accessed in the constructor.
+    "2716", // Type parameter 'T' has a circular default.
+    "2717", // Subsequent property declarations must have the same type.  Property 'a' must be of type '() => number', but here has type 'number'.
+    "2719", // Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
+    "2720", // Class 'C' incorrectly implements class 'A'. Did you mean to extend 'A' and inherit its members as a subclass?
+    "2721", // Cannot invoke an object which is possibly 'null'.
+    "2722", // Cannot invoke an object which is possibly 'undefined'.
+    "2723", // Cannot invoke an object which is possibly 'null' or 'undefined'.
+    "2724", // '"./a"' has no exported member named 'assertNevar'. Did you mean 'assertNever'?
+    "2725", // Class name cannot be 'Object' when targeting ES5 and above with module CommonJS.
+    "2729", // Property 'prop' is used before its initialization.
+    "2731", // Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
+    "2732", // Cannot find module './b.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
+    "2736", // Operator '+' cannot be applied to type 'bigint'.
+    "2737", // BigInt literals are not available when targeting lower than ES2020.
+    "2739", // Type 'undefined[]' is missing the following properties from type 'C1': IM1, C1M1
+    "2740", // Type '{ one: number; }' is missing the following properties from type 'any[]': length, pop, push, concat, and 16 more.
+    "2741", // Property '2' is missing in type 'StrNum' but required in type '[number, number, number]'.
+    "2742", // The inferred type of 'x' cannot be named without a reference to 'foo/node_modules/nested'. This is likely not portable. A type annotation is necessary.
+    "2743", // No overload expects 2 type arguments, but overloads do exist that expect either 1 or 3 type arguments.
+    "2744", // Type parameter defaults can only reference previously declared type parameters.
+    "2745", // This JSX tag's 'children' prop expects type '((x: number) => string)[]' which requires multiple children, but only a single child was provided.
+    "2746", // This JSX tag's 'children' prop expects a single child of type 'Element', but multiple children were provided.
+    "2747", // 'Comp' components don't accept text as child elements. Text in JSX has the type 'string', but the expected type of 'children' is 'Element | Element[]'.
+    "2748", // Cannot access ambient const enums when 'isolatedModules' is enabled.
+    "2749", // 'originalZZZ' refers to a value, but is being used as a type here. Did you mean 'typeof originalZZZ'?
+    "2763", // Cannot iterate value because the 'next' method of its iterator expects type 'string', but for-of will always send 'undefined'.
+    "2764", // Cannot iterate value because the 'next' method of its iterator expects type 'string', but array spread will always send 'undefined'.
+    "2765", // Cannot iterate value because the 'next' method of its iterator expects type 'string', but array destructuring will always send 'undefined'.
+    "2766", // Cannot delegate iteration to value because the 'next' method of its iterator expects type 'string', but the containing generator will always send 'boolean'.
+    "2767", // The 'return' property of an iterator must be a method.
+    "2769", // No overload matches this call.
+    "2774", // This condition will always return true since this function is always defined. Did you mean to call it instead?
+    "2775", // Assertions require every name in the call target to be declared with an explicit type annotation.
+    "2776", // Assertions require the call target to be an identifier or qualified name.
+    "2783", // 'a' is specified more than once, so this usage will be overwritten.
+    "2786", // 'MySFC' cannot be used as a JSX component.
+    "2790", // The operand of a 'delete' operator must be optional.
+    "2791", // Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+    "2792", // Cannot find module 'foo'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?
+    "2796", // It is likely that you are missing a comma to separate these two template expressions. They form a tagged template expression which cannot be invoked.
+    "2797", // A mixin class that extends from a type variable containing an abstract construct signature must also be declared 'abstract'.
+    "2799", // Type produces a tuple type that is too large to represent.
+    "2800", // Expression produces a tuple type that is too large to represent.
+    "2801", // This condition will always return true since this 'Promise<number>' is always defined.
+    "2802", // Type 'Set<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
+    "2803", // Cannot assign to private method '#m'. Private methods are not writable.
+    "2806", // Private accessor was defined without a getter.
+    "2807", // This syntax requires an imported helper named '__spreadArray' with 3 parameters, which is not compatible with the one in 'tslib'. Consider upgrading your version of 'tslib'.
+    "2808", // A get accessor must be at least as accessible as the setter
+    "2812", // Property 'textContent' does not exist on type 'Element'. Try changing the 'lib' compiler option to include 'dom'.
+    "2813", // Class declaration cannot implement overload list for 'c2'.
+    "2814", // Function with bodies can only merge with classes that are ambient.
+    "2818", // Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    "2820", // Type '"strong"' is not assignable to type 'T1'. Did you mean '"string"'?
+    "2821", // Import assertions are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    "2823", // Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'node20', 'nodenext', or 'preserve'.
+    "2833", // Cannot find namespace 'b'. Did you mean 'B'?
+    "2834", // Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
+    "2835", // Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './foo.mjs'?
+    "2836", // Import assertions are not allowed on statements that compile to CommonJS 'require' calls.
+    "2838", // All declarations of 'U' must have identical constraints.
+    "2839", // This condition will always return 'false' since JavaScript compares objects by reference, not value.
+    "2840", // An interface cannot extend a primitive type like 'string'. It can only extend other named object types.
+    "2842", // 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+    "2844", // Type of instance member variable 'b' cannot reference identifier 'x' declared in the constructor.
+    "2845", // This condition will always return 'false'.
+    "2846", // A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
+    "2850", // The initializer of a 'using' declaration must be either an object with a '[Symbol.dispose]()' method, or be 'null' or 'undefined'.
+    "2851", // The initializer of an 'await using' declaration must be either an object with a '[Symbol.asyncDispose]()' or '[Symbol.dispose]()' method, or be 'null' or 'undefined'.
+    "2854", // Top-level 'await using' statements are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    "2855", // Class field 'x' defined by the parent class is not accessible in the child class via super.
+    "2856", // Import attributes are not allowed on statements that compile to CommonJS 'require' calls.
+    "2859", // Excessive complexity comparing types 'T1 & T2' and 'T1 | null'.
+    "2860", // The left-hand side of an 'instanceof' expression must be assignable to the first argument of the right-hand side's '[Symbol.hasInstance]' method.
+    "2861", // An object's '[Symbol.hasInstance]' method must return a boolean value for it to be used on the right-hand side of an 'instanceof' expression.
+    "2862", // Type 'T' is generic and can only be indexed for reading.
+    "2863", // A class cannot extend a primitive type like 'number'. Classes can only extend constructable values.
+    "2864", // A class cannot implement a primitive type like 'number'. It can only implement other named object types.
+    "2865", // Import 'T' conflicts with local value, so must be declared with a type-only import when 'isolatedModules' is enabled.
+    "2867", // Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun`.
+    "2868", // Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
+    "2869", // Right operand of ?? is unreachable because the left operand is never nullish.
+    "2871", // This expression is always nullish.
+    "2872", // This kind of expression is always truthy.
+    "2873", // This kind of expression is always falsy.
+    "2874", // This JSX tag requires 'React' to be in scope, but it could not be found.
+    "2875", // This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+    "2876", // This relative import path is unsafe to rewrite because it looks like a file name, but actually resolves to "./foo.ts/index.ts".
+    "2877", // This import uses a '.ts' extension to resolve to an input TypeScript file, but will not be rewritten during emit because it is not a relative path.
+    "2879", // Using JSX fragments requires fragment factory 'React' to be in scope, but it could not be found.
+    "2881", // This expression is never nullish.
     "4023", // Exported variable 'foo' has or is using name 'Foo' from external module "type" but cannot be named.
     "4025", // Exported variable 'b' has or is using private name 'a'.
     "4032", // Property 'val' of exported interface has or is using name 'I' from private module '"a"'.


### PR DESCRIPTION
Part of https://github.com/oxc-project/oxc/issues/11582

Used the same hash in https://github.com/oxc-project/oxc/issues/11582#issuecomment-3008344585 (261630d650c0c961860187bebc86e25c3707c05d).

Hope you don't mind 😀
