### PR TITLE
perf(language_server): pass file content as a referenced `String`

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -492,7 +492,7 @@ impl LanguageServer for Backend {
             self.file_system.write().await.set(uri, content.clone());
         }
 
-        if let Some(diagnostics) = worker.run_diagnostic_on_change(uri, content).await {
+        if let Some(diagnostics) = worker.run_diagnostic_on_change(uri, content.as_deref()).await {
             self.client
                 .publish_diagnostics(uri.clone(), diagnostics, Some(params.text_document.version))
                 .await;
@@ -516,7 +516,7 @@ impl LanguageServer for Backend {
             self.file_system.write().await.set(uri, content.clone());
         }
 
-        if let Some(diagnostics) = worker.run_diagnostic(uri, Some(content)).await {
+        if let Some(diagnostics) = worker.run_diagnostic(uri, Some(&content)).await {
             self.client
                 .publish_diagnostics(uri.clone(), diagnostics, Some(params.text_document.version))
                 .await;
@@ -599,7 +599,7 @@ impl LanguageServer for Backend {
         let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
             return Ok(None);
         };
-        Ok(worker.format_file(uri, self.file_system.read().await.get(uri)).await)
+        Ok(worker.format_file(uri, self.file_system.read().await.get(uri).as_deref()).await)
     }
 }
 

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -102,16 +102,17 @@ impl IsolatedLintHandler {
         Self { runner, unused_directives_severity: lint_options.report_unused_directive }
     }
 
-    pub fn run_single(&self, uri: &Uri, content: Option<String>) -> Option<Vec<DiagnosticReport>> {
+    pub fn run_single(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<DiagnosticReport>> {
         let path = uri.to_file_path()?;
 
         if !Self::should_lint_path(&path) {
             return None;
         }
 
-        let source_text = content.or_else(|| read_to_string(&path).ok())?;
+        let source_text =
+            if let Some(content) = content { content } else { &read_to_string(&path).ok()? };
 
-        let mut diagnostics = self.lint_path(&path, uri, &source_text);
+        let mut diagnostics = self.lint_path(&path, uri, source_text);
         diagnostics.append(&mut generate_inverted_diagnostics(&diagnostics, uri));
         Some(diagnostics)
     }

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -455,7 +455,7 @@ impl Tool for ServerLinter {
     /// Lint a file with the current linter
     /// - If the file is not lintable or ignored, [`None`] is returned
     /// - If the file is lintable, but no diagnostics are found, an empty vector is returned
-    fn run_diagnostic(&self, uri: &Uri, content: Option<String>) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<Diagnostic>> {
         self.run_file(uri, content)
             .map(|reports| reports.into_iter().map(|report| report.diagnostic).collect())
     }
@@ -467,7 +467,7 @@ impl Tool for ServerLinter {
     fn run_diagnostic_on_change(
         &self,
         uri: &Uri,
-        content: Option<String>,
+        content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         if self.run != Run::OnType {
             return None;
@@ -479,11 +479,7 @@ impl Tool for ServerLinter {
     /// - If the file is not lintable or ignored, [`None`] is returned
     /// - If the linter is not set to `OnSave`, [`None`] is returned
     /// - If the file is lintable, but no diagnostics are found, an empty vector is returned
-    fn run_diagnostic_on_save(
-        &self,
-        uri: &Uri,
-        content: Option<String>,
-    ) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic_on_save(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<Diagnostic>> {
         if self.run != Run::OnSave {
             return None;
         }
@@ -563,7 +559,7 @@ impl ServerLinter {
     }
 
     /// Lint a single file, return `None` if the file is ignored.
-    fn run_file(&self, uri: &Uri, content: Option<String>) -> Option<Vec<DiagnosticReport>> {
+    fn run_file(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<DiagnosticReport>> {
         if self.is_ignored(uri) {
             return None;
         }

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -69,7 +69,7 @@ pub trait Tool: Sized {
     /// Returns a vector of `TextEdit` representing the formatting changes.
     ///
     /// Not all tools will implement formatting, so the default implementation returns `None`.
-    fn run_format(&self, _uri: &Uri, _content: Option<String>) -> Option<Vec<TextEdit>> {
+    fn run_format(&self, _uri: &Uri, _content: Option<&str>) -> Option<Vec<TextEdit>> {
         None
     }
 
@@ -77,7 +77,7 @@ pub trait Tool: Sized {
     /// If `content` is `None`, the tool should read the content from the file system.
     /// Returns a vector of `Diagnostic` representing the diagnostic results.
     /// Not all tools will implement diagnostics, so the default implementation returns `None`.
-    fn run_diagnostic(&self, _uri: &Uri, _content: Option<String>) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic(&self, _uri: &Uri, _content: Option<&str>) -> Option<Vec<Diagnostic>> {
         None
     }
 
@@ -88,7 +88,7 @@ pub trait Tool: Sized {
     fn run_diagnostic_on_save(
         &self,
         _uri: &Uri,
-        _content: Option<String>,
+        _content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         None
     }
@@ -100,7 +100,7 @@ pub trait Tool: Sized {
     fn run_diagnostic_on_change(
         &self,
         _uri: &Uri,
-        _content: Option<String>,
+        _content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         None
     }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -149,7 +149,7 @@ impl WorkspaceWorker {
     pub async fn run_diagnostic(
         &self,
         uri: &Uri,
-        content: Option<String>,
+        content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         let Some(server_linter) = &*self.server_linter.read().await else {
             return None;
@@ -162,7 +162,7 @@ impl WorkspaceWorker {
     pub async fn run_diagnostic_on_change(
         &self,
         uri: &Uri,
-        content: Option<String>,
+        content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         let Some(server_linter) = &*self.server_linter.read().await else {
             return None;
@@ -175,7 +175,7 @@ impl WorkspaceWorker {
     pub async fn run_diagnostic_on_save(
         &self,
         uri: &Uri,
-        content: Option<String>,
+        content: Option<&str>,
     ) -> Option<Vec<Diagnostic>> {
         let Some(server_linter) = &*self.server_linter.read().await else {
             return None;
@@ -187,7 +187,7 @@ impl WorkspaceWorker {
     /// Format a file with the current formatter
     /// - If no file is not formattable or ignored, [`None`] is returned
     /// - If the file is formattable, but no changes are made, an empty vector is returned
-    pub async fn format_file(&self, uri: &Uri, content: Option<String>) -> Option<Vec<TextEdit>> {
+    pub async fn format_file(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<TextEdit>> {
         let Some(server_formatter) = &*self.server_formatter.read().await else {
             return None;
         };


### PR DESCRIPTION
> This PR optimizes performance by passing file content as a reference (&String) instead of by value (String) throughout the language server's diagnostic and formatting functions. This avoids unnecessary string clones when passing file content through the call chain.