### PR TITLE
perf(lexer): inline `handle_byte` into `read_next_token`

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -12,6 +12,9 @@ impl Lexer<'_> {
     /// * Lexer must not be at end of file.
     /// * `byte` must be next byte of source code, corresponding to current position of `lexer.source`.
     /// * Only `BYTE_HANDLERS` for ASCII characters may use the `ascii_byte_handler!()` macro.
+    // `#[inline(always)]` to ensure is inlined into `read_next_token`
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     pub(super) unsafe fn handle_byte(&mut self, byte: u8) -> Kind {
         // SAFETY: Caller guarantees to uphold safety invariants
         unsafe { BYTE_HANDLERS[byte as usize](self) }


### PR DESCRIPTION
Preparatory step for #15513. That PR adds a 2nd callsite for `handle_byte`. Mark it as `#[inline(always)]` to make sure it gets inlined in both places.

This was originally part of #15513, but have split it out into a separate PR so that Codspeed's results on #15513 measure the actual substantive change in isolation - to check that change is having the effect I think it is, and that the gain wasn't actually coming from adding `#[inline(always)]` here. This PR has no effect on performance, so the gain *is* in #15513.