### PR TITLE
style(linter/plugins): update `oxfmt` config to format `oxlint` fixtures

### DIFF
--- a/oxfmtrc.jsonc
+++ b/oxfmtrc.jsonc
@@ -6,7 +6,9 @@
     "**/dist/**",
     "**/tests/**",
     "**/generated/**",
+    // Ignore `fixtures` directories except for `apps/oxlint/test/fixtures`
     "**/fixtures/**",
+    "!apps/oxlint/test/fixtures/**",
     "tasks/coverage/node-compat-table",
     "tasks/coverage/misc",
     "tasks/coverage/src/runtime/babelHelpers.js",


### PR DESCRIPTION
Update `oxfmt` config so it formats `apps/oxlint/test/fixtures`.

Actual formatting changes were in PRs #15600 and #15674. This PR alters the config so all these files will continue to be formatted in future.