### PR TITLE
perf(lexer): hint to compiler that EOF only happens once

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -324,7 +324,12 @@ impl<'a> Lexer<'a> {
             self.token.set_start(offset);
 
             let Some(byte) = self.peek_byte() else {
-                return Kind::Eof;
+                // Hint to compiler that this branch is rarely taken (only once at EOF)
+                #[cold]
+                fn eof() -> Kind {
+                    Kind::Eof
+                }
+                return eof();
             };
 
             // SAFETY: `byte` is byte value at current position in source


### PR DESCRIPTION
In `Lexer::read_next_token`, reaching EOF is very uncommon (because it only happens once at end of the file). Inform compiler of this using a `#[cold]` function, so it makes "not at EOF" the default path.

Small improvement on all the lexer and parser benchmarks (+1% on most lexer benchmarks).