### PR TITLE
style(linter/plugins): use `prettier-ignore` in test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/estree/files/index.ts
+++ b/apps/oxlint/test/fixtures/estree/files/index.ts
@@ -4,10 +4,12 @@
 let a = { x: y };
 
 // No `ParenthesizedExpression`s in AST
+// prettier-ignore
 const b = (x * ((('str' + ((123))))));
 
 // TS syntax
 type T = string;
 
 // No `TSParenthesizedType`s in AST
+// prettier-ignore
 type U = (((((string)) | ((number)))));

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -38,31 +38,35 @@
   4 | ,-> let a = { x: y };
   5 | |   
   6 | |   // No `ParenthesizedExpression`s in AST
-  7 | |   const b = (x * ((('str' + ((123))))));
-  8 | |   
-  9 | |   // TS syntax
- 10 | |   type T = string;
- 11 | |   
- 12 | |   // No `TSParenthesizedType`s in AST
- 13 | `-> type U = (((((string)) | ((number)))));
+  7 | |   // prettier-ignore
+  8 | |   const b = (x * ((('str' + ((123))))));
+  9 | |   
+ 10 | |   // TS syntax
+ 11 | |   type T = string;
+ 12 | |   
+ 13 | |   // No `TSParenthesizedType`s in AST
+ 14 | |   // prettier-ignore
+ 15 | `-> type U = (((((string)) | ((number)))));
     `----
 
   x estree-check(check): program:
-  | start/end: [37,243]
-  | range: [37,243]
-  | loc: [{"start":{"line":4,"column":0},"end":{"line":14,"column":0}}]
+  | start/end: [37,281]
+  | range: [37,281]
+  | loc: [{"start":{"line":4,"column":0},"end":{"line":16,"column":0}}]
     ,-[files/index.ts:4:1]
   3 |     // All `Identifier`s
   4 | ,-> let a = { x: y };
   5 | |   
   6 | |   // No `ParenthesizedExpression`s in AST
-  7 | |   const b = (x * ((('str' + ((123))))));
-  8 | |   
-  9 | |   // TS syntax
- 10 | |   type T = string;
- 11 | |   
- 12 | |   // No `TSParenthesizedType`s in AST
- 13 | `-> type U = (((((string)) | ((number)))));
+  7 | |   // prettier-ignore
+  8 | |   const b = (x * ((('str' + ((123))))));
+  9 | |   
+ 10 | |   // TS syntax
+ 11 | |   type T = string;
+ 12 | |   
+ 13 | |   // No `TSParenthesizedType`s in AST
+ 14 | |   // prettier-ignore
+ 15 | `-> type U = (((((string)) | ((number)))));
     `----
 
   x estree-check(check): ident "a":
@@ -99,45 +103,45 @@
    `----
 
   x estree-check(check): ident "b":
-  | start/end: [102,103]
-  | range: [102,103]
-  | loc: [{"start":{"line":7,"column":6},"end":{"line":7,"column":7}}]
-   ,-[files/index.ts:7:7]
- 6 | // No `ParenthesizedExpression`s in AST
- 7 | const b = (x * ((('str' + ((123))))));
+  | start/end: [121,122]
+  | range: [121,122]
+  | loc: [{"start":{"line":8,"column":6},"end":{"line":8,"column":7}}]
+   ,-[files/index.ts:8:7]
+ 7 | // prettier-ignore
+ 8 | const b = (x * ((('str' + ((123))))));
    :       ^
- 8 | 
+ 9 | 
    `----
 
   x estree-check(check): ident "x":
-  | start/end: [107,108]
-  | range: [107,108]
-  | loc: [{"start":{"line":7,"column":11},"end":{"line":7,"column":12}}]
-   ,-[files/index.ts:7:12]
- 6 | // No `ParenthesizedExpression`s in AST
- 7 | const b = (x * ((('str' + ((123))))));
+  | start/end: [126,127]
+  | range: [126,127]
+  | loc: [{"start":{"line":8,"column":11},"end":{"line":8,"column":12}}]
+   ,-[files/index.ts:8:12]
+ 7 | // prettier-ignore
+ 8 | const b = (x * ((('str' + ((123))))));
    :            ^
- 8 | 
+ 9 | 
    `----
 
   x estree-check(check): ident "T":
-  | start/end: [154,155]
-  | range: [154,155]
-  | loc: [{"start":{"line":10,"column":5},"end":{"line":10,"column":6}}]
-    ,-[files/index.ts:10:6]
-  9 | // TS syntax
- 10 | type T = string;
+  | start/end: [173,174]
+  | range: [173,174]
+  | loc: [{"start":{"line":11,"column":5},"end":{"line":11,"column":6}}]
+    ,-[files/index.ts:11:6]
+ 10 | // TS syntax
+ 11 | type T = string;
     :      ^
- 11 | 
+ 12 | 
     `----
 
   x estree-check(check): ident "U":
-  | start/end: [208,209]
-  | range: [208,209]
-  | loc: [{"start":{"line":13,"column":5},"end":{"line":13,"column":6}}]
-    ,-[files/index.ts:13:6]
- 12 | // No `TSParenthesizedType`s in AST
- 13 | type U = (((((string)) | ((number)))));
+  | start/end: [246,247]
+  | range: [246,247]
+  | loc: [{"start":{"line":15,"column":5},"end":{"line":15,"column":6}}]
+    ,-[files/index.ts:15:6]
+ 14 | // prettier-ignore
+ 15 | type U = (((((string)) | ((number)))));
     :      ^
     `----
 

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -34,13 +34,6 @@ const plugin: Plugin = {
           VariableDeclarator(decl) {
             // `init` should not be `ParenthesizedExpression`
             visits.push(`${decl.type}: (init: ${decl.init.type})`);
-
-            // Make sure the fixture hasn't been formatted by accident,
-            // which would prevent this test from testing what it's meant to.
-            // Formatter would remove all the parentheses.
-            if (decl.id.type === 'Identifier' && decl.id.name === 'b') {
-              assert(context.sourceCode.getText(decl) === "b = (x * ((('str' + ((123))))))");
-            }
           },
           Identifier(ident) {
             // Check `loc` property returns same object each time it's accessed
@@ -75,13 +68,6 @@ const plugin: Plugin = {
           TSTypeAliasDeclaration(decl) {
             // `typeAnnotation` should not be `TSParenthesizedType`
             visits.push(`${decl.type}: (typeAnnotation: ${decl.typeAnnotation.type})`);
-
-            // Make sure the fixture hasn't been formatted by accident,
-            // which would prevent this test from testing what it's meant to.
-            // Formatter would remove all the parentheses.
-            if (decl.id.name === 'U') {
-              assert(context.sourceCode.getText(decl) === 'type U = (((((string)) | ((number)))));');
-            }
           },
           'TSTypeAliasDeclaration:exit'(decl) {
             // `typeAnnotation` should not be `TSParenthesizedType`

--- a/apps/oxlint/test/fixtures/isSpaceBetween/files/index.js
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/files/index.js
@@ -1,18 +1,26 @@
+// prettier-ignore
 noSpace=1;
 
+// prettier-ignore
 singleSpaceBefore =2;
 
+// prettier-ignore
 singleSpaceAfter= 3;
 
+// prettier-ignore
 multipleSpaces   =   4;
 
+// prettier-ignore
 newlineBefore=
 5;
 
+// prettier-ignore
 newlineAfter
 =6;
 
+// prettier-ignore
 nested = 7 + 8;
 
 // We should return `false` for `isSpaceBetween(beforeString, afterString)`, but we currently return `true`
+// prettier-ignore
 beforeString," ",afterString;

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -10,33 +10,21 @@
   | isSpaceBetween(node, left): false
   | isSpaceBetween(right, node): false
   | isSpaceBetween(node, right): false
-   ,-[files/index.js:1:1]
- 1 | noSpace=1;
+   ,-[files/index.js:2:1]
+ 1 | // prettier-ignore
+ 2 | noSpace=1;
    : ^^^^^^^^^
- 2 | 
+ 3 | 
    `----
 
   x test-plugin(is-space-between):
   | isSpaceBetween(leftExtended, right): false
   | isSpaceBetween(right, leftExtended): false
-   ,-[files/index.js:1:1]
- 1 | noSpace=1;
+   ,-[files/index.js:2:1]
+ 1 | // prettier-ignore
+ 2 | noSpace=1;
    : ^^^^^^^^^
- 2 | 
-   `----
-
-  x test-plugin(is-space-between):
-  | isSpaceBetween(left, right): true
-  | isSpaceBetween(right, left): true
-  | isSpaceBetween(left, node): false
-  | isSpaceBetween(node, left): false
-  | isSpaceBetween(right, node): false
-  | isSpaceBetween(node, right): false
-   ,-[files/index.js:3:1]
- 2 | 
- 3 | singleSpaceBefore =2;
-   : ^^^^^^^^^^^^^^^^^^^^
- 4 | 
+ 3 | 
    `----
 
   x test-plugin(is-space-between):
@@ -47,10 +35,24 @@
   | isSpaceBetween(right, node): false
   | isSpaceBetween(node, right): false
    ,-[files/index.js:5:1]
- 4 | 
- 5 | singleSpaceAfter= 3;
+ 4 | // prettier-ignore
+ 5 | singleSpaceBefore =2;
+   : ^^^^^^^^^^^^^^^^^^^^
+ 6 | 
+   `----
+
+  x test-plugin(is-space-between):
+  | isSpaceBetween(left, right): true
+  | isSpaceBetween(right, left): true
+  | isSpaceBetween(left, node): false
+  | isSpaceBetween(node, left): false
+  | isSpaceBetween(right, node): false
+  | isSpaceBetween(node, right): false
+   ,-[files/index.js:8:1]
+ 7 | // prettier-ignore
+ 8 | singleSpaceAfter= 3;
    : ^^^^^^^^^^^^^^^^^^^
- 6 | 
+ 9 | 
    `----
 
   x test-plugin(is-space-between):
@@ -60,25 +62,11 @@
   | isSpaceBetween(node, left): false
   | isSpaceBetween(right, node): false
   | isSpaceBetween(node, right): false
-   ,-[files/index.js:7:1]
- 6 | 
- 7 | multipleSpaces   =   4;
-   : ^^^^^^^^^^^^^^^^^^^^^^
- 8 | 
-   `----
-
-  x test-plugin(is-space-between):
-  | isSpaceBetween(left, right): true
-  | isSpaceBetween(right, left): true
-  | isSpaceBetween(left, node): false
-  | isSpaceBetween(node, left): false
-  | isSpaceBetween(right, node): false
-  | isSpaceBetween(node, right): false
-    ,-[files/index.js:9:1]
-  8 |     
-  9 | ,-> newlineBefore=
- 10 | `-> 5;
- 11 |     
+    ,-[files/index.js:11:1]
+ 10 | // prettier-ignore
+ 11 | multipleSpaces   =   4;
+    : ^^^^^^^^^^^^^^^^^^^^^^
+ 12 | 
     `----
 
   x test-plugin(is-space-between):
@@ -88,21 +76,35 @@
   | isSpaceBetween(node, left): false
   | isSpaceBetween(right, node): false
   | isSpaceBetween(node, right): false
-    ,-[files/index.js:12:1]
- 11 |     
- 12 | ,-> newlineAfter
- 13 | `-> =6;
- 14 |     
+    ,-[files/index.js:14:1]
+ 13 |     // prettier-ignore
+ 14 | ,-> newlineBefore=
+ 15 | `-> 5;
+ 16 |     
+    `----
+
+  x test-plugin(is-space-between):
+  | isSpaceBetween(left, right): true
+  | isSpaceBetween(right, left): true
+  | isSpaceBetween(left, node): false
+  | isSpaceBetween(node, left): false
+  | isSpaceBetween(right, node): false
+  | isSpaceBetween(node, right): false
+    ,-[files/index.js:18:1]
+ 17 |     // prettier-ignore
+ 18 | ,-> newlineAfter
+ 19 | `-> =6;
+ 20 |     
     `----
 
   x test-plugin(is-space-between):
   | isSpaceBetween(node, binaryLeft): false
   | isSpaceBetween(binaryLeft, node): false
-    ,-[files/index.js:15:1]
- 14 | 
- 15 | nested = 7 + 8;
+    ,-[files/index.js:22:1]
+ 21 | // prettier-ignore
+ 22 | nested = 7 + 8;
     : ^^^^^^^^^^^^^^
- 16 | 
+ 23 | 
     `----
 
   x test-plugin(is-space-between):
@@ -112,19 +114,19 @@
   | isSpaceBetween(node, left): false
   | isSpaceBetween(right, node): false
   | isSpaceBetween(node, right): false
-    ,-[files/index.js:15:1]
- 14 | 
- 15 | nested = 7 + 8;
+    ,-[files/index.js:22:1]
+ 21 | // prettier-ignore
+ 22 | nested = 7 + 8;
     : ^^^^^^^^^^^^^^
- 16 | 
+ 23 | 
     `----
 
   x test-plugin(is-space-between):
   | isSpaceBetween(beforeString, afterString): true
   | isSpaceBetween(afterString, beforeString): true
-    ,-[files/index.js:18:1]
- 17 | // We should return `false` for `isSpaceBetween(beforeString, afterString)`, but we currently return `true`
- 18 | beforeString," ",afterString;
+    ,-[files/index.js:26:1]
+ 25 | // prettier-ignore
+ 26 | beforeString," ",afterString;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 


### PR DESCRIPTION
Follow-on after #15593 and #15600. Use `// prettier-ignore` comments in test fixture files to prevent them being formatted, where formatting would break the test.