### PR TITLE
release(apps): oxlint v1.27.0 && oxfmt v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "bitflags 2.10.0",
  "constcat",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bpaf",
  "cow-utils",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.12.0] - 2025-11-10
+
+### 🚀 Features
+
+- 3251000 oxfmt: Use `prettier` directly and bundle `prettier` (#15544) (Dunqing)
+- 7b1e6f3 apps: Add pure rust binaries and release to github (#15469) (Boshen)
+- 33ad374 oxfmt: Disable embedded formatting by default for alpha (#15402) (leaysgur)
+
+### ⚡ Performance
+
+- a6808a0 oxfmt: Use `AllocatorPool` to reuse allocator between threads (#15412) (leaysgur)
+
 
 ## [0.10.0] - 2025-11-04
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.27.0] - 2025-11-10
+
+### 🚀 Features
+
+- 222a8f0 linter/plugins: Implement `SourceCode#isSpaceBetween` (#15498) (overlookmotel)
+- 2f9735d linter/plugins: Implement `context.languageOptions` (#15486) (overlookmotel)
+- bc731ff linter/plugins: Stub out all `Context` APIs (#15479) (overlookmotel)
+- 5822cb4 linter/plugins: Add `extend` method to `FILE_CONTEXT` (#15477) (overlookmotel)
+- 7b1e6f3 apps: Add pure rust binaries and release to github (#15469) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 6957fb9 linter/plugins: Do not allow access to `Context#id` in `createOnce` (#15489) (overlookmotel)
+- 7409630 linter/plugins: Allow access to `cwd` in `createOnce` in ESLint interop mode (#15488) (overlookmotel)
+- a17ca32 linter/plugins: Replace `Context` class (#15448) (overlookmotel)
+- fde753e linter/plugins: Block access to `context.settings` in `createOnce` (#15394) (overlookmotel)
+- cc403f5 linter/plugins: Return empty object for unimplemented parserServices (#15364) (magic-akari)
+
+### ⚡ Performance
+
+- 3c57291 linter/plugins: Optimize loops (#15449) (overlookmotel)
+- 3166233 linter/plugins: Remove `Arc`s (#15431) (overlookmotel)
+- 9de1322 linter/plugins: Lazily deserialize settings JSON (#15395) (overlookmotel)
+- 3049ec2 linter/plugins: Optimize `deepFreezeSettings` (#15392) (overlookmotel)
+- 444ebfd linter/plugins: Use single object for `parserServices` (#15378) (overlookmotel)
+
+### 📚 Documentation
+
+- 97d2104 linter: Update comment in lint.rs about default value for tsconfig path (#15530) (Connor Shea)
+
 ## [1.26.0] - 2025-11-05
 
 ### 🚀 Features

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.26.0"
+version = "1.27.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/oxlint/src-js/bindings.js
+++ b/apps/oxlint/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm64')
         const bindingPackageVersion = require('@oxlint/android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/android-arm-eabi')
         const bindingPackageVersion = require('@oxlint/android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64-gnu')
         const bindingPackageVersion = require('@oxlint/win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-x64')
         const bindingPackageVersion = require('@oxlint/win32-x64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-ia32')
         const bindingPackageVersion = require('@oxlint/win32-ia32/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/win32-arm64')
         const bindingPackageVersion = require('@oxlint/win32-arm64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxlint/darwin-universal')
       const bindingPackageVersion = require('@oxlint/darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-x64')
         const bindingPackageVersion = require('@oxlint/darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/darwin-arm64')
         const bindingPackageVersion = require('@oxlint/darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-x64')
         const bindingPackageVersion = require('@oxlint/freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/freebsd-arm64')
         const bindingPackageVersion = require('@oxlint/freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-musl')
           const bindingPackageVersion = require('@oxlint/linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-x64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-musl')
           const bindingPackageVersion = require('@oxlint/linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxlint/linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-musl')
           const bindingPackageVersion = require('@oxlint/linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-loong64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-musl')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxlint/linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxlint/linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxlint/linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/linux-s390x-gnu')
         const bindingPackageVersion = require('@oxlint/linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm64')
         const bindingPackageVersion = require('@oxlint/openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-x64')
         const bindingPackageVersion = require('@oxlint/openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxlint/openharmony-arm')
         const bindingPackageVersion = require('@oxlint/openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.26.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.26.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.27.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.27.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.12.0] - 2025-11-10
+
+### 🚀 Features
+
+- 33ad374 oxfmt: Disable embedded formatting by default for alpha (#15402) (leaysgur)
+- 5708126 formatter/sort_imports: Add `options.newlinesBetween` (#15369) (leaysgur)
+- 2dfc3bd formatter: Remove `Tag::StartVerbatim` and `Tag::EndVerbatim` (#15370) (Dunqing)
+- 88c7530 formatter: Remove `FormatElement::LocatedTokenText` (#15367) (Dunqing)
+
+### 🐛 Bug Fixes
+
+- d32d22e formatter: Correct `FormatElement` size check (#15461) (Dunqing)
+- b0f43f9 formatter: Test call difference (#15356) (Dunqing)
+- 01f20f3 formatter: Incorrect comment checking logic for grouping argument (#15354) (Dunqing)
+
+### ⚡ Performance
+
+- f4b75b6 formatter: Pre-allocate enough space for the FormatElement buffer (#15422) (Dunqing)
+- 5a61189 formatter: Avoid unnecessary allocation for `BinaryLikeExpression` (#15467) (Dunqing)
+- 064f835 formatter: Optimize printing call arguments (#15464) (Dunqing)
+- 29f35b2 formatter: Reuse previous indent stack in `FitsMeasurer` (#15416) (Dunqing)
+- 2515045 formatter: Use CodeBuffer's built-in print_indent to print indentation (#15406) (Dunqing)
+- 681607b formatter: Check the `Text` to see whether it has multiple lines based on its width (#15405) (Dunqing)
+- b92deb4 formatter: Replace String buffer with byte-oriented CodeBuffer (#14752) (Boshen)
+- 963b87f formatter: Add `text_without_whitespace` for text that can never have whitespace (#15403) (Dunqing)
+- f30ce4b formatter: Optimize formatting literal string (#15380) (Dunqing)
+- 8f25a0e formatter: Memorize text width for `FormatElement::Text` (#15372) (Dunqing)
+- f913543 formatter: Avoid allocation for `SyntaxTokenCowSlice` (#15366) (Dunqing)
+- 98c9234 formatter: Optimize `FormatElement::Token` printing (#15365) (Dunqing)
+
 
 ## [0.10.0] - 2025-11-04
 

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.27.0] - 2025-11-10
+
+### 🐛 Bug Fixes
+
+- ecf2f7b language_server: Fail gracefully when tsgolint executable not found (#15436) (camc314)
+
+### ⚡ Performance
+
+- 25d577e language_server: Start tools in parallel (#15500) (Sysix)
+
 ## [1.26.0] - 2025-11-05
 
 ### 🚀 Features

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.26.0"
+version = "1.27.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.27.0] - 2025-11-10
+
+### 🚀 Features
+
+- 2a89b43 linter: Introduce debug assertions after fixes to assert validity (#15389) (camc314)
+
+### 🐛 Bug Fixes
+
+- 6f3cd77 linter/no-var: Incorrect warning for blocks (#15504) (Hamir Mahal)
+- 732205e parser: Reject `using` / `await using` in a switch `case` / `default` clause (#15225) (sapphi-red)
+- 3c8d3a7 lang-server: Improve logging in failure case for tsgolint (#15299) (camc314)
+- ef71410 linter: Use jsx if source type is JS in fix debug assertion (#15434) (camc314)
+- e32bbf6 linter/no-var: Handle TypeScript declare keyword in fixer (#15426) (camc314)
+- 6565dbe linter/switch-case-braces: Skip comments when searching for `:` token (#15425) (camc314)
+- 85bd19a linter/prefer-class-fields: Insert value after type annotation in fixer (#15423) (camc314)
+- ddd9f9f linter/forward-ref-uses-ref: Dont suggest removing wrapper in invalid positions (#15388) (camc314)
+- dac2a9c linter/no-template-curly-in-string: Remove fixer (#15387) (camc314)
+- 989b8e3 linter/no-var: Only fix to `const` if the var has an initializer (#15385) (camc314)
+
+### ⚡ Performance
+
+- 3166233 linter/plugins: Remove `Arc`s (#15431) (overlookmotel)
+
+### 📚 Documentation
+
+- 2c6bd9e linter: Always refer as "ES2015" instead of "ES6" (#15411) (sapphi-red)
+- a0c5203 linter/import/named: Update "ES7" comment in examples (#15410) (sapphi-red)
+- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
+- 2ad77fb linter/no-this-before-super: Correct "Why is this bad?" section (#15408) (sapphi-red)
+- 57f0ce1 linter: Add backquotes where appropriate (#15407) (sapphi-red)
+
 ## [1.26.0] - 2025-11-05
 
 ### 🚀 Features

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.26.0"
+version = "1.27.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.27.0] - 2025-11-10
+
+### 🚀 Features
+
+- ad3c45a editor: Add `oxc.path.node` option (#15040) (Sysix)
+
 ## [1.26.0] - 2025-11-05
 
 ### 🐛 Bug Fixes

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vscode extension",
   "license": "MIT",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.12.0] - 2025-11-10
+
+### 🚀 Features
+
+- 3251000 oxfmt: Use `prettier` directly and bundle `prettier` (#15544) (Dunqing)
+- 5708126 formatter/sort_imports: Add `options.newlinesBetween` (#15369) (leaysgur)
+
 ## [0.11.0] - 2025-11-06
 
 ### 🐛 Bug Fixes

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
# Oxlint
### 🚀 Features

- 222a8f0 linter/plugins: Implement `SourceCode#isSpaceBetween` (#15498) (overlookmotel)
- 2f9735d linter/plugins: Implement `context.languageOptions` (#15486) (overlookmotel)
- bc731ff linter/plugins: Stub out all `Context` APIs (#15479) (overlookmotel)
- 5822cb4 linter/plugins: Add `extend` method to `FILE_CONTEXT` (#15477) (overlookmotel)
- 7b1e6f3 apps: Add pure rust binaries and release to github (#15469) (Boshen)
- 2a89b43 linter: Introduce debug assertions after fixes to assert validity (#15389) (camc314)
- ad3c45a editor: Add `oxc.path.node` option (#15040) (Sysix)

### 🐛 Bug Fixes

- 6f3cd77 linter/no-var: Incorrect warning for blocks (#15504) (Hamir Mahal)
- 6957fb9 linter/plugins: Do not allow access to `Context#id` in `createOnce` (#15489) (overlookmotel)
- 7409630 linter/plugins: Allow access to `cwd` in `createOnce` in ESLint interop mode (#15488) (overlookmotel)
- 732205e parser: Reject `using` / `await using` in a switch `case` / `default` clause (#15225) (sapphi-red)
- a17ca32 linter/plugins: Replace `Context` class (#15448) (overlookmotel)
- ecf2f7b language_server: Fail gracefully when tsgolint executable not found (#15436) (camc314)
- 3c8d3a7 lang-server: Improve logging in failure case for tsgolint (#15299) (camc314)
- ef71410 linter: Use jsx if source type is JS in fix debug assertion (#15434) (camc314)
- e32bbf6 linter/no-var: Handle TypeScript declare keyword in fixer (#15426) (camc314)
- 6565dbe linter/switch-case-braces: Skip comments when searching for `:` token (#15425) (camc314)
- 85bd19a linter/prefer-class-fields: Insert value after type annotation in fixer (#15423) (camc314)
- fde753e linter/plugins: Block access to `context.settings` in `createOnce` (#15394) (overlookmotel)
- ddd9f9f linter/forward-ref-uses-ref: Dont suggest removing wrapper in invalid positions (#15388) (camc314)
- dac2a9c linter/no-template-curly-in-string: Remove fixer (#15387) (camc314)
- 989b8e3 linter/no-var: Only fix to `const` if the var has an initializer (#15385) (camc314)
- cc403f5 linter/plugins: Return empty object for unimplemented parserServices (#15364) (magic-akari)

### ⚡ Performance

- 25d577e language_server: Start tools in parallel (#15500) (Sysix)
- 3c57291 linter/plugins: Optimize loops (#15449) (overlookmotel)
- 3166233 linter/plugins: Remove `Arc`s (#15431) (overlookmotel)
- 9de1322 linter/plugins: Lazily deserialize settings JSON (#15395) (overlookmotel)
- 3049ec2 linter/plugins: Optimize `deepFreezeSettings` (#15392) (overlookmotel)
- 444ebfd linter/plugins: Use single object for `parserServices` (#15378) (overlookmotel)

### 📚 Documentation

- 97d2104 linter: Update comment in lint.rs about default value for tsconfig path (#15530) (Connor Shea)
- 2c6bd9e linter: Always refer as "ES2015" instead of "ES6" (#15411) (sapphi-red)
- a0c5203 linter/import/named: Update "ES7" comment in examples (#15410) (sapphi-red)
- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
- 2ad77fb linter/no-this-before-super: Correct "Why is this bad?" section (#15408) (sapphi-red)
- 57f0ce1 linter: Add backquotes where appropriate (#15407) (sapphi-red)
# Oxfmt
### 🚀 Features

- 3251000 oxfmt: Use `prettier` directly and bundle `prettier` (#15544) (Dunqing)
- 7b1e6f3 apps: Add pure rust binaries and release to github (#15469) (Boshen)
- 33ad374 oxfmt: Disable embedded formatting by default for alpha (#15402) (leaysgur)
- 5708126 formatter/sort_imports: Add `options.newlinesBetween` (#15369) (leaysgur)
- 2dfc3bd formatter: Remove `Tag::StartVerbatim` and `Tag::EndVerbatim` (#15370) (Dunqing)
- 88c7530 formatter: Remove `FormatElement::LocatedTokenText` (#15367) (Dunqing)

### 🐛 Bug Fixes

- d32d22e formatter: Correct `FormatElement` size check (#15461) (Dunqing)
- b0f43f9 formatter: Test call difference (#15356) (Dunqing)
- 01f20f3 formatter: Incorrect comment checking logic for grouping argument (#15354) (Dunqing)

### ⚡ Performance

- f4b75b6 formatter: Pre-allocate enough space for the FormatElement buffer (#15422) (Dunqing)
- 5a61189 formatter: Avoid unnecessary allocation for `BinaryLikeExpression` (#15467) (Dunqing)
- 064f835 formatter: Optimize printing call arguments (#15464) (Dunqing)
- 29f35b2 formatter: Reuse previous indent stack in `FitsMeasurer` (#15416) (Dunqing)
- a6808a0 oxfmt: Use `AllocatorPool` to reuse allocator between threads (#15412) (leaysgur)
- 2515045 formatter: Use CodeBuffer's built-in print_indent to print indentation (#15406) (Dunqing)
- 681607b formatter: Check the `Text` to see whether it has multiple lines based on its width (#15405) (Dunqing)
- b92deb4 formatter: Replace String buffer with byte-oriented CodeBuffer (#14752) (Boshen)
- 963b87f formatter: Add `text_without_whitespace` for text that can never have whitespace (#15403) (Dunqing)
- f30ce4b formatter: Optimize formatting literal string (#15380) (Dunqing)
- 8f25a0e formatter: Memorize text width for `FormatElement::Text` (#15372) (Dunqing)
- f913543 formatter: Avoid allocation for `SyntaxTokenCowSlice` (#15366) (Dunqing)
- 98c9234 formatter: Optimize `FormatElement::Token` printing (#15365) (Dunqing)