### PR TITLE
docs(linter): Improve error message for missing tsgolint.

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -1049,7 +1049,7 @@ pub fn try_find_tsgolint_executable(cwd: &Path) -> Result<PathBuf, String> {
         }
     }
 
-    Err("Failed to find tsgolint executable".to_string())
+    Err("Failed to find tsgolint executable. You may need to add the `oxlint-tsgolint` package to your project?".to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Provide some possible guidance on how to fix the problem if someone is using `oxlint --type-aware` without having installed tsgolint.

Previously you'd just get this, which isn't very helpful:

```
project % pnpm oxlint --type-aware
Failed to find tsgolint executable
```

Before merging this, will need to confirm that this is the correct way to resolve the problem? It may also have been a mistake on my part when messing with oxlint locally, and this error may not be hit very often anymore?