### PR TITLE
fix(linter): Allow file extensions without a dot in react/jsx-filename-extension rule

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -277,8 +277,8 @@ fn test() {
             None,
             Some(PathBuf::from("foo.js")),
         ),
+        // Test that a commented-out JSX code snippet does not count.
         (
-            // Test that a commented-out JSX code snippet does not count.
             "// export function MyComponent() { return <><Comp /><Comp /></>;}\n",
             Some(serde_json::json!([{ "allow": "as-needed", "ignoreFilesWithoutCode": true }])),
             None,

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -128,7 +128,7 @@ impl Rule for JsxFilenameExtension {
                     .filter_map(serde_json::Value::as_str)
                     .map(|s| {
                         // Strip leading dot if present to match ESLint behavior
-                        if s.starts_with('.') { &s[1..] } else { s }
+                        s.strip_prefix('.').unwrap_or(s)
                     })
                     .map(CompactStr::from)
                     .collect()

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -291,6 +291,12 @@ fn test() {
             Some(PathBuf::from("foo.js")),
         ),
         (
+            "/* export function MyComponent() { return <><Comp /><Comp /></>;} */\nconsole.log('code');",
+            Some(serde_json::json!([{ "allow": "as-needed" }])),
+            None,
+            Some(PathBuf::from("foo.js")),
+        ),
+        (
             "//test\n\n//comment",
             Some(serde_json::json!([{ "allow": "as-needed", "ignoreFilesWithoutCode": true }])),
             None,

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -49,6 +49,7 @@ pub struct JsxFilenameExtensionConfig {
     /// Set this to `as-needed` to only allow JSX file extensions in files that contain JSX syntax.
     allow: AllowType,
     /// The set of allowed file extensions.
+    /// Can include or exclude the leading dot (e.g., "jsx" and ".jsx" are both valid).
     extensions: Vec<CompactStr>,
     /// If enabled, files that do not contain code (i.e. are empty, contain only whitespaces or comments) will not be rejected.
     ignore_files_without_code: bool,
@@ -272,6 +273,19 @@ fn test() {
         ),
         (
             "//test\n\n//comment",
+            Some(serde_json::json!([{ "allow": "as-needed" }])),
+            None,
+            Some(PathBuf::from("foo.js")),
+        ),
+        (
+            // Test that a commented-out JSX code snippet does not count.
+            "// export function MyComponent() { return <><Comp /><Comp /></>;}\n",
+            Some(serde_json::json!([{ "allow": "as-needed", "ignoreFilesWithoutCode": true }])),
+            None,
+            Some(PathBuf::from("foo.js")),
+        ),
+        (
+            "// export function MyComponent() { return <><Comp /><Comp /></>;}\nconsole.log('code');",
             Some(serde_json::json!([{ "allow": "as-needed" }])),
             None,
             Some(PathBuf::from("foo.js")),

--- a/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_filename_extension.rs
@@ -11,7 +11,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_jsx_with_filename_extension_diagnostic(ext: &str, span: Span, allowed_extensions: &[CompactStr]) -> OxcDiagnostic {
+fn no_jsx_with_filename_extension_diagnostic(
+    ext: &str,
+    span: Span,
+    allowed_extensions: &[CompactStr],
+) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("JSX not allowed in files with extension '.{ext}'"))
         .with_help(format!(
             "Rename the file to use an allowed extension: {}",

--- a/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
@@ -78,7 +78,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                        ─────────────────────
    ╰────
-  help: Rename the file to use an allowed extension: .tsx, .ts, .js
+  help: Rename the file to use an allowed extension: .js, .tsx, .ts
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:50]

--- a/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
@@ -79,3 +79,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                  ─────────────────────
    ╰────
   help: Rename the file with a good extension.
+
+  ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
+   ╭─[jsx_filename_extension.tsx:1:50]
+ 1 │ ╭─▶ module.exports = function MyComponent() { return <div>
+ 2 │ │   <div />
+ 3 │ ╰─▶ </div>; }
+   ╰────
+  help: Rename the file with a good extension.

--- a/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
@@ -11,14 +11,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:48]
- 1 │ export default function MyComponent() { return <Comp />;}
+ 1 │ export default function MyComponent() { return <Comp />; }
    ·                                                ────────
    ╰────
   help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:40]
- 1 │ export function MyComponent() { return <div><Comp /></div>;}
+ 1 │ export function MyComponent() { return <div><Comp /></div>; }
    ·                                        ───────────────────
    ╰────
   help: Rename the file to use an allowed extension: .jsx
@@ -54,7 +54,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:40]
- 1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
+ 1 │ export function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                        ─────────────────────
    ╰────
   help: Rename the file to use an allowed extension: .jsx
@@ -68,17 +68,31 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:40]
- 1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
+ 1 │ export function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                        ─────────────────────
    ╰────
   help: Rename the file to use an allowed extension: .js
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:40]
- 1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
+ 1 │ export function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                        ─────────────────────
    ╰────
-  help: Rename the file to use an allowed extension: .js, .tsx, .ts
+  help: Rename the file to use an allowed extension: .tsx, .ts, .js
+
+  ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
+   ╭─[jsx_filename_extension.tsx:1:50]
+ 1 │ module.exports = function MyComponent() { return <><Comp /><Comp /></>; }
+   ·                                                  ─────────────────────
+   ╰────
+  help: Rename the file to use an allowed extension: .js
+
+  ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
+   ╭─[jsx_filename_extension.tsx:1:50]
+ 1 │ module.exports = function MyComponent() { return <><Comp /><Comp /></>; }
+   ·                                                  ─────────────────────
+   ╰────
+  help: Rename the file to use an allowed extension: .js
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:50]

--- a/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_filename_extension.snap
@@ -7,28 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │   <div />
  3 │ ╰─▶ </div>; }
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:48]
  1 │ export default function MyComponent() { return <Comp />;}
    ·                                                ────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:40]
  1 │ export function MyComponent() { return <div><Comp /></div>;}
    ·                                        ───────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:28]
  1 │ const MyComponent = () => (<div><Comp /></div>); export default MyComponent;
    ·                            ───────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): Only files containing JSX may use the extension '.jsx'
   help: Rename the file with a good extension.
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │   <div />
  3 │ ╰─▶ </div>; }
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:50]
@@ -50,35 +50,42 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │   <div />
  3 │ ╰─▶ </div>; }
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .js
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:40]
  1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
    ·                                        ─────────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.js'
    ╭─[jsx_filename_extension.tsx:1:50]
  1 │ module.exports = function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                                  ─────────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .jsx
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:40]
  1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
    ·                                        ─────────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .js
+
+  ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
+   ╭─[jsx_filename_extension.tsx:1:40]
+ 1 │ export function MyComponent() { return <><Comp /><Comp /></>;}
+   ·                                        ─────────────────────
+   ╰────
+  help: Rename the file to use an allowed extension: .js, .tsx, .ts
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:50]
  1 │ module.exports = function MyComponent() { return <><Comp /><Comp /></>; }
    ·                                                  ─────────────────────
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .js
 
   ⚠ eslint-plugin-react(jsx-filename-extension): JSX not allowed in files with extension '.jsx'
    ╭─[jsx_filename_extension.tsx:1:50]
@@ -86,4 +93,4 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │   <div />
  3 │ ╰─▶ </div>; }
    ╰────
-  help: Rename the file with a good extension.
+  help: Rename the file to use an allowed extension: .tsx


### PR DESCRIPTION
Allow `tsx` to work fine for the rule config, previously it would be thrown out.

Also update the help diagnostic to note which extensions are allowed by the current config, and add a few more tests.

Fixes #15508 