### PR TITLE
release(crates): oxc v0.97.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,22 +1631,22 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "oxc"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
  "oxc_cfg",
- "oxc_codegen 0.96.0",
- "oxc_diagnostics 0.96.0",
+ "oxc_codegen 0.97.0",
+ "oxc_diagnostics 0.97.0",
  "oxc_isolated_declarations",
- "oxc_mangler 0.96.0",
- "oxc_minifier 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_regular_expression 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_mangler 0.97.0",
+ "oxc_minifier 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_regular_expression 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "oxc_transformer",
  "oxc_transformer_plugins",
 ]
@@ -1709,34 +1709,36 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.96.0"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.16.0",
- "oxc_ast_macros 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_estree 0.96.0",
- "rustc-hash",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.16.0",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.96.0",
  "rustc-hash",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.97.0"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.16.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_estree 0.97.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "oxc_ast"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad9195311a1961bb6ef1de0ce6a52147bccea50b5a40423b7b44e8448ed4fc"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator 0.96.0",
@@ -1751,24 +1753,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad9195311a1961bb6ef1de0ce6a52147bccea50b5a40423b7b44e8448ed4fc"
+version = "0.97.0"
 dependencies = [
  "bitflags 2.10.0",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_estree 0.97.0",
+ "oxc_regular_expression 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f03da6fac191c0817a32ae1a7dde27fd27d98732c61fcaeb55a99a4d543ba49"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1778,9 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f03da6fac191c0817a32ae1a7dde27fd27d98732c61fcaeb55a99a4d543ba49"
+version = "0.97.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1799,16 +1799,16 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy-regex",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_ast_visit 0.96.0",
+ "oxc_codegen 0.96.0",
+ "oxc_data_structures 0.97.0",
  "oxc_index",
- "oxc_minifier 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_minifier 0.96.0",
+ "oxc_parser 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "phf",
  "phf_codegen",
  "prettyplease",
@@ -1824,6 +1824,8 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42fcdb162d247a0e9c1aa985b388f000eba19fb1ee1845b2ec0ddc595f95131"
 dependencies = [
  "oxc_allocator 0.96.0",
  "oxc_ast 0.96.0",
@@ -1833,14 +1835,12 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42fcdb162d247a0e9c1aa985b388f000eba19fb1ee1845b2ec0ddc595f95131"
+version = "0.97.0"
 dependencies = [
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
 ]
 
 [[package]]
@@ -1849,18 +1849,18 @@ version = "0.0.0"
 dependencies = [
  "cow-utils",
  "criterion2",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_codegen 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_codegen 0.97.0",
  "oxc_formatter",
  "oxc_isolated_declarations",
  "oxc_linter",
- "oxc_mangler 0.96.0",
- "oxc_minifier 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_mangler 0.97.0",
+ "oxc_minifier 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "rustc-hash",
@@ -1870,35 +1870,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bitflags 2.10.0",
  "itertools",
  "oxc_index",
- "oxc_syntax 0.96.0",
+ "oxc_syntax 0.97.0",
  "petgraph",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_codegen"
-version = "0.96.0"
-dependencies = [
- "bitflags 2.10.0",
- "cow-utils",
- "dragonbox_ecma",
- "insta",
- "itoa",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_index",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_sourcemap",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
- "pico-args",
  "rustc-hash",
 ]
 
@@ -1912,26 +1890,37 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_data_structures 0.96.0",
  "oxc_index",
- "oxc_semantic 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_semantic 0.96.0",
  "oxc_sourcemap",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
  "rustc-hash",
 ]
 
 [[package]]
-name = "oxc_compat"
-version = "0.96.0"
+name = "oxc_codegen"
+version = "0.97.0"
 dependencies = [
+ "bitflags 2.10.0",
  "cow-utils",
- "oxc-browserslist",
- "oxc_syntax 0.96.0",
+ "dragonbox_ecma",
+ "insta",
+ "itoa",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_index",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_sourcemap",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
+ "pico-args",
  "rustc-hash",
- "serde",
 ]
 
 [[package]]
@@ -1942,7 +1931,18 @@ checksum = "271a875e3e9e1f6d259c99e0557fcc83d96b025ddfca40e215d6bbb58bae9d45"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.96.0",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
+name = "oxc_compat"
+version = "0.97.0"
+dependencies = [
+ "cow-utils",
+ "oxc-browserslist",
+ "oxc_syntax 0.97.0",
  "rustc-hash",
  "serde",
 ]
@@ -1992,23 +1992,14 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.96.0"
-dependencies = [
- "ropey",
-]
-
-[[package]]
-name = "oxc_data_structures"
-version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f5171d7b8bc907a1b29e557d14f8478509a2154272d56db9ee8aed6bfe8dec"
 
 [[package]]
-name = "oxc_diagnostics"
-version = "0.96.0"
+name = "oxc_data_structures"
+version = "0.97.0"
 dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
+ "ropey",
 ]
 
 [[package]]
@@ -2023,16 +2014,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_ecmascript"
-version = "0.96.0"
+name = "oxc_diagnostics"
+version = "0.97.0"
 dependencies = [
  "cow-utils",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc-miette",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2044,19 +2031,23 @@ dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
 ]
 
 [[package]]
-name = "oxc_estree"
-version = "0.96.0"
+name = "oxc_ecmascript"
+version = "0.97.0"
 dependencies = [
- "dragonbox_ecma",
- "itoa",
- "oxc_data_structures 0.96.0",
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
 ]
 
 [[package]]
@@ -2067,7 +2058,16 @@ checksum = "5644d3399116ff3f0cfb81f9a790c4b8173b504ed52274ecc757b57f30098ad1"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.96.0",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.97.0"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures 0.97.0",
 ]
 
 [[package]]
@@ -2078,13 +2078,13 @@ dependencies = [
  "insta",
  "json-strip-comments",
  "oxc-schemars",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "phf",
  "pico-args",
  "project-root",
@@ -2106,19 +2106,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bitflags 2.10.0",
  "insta",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_codegen 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_ecmascript 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "rustc-hash",
 ]
 
@@ -2131,12 +2131,12 @@ dependencies = [
  "ignore",
  "insta",
  "log",
- "oxc_allocator 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_diagnostics 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
  "oxc_formatter",
  "oxc_linter",
- "oxc_parser 0.96.0",
+ "oxc_parser 0.97.0",
  "papaya",
  "rustc-hash",
  "serde",
@@ -2166,23 +2166,23 @@ dependencies = [
  "markdown",
  "memchr",
  "oxc-schemars",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_macros 0.96.0",
- "oxc_ast_visit 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_ast_visit 0.97.0",
  "oxc_cfg",
- "oxc_codegen 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_ecmascript 0.96.0",
+ "oxc_codegen 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
  "oxc_index",
  "oxc_macros",
- "oxc_parser 0.96.0",
- "oxc_regular_expression 0.96.0",
+ "oxc_parser 0.97.0",
+ "oxc_regular_expression 0.97.0",
  "oxc_resolver",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "papaya",
  "phf",
  "project-root",
@@ -2220,13 +2220,14 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3695e3b0694093d24f0f7c8b77dc36b1a4b55020bf52166271010c8095bba5"
 dependencies = [
  "itertools",
  "oxc_allocator 0.96.0",
  "oxc_ast 0.96.0",
  "oxc_data_structures 0.96.0",
  "oxc_index",
- "oxc_parser 0.96.0",
  "oxc_semantic 0.96.0",
  "oxc_span 0.96.0",
  "oxc_syntax 0.96.0",
@@ -2235,28 +2236,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3695e3b0694093d24f0f7c8b77dc36b1a4b55020bf52166271010c8095bba5"
+version = "0.97.0"
 dependencies = [
  "itertools",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_data_structures 0.97.0",
  "oxc_index",
- "oxc_semantic 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869d4f7493209202a6d2824a1d18a3bced22c7e6a32b9b0f41d718dc090fa4dc"
 dependencies = [
  "cow-utils",
- "insta",
- "javascript-globals",
  "oxc_allocator 0.96.0",
  "oxc_ast 0.96.0",
  "oxc_ast_visit 0.96.0",
@@ -2269,56 +2269,56 @@ dependencies = [
  "oxc_parser 0.96.0",
  "oxc_regular_expression 0.96.0",
  "oxc_semantic 0.96.0",
- "oxc_sourcemap",
  "oxc_span 0.96.0",
  "oxc_syntax 0.96.0",
  "oxc_traverse 0.96.0",
- "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d4f7493209202a6d2824a1d18a3bced22c7e6a32b9b0f41d718dc090fa4dc"
+version = "0.97.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_codegen 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_compat 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "insta",
+ "javascript-globals",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_compat 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_ecmascript 0.97.0",
  "oxc_index",
- "oxc_mangler 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_parser 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_traverse 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_mangler 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_regular_expression 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_sourcemap",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
+ "oxc_traverse 0.97.0",
+ "pico-args",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_allocator 0.96.0",
- "oxc_codegen 0.96.0",
- "oxc_compat 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_minifier 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_compat 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_minifier 0.97.0",
  "oxc_napi",
- "oxc_parser 0.96.0",
+ "oxc_parser 0.97.0",
  "oxc_sourcemap",
- "oxc_span 0.96.0",
+ "oxc_span 0.97.0",
 ]
 
 [[package]]
@@ -2328,12 +2328,12 @@ dependencies = [
  "cow-utils",
  "flate2",
  "humansize",
- "oxc_allocator 0.96.0",
- "oxc_codegen 0.96.0",
- "oxc_minifier 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_minifier 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
  "oxc_tasks_common",
  "oxc_transformer_plugins",
  "pico-args",
@@ -2343,39 +2343,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
-]
-
-[[package]]
-name = "oxc_parser"
-version = "0.96.0"
-dependencies = [
- "bitflags 2.10.0",
- "cow-utils",
- "memchr",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_ecmascript 0.96.0",
- "oxc_regular_expression 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
- "pico-args",
- "rustc-hash",
- "seq-macro",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
 ]
 
 [[package]]
@@ -2389,29 +2366,52 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_regular_expression 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.96.0",
+ "oxc_ast 0.96.0",
+ "oxc_data_structures 0.96.0",
+ "oxc_diagnostics 0.96.0",
+ "oxc_ecmascript 0.96.0",
+ "oxc_regular_expression 0.96.0",
+ "oxc_span 0.96.0",
+ "oxc_syntax 0.96.0",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.97.0"
+dependencies = [
+ "bitflags 2.10.0",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
+ "oxc_regular_expression 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
+ "pico-args",
  "rustc-hash",
  "seq-macro",
 ]
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
  "oxc",
- "oxc_ast_macros 0.96.0",
- "oxc_estree 0.96.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_estree 0.97.0",
  "oxc_napi",
  "rustc-hash",
 ]
@@ -2438,12 +2438,12 @@ name = "oxc_prettier_conformance"
 version = "0.0.0"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
  "oxc_formatter",
- "oxc_parser 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
  "oxc_tasks_common",
  "pico-args",
  "rustc-hash",
@@ -2454,6 +2454,8 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb87ab0b072e1e97d8101cb1678204bc3873d84f13255ae5aa088f1b85f7a8e1"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator 0.96.0",
@@ -2467,15 +2469,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb87ab0b072e1e97d8101cb1678204bc3873d84f13255ae5aa088f1b85f7a8e1"
+version = "0.97.0"
 dependencies = [
  "bitflags 2.10.0",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_span 0.97.0",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -2520,45 +2520,45 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56958658ca1f9f5f050dc4317821255d2ca132763b6fbee9227e45ef79ed173"
 dependencies = [
- "insta",
  "itertools",
  "oxc_allocator 0.96.0",
  "oxc_ast 0.96.0",
  "oxc_ast_visit 0.96.0",
- "oxc_cfg",
  "oxc_data_structures 0.96.0",
  "oxc_diagnostics 0.96.0",
  "oxc_ecmascript 0.96.0",
  "oxc_index",
- "oxc_parser 0.96.0",
  "oxc_span 0.96.0",
  "oxc_syntax 0.96.0",
  "phf",
  "rustc-hash",
  "self_cell",
- "serde_json",
 ]
 
 [[package]]
 name = "oxc_semantic"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56958658ca1f9f5f050dc4317821255d2ca132763b6fbee9227e45ef79ed173"
+version = "0.97.0"
 dependencies = [
+ "insta",
  "itertools",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_diagnostics 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_cfg",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
  "oxc_index",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "phf",
  "rustc-hash",
  "self_cell",
+ "serde_json",
 ]
 
 [[package]]
@@ -2580,10 +2580,11 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41422232cfd9915d31dbb76ba2e5ae212884cad232e37203bdcb15bd1466951d"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc-schemars",
  "oxc_allocator 0.96.0",
  "oxc_ast_macros 0.96.0",
  "oxc_estree 0.96.0",
@@ -2592,21 +2593,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41422232cfd9915d31dbb76ba2e5ae212884cad232e37203bdcb15bd1466951d"
+version = "0.97.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc-schemars",
+ "oxc_allocator 0.97.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_estree 0.97.0",
  "serde",
 ]
 
 [[package]]
 name = "oxc_syntax"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea81736f2343df141c7d8de78a91d155be4f712dfa6cd1bdd9a8b4f0676f01f"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2625,20 +2627,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea81736f2343df141c7d8de78a91d155be4f712dfa6cd1bdd9a8b4f0676f01f"
+version = "0.97.0"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_macros 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_estree 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast_macros 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_estree 0.97.0",
  "oxc_index",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.97.0",
  "phf",
  "serde",
  "unicode-id-start",
@@ -2649,7 +2649,7 @@ name = "oxc_tasks_common"
 version = "0.0.0"
 dependencies = [
  "console 0.16.1",
- "oxc_span 0.96.0",
+ "oxc_span 0.97.0",
  "project-root",
  "similar",
  "ureq",
@@ -2660,13 +2660,13 @@ name = "oxc_tasks_transform_checker"
 version = "0.0.0"
 dependencies = [
  "indexmap",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "rustc-hash",
 ]
 
@@ -2676,10 +2676,10 @@ version = "0.0.0"
 dependencies = [
  "humansize",
  "mimalloc-safe",
- "oxc_allocator 0.96.0",
- "oxc_minifier 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_minifier 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
  "oxc_tasks_common",
  "oxc_transformer",
 ]
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2722,20 +2722,20 @@ dependencies = [
  "insta",
  "itoa",
  "memchr",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_codegen 0.96.0",
- "oxc_compat 0.96.0",
- "oxc_data_structures 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_ecmascript 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_regular_expression 0.96.0",
- "oxc_semantic 0.96.0",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
- "oxc_traverse 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_compat 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_regular_expression 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
+ "oxc_traverse 0.97.0",
  "pico-args",
  "rustc-hash",
  "serde",
@@ -2745,26 +2745,26 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "cow-utils",
  "insta",
  "itoa",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_codegen 0.96.0",
- "oxc_diagnostics 0.96.0",
- "oxc_ecmascript 0.96.0",
- "oxc_minifier 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_semantic 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_codegen 0.97.0",
+ "oxc_diagnostics 0.97.0",
+ "oxc_ecmascript 0.97.0",
+ "oxc_minifier 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_semantic 0.97.0",
  "oxc_sourcemap",
- "oxc_span 0.96.0",
- "oxc_syntax 0.96.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "oxc_tasks_common",
  "oxc_transformer",
- "oxc_traverse 0.96.0",
+ "oxc_traverse 0.97.0",
  "pico-args",
  "rustc-hash",
  "similar",
@@ -2773,6 +2773,8 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcbcda1412b43a921856314e2984cb9282f0d23c1439ae21bd5879110e01681"
 dependencies = [
  "itoa",
  "oxc_allocator 0.96.0",
@@ -2788,19 +2790,17 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcbcda1412b43a921856314e2984cb9282f0d23c1439ae21bd5879110e01681"
+version = "0.97.0"
 dependencies = [
  "itoa",
- "oxc_allocator 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ast_visit 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_data_structures 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_ecmascript 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_semantic 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_span 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxc_syntax 0.96.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_data_structures 0.97.0",
+ "oxc_ecmascript 0.97.0",
+ "oxc_semantic 0.97.0",
+ "oxc_span 0.97.0",
+ "oxc_syntax 0.97.0",
  "rustc-hash",
 ]
 
@@ -2816,11 +2816,11 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc-miette",
- "oxc_allocator 0.96.0",
- "oxc_diagnostics 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_diagnostics 0.97.0",
  "oxc_formatter",
- "oxc_parser 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
  "rayon",
  "tracing-subscriber",
 ]
@@ -2839,10 +2839,10 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc-miette",
- "oxc_allocator 0.96.0",
- "oxc_diagnostics 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_diagnostics 0.97.0",
  "oxc_linter",
- "oxc_span 0.96.0",
+ "oxc_span 0.97.0",
  "rayon",
  "rustc-hash",
  "serde",
@@ -3189,11 +3189,11 @@ dependencies = [
  "convert_case 0.9.0",
  "handlebars",
  "lazy-regex",
- "oxc_allocator 0.96.0",
- "oxc_ast 0.96.0",
- "oxc_ast_visit 0.96.0",
- "oxc_parser 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_ast 0.97.0",
+ "oxc_ast_visit 0.97.0",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
  "oxc_tasks_common",
  "rustc-hash",
  "serde",
@@ -4072,11 +4072,11 @@ dependencies = [
  "itertools",
  "markdown",
  "oxc-schemars",
- "oxc_allocator 0.96.0",
- "oxc_diagnostics 0.96.0",
+ "oxc_allocator 0.97.0",
+ "oxc_diagnostics 0.97.0",
  "oxc_linter",
- "oxc_parser 0.96.0",
- "oxc_span 0.96.0",
+ "oxc_parser 0.97.0",
+ "oxc_span 0.97.0",
  "oxlint",
  "pico-args",
  "project-root",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,33 +103,33 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.96.0", path = "crates/oxc" } # Main entry point
-oxc_allocator = { version = "0.96.0", path = "crates/oxc_allocator" } # Memory management
-oxc_ast = { version = "0.96.0", path = "crates/oxc_ast" } # AST definitions
-oxc_ast_macros = { version = "0.96.0", path = "crates/oxc_ast_macros" } # AST proc macros
-oxc_ast_visit = { version = "0.96.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
-oxc_cfg = { version = "0.96.0", path = "crates/oxc_cfg" } # Control flow graph
-oxc_codegen = { version = "0.96.0", path = "crates/oxc_codegen" } # Code generation
-oxc_compat = { version = "0.96.0", path = "crates/oxc_compat" } # Browser compatibility
-oxc_data_structures = { version = "0.96.0", path = "crates/oxc_data_structures" } # Shared data structures
-oxc_diagnostics = { version = "0.96.0", path = "crates/oxc_diagnostics" } # Error reporting
-oxc_ecmascript = { version = "0.96.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
-oxc_estree = { version = "0.96.0", path = "crates/oxc_estree" } # ESTree format
-oxc_isolated_declarations = { version = "0.96.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
-oxc_mangler = { version = "0.96.0", path = "crates/oxc_mangler" } # Name mangling
-oxc_minifier = { version = "0.96.0", path = "crates/oxc_minifier" } # Code minification
-oxc_minify_napi = { version = "0.96.0", path = "napi/minify" } # Node.js minifier binding
-oxc_napi = { version = "0.96.0", path = "crates/oxc_napi" } # NAPI utilities
-oxc_parser = { version = "0.96.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
-oxc_parser_napi = { version = "0.96.0", path = "napi/parser" } # Node.js parser binding
-oxc_regular_expression = { version = "0.96.0", path = "crates/oxc_regular_expression" } # Regex parser
-oxc_semantic = { version = "0.96.0", path = "crates/oxc_semantic" } # Semantic analysis
-oxc_span = { version = "0.96.0", path = "crates/oxc_span" } # Source positions
-oxc_syntax = { version = "0.96.0", path = "crates/oxc_syntax" } # Syntax utilities
-oxc_transform_napi = { version = "0.96.0", path = "napi/transform" } # Node.js transformer binding
-oxc_transformer = { version = "0.96.0", path = "crates/oxc_transformer" } # Code transformation
-oxc_transformer_plugins = { version = "0.96.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
-oxc_traverse = { version = "0.96.0", path = "crates/oxc_traverse" } # AST traversal
+oxc = { version = "0.97.0", path = "crates/oxc" } # Main entry point
+oxc_allocator = { version = "0.97.0", path = "crates/oxc_allocator" } # Memory management
+oxc_ast = { version = "0.97.0", path = "crates/oxc_ast" } # AST definitions
+oxc_ast_macros = { version = "0.97.0", path = "crates/oxc_ast_macros" } # AST proc macros
+oxc_ast_visit = { version = "0.97.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
+oxc_cfg = { version = "0.97.0", path = "crates/oxc_cfg" } # Control flow graph
+oxc_codegen = { version = "0.97.0", path = "crates/oxc_codegen" } # Code generation
+oxc_compat = { version = "0.97.0", path = "crates/oxc_compat" } # Browser compatibility
+oxc_data_structures = { version = "0.97.0", path = "crates/oxc_data_structures" } # Shared data structures
+oxc_diagnostics = { version = "0.97.0", path = "crates/oxc_diagnostics" } # Error reporting
+oxc_ecmascript = { version = "0.97.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
+oxc_estree = { version = "0.97.0", path = "crates/oxc_estree" } # ESTree format
+oxc_isolated_declarations = { version = "0.97.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
+oxc_mangler = { version = "0.97.0", path = "crates/oxc_mangler" } # Name mangling
+oxc_minifier = { version = "0.97.0", path = "crates/oxc_minifier" } # Code minification
+oxc_minify_napi = { version = "0.97.0", path = "napi/minify" } # Node.js minifier binding
+oxc_napi = { version = "0.97.0", path = "crates/oxc_napi" } # NAPI utilities
+oxc_parser = { version = "0.97.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
+oxc_parser_napi = { version = "0.97.0", path = "napi/parser" } # Node.js parser binding
+oxc_regular_expression = { version = "0.97.0", path = "crates/oxc_regular_expression" } # Regex parser
+oxc_semantic = { version = "0.97.0", path = "crates/oxc_semantic" } # Semantic analysis
+oxc_span = { version = "0.97.0", path = "crates/oxc_span" } # Source positions
+oxc_syntax = { version = "0.97.0", path = "crates/oxc_syntax" } # Syntax utilities
+oxc_transform_napi = { version = "0.97.0", path = "napi/transform" } # Node.js transformer binding
+oxc_transformer = { version = "0.97.0", path = "crates/oxc_transformer" } # Code transformation
+oxc_transformer_plugins = { version = "0.97.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
+oxc_traverse = { version = "0.97.0", path = "crates/oxc_traverse" } # AST traversal
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- b401708 allocator: Add `Box::as_non_null` method (#15321) (overlookmotel)
+- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
+
+### 🐛 Bug Fixes
+
+- 55b533c allocator: Avoid dereferencing `Box` when obtaining its `Address` (#15322) (overlookmotel)
+
+### ⚡ Performance
+
+- b6f3424 allocator: Add `#[inline(always)]` to trivial `RawVec` methods (#15470) (overlookmotel)
+- b5d6360 allocator: `#[inline(always)]` all `Address` methods (#15324) (overlookmotel)
+- bfd17fd allocator/address: Add `#[repr(transparent)]` to `Address` (#15312) (overlookmotel)
+
+### 📚 Documentation
+
+- ed0e023 allocator/address: Improve docs for `Address::from_ptr` (#15311) (overlookmotel)
+
 
 
 ## [0.94.0] - 2025-10-06

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
+- 977a6a0 ast: Implement `GetAddress` for `ModuleDeclarationKind` and `PropertyKeyKind` (#15313) (overlookmotel)
+- 682dca2 parser: Add more helps to parser errors (#15186) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 40231a6 linter/plugins, napi/parser: Add `parent` field to `FormalParameterRest` and `TSParameterProperty` in TS type defs (#15337) (overlookmotel)
+- 7f079ab ast/estree: Fix raw transfer deserializer for `AssignmentTargetPropertyIdentifier` (#15304) (overlookmotel)
+- d92451e ast/estree: Correct raw transfer deserializer for `FormalParameter` (#15302) (overlookmotel)
+- 75c9164 ast: Treat `TSEmptyBodyFunctionExpression` as expression in Function::is_expression (#14945) (Liang Mi)
+
+### 📚 Documentation
+
+- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚀 Features

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🐛 Bug Fixes
+
+- 020aa4f codegen: Print space before `BindingRestElement` in `ObjectPattern` (#15315) (overlookmotel)
+
+### ⚡ Performance
+
+- ab4b12b codegen: Reduce branches printing `ObjectPattern` (#15316) (overlookmotel)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_compat/CHANGELOG.md
+++ b/crates/oxc_compat/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 2c15353 transformer: Warn top level await usage if not supported (#14276) (Copilot)
+- aee6310 transformer: Add warning for arbitrary module namespace identifier names (#15035) (Copilot)
+
 
 ## [0.95.0] - 2025-10-15
 

--- a/crates/oxc_compat/Cargo.toml
+++ b/crates/oxc_compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_compat"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🐛 Bug Fixes
+
+- 8b14ec9 minifier: Handle `{ __proto__: null } instanceof Object` correctly (#15217) (sapphi-red)
+
 
 
 

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🐛 Bug Fixes
+
+- 2c23e15 isolated-declarations: Incorrectly dropping namespace even if it is being referenced (#15123) (Copilot)
+
 
 
 

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🐛 Bug Fixes
+
+- 8b14ec9 minifier: Handle `{ __proto__: null } instanceof Object` correctly (#15217) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 8951953 parser: Improve diagnostic messages for merge conflicts (#15443) (camc314)
+- 73f9e29 parser: Show allowed modifiers in invalid modifier error messages (#15442) (sapphi-red)
+- 5616ad5 parser,semantic: Add TS1274 error (#15441) (sapphi-red)
+- 0fa484d parser: Improve error messages for missing closing parentheses (#15446) (sapphi-red)
+- 4decc1d parser: Improve error message for missing block closing tokens (#15445) (sapphi-red)
+- e1704a4 parser: Improve error message for missing closing tokens that may be followed by a rest element (#15444) (sapphi-red)
+- b7e3849 parser: Add more help messages to diagnostics (#15440) (sapphi-red)
+- d4f6545 parser: Improve error message for missing closing tokens (#15269) (sapphi-red)
+- 2ef8f01 parser: Improve error message for missing conditional alternative (#15268) (sapphi-red)
+- 5f203c6 parser: Improve trailing comma error messages (#15267) (sapphi-red)
+- e62d14a parser: Improve error message for using declarations with `export` (#15266) (sapphi-red)
+- 682dca2 parser: Add more helps to parser errors (#15186) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 732205e parser: Reject `using` / `await using` in a switch `case` / `default` clause (#15225) (sapphi-red)
+- 4668004 parser: Reject `using` / `await using` in single statement contexts (#15224) (sapphi-red)
+- 0398d40 parser: Reject trailing commas after rest elements in object patterns (#15223) (sapphi-red)
+- c28807b parser: Reject `async await => {}` in scripts (#15222) (sapphi-red)
+- 837ef21 parser: Reject `yield` and `await` in object destructing shorthand property parameters (#15221) (sapphi-red)
+- 2d6d3a8 parser: Reject `for (let.something of ...)` (#15220) (sapphi-red)
+- 97ab60d parser: Reject invalid assignment operator in assignment targets (#15219) (sapphi-red)
+
+### ⚡ Performance
+
+- f1efc63 lexer: Skip single space in `read_next_token` (#15513) (overlookmotel)
+- b310c28 lexer: Inline `handle_byte` into `read_next_token` (#15520) (overlookmotel)
+- 2f0518d lexer: Hint to compiler that EOF only happens once (#15512) (overlookmotel)
+- 5f08c69 lexer: Remove branches from unicode handling (#15328) (overlookmotel)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 5616ad5 parser,semantic: Add TS1274 error (#15441) (sapphi-red)
+- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
+- 682dca2 parser: Add more helps to parser errors (#15186) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 4a54107 semantic: Allow `arguments` in the class field keys (#15227) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚀 Features

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 📚 Documentation
+
+- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
+
 
 
 

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
+- 2c15353 transformer: Warn top level await usage if not supported (#14276) (Copilot)
+- aee6310 transformer: Add warning for arbitrary module namespace identifier names (#15035) (Copilot)
+
+### 🐛 Bug Fixes
+
+- 7a5c011 transformer: Convert enum numbers to strings in template literals (#15183) (Copilot)
+
+### 📚 Documentation
+
+- 4b904b1 transformer: Clarify `jsx.pure` option would affect JSX elements (#15376) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
+- 9d568eb transformer_plugins: Support import.meta injection in inject_global_variables (#15125) (Copilot)
+
 
 ## [0.95.0] - 2025-10-15
 

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 1c31cb1 napi/minify: Expose `treeshake` options (#15109) (copilot-swe-agent)
+
+### 📚 Documentation
+
+- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚀 Features

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/index.js
+++ b/napi/minify/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-minify/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-minify/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🚀 Features
+
+- 682dca2 parser: Add more helps to parser errors (#15186) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 7f079ab ast/estree: Fix raw transfer deserializer for `AssignmentTargetPropertyIdentifier` (#15304) (overlookmotel)
+
+### ⚡ Performance
+
+- c82fab0 ast/estree: Remove pointless assignments from raw transfer deserializers (#15305) (overlookmotel)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚀 Features

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "type": "module",
   "main": "src-js/index.js",
   "browser": "src-js/wasm.js",

--- a/napi/parser/src-js/bindings.js
+++ b/napi/parser/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-parser/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-parser/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 📚 Documentation
+
+- 4b904b1 transformer: Clarify `jsx.pure` option would affect JSX elements (#15376) (sapphi-red)
+
 
 
 ## [0.94.0] - 2025-10-06

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-transform/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-transform/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.96.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.96.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.97.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.97.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/oxc-types/CHANGELOG.md
+++ b/npm/oxc-types/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.97.0] - 2025-11-11
+
+### 🐛 Bug Fixes
+
+- 40231a6 linter/plugins, napi/parser: Add `parent` field to `FormalParameterRest` and `TSParameterProperty` in TS type defs (#15337) (overlookmotel)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🐛 Bug Fixes

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "Types for Oxc AST nodes",
   "type": "module",
   "keywords": [

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "Oxc's modular runtime helpers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### 🚀 Features

- 8951953 parser: Improve diagnostic messages for merge conflicts (#15443) (camc314)
- 73f9e29 parser: Show allowed modifiers in invalid modifier error messages (#15442) (sapphi-red)
- 5616ad5 parser,semantic: Add TS1274 error (#15441) (sapphi-red)
- 0fa484d parser: Improve error messages for missing closing parentheses (#15446) (sapphi-red)
- 4decc1d parser: Improve error message for missing block closing tokens (#15445) (sapphi-red)
- e1704a4 parser: Improve error message for missing closing tokens that may be followed by a rest element (#15444) (sapphi-red)
- b7e3849 parser: Add more help messages to diagnostics (#15440) (sapphi-red)
- b401708 allocator: Add `Box::as_non_null` method (#15321) (overlookmotel)
- 8d69661 allocator: Add `Address::from_ref` method (#15318) (overlookmotel)
- 977a6a0 ast: Implement `GetAddress` for `ModuleDeclarationKind` and `PropertyKeyKind` (#15313) (overlookmotel)
- d4f6545 parser: Improve error message for missing closing tokens (#15269) (sapphi-red)
- 2ef8f01 parser: Improve error message for missing conditional alternative (#15268) (sapphi-red)
- 5f203c6 parser: Improve trailing comma error messages (#15267) (sapphi-red)
- e62d14a parser: Improve error message for using declarations with `export` (#15266) (sapphi-red)
- 2c15353 transformer: Warn top level await usage if not supported (#14276) (Copilot)
- 682dca2 parser: Add more helps to parser errors (#15186) (sapphi-red)
- 9d568eb transformer_plugins: Support import.meta injection in inject_global_variables (#15125) (Copilot)
- aee6310 transformer: Add warning for arbitrary module namespace identifier names (#15035) (Copilot)
- 1c31cb1 napi/minify: Expose `treeshake` options (#15109) (copilot-swe-agent)

### 🐛 Bug Fixes

- 732205e parser: Reject `using` / `await using` in a switch `case` / `default` clause (#15225) (sapphi-red)
- 40231a6 linter/plugins, napi/parser: Add `parent` field to `FormalParameterRest` and `TSParameterProperty` in TS type defs (#15337) (overlookmotel)
- 55b533c allocator: Avoid dereferencing `Box` when obtaining its `Address` (#15322) (overlookmotel)
- 020aa4f codegen: Print space before `BindingRestElement` in `ObjectPattern` (#15315) (overlookmotel)
- 7f079ab ast/estree: Fix raw transfer deserializer for `AssignmentTargetPropertyIdentifier` (#15304) (overlookmotel)
- d92451e ast/estree: Correct raw transfer deserializer for `FormalParameter` (#15302) (overlookmotel)
- 7a5c011 transformer: Convert enum numbers to strings in template literals (#15183) (Copilot)
- 4a54107 semantic: Allow `arguments` in the class field keys (#15227) (sapphi-red)
- 8b14ec9 minifier: Handle `{ __proto__: null } instanceof Object` correctly (#15217) (sapphi-red)
- 4668004 parser: Reject `using` / `await using` in single statement contexts (#15224) (sapphi-red)
- 0398d40 parser: Reject trailing commas after rest elements in object patterns (#15223) (sapphi-red)
- c28807b parser: Reject `async await => {}` in scripts (#15222) (sapphi-red)
- 837ef21 parser: Reject `yield` and `await` in object destructing shorthand property parameters (#15221) (sapphi-red)
- 2d6d3a8 parser: Reject `for (let.something of ...)` (#15220) (sapphi-red)
- 97ab60d parser: Reject invalid assignment operator in assignment targets (#15219) (sapphi-red)
- 75c9164 ast: Treat `TSEmptyBodyFunctionExpression` as expression in Function::is_expression (#14945) (Liang Mi)
- 2c23e15 isolated-declarations: Incorrectly dropping namespace even if it is being referenced (#15123) (Copilot)

### ⚡ Performance

- f1efc63 lexer: Skip single space in `read_next_token` (#15513) (overlookmotel)
- b310c28 lexer: Inline `handle_byte` into `read_next_token` (#15520) (overlookmotel)
- 2f0518d lexer: Hint to compiler that EOF only happens once (#15512) (overlookmotel)
- b6f3424 allocator: Add `#[inline(always)]` to trivial `RawVec` methods (#15470) (overlookmotel)
- b5d6360 allocator: `#[inline(always)]` all `Address` methods (#15324) (overlookmotel)
- 5f08c69 lexer: Remove branches from unicode handling (#15328) (overlookmotel)
- ab4b12b codegen: Reduce branches printing `ObjectPattern` (#15316) (overlookmotel)
- bfd17fd allocator/address: Add `#[repr(transparent)]` to `Address` (#15312) (overlookmotel)
- c82fab0 ast/estree: Remove pointless assignments from raw transfer deserializers (#15305) (overlookmotel)

### 📚 Documentation

- 3dc24b5 linter,minifier: Always refer as "ES Modules" instead of "ES6 Modules" (#15409) (sapphi-red)
- 4b904b1 transformer: Clarify `jsx.pure` option would affect JSX elements (#15376) (sapphi-red)
- ed0e023 allocator/address: Improve docs for `Address::from_ptr` (#15311) (overlookmotel)