### PR TITLE
refactor(language_server): move tools definitions to `Backend`

### DIFF
--- a/crates/oxc_language_server/src/formatter/tester.rs
+++ b/crates/oxc_language_server/src/formatter/tester.rs
@@ -7,7 +7,7 @@ use tower_lsp_server::{
 
 use crate::{
     formatter::server_formatter::{ServerFormatter, ServerFormatterBuilder},
-    tool::{Tool, ToolBuilder},
+    tool::Tool,
 };
 
 /// Given a file path relative to the crate root directory, return the absolute path of the file.
@@ -62,7 +62,7 @@ impl Tester<'_> {
             .join(self.relative_root_dir);
         let uri = Uri::from_file_path(absolute_path).expect("could not convert current dir to uri");
 
-        ServerFormatterBuilder::new(uri, self.options.clone()).build()
+        ServerFormatterBuilder::build(&uri, self.options.clone())
     }
 
     pub fn format_and_snapshot_single_file(&self, relative_file_path: &str) {

--- a/crates/oxc_language_server/src/linter/tester.rs
+++ b/crates/oxc_language_server/src/linter/tester.rs
@@ -10,7 +10,7 @@ use tower_lsp_server::{
 
 use crate::{
     linter::{ServerLinterBuilder, server_linter::ServerLinter},
-    tool::{Tool, ToolBuilder},
+    tool::Tool,
 };
 
 /// Given a file path relative to the crate root directory, return the absolute path of the file.
@@ -171,7 +171,7 @@ impl Tester<'_> {
             .join(self.relative_root_dir);
         let uri = Uri::from_file_path(absolute_path).expect("could not convert current dir to uri");
 
-        ServerLinterBuilder::new(uri, self.options.clone()).build()
+        ServerLinterBuilder::build(&uri, self.options.clone())
     }
 
     /// Given a relative file path (relative to `oxc_language_server` crate root), run the linter

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -6,9 +6,8 @@ use tower_lsp_server::{
     },
 };
 
-pub trait ToolBuilder<T: Tool> {
-    fn new(root_uri: Uri, options: serde_json::Value) -> Self;
-    fn build(&self) -> T;
+pub trait ToolBuilder: Send + Sync {
+    fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;
 }
 
 pub trait Tool: Send + Sync {


### PR DESCRIPTION
> This PR refactors the language server architecture by moving tool definitions (linter and formatter) from individual workers to the Backend. The ToolBuilder trait is redesigned to use a method that returns boxed trait objects, and builder structs are simplified to stateless types.

Now it should be easy to implement something like `Backend::new(vec![ServerLinterBuilder]);`