### PR TITLE
ci(ast_tools): run "AST Changes" CI task when CI workflow file changes

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -3,6 +3,7 @@
 
 src:
   - '.github/generated/ast_changes_watch_list.yml'
+  - '.github/workflows/ci.yml'
   - 'apps/oxlint/src-js/generated/constants.ts'
   - 'apps/oxlint/src-js/generated/deserialize.js'
   - 'apps/oxlint/src-js/generated/keys.ts'

--- a/tasks/ast_tools/src/output/yaml.rs
+++ b/tasks/ast_tools/src/output/yaml.rs
@@ -10,15 +10,21 @@ pub fn print_yaml(code: &str, generator_path: &str) -> String {
 impl Output {
     /// Generate a watch list YAML file.
     ///
-    /// The path of the watch list itself and `tasks/ast_tools/src/**` are added to the list.
+    /// The path of the watch list itself, `tasks/ast_tools/src/**`, and the CI workflow file are added to the list.
     pub fn yaml_watch_list<'s>(
         watch_list_path: &'s str,
         paths: impl IntoIterator<Item = &'s str>,
     ) -> Self {
-        let mut paths = paths
-            .into_iter()
-            .chain([watch_list_path, "tasks/ast_tools/src/**"])
-            .collect::<Vec<_>>();
+        let additional_paths = [
+            // This watch list file
+            watch_list_path,
+            // All code in `ast_tools`
+            "tasks/ast_tools/src/**",
+            // Workflow which runs `ast_tools`
+            ".github/workflows/ci.yml",
+        ];
+
+        let mut paths = paths.into_iter().chain(additional_paths).collect::<Vec<_>>();
         paths.sort_unstable();
 
         let mut code = "src:\n".to_string();


### PR DESCRIPTION
Add path to CI workflow file to the watch list for "AST Changes" CI task, so the task runs if the workflow is altered.