### PR TITLE
fix(semantic): allow reserved keywords in typescript ambient contexts

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -16,14 +16,14 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
             js::check_unresolved_exports(program, ctx);
         }
         AstKind::BindingIdentifier(ident) => {
-            js::check_identifier(&ident.name, ident.span, ctx);
+            js::check_identifier(&ident.name, ident.span, ident.symbol_id.get(), ctx);
             js::check_binding_identifier(ident, ctx);
         }
         AstKind::IdentifierReference(ident) => {
-            js::check_identifier(&ident.name, ident.span, ctx);
+            js::check_identifier(&ident.name, ident.span, None, ctx);
             js::check_identifier_reference(ident, ctx);
         }
-        AstKind::LabelIdentifier(ident) => js::check_identifier(&ident.name, ident.span, ctx),
+        AstKind::LabelIdentifier(ident) => js::check_identifier(&ident.name, ident.span, None, ctx),
         AstKind::PrivateIdentifier(ident) => js::check_private_identifier_outside_class(ident, ctx),
         AstKind::NumericLiteral(lit) => js::check_number_literal(lit, ctx),
         AstKind::StringLiteral(lit) => js::check_string_literal(lit, ctx),

--- a/tasks/coverage/misc/pass/declare-let-private.ts
+++ b/tasks/coverage/misc/pass/declare-let-private.ts
@@ -1,0 +1,3 @@
+declare let private: number;
+
+export {};

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 50/50 (100.00%)
-Positive Passed: 50/50 (100.00%)
+AST Parsed     : 51/51 (100.00%)
+Positive Passed: 51/51 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 50/50 (100.00%)
-Positive Passed: 50/50 (100.00%)
+AST Parsed     : 51/51 (100.00%)
+Positive Passed: 51/51 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 50/50 (100.00%)
-Positive Passed: 50/50 (100.00%)
+AST Parsed     : 51/51 (100.00%)
+Positive Passed: 51/51 (100.00%)
 Negative Passed: 118/118 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: cc2610fd
 
 parser_typescript Summary:
 AST Parsed     : 9821/9822 (99.99%)
-Positive Passed: 9809/9822 (99.87%)
+Positive Passed: 9810/9822 (99.88%)
 Negative Passed: 1455/2545 (57.17%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 
@@ -2364,23 +2364,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExp
     · ────
  65 │     var y = _;
     ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.3.ts
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwait.3.ts:3:15]
- 2 │ export {};
- 3 │ declare const await: any;
-   ·               ──────────
- 4 │ declare class C extends await {}
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwait.3.ts:4:25]
- 3 │ declare const await: any;
- 4 │ declare class C extends await {}
-   ·                         ─────
-   ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,11 @@
 semantic_misc Summary:
-AST Parsed     : 50/50 (100.00%)
-Positive Passed: 32/50 (64.00%)
+AST Parsed     : 51/51 (100.00%)
+Positive Passed: 32/51 (62.75%)
+semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["private"]
+rebuilt        : ScopeId(0): []
+
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: cc2610fd
 
 semantic_typescript Summary:
 AST Parsed     : 6148/6148 (100.00%)
-Positive Passed: 2661/6148 (43.28%)
+Positive Passed: 2662/6148 (43.30%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -42823,10 +42823,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.3.ts
-The keyword 'await' is reserved
-The keyword 'await' is reserved
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
 Scope children mismatch:

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 50/50 (100.00%)
-Positive Passed: 50/50 (100.00%)
+AST Parsed     : 51/51 (100.00%)
+Positive Passed: 51/51 (100.00%)


### PR DESCRIPTION
Reserved keywords are allowed as an identifier in ambient contexts.
```ts
declare const private: number
```
This is allowed.
