### PR TITLE
fix(tools): fix `just benchmark-one`

### DIFF
--- a/justfile
+++ b/justfile
@@ -99,7 +99,10 @@ benchmark:
 
 # Run benchmarks for a single component
 benchmark-one *args:
-  cargo benchmark --bench {{args}} --no-default-features --features {{args}}
+  cargo benchmark --bench {{args}} --no-default-features --features compiler
+
+benchmark-linter:
+  cargo benchmark --bench linter --no-default-features --features linter
 
 # ==================== TESTING & CONFORMANCE ====================
 


### PR DESCRIPTION
`just benchmark-one` was broken when all benchmarks except linter got combined into a single `compiler` cargo feature. Fix it. Add a separate `just benchmark-linter` command for linter (different cargo feature).