### PR TITLE
ci(benchmarks/lexer): reduce string cloning in source cleaner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
 name = "oxc_benchmark"
 version = "0.0.0"
 dependencies = [
+ "cow-utils",
  "criterion2",
  "oxc_allocator 0.96.0",
  "oxc_ast 0.96.0",

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -78,6 +78,9 @@ criterion2 = { workspace = true }
 
 rustc-hash = { workspace = true }
 
+# Only for lexer benchmark
+cow-utils = { workspace = true, optional = true }
+
 # Only for NAPI benchmark
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -104,6 +107,7 @@ compiler = [
   "dep:oxc_span",
   "dep:oxc_tasks_common",
   "dep:oxc_transformer",
+  "dep:cow-utils",
 ]
 linter = [
   "dep:oxc_allocator",

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -1,4 +1,7 @@
-#![expect(clippy::disallowed_methods)]
+use std::borrow::Cow;
+
+use cow_utils::CowUtils;
+
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
@@ -26,10 +29,7 @@ fn bench_lexer(criterion: &mut Criterion) {
         .map(|file| {
             let source_type = SourceType::from_path(&file.file_name).unwrap();
 
-            let mut cleaner = SourceCleaner::new(&file.source_text);
-            cleaner.clean(source_type, &allocator);
-            let source_text = cleaner.source_text;
-
+            let source_text = clean(&file.source_text, source_type, &allocator);
             allocator.reset();
 
             TestFile {
@@ -81,7 +81,7 @@ fn lex_whole_file<'a>(
     lexer
 }
 
-/// Cleaner of source text.
+/// Clean source text.
 ///
 /// Purpose is to allow lexer to complete without any errors.
 /// Usually sources Oxc is asked to parse will not produce lexer errors, and generating diagnostics is
@@ -95,9 +95,40 @@ fn lex_whole_file<'a>(
 /// * `RegExpLiteral`
 /// * `TemplateLiteral`
 /// * `JSXText`
-struct SourceCleaner {
-    source_text: String,
+fn clean<'a>(source_text: &'a str, source_type: SourceType, allocator: &'a Allocator) -> String {
+    // Parse
+    let parser_ret = Parser::new(allocator, source_text, source_type).parse();
+    assert!(parser_ret.errors.is_empty());
+    let program = parser_ret.program;
+
+    // Visit AST and compile list of replacements
+    let mut cleaner = SourceCleaner::new(source_text);
+    cleaner.visit_program(&program);
+    let mut replacements = cleaner.replacements;
+
+    // Make replacements
+    replacements.sort_unstable_by_key(|replacement| replacement.span);
+
+    let mut clean_source_text = String::with_capacity(cleaner.clean_source_text_len);
+    let mut last_index = 0;
+    for Replacement { span, text } in replacements {
+        clean_source_text.push_str(&source_text[last_index..span.start as usize]);
+        clean_source_text.push_str(&text);
+        last_index = span.end as usize;
+    }
+    clean_source_text.push_str(&source_text[last_index..]);
+
+    // Check lexer can lex it without any errors
+    let lexer = lex_whole_file(allocator, &clean_source_text, source_type);
+    assert!(lexer.errors().is_empty());
+
+    clean_source_text
+}
+
+struct SourceCleaner<'a> {
+    source_text: &'a str,
     replacements: Vec<Replacement>,
+    clean_source_text_len: usize,
 }
 
 struct Replacement {
@@ -105,41 +136,18 @@ struct Replacement {
     text: String,
 }
 
-impl SourceCleaner {
-    fn new(source_text: &str) -> Self {
-        Self { source_text: source_text.to_string(), replacements: vec![] }
-    }
-
-    fn clean(&mut self, source_type: SourceType, allocator: &Allocator) {
-        // Parse
-        let source_text = self.source_text.clone();
-        let parser_ret = Parser::new(allocator, &source_text, source_type).parse();
-        assert!(parser_ret.errors.is_empty());
-        let program = parser_ret.program;
-
-        // Visit AST and compile list of replacements
-        self.visit_program(&program);
-
-        // Make replacements
-        self.replacements.sort_unstable_by_key(|replacement| replacement.span);
-
-        for replacement in self.replacements.iter().rev() {
-            let span = replacement.span;
-            self.source_text
-                .replace_range(span.start as usize..span.end as usize, &replacement.text);
-        }
-
-        // Check lexer can lex it without any errors
-        let lexer = lex_whole_file(allocator, &self.source_text, source_type);
-        assert!(lexer.errors().is_empty());
+impl<'a> SourceCleaner<'a> {
+    fn new(source_text: &'a str) -> Self {
+        Self { source_text, replacements: vec![], clean_source_text_len: source_text.len() }
     }
 
     fn replace(&mut self, span: Span, text: String) {
+        self.clean_source_text_len += text.len() - span.size() as usize;
         self.replacements.push(Replacement { span, text });
     }
 }
 
-impl<'a> Visit<'a> for SourceCleaner {
+impl<'a> Visit<'a> for SourceCleaner<'a> {
     fn visit_reg_exp_literal(&mut self, regexp: &RegExpLiteral<'a>) {
         let pattern_text = regexp.regex.pattern.text.as_str();
         let span = Span::sized(regexp.span.start, u32::try_from(pattern_text.len()).unwrap() + 2);
@@ -149,15 +157,15 @@ impl<'a> Visit<'a> for SourceCleaner {
 
     fn visit_template_literal(&mut self, lit: &TemplateLiteral<'a>) {
         let span = lit.span;
-        let text = span.shrink(1).source_text(&self.source_text);
-        let text = convert_to_string(text).replace('\n', " ");
+        let text = span.shrink(1).source_text(self.source_text);
+        let text = convert_to_string(&text.cow_replace('\n', " "));
         self.replace(span, text);
     }
 
     fn visit_jsx_text(&mut self, jsx_text: &JSXText<'a>) {
         let span = jsx_text.span;
-        let text = span.source_text(&self.source_text);
-        let text = convert_to_string(text).replace('\n', " ");
+        let text = span.source_text(self.source_text);
+        let text = convert_to_string(&text.cow_replace('\n', " "));
         self.replace(span, text);
     }
 }
@@ -169,6 +177,13 @@ fn convert_to_string(text: &str) -> String {
 
     let (quote, other_quote) =
         if single_quote_count <= double_quote_count { ('\'', "\"") } else { ('"', "'") };
-    let text = text.replace(quote, other_quote);
+
+    #[expect(clippy::disallowed_methods)]
+    let text = if single_quote_count == 0 || double_quote_count == 0 {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(text.replace(quote, other_quote))
+    };
+
     format!("{quote}{text}{quote}")
 }


### PR DESCRIPTION
Improve the source text cleaner in lexer benchmark to do less string cloning and allocations. Does not affect the benchmark itself, only makes the setup more efficient.