### PR TITLE
test(linter/plugins): remove `dprint-ignore-file` comments from test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/files/index.js
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/files/index.js
@@ -1,5 +1,3 @@
-// dprint-ignore-file
-
 var shouldError = 1;
 
 // oxlint-disable-next-line test-plugin/no-var

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/output.snap.md
@@ -4,42 +4,41 @@
 # stdout
 ```
   x test-plugin(no-var): Use let or const instead of var
-   ,-[files/index.js:3:1]
- 2 | 
- 3 | var shouldError = 1;
+   ,-[files/index.js:1:1]
+ 1 | var shouldError = 1;
    : ^^^^^^^^^^^^^^^^^^^^
- 4 | 
+ 2 | 
    `----
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-    ,-[files/index.js:12:1]
- 11 | // should trigger an error
- 12 | debugger;
+    ,-[files/index.js:10:1]
+  9 | // should trigger an error
+ 10 | debugger;
     : ^^^^^^^^^
- 13 | 
+ 11 | 
     `----
   help: Remove the debugger statement
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:18:1]
- 17 | /* oxlint-disable-next-line test-plugin */ // `test-plugin` should be `test-plugin/no-var`
- 18 | var incorrectlyDisabled = 4;
+    ,-[files/index.js:16:1]
+ 15 | /* oxlint-disable-next-line test-plugin */ // `test-plugin` should be `test-plugin/no-var`
+ 16 | var incorrectlyDisabled = 4;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 19 | 
+ 17 | 
     `----
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:21:1]
- 20 | /* oxlint-disable-next-line no-var */ // `no-var` should be `test-plugin/no-var`
- 21 | var anotherIncorrectlyDisabled = 4;
+    ,-[files/index.js:19:1]
+ 18 | /* oxlint-disable-next-line no-var */ // `no-var` should be `test-plugin/no-var`
+ 19 | var anotherIncorrectlyDisabled = 4;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 22 | 
+ 20 | 
     `----
 
   x test-plugin(no-var): Use let or const instead of var
-    ,-[files/index.js:24:1]
- 23 | // This var should trigger an error again
- 24 | var shouldErrorAgain = 3;
+    ,-[files/index.js:22:1]
+ 21 | // This var should trigger an error again
+ 22 | var shouldErrorAgain = 3;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 

--- a/apps/oxlint/test/fixtures/estree/files/index.ts
+++ b/apps/oxlint/test/fixtures/estree/files/index.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-// dprint-ignore-file
 
 // All `Identifier`s
 let a = { x: y };

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -33,111 +33,111 @@
   | * TSUnionType:exit: (types: TSStringKeyword, TSNumberKeyword)
   | * TSTypeAliasDeclaration:exit: (typeAnnotation: TSUnionType)
   | * Program:exit
-    ,-[files/index.ts:5:1]
-  4 |     // All `Identifier`s
-  5 | ,-> let a = { x: y };
-  6 | |   
-  7 | |   // No `ParenthesizedExpression`s in AST
-  8 | |   const b = (x * ((('str' + ((123))))));
-  9 | |   
- 10 | |   // TS syntax
- 11 | |   type T = string;
- 12 | |   
- 13 | |   // No `TSParenthesizedType`s in AST
- 14 | `-> type U = (((((string)) | ((number)))));
+    ,-[files/index.ts:4:1]
+  3 |     // All `Identifier`s
+  4 | ,-> let a = { x: y };
+  5 | |   
+  6 | |   // No `ParenthesizedExpression`s in AST
+  7 | |   const b = (x * ((('str' + ((123))))));
+  8 | |   
+  9 | |   // TS syntax
+ 10 | |   type T = string;
+ 11 | |   
+ 12 | |   // No `TSParenthesizedType`s in AST
+ 13 | `-> type U = (((((string)) | ((number)))));
     `----
 
   x estree-check(check): program:
-  | start/end: [59,265]
-  | range: [59,265]
-  | loc: [{"start":{"line":5,"column":0},"end":{"line":15,"column":0}}]
-    ,-[files/index.ts:5:1]
-  4 |     // All `Identifier`s
-  5 | ,-> let a = { x: y };
-  6 | |   
-  7 | |   // No `ParenthesizedExpression`s in AST
-  8 | |   const b = (x * ((('str' + ((123))))));
-  9 | |   
- 10 | |   // TS syntax
- 11 | |   type T = string;
- 12 | |   
- 13 | |   // No `TSParenthesizedType`s in AST
- 14 | `-> type U = (((((string)) | ((number)))));
+  | start/end: [37,243]
+  | range: [37,243]
+  | loc: [{"start":{"line":4,"column":0},"end":{"line":14,"column":0}}]
+    ,-[files/index.ts:4:1]
+  3 |     // All `Identifier`s
+  4 | ,-> let a = { x: y };
+  5 | |   
+  6 | |   // No `ParenthesizedExpression`s in AST
+  7 | |   const b = (x * ((('str' + ((123))))));
+  8 | |   
+  9 | |   // TS syntax
+ 10 | |   type T = string;
+ 11 | |   
+ 12 | |   // No `TSParenthesizedType`s in AST
+ 13 | `-> type U = (((((string)) | ((number)))));
     `----
 
   x estree-check(check): ident "a":
-  | start/end: [63,64]
-  | range: [63,64]
-  | loc: [{"start":{"line":5,"column":4},"end":{"line":5,"column":5}}]
-   ,-[files/index.ts:5:5]
- 4 | // All `Identifier`s
- 5 | let a = { x: y };
+  | start/end: [41,42]
+  | range: [41,42]
+  | loc: [{"start":{"line":4,"column":4},"end":{"line":4,"column":5}}]
+   ,-[files/index.ts:4:5]
+ 3 | // All `Identifier`s
+ 4 | let a = { x: y };
    :     ^
- 6 | 
+ 5 | 
    `----
 
   x estree-check(check): ident "x":
-  | start/end: [69,70]
-  | range: [69,70]
-  | loc: [{"start":{"line":5,"column":10},"end":{"line":5,"column":11}}]
-   ,-[files/index.ts:5:11]
- 4 | // All `Identifier`s
- 5 | let a = { x: y };
+  | start/end: [47,48]
+  | range: [47,48]
+  | loc: [{"start":{"line":4,"column":10},"end":{"line":4,"column":11}}]
+   ,-[files/index.ts:4:11]
+ 3 | // All `Identifier`s
+ 4 | let a = { x: y };
    :           ^
- 6 | 
+ 5 | 
    `----
 
   x estree-check(check): ident "y":
-  | start/end: [72,73]
-  | range: [72,73]
-  | loc: [{"start":{"line":5,"column":13},"end":{"line":5,"column":14}}]
-   ,-[files/index.ts:5:14]
- 4 | // All `Identifier`s
- 5 | let a = { x: y };
+  | start/end: [50,51]
+  | range: [50,51]
+  | loc: [{"start":{"line":4,"column":13},"end":{"line":4,"column":14}}]
+   ,-[files/index.ts:4:14]
+ 3 | // All `Identifier`s
+ 4 | let a = { x: y };
    :              ^
- 6 | 
+ 5 | 
    `----
 
   x estree-check(check): ident "b":
-  | start/end: [124,125]
-  | range: [124,125]
-  | loc: [{"start":{"line":8,"column":6},"end":{"line":8,"column":7}}]
-   ,-[files/index.ts:8:7]
- 7 | // No `ParenthesizedExpression`s in AST
- 8 | const b = (x * ((('str' + ((123))))));
+  | start/end: [102,103]
+  | range: [102,103]
+  | loc: [{"start":{"line":7,"column":6},"end":{"line":7,"column":7}}]
+   ,-[files/index.ts:7:7]
+ 6 | // No `ParenthesizedExpression`s in AST
+ 7 | const b = (x * ((('str' + ((123))))));
    :       ^
- 9 | 
+ 8 | 
    `----
 
   x estree-check(check): ident "x":
-  | start/end: [129,130]
-  | range: [129,130]
-  | loc: [{"start":{"line":8,"column":11},"end":{"line":8,"column":12}}]
-   ,-[files/index.ts:8:12]
- 7 | // No `ParenthesizedExpression`s in AST
- 8 | const b = (x * ((('str' + ((123))))));
+  | start/end: [107,108]
+  | range: [107,108]
+  | loc: [{"start":{"line":7,"column":11},"end":{"line":7,"column":12}}]
+   ,-[files/index.ts:7:12]
+ 6 | // No `ParenthesizedExpression`s in AST
+ 7 | const b = (x * ((('str' + ((123))))));
    :            ^
- 9 | 
+ 8 | 
    `----
 
   x estree-check(check): ident "T":
-  | start/end: [176,177]
-  | range: [176,177]
-  | loc: [{"start":{"line":11,"column":5},"end":{"line":11,"column":6}}]
-    ,-[files/index.ts:11:6]
- 10 | // TS syntax
- 11 | type T = string;
+  | start/end: [154,155]
+  | range: [154,155]
+  | loc: [{"start":{"line":10,"column":5},"end":{"line":10,"column":6}}]
+    ,-[files/index.ts:10:6]
+  9 | // TS syntax
+ 10 | type T = string;
     :      ^
- 12 | 
+ 11 | 
     `----
 
   x estree-check(check): ident "U":
-  | start/end: [230,231]
-  | range: [230,231]
-  | loc: [{"start":{"line":14,"column":5},"end":{"line":14,"column":6}}]
-    ,-[files/index.ts:14:6]
- 13 | // No `TSParenthesizedType`s in AST
- 14 | type U = (((((string)) | ((number)))));
+  | start/end: [208,209]
+  | range: [208,209]
+  | loc: [{"start":{"line":13,"column":5},"end":{"line":13,"column":6}}]
+    ,-[files/index.ts:13:6]
+ 12 | // No `TSParenthesizedType`s in AST
+ 13 | type U = (((((string)) | ((number)))));
     :      ^
     `----
 

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -33,6 +33,13 @@ const plugin: Plugin = {
           VariableDeclarator(decl) {
             // `init` should not be `ParenthesizedExpression`
             visits.push(`${decl.type}: (init: ${decl.init.type})`);
+
+            // Make sure the fixture hasn't been formatted by accident,
+            // which would prevent this test from testing what it's meant to.
+            // Formatter would remove all the parentheses.
+            if (decl.id.type === 'Identifier' && decl.id.name === 'b') {
+              assert(context.sourceCode.getText(decl) === "b = (x * ((('str' + ((123))))))");
+            }
           },
           Identifier(ident) {
             // Check `loc` property returns same object each time it's accessed
@@ -66,6 +73,13 @@ const plugin: Plugin = {
           TSTypeAliasDeclaration(decl) {
             // `typeAnnotation` should not be `TSParenthesizedType`
             visits.push(`${decl.type}: (typeAnnotation: ${decl.typeAnnotation.type})`);
+
+            // Make sure the fixture hasn't been formatted by accident,
+            // which would prevent this test from testing what it's meant to.
+            // Formatter would remove all the parentheses.
+            if (decl.id.name === 'U') {
+              assert(context.sourceCode.getText(decl) === 'type U = (((((string)) | ((number)))));');
+            }
           },
           'TSTypeAliasDeclaration:exit'(decl) {
             // `typeAnnotation` should not be `TSParenthesizedType`


### PR DESCRIPTION
We don't use `dprint` any more to format JS/TS. So remove defunct `// dprint-ignore-file` comments from test fixtures.