### PR TITLE
fix(linter): Update the unicorn/prefer-add-event-listener rule with new JavaScript APIs

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -71,6 +71,14 @@ impl Rule for PreferAddEventListener {
     }
 }
 
+// Can refer to the following sources for the list of event handler names, compare
+// this array against any new `onx` functions introduced in browsers:
+// - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes#list_of_global_event_handler_attributes
+// - https://github.com/mdn/browser-compat-data/blob/d5d5f2e21ef3f798784d1f5f75bde7c7f10f250e/api/Element.json
+// - https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/f915ac0c987300d75af41bfe4a34bb29a0fb941f/baselines/dom.generated.d.ts
+//
+// Please avoid adding new events that are not implemented in at least two major browser engines!
+// Last updated: Nov 2025
 const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "AnimationEnd",
     "AnimationIteration",
@@ -104,9 +112,10 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "activate",
     "afterblur",
     "afterprint",
-    "animationEnd",
-    "animationStart",
+    "animationcancel",
+    "animationend",
     "animationiteration",
+    "animationstart",
     "appinstalled",
     "auxclick",
     "beforeblur",
@@ -114,8 +123,10 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "beforecut",
     "beforeinput",
     "beforeinstallprompt",
+    "beforematch",
     "beforepaste",
     "beforeprint",
+    "beforetoggle",
     "beforeunload",
     "blur",
     "cancel",
@@ -129,9 +140,12 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "compositionupdate",
     "connect",
     "consolemessage",
+    "contextlost",
     "contextmenu",
+    "contextrestored",
     "controllerchange",
     "copy",
+    "cuechange",
     "cut",
     "dblclick",
     "deactivate",
@@ -157,6 +171,7 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "focusin",
     "focusout",
     "foreignfetch",
+    "formdata",
     "fullscreenchange",
     "gotpointercapture",
     "hashchange",
@@ -208,6 +223,7 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "pointermove",
     "pointerout",
     "pointerover",
+    "pointerrawupdate",
     "pointerup",
     "popstate",
     "progress",
@@ -219,7 +235,9 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "responsive",
     "rightclick",
     "scroll",
+    "scrollend",
     "search",
+    "securitypolicyviolation",
     "seeked",
     "seeking",
     "select",
@@ -227,6 +245,7 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "selectstart",
     "show",
     "sizechanged",
+    "slotchange",
     "sourceclosed",
     "sourceended",
     "sourceopen",
@@ -236,15 +255,18 @@ const DOM_EVENT_TYPE_NAMES: phf::Set<&'static str> = phf::phf_set![
     "submit",
     "suspend",
     "text",
-    "textInput",
     "textinput",
+    "textInput",
     "timeupdate",
     "toggle",
     "touchcancel",
     "touchend",
     "touchmove",
     "touchstart",
+    "transitioncancel",
     "transitionend",
+    "transitionrun",
+    "transitionstart",
     "unload",
     "unresponsive",
     "update",


### PR DESCRIPTION
This will cause new violations for some users if they're using particularly new APIs, but that should be fine.

For users migrating from the ESLint plugin, I wonder if we should consider calling out in the docs that this rule (and other rules of this nature) will potentially differ from the original Unicorn rule due to data updates over time? I ran into problems with the jsx-a11y rule in my work codebase due to this kind of improvement, so it may be worth calling out.

This also renames `animationStart` and `animationEnd` to be lowercase, as I believe this discrepancy was a mistake in the porting process. The original rule undercases these when processing them with vendor prefixes: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/609d4870f3731d39bd5b5f184628e2cf06578dba/rules/shared/dom-events.js

Sources:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes#list_of_global_event_handler_attributes
- https://github.com/mdn/browser-compat-data/blob/d5d5f2e21ef3f798784d1f5f75bde7c7f10f250e/api/Element.json
- https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/f915ac0c987300d75af41bfe4a34bb29a0fb941f/baselines/dom.generated.d.ts

I used AI to compare the lists since they're in such different formats and then checked against MDN to ensure the additions were actually real. Prompt for future reference, since I think the pattern is useful:

```
Are there any onX methods defined here:

\`\`\`
declare var onabort: ((this: Window, ev: UIEvent) => any) | null;
// and so on from here...
\`\`\`

That are not defined in this Rust array?:

\`\`\`
paste the DOM_EVENT_TYPE_NAMES array from the Rust file here
\`\`\`

Note that the list in rust strips out the `on` at the start. Capitalization differences matter. Link the MDN page for each function if it isn't found in the Rust list, please.
```

Will have to grab the first list from one of the sources above, I used the TS DOM lib generator because it tends to be quite up-to-date. Also remove the backslashes, obviously.

I also added a comment about sourcing this data for future reference.