### PR TITLE
style(oxlint/plugins): format test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -29,14 +29,16 @@ const testCommentsRule: Rule = {
     assert(topLevelFunction.type === 'FunctionDeclaration');
 
     context.report({
-      message: 'commentsExistBetween(topLevelVariable2, topLevelFunction): ' +
+      message:
+        'commentsExistBetween(topLevelVariable2, topLevelFunction): ' +
         sourceCode.commentsExistBetween(topLevelVariable2, topLevelFunction),
       node: topLevelVariable2,
     });
 
     // Test `commentsExistBetween` returns `false` when start node is after end node
     context.report({
-      message: 'commentsExistBetween(topLevelFunction, topLevelVariable2): ' +
+      message:
+        'commentsExistBetween(topLevelFunction, topLevelVariable2): ' +
         sourceCode.commentsExistBetween(topLevelFunction, topLevelVariable2),
       node: topLevelFunction,
     });
@@ -50,7 +52,8 @@ const testCommentsRule: Rule = {
         assert(init !== null);
 
         context.report({
-          message: `VariableDeclaration(${id.name}):\n` +
+          message:
+            `VariableDeclaration(${id.name}):\n` +
             `getCommentsBefore: ${formatComments(sourceCode.getCommentsBefore(node))}\n` +
             `getCommentsInside: ${formatComments(sourceCode.getCommentsInside(node))}\n` +
             `getCommentsAfter: ${formatComments(sourceCode.getCommentsAfter(node))}\n` +
@@ -60,7 +63,8 @@ const testCommentsRule: Rule = {
       },
       FunctionDeclaration(node) {
         context.report({
-          message: `FunctionDeclaration(${node.id.name}):\n` +
+          message:
+            `FunctionDeclaration(${node.id.name}):\n` +
             `getCommentsBefore: ${formatComments(sourceCode.getCommentsBefore(node))}\n` +
             `getCommentsInside: ${formatComments(sourceCode.getCommentsInside(node))}\n` +
             `getCommentsAfter: ${formatComments(sourceCode.getCommentsAfter(node))}`,

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -16,7 +16,8 @@ const plugin: Plugin = {
         return {
           Program(program) {
             context.report({
-              message: 'program:\n' +
+              message:
+                'program:\n' +
                 `start/end: [${program.start},${program.end}]\n` +
                 `range: [${program.range}]\n` +
                 `loc: [${JSON.stringify(program.loc)}]`,
@@ -48,7 +49,8 @@ const plugin: Plugin = {
             assert(loc2 === loc);
 
             context.report({
-              message: `ident "${ident.name}":\n` +
+              message:
+                `ident "${ident.name}":\n` +
                 `start/end: [${ident.start},${ident.end}]\n` +
                 `range: [${ident.range}]\n` +
                 `loc: [${JSON.stringify(loc)}]`,
@@ -94,11 +96,11 @@ const plugin: Plugin = {
           },
           TSUnionType(union) {
             // `types` should not be `TSParenthesizedType`
-            visits.push(`${union.type}: (types: ${union.types.map(t => t.type).join(', ')})`);
+            visits.push(`${union.type}: (types: ${union.types.map((t) => t.type).join(', ')})`);
           },
           'TSUnionType:exit'(union) {
             // `types` should not be `TSParenthesizedType`
-            visits.push(`${union.type}:exit: (types: ${union.types.map(t => t.type).join(', ')})`);
+            visits.push(`${union.type}:exit: (types: ${union.types.map((t) => t.type).join(', ')})`);
           },
           TSNumberKeyword(keyword) {
             visits.push(keyword.type);

--- a/apps/oxlint/test/fixtures/fixes/plugin.ts
+++ b/apps/oxlint/test/fixtures/fixes/plugin.ts
@@ -5,7 +5,7 @@ const plugin: Plugin = {
     name: 'fixes-plugin',
   },
   rules: {
-    'fixes': {
+    fixes: {
       meta: {
         fixable: 'code',
       },

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -59,12 +59,12 @@ const testRule: Rule = {
 
         // We get this wrong. Should be `false`, but we get `true`.
         context.report({
-            message:
-              '\n' +
-              `isSpaceBetween(beforeString, afterString): ${isSpaceBetween(beforeString, afterString)}\n` +
-              `isSpaceBetween(afterString, beforeString): ${isSpaceBetween(afterString, beforeString)}`,
-            node,
-          });
+          message:
+            '\n' +
+            `isSpaceBetween(beforeString, afterString): ${isSpaceBetween(beforeString, afterString)}\n` +
+            `isSpaceBetween(afterString, beforeString): ${isSpaceBetween(afterString, beforeString)}`,
+          node,
+        });
       },
     };
   },

--- a/apps/oxlint/test/fixtures/parent/plugin.ts
+++ b/apps/oxlint/test/fixtures/parent/plugin.ts
@@ -9,10 +9,14 @@ const plugin: Plugin = {
       create(context) {
         function reportAncestry(node: any) {
           context.report({
-            message: `${node.type}:\n` +
+            message:
+              `${node.type}:\n` +
               `parent: ${node.parent?.type}\n` +
-              // @ts-ignore
-              `ancestors: [ ${context.sourceCode.getAncestors(node).map(node => node.type).join(', ')} ]`,
+              `ancestors: [ ${context.sourceCode
+                .getAncestors(node)
+                // @ts-expect-error - Shouldn't be an error. We need to fix our types.
+                .map((node) => node.type)
+                .join(', ')} ]`,
             node,
           });
         }

--- a/apps/oxlint/test/fixtures/scope_manager/plugin.ts
+++ b/apps/oxlint/test/fixtures/scope_manager/plugin.ts
@@ -24,9 +24,9 @@ const rule: Rule = {
         assert.equal(moduleScope.upper, scopeManager.globalScope);
 
         context.report({
-          message: `File has ${scopeManager.scopes.length} scopes: ${
-            scopeManager.scopes.map((s: any) => s.block?.id?.name ?? '<' + s.constructor.name + '>').join(', ')
-          }`,
+          message: `File has ${scopeManager.scopes.length} scopes: ${scopeManager.scopes
+            .map((s: any) => s.block?.id?.name ?? '<' + s.constructor.name + '>')
+            .join(', ')}`,
           node: SPAN,
         });
 
@@ -37,9 +37,9 @@ const rule: Rule = {
         if (node.declarations[0].id.type === 'ObjectPattern') {
           const variables = context.sourceCode.scopeManager.getDeclaredVariables(node);
           context.report({
-            message: `VariableDeclaration declares ${variables.length} variables: ${
-              variables.map(v => v.name).join(', ')
-            }.`,
+            message: `VariableDeclaration declares ${variables.length} variables: ${variables
+              .map((v) => v.name)
+              .join(', ')}.`,
             node: node,
           });
         }
@@ -49,9 +49,9 @@ const rule: Rule = {
           const topLevelFunctionScope = context.sourceCode.scopeManager.acquire(node)!;
           assert.equal(topLevelFunctionScope.upper, moduleScope);
           context.report({
-            message: `topLevelFunction has ${topLevelFunctionScope.variables.length} local variables: ${
-              topLevelFunctionScope?.variables.map(v => v.name).join(', ')
-            }. Child scopes: ${topLevelFunctionScope.childScopes.length}.`,
+            message: `topLevelFunction has ${topLevelFunctionScope.variables.length} local variables: ${topLevelFunctionScope?.variables
+              .map((v) => v.name)
+              .join(', ')}. Child scopes: ${topLevelFunctionScope.childScopes.length}.`,
             node: topLevelFunctionScope.block,
           });
         }
@@ -61,9 +61,9 @@ const rule: Rule = {
           const topLevelModuleScope = context.sourceCode.scopeManager.acquire(node)!;
           assert.equal(topLevelModuleScope.upper, moduleScope);
           context.report({
-            message: `TopLevelModule has ${topLevelModuleScope.variables.length} local variables: ${
-              topLevelModuleScope?.variables.map(v => v.name).join(', ')
-            }. Child scopes: ${topLevelModuleScope.childScopes.length}.`,
+            message: `TopLevelModule has ${topLevelModuleScope.variables.length} local variables: ${topLevelModuleScope?.variables
+              .map((v) => v.name)
+              .join(', ')}. Child scopes: ${topLevelModuleScope.childScopes.length}.`,
             node: topLevelModuleScope.block,
           });
         }
@@ -78,9 +78,9 @@ const rule: Rule = {
         assert('name' in upperBlock.id);
         assert.equal(upperBlock.id.name, 'TestClass');
         context.report({
-          message: `TestClass static block has ${staticBlockScope.variables.length} local variables: ${
-            staticBlockScope?.variables.map(v => v.name).join(', ')
-          }. Child scopes: ${staticBlockScope.childScopes.length}.`,
+          message: `TestClass static block has ${staticBlockScope.variables.length} local variables: ${staticBlockScope?.variables
+            .map((v) => v.name)
+            .join(', ')}. Child scopes: ${staticBlockScope.childScopes.length}.`,
           node: node,
         });
       },
@@ -88,9 +88,9 @@ const rule: Rule = {
         const labeledStatementScope = context.sourceCode.scopeManager.acquire(node.body)!;
         assert.equal(labeledStatementScope.upper, moduleScope);
         context.report({
-          message: `LabeledStatement's block has ${labeledStatementScope.variables.length} local variables: ${
-            labeledStatementScope?.variables.map(v => v.name).join(', ')
-          }. Child scopes: ${labeledStatementScope.childScopes.length}.`,
+          message: `LabeledStatement's block has ${labeledStatementScope.variables.length} local variables: ${labeledStatementScope?.variables
+            .map((v) => v.name)
+            .join(', ')}. Child scopes: ${labeledStatementScope.childScopes.length}.`,
           node: node,
         });
       },

--- a/apps/oxlint/test/fixtures/selector/files/index.js
+++ b/apps/oxlint/test/fixtures/selector/files/index.js
@@ -3,4 +3,4 @@ const obj = { a: [b, c], ...d };
 function foo() {}
 function bar() {}
 
-(() => {});
+() => {};

--- a/apps/oxlint/test/fixtures/selector/output.snap.md
+++ b/apps/oxlint/test/fixtures/selector/output.snap.md
@@ -117,7 +117,7 @@
  3 | |   function foo() {}
  4 | |   function bar() {}
  5 | |   
- 6 | `-> (() => {});
+ 6 | `-> () => {};
    `----
 
 Found 0 warnings and 1 error.

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -59,16 +59,18 @@ const plugin: Plugin = {
         }
 
         visitor['Program:exit'] = (program) => {
-          const visitLog = visits.map(({ key, node }) => {
-            const { type } = node;
-            let nodeDescription = type;
-            if (type === 'Identifier') {
-              nodeDescription += `(${node.name})`;
-            } else if (type === 'FunctionDeclaration') {
-              nodeDescription += `(${node.id.name})`;
-            }
-            return `${key}: ${nodeDescription}`;
-          }).join('\n');
+          const visitLog = visits
+            .map(({ key, node }) => {
+              const { type } = node;
+              let nodeDescription = type;
+              if (type === 'Identifier') {
+                nodeDescription += `(${node.name})`;
+              } else if (type === 'FunctionDeclaration') {
+                nodeDescription += `(${node.id.name})`;
+              }
+              return `${key}: ${nodeDescription}`;
+            })
+            .join('\n');
 
           context.report({
             message: `\n${visitLog}`,

--- a/apps/oxlint/test/fixtures/settings/plugin.ts
+++ b/apps/oxlint/test/fixtures/settings/plugin.ts
@@ -15,7 +15,7 @@ const rule: Rule = {
     const settings = context.settings;
 
     // Report each setting key and value
-    Object.keys(settings).forEach(key => {
+    Object.keys(settings).forEach((key) => {
       const value = settings[key];
       context.report({
         message: `setting ${key}: ${JSON.stringify(value)}`,

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -22,12 +22,14 @@ const createRule: Rule = {
     for (let offset = 0; offset <= text.length; offset++) {
       const loc = context.sourceCode.getLocFromIndex(offset);
       assert(context.sourceCode.getIndexFromLoc(loc) === offset);
-      locs += `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
+      locs +=
+        `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
         `(${JSON.stringify(text[offset] || '<EOF>')})`;
     }
 
     context.report({
-      message: 'create:\n' +
+      message:
+        'create:\n' +
         `text: ${JSON.stringify(text)}\n` +
         `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
         `lines: ${JSON.stringify(lines)}\n` +
@@ -55,7 +57,8 @@ const createRule: Rule = {
         assert(context.sourceCode.getIndexFromLoc(endLoc) === node.end);
 
         context.report({
-          message: `ident "${node.name}":\n` +
+          message:
+            `ident "${node.name}":\n` +
             `source: "${context.sourceCode.getText(node)}"\n` +
             `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
             `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
@@ -82,12 +85,14 @@ const createOnceRule: Rule = {
         for (let offset = 0; offset <= text.length; offset++) {
           const loc = context.sourceCode.getLocFromIndex(offset);
           assert(context.sourceCode.getIndexFromLoc(loc) === offset);
-          locs += `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
+          locs +=
+            `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
             `(${JSON.stringify(text[offset] || '<EOF>')})`;
         }
 
         context.report({
-          message: 'before:\n' +
+          message:
+            'before:\n' +
             `text: ${JSON.stringify(text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
             `lines: ${JSON.stringify(lines)}\n` +
@@ -114,7 +119,8 @@ const createOnceRule: Rule = {
         assert(context.sourceCode.getIndexFromLoc(endLoc) === node.end);
 
         context.report({
-          message: `ident "${node.name}":\n` +
+          message:
+            `ident "${node.name}":\n` +
             `source: "${context.sourceCode.getText(node)}"\n` +
             `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
             `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
@@ -129,8 +135,7 @@ const createOnceRule: Rule = {
         ast = null;
 
         context.report({
-          message: 'after:\n' +
-            `source: ${JSON.stringify(context.sourceCode.text)}`,
+          message: 'after:\n' + `source: ${JSON.stringify(context.sourceCode.text)}`,
           node: SPAN,
         });
       },

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
@@ -31,7 +31,8 @@ const createRule: Rule = {
         assert(ast === node);
 
         context.report({
-          message: 'program:\n' +
+          message:
+            'program:\n' +
             `text: ${JSON.stringify(context.sourceCode.text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}`,
           node: SPAN,
@@ -49,7 +50,8 @@ const createRule: Rule = {
         assert(context.sourceCode.ast === ast);
 
         context.report({
-          message: `ident "${node.name}":\n` +
+          message:
+            `ident "${node.name}":\n` +
             `source: "${context.sourceCode.getText(node)}"\n` +
             `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
             `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
@@ -71,7 +73,8 @@ const createOnceRule: Rule = {
         assert(ast === node);
 
         context.report({
-          message: 'program:\n' +
+          message:
+            'program:\n' +
             `text: ${JSON.stringify(context.sourceCode.text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}`,
           node: SPAN,
@@ -89,7 +92,8 @@ const createOnceRule: Rule = {
         assert(context.sourceCode.ast === ast);
 
         context.report({
-          message: `ident "${node.name}":\n` +
+          message:
+            `ident "${node.name}":\n` +
             `source: "${context.sourceCode.getText(node)}"\n` +
             `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
             `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
@@ -102,8 +106,7 @@ const createOnceRule: Rule = {
         ast = null;
 
         context.report({
-          message: 'after:\n' +
-            `source: ${JSON.stringify(context.sourceCode.text)}`,
+          message: 'after:\n' + `source: ${JSON.stringify(context.sourceCode.text)}`,
           node: SPAN,
         });
       },

--- a/apps/oxlint/test/fixtures/sourceCode_late_access_after_only/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access_after_only/plugin.ts
@@ -19,7 +19,8 @@ const createOnceRule: Rule = {
       Program(_program) {},
       after() {
         context.report({
-          message: 'after:\n' +
+          message:
+            'after:\n' +
             `text: ${JSON.stringify(context.sourceCode.text)}\n` +
             `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
             // @ts-ignore

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -28,7 +28,7 @@ const rule: Rule = {
       VariableDeclaration(node) {
         const variables = sourceCode.getDeclaredVariables(node);
         context.report({
-          message: `getDeclaredVariables(): ${variables.map(v => v.name).join(', ')}`,
+          message: `getDeclaredVariables(): ${variables.map((v) => v.name).join(', ')}`,
           node,
         });
       },
@@ -45,8 +45,8 @@ const rule: Rule = {
         let text = '';
         text += `type: ${scope.type}\n`;
         text += `isStrict: ${scope.isStrict}\n`;
-        text += `vars: [${scope.variables.map(v => v.name).join(', ')}]\n`;
-        text += `through: [${scope.through.map(r => (r.identifier as any).name).join(', ')}]\n`;
+        text += `vars: [${scope.variables.map((v) => v.name).join(', ')}]\n`;
+        text += `through: [${scope.through.map((r) => (r.identifier as any).name).join(', ')}]\n`;
         if (scope.upper) text += `upper: ${scope.upper.type}\n`;
 
         context.report({

--- a/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
+++ b/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
@@ -10,7 +10,8 @@ const plugin: Plugin = {
         return {
           Program(program) {
             context.report({
-              message: 'program:\n' +
+              message:
+                'program:\n' +
                 `start/end: [${program.start},${program.end}]\n` +
                 `range: [${program.range}]\n` +
                 `loc: [${JSON.stringify(program.loc)}]`,
@@ -19,7 +20,8 @@ const plugin: Plugin = {
           },
           DebuggerStatement(debuggerStatement) {
             context.report({
-              message: 'debugger:\n' +
+              message:
+                'debugger:\n' +
                 `start/end: [${debuggerStatement.start},${debuggerStatement.end}]\n` +
                 `range: [${debuggerStatement.range}]\n` +
                 `loc: [${JSON.stringify(debuggerStatement.loc)}]`,


### PR DESCRIPTION
Format `oxlint` test fixtures. The directory `fixtures` contains not just the fixtures themselves, but also Oxlint plugins, which should be formatted.

Skip 2 specific test fixture files which must not be formatted to maintain correctness of the tests.