### PR TITLE
docs(linter): Update comment in lint.rs about default value for tsconfig path

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -115,6 +115,7 @@ pub struct BasicOptions {
     pub config: Option<PathBuf>,
 
     /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
+    /// If not provided, will look for `tsconfig.json` in the current working directory.
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -114,7 +114,7 @@ pub struct BasicOptions {
     #[bpaf(long, short, argument("./.oxlintrc.json"))]
     pub config: Option<PathBuf>,
 
-    /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
+    /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin.
     /// If not provided, will look for `tsconfig.json` in the current working directory.
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -14,7 +14,7 @@ expression: snapshot
 
   If not provided, Oxlint will look for `.oxlintrc.json` in the current working directory.
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
-  TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
+  TypeScript `tsconfig.json` path for reading path alias and project references for import plugin. If not provided, will look for `tsconfig.json` in the current working directory.
 - **`    --init`** &mdash; 
   Initialize oxlint configuration with default values
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -10,7 +10,8 @@ Basic Configuration
                               * you can use comments in configuration files.
                               * tries to be compatible with the ESLint v8's format
         --tsconfig=<./tsconfig.json>  TypeScript `tsconfig.json` path for reading path alias and
-                              project references for import plugin
+                              project references for import plugin. If not provided, will look for
+                              `tsconfig.json` in the current working directory.
         --init                Initialize oxlint configuration with default values
 
 Allowing / Denying Multiple Lints


### PR DESCRIPTION
It wasn't previously clear what would be done if no tsconfig path was provided, so this clarifies that.

This comment will be automatically used by the CLI and documentation website: https://oxc.rs/docs/guide/usage/linter/cli.html#basic-configuration