### PR TITLE
feat(formatter/sort_imports): Sort imports by `Array<Array<string>>` groups

### DIFF
--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -28,6 +28,7 @@ fn main() -> Result<(), String> {
         sort_side_effects,
         ignore_case,
         newlines_between,
+        groups: SortImports::default_groups(),
     };
 
     // Read source file
@@ -50,7 +51,7 @@ fn main() -> Result<(), String> {
 
     // Format the parsed code
     let options = FormatOptions {
-        experimental_sort_imports: Some(sort_imports_options),
+        experimental_sort_imports: Some(sort_imports_options.clone()),
         ..Default::default()
     };
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -167,21 +167,22 @@ impl SortImportsTransform {
                     // const YET_ANOTHER_BOUNDARY = true;
                     // ```
                     let (mut import_units, trailing_lines) = chunk.into_import_units(prev_elements);
-                    import_units.sort_imports(prev_elements, self.options);
+                    import_units.sort_imports(prev_elements, &self.options);
 
                     // Output sorted import units
                     let preserve_empty_line = self.options.partition_by_newline;
-                    let mut prev_group = None;
+                    let mut prev_group_idx = None;
                     for sortable_import in import_units {
                         // Insert blank line between different groups if enabled
                         if self.options.newlines_between {
-                            let current_group = sortable_import.get_metadata(prev_elements).group();
-                            if let Some(prev) = prev_group
-                                && prev != current_group
+                            let metadata = sortable_import.get_metadata(prev_elements);
+                            let current_group_idx = metadata.match_group(&self.options.groups);
+                            if let Some(prev_idx) = prev_group_idx
+                                && prev_idx != current_group_idx
                             {
                                 next_elements.push(FormatElement::Line(LineMode::Empty));
                             }
-                            prev_group = Some(current_group);
+                            prev_group_idx = Some(current_group_idx);
                         }
 
                         // Output leading lines and import line

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -80,7 +80,7 @@ impl<'a> Formatter<'a> {
         let source_text = program.source_text;
         self.source_text = source_text;
 
-        let experimental_sort_imports = self.options.experimental_sort_imports;
+        let experimental_sort_imports = self.options.experimental_sort_imports.clone();
 
         let mut context = FormatContext::new(
             program.source_text,

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -963,7 +963,7 @@ impl fmt::Display for EmbeddedLanguageFormatting {
 
 // ---
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SortImports {
     /// Partition imports by newlines.
     /// Default is `false`.
@@ -986,6 +986,9 @@ pub struct SortImports {
     ///
     /// NOTE: Cannot be used together with `partition_by_newline: true`.
     pub newlines_between: bool,
+    /// Groups configuration for organizing imports.
+    /// Each inner `Vec` represents a group, and multiple group names in the same `Vec` are treated as one.
+    pub groups: Vec<Vec<String>>,
 }
 
 impl Default for SortImports {
@@ -997,7 +1000,27 @@ impl Default for SortImports {
             order: SortOrder::default(),
             ignore_case: true,
             newlines_between: true,
+            groups: Self::default_groups(),
         }
+    }
+}
+
+impl SortImports {
+    pub fn default_groups() -> Vec<Vec<String>> {
+        vec![
+            vec!["type-import".to_string()],
+            vec!["value-builtin".to_string(), "value-external".to_string()],
+            vec!["type-internal".to_string()],
+            vec!["value-internal".to_string()],
+            vec!["type-parent".to_string(), "type-sibling".to_string(), "type-index".to_string()],
+            vec![
+                "value-parent".to_string(),
+                "value-sibling".to_string(),
+                "value-index".to_string(),
+            ],
+            // vec!["ts-equals-import".to_string()],
+            vec!["unknown".to_string()],
+        ]
     }
 }
 

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -332,6 +332,8 @@ impl Oxfmtrc {
                 }),
                 ignore_case: sort_imports_config.ignore_case,
                 newlines_between: sort_imports_config.newlines_between,
+                // TODO: Make this configurable later
+                groups: SortImports::default_groups(),
             });
         }
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -514,6 +514,8 @@ impl Oxc {
                 .as_ref()
                 .and_then(|o| o.parse::<SortOrder>().ok())
                 .unwrap_or_default();
+            // TODO: support from options
+            let groups = SortImports::default_groups();
 
             format_options.experimental_sort_imports = Some(SortImports {
                 partition_by_newline: sort_imports_config.partition_by_newline.unwrap_or(false),
@@ -522,6 +524,7 @@ impl Oxc {
                 order,
                 ignore_case: sort_imports_config.ignore_case.unwrap_or(true),
                 newlines_between: sort_imports_config.newlines_between.unwrap_or(true),
+                groups,
             });
         }
 

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -146,7 +146,7 @@ pub struct OxcFormatterOptions {
     pub single_attribute_per_line: Option<bool>,
     /// Operator position: "start" | "end" (default: "end")
     pub experimental_operator_position: Option<String>,
-    /// Sort imports configuration
+    /// Sort imports configuration (default: None)
     pub experimental_sort_imports: Option<OxcSortImportsOptions>,
 }
 
@@ -165,4 +165,6 @@ pub struct OxcSortImportsOptions {
     pub ignore_case: Option<bool>,
     /// Add newlines between import groups (default: true)
     pub newlines_between: Option<bool>,
+    /// Custom groups of imports
+    pub groups: Option<Vec<Vec<String>>>,
 }


### PR DESCRIPTION
Current implementation was performimg sort based on hard-coded `enum`.

This PR changed it to use group definitions like this.

```js
[
  'type-import',
  ['value-builtin', 'value-external'],
  'type-internal',
  'value-internal',
  ['type-parent', 'type-sibling', 'type-index'],
  ['value-parent', 'value-sibling', 'value-index'],
  'ts-equals-import',
  'unknown',
]
```

> https://perfectionist.dev/rules/sort-imports#groups

And this will be refactored in the subsequent 2 PRs.