### PR TITLE
refactor(tools): merge `just benchmark-linter` into `just benchmark-one`

### DIFF
--- a/justfile
+++ b/justfile
@@ -99,10 +99,7 @@ benchmark:
 
 # Run benchmarks for a single component
 benchmark-one *args:
-  cargo benchmark --bench {{args}} --no-default-features --features compiler
-
-benchmark-linter:
-  cargo benchmark --bench linter --no-default-features --features linter
+  cargo benchmark --bench {{args}} --no-default-features --features {{ if args == "linter" { "linter" } else { "compiler" } }}
 
 # ==================== TESTING & CONFORMANCE ====================
 


### PR DESCRIPTION
Follow on after #15532. Merge `just benchmark-one` and `just benchmark-linter` into 1 command, as suggested by @leaysgur in https://github.com/oxc-project/oxc/pull/15533#pullrequestreview-3440492262.