### PR TITLE
refactor(linter/plugins): add comments on `Context#extend`

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -181,6 +181,7 @@ const FILE_CONTEXT: FileContext = freeze({
    *   and the specified properties as its own properties.
    */
   extend(this: FileContext, extension: Record<string | number | symbol, unknown>): FileContext {
+    // Note: We can allow calling `extend` in `createOnce`, as it involves no file-specific state
     return freeze(ObjectAssign(ObjectCreate(this), extension));
   },
 

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -227,6 +227,7 @@ const FILE_CONTEXT = freeze({
    *   and the specified properties as its own properties.
    */
   extend(this: FileContext, extension: Record<string | number | symbol, unknown>): FileContext {
+    // Note: We can allow calling `extend` in `createOnce`, as it involves no file-specific state
     return freeze(ObjectAssign(ObjectCreate(this), extension));
   },
 


### PR DESCRIPTION
Add comments on `extend` methods explaining why they're OK to use in `createContext`.