### PR TITLE
docs(linter): Fix a typo in the docs for react/no-is-mounted.

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -26,11 +26,12 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// isMounted is an anti-pattern, is not available when using classes,
-    /// and it is on its way to being officially deprecated.///
+    /// and it is on its way to being officially deprecated.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
+    ///
     /// ```jsx
     /// class Hello extends React.Component {
     ///     someMethod() {
@@ -99,6 +100,18 @@ fn test() {
                     return <div>Hello</div>;
                 }
             });
+            ",
+            None,
+        ),
+        (
+            "
+            class Hello extends React.Component {
+                notIsMounted() {}
+                render() {
+                    this.notIsMounted();
+                    return <div>Hello</div>;
+                }
+            };
             ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 
 fn no_is_mounted_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use isMounted")
-        .with_help("isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.")
+    OxcDiagnostic::warn("Do not use `isMounted`")
+        .with_help("`isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.")
         .with_label(span)
 }
 
@@ -21,11 +21,11 @@ pub struct NoIsMounted;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule prevents using isMounted in classes
+    /// This rule prevents using `isMounted` in classes.
     ///
     /// ### Why is this bad?
     ///
-    /// isMounted is an anti-pattern, is not available when using classes,
+    /// `isMounted` is an anti-pattern, is not available when using classes,
     /// and it is on its way to being officially deprecated.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/snapshots/react_no_is_mounted.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_is_mounted.snap
@@ -1,29 +1,29 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 componentDidUpdate: function() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.
+  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.
 
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod: function() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.
+  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.
 
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.
+  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.


### PR DESCRIPTION
Also add an additional test from the upstream plugin.