### PR TITLE
ci(benchmarks/formatter): Update formatter bench with sort-imports

### DIFF
--- a/tasks/benchmark/benches/formatter.rs
+++ b/tasks/benchmark/benches/formatter.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
+use oxc_formatter::{FormatOptions, Formatter, SortImports, get_parse_options};
 use oxc_parser::Parser;
 use oxc_tasks_common::TestFiles;
 
@@ -19,7 +19,10 @@ fn bench_formatter(criterion: &mut Criterion) {
                     .with_options(get_parse_options())
                     .parse()
                     .program;
-                let format_options = FormatOptions::default();
+                let format_options = FormatOptions {
+                    experimental_sort_imports: Some(SortImports::default()),
+                    ..Default::default()
+                };
                 runner.run(|| {
                     Formatter::new(&allocator, format_options).build(&program);
                 });


### PR DESCRIPTION
> I think we don't need to add another benchmark for the sort import feature; enabling it in > formatter.rs is enough. Any of the current benchmark files contains many import statements.

It seems there was no need to create a separate file after all.

My intention was to confirm that the benchmark for the formatter alone consistently produced better results than the benchmark with sorting enabled.

To verify this, shouldn't the benchmarks be separated?