### PR TITLE
feat(oxfmt): use `prettier` directly and bundle `prettier`

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -20,8 +20,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
-    "prettier": "3.6.2",
-    "@prettier/sync": "0.6.1"
+    "prettier": "3.6.2"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/oxfmt/src-js/embedded.ts
+++ b/apps/oxfmt/src-js/embedded.ts
@@ -1,4 +1,4 @@
-import prettier from '@prettier/sync';
+import prettier from 'prettier';
 
 // Map template tag names to Prettier parsers
 const TAG_TO_PARSER: Record<string, string> = {
@@ -25,7 +25,7 @@ const TAG_TO_PARSER: Record<string, string> = {
  * @param code - The code to format
  * @returns Formatted code
  */
-export function formatEmbeddedCode(tagName: string, code: string): string {
+export async function formatEmbeddedCode(tagName: string, code: string): Promise<string> {
   const parser = TAG_TO_PARSER[tagName];
 
   if (!parser) {
@@ -33,19 +33,14 @@ export function formatEmbeddedCode(tagName: string, code: string): string {
     return code;
   }
 
-  try {
-    const formatted = prettier.format(code, {
+  return prettier
+    .format(code, {
       parser,
       printWidth: 80,
       tabWidth: 2,
       semi: true,
       singleQuote: false,
-    });
-
-    // Remove trailing newline that Prettier adds
-    return formatted.trimEnd();
-  } catch {
-    // If Prettier fails to format, return original code
-    return code;
-  }
+    })
+    .then((formatted) => formatted.trimEnd())
+    .catch(() => code);
 }

--- a/apps/oxfmt/src/run.rs
+++ b/apps/oxfmt/src/run.rs
@@ -24,11 +24,12 @@ use crate::{
 #[allow(clippy::trailing_empty_array, clippy::unused_async)] // https://github.com/napi-rs/napi-rs/issues/2758
 #[napi]
 pub async fn format(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> bool {
-    format_impl(&args, format_embedded_cb).report() == ExitCode::SUCCESS
+    format_impl(args, format_embedded_cb).report() == ExitCode::SUCCESS
 }
 
 /// Run the formatter.
-fn format_impl(args: &[String], format_embedded_cb: JsFormatEmbeddedCb) -> CliRunResult {
+#[expect(clippy::needless_pass_by_value)]
+fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> CliRunResult {
     init_tracing();
     init_miette();
 

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   outDir: 'dist',
   shims: false,
+  noExternal: ['prettier'],
 });

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -24,10 +24,6 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "dependencies": {
-    "prettier": "3.6.2",
-    "@prettier/sync": "0.6.1"
-  },
   "files": [
     "bin/oxfmt",
     "configuration_schema.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
 
   apps/oxfmt:
     dependencies:
-      '@prettier/sync':
-        specifier: 0.6.1
-        version: 0.6.1(prettier@3.6.2)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -230,14 +227,7 @@ importers:
 
   npm/oxc-types: {}
 
-  npm/oxfmt:
-    dependencies:
-      '@prettier/sync':
-        specifier: 0.6.1
-        version: 0.6.1(prettier@3.6.2)
-      prettier:
-        specifier: 3.6.2
-        version: 3.6.2
+  npm/oxfmt: {}
 
   npm/oxlint: {}
 
@@ -1611,11 +1601,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@prettier/sync@0.6.1':
-    resolution: {integrity: sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==}
-    peerDependencies:
-      prettier: '*'
 
   '@publint/pack@0.1.2':
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
@@ -3191,9 +3176,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-synchronized@0.8.0:
-    resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -5414,11 +5396,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prettier/sync@0.6.1(prettier@3.6.2)':
-    dependencies:
-      make-synchronized: 0.8.0
-      prettier: 3.6.2
-
   '@publint/pack@0.1.2': {}
 
   '@quansync/fs@0.1.5':
@@ -6960,8 +6937,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
-
-  make-synchronized@0.8.0: {}
 
   markdown-it@14.1.0:
     dependencies:


### PR DESCRIPTION
`@prettier/sync` is the synchronous version of `prettier`, which uses the `Worker` to hack it and make it synchronous. 

Everything worked fine before we wanted to bundle them together. However, it hangs when they are bundled. I haven't found the reason why it hangs. Anyway, I don't think `@prettier/sync` is a good choice because it is not `real` synchronous, which sacrifices some performance to make it available. 

Note: I am not familiar with NAPI, so I'm not sure whether the API is used correctly.