### PR TITLE
feat(oxlint): add `--lsp` flag to run the language server

### DIFF
--- a/.github/workflows/ci_vscode.yml
+++ b/.github/workflows/ci_vscode.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "pnpm-lock.yaml"
       - "crates/oxc_language_server/**"
+      - "apps/oxlint/src/lsp.rs"
       - "editors/vscode/**"
       - ".github/workflows/ci_vscode.yml"
 
@@ -44,6 +45,10 @@ jobs:
       - name: Build Language Server
         working-directory: editors/vscode
         run: pnpm run server:build:debug
+
+      - name: Build oxlint (with napi)
+        working-directory: editors/vscode
+        run: pnpm run oxlint:build:debug
 
       - name: Compile VSCode
         working-directory: editors/vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,7 @@ dependencies = [
  "oxc-miette",
  "oxc_allocator",
  "oxc_diagnostics",
+ "oxc_language_server",
  "oxc_linter",
  "oxc_span",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ oxc_traverse = { version = "0.97.0", path = "crates/oxc_traverse" } # AST traver
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
+oxc_language_server = { path = "crates/oxc_language_server" } # Language server
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
 oxc_tasks_common = { path = "tasks/common" } # Task utilities

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -29,6 +29,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_diagnostics = { workspace = true }
+oxc_language_server = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_span = { workspace = true }
 
@@ -44,7 +45,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -39,6 +39,10 @@ pub struct LintCommand {
     #[bpaf(long("rules"), switch, hide_usage)]
     pub list_rules: bool,
 
+    /// Start the language server
+    #[bpaf(long("lsp"), switch, hide_usage)]
+    pub lsp: bool,
+
     #[bpaf(external)]
     pub misc_options: MiscOptions,
 

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -4,6 +4,7 @@
 mod command;
 mod init;
 mod lint;
+mod lsp;
 mod output_formatter;
 mod result;
 mod walk;
@@ -13,7 +14,7 @@ mod tester;
 
 /// Re-exported CLI-related items for use in `tasks/website`.
 pub mod cli {
-    pub use super::{command::*, init::*, lint::CliRunner, result::CliRunResult};
+    pub use super::{command::*, init::*, lint::CliRunner, lsp::run_lsp, result::CliRunResult};
 }
 
 // Only include code to run linter when the `napi` feature is enabled.

--- a/apps/oxlint/src/lsp.rs
+++ b/apps/oxlint/src/lsp.rs
@@ -1,0 +1,4 @@
+/// Run the language server
+pub async fn run_lsp() {
+    oxc_language_server::run_server(vec![Box::new(oxc_language_server::ServerLinterBuilder)]).await;
+}

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -1,13 +1,20 @@
 use std::io::BufWriter;
 
-use oxlint::cli::{CliRunResult, CliRunner, init_miette, init_tracing, lint_command};
+use oxlint::cli::{CliRunResult, CliRunner, init_miette, init_tracing, lint_command, run_lsp};
 
-fn main() -> CliRunResult {
-    init_tracing();
-    init_miette();
-
+#[tokio::main]
+async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = lint_command().run();
+
+    // If --lsp flag is set, run the language server
+    if command.lsp {
+        run_lsp().await;
+        return CliRunResult::LintSucceeded;
+    }
+
+    init_tracing();
+    init_miette();
 
     command.handle_threads();
 

--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -16,11 +16,12 @@ const ext = process.platform === 'win32' ? '.exe' : '';
 
 export default defineConfig({
   tests: [
+    // Single-folder workspace tests
     {
       files: 'out/**/*.spec.js',
       workspaceFolder: './test_workspace',
       launchArgs: [
-        // This disables all extensions except the one being testing
+        // This disables all extensions except the one being tested
         '--disable-extensions',
       ],
       env: {
@@ -31,16 +32,35 @@ export default defineConfig({
         timeout: 10_000,
       },
     },
+    // Multi-root workspace tests
     {
       files: 'out/**/*.spec.js',
       workspaceFolder: multiRootWorkspaceFile,
       launchArgs: [
-        // This disables all extensions except the one being testing
+        // This disables all extensions except the one being tested
         '--disable-extensions',
       ],
       env: {
         MULTI_FOLDER_WORKSPACE: 'true',
         SERVER_PATH_DEV: path.resolve(import.meta.dirname, `./target/debug/oxc_language_server${ext}`),
+      },
+      mocha: {
+        timeout: 10_000,
+      },
+    },
+    // Oxlint --lsp tests
+    {
+      files: 'out/**/*.spec.js',
+      workspaceFolder: './test_workspace',
+      launchArgs: [
+        // This disables all extensions except the one being tested
+        '--disable-extensions',
+      ],
+      env: {
+        SINGLE_FOLDER_WORKSPACE: 'true',
+        OXLINT_LSP_TEST: 'true',
+        SERVER_PATH_DEV: path.resolve(import.meta.dirname, `../../apps/oxlint/dist/cli.js`),
+        SKIP_FORMATTER_TEST: 'true',
       },
       mocha: {
         timeout: 10_000,

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -144,8 +144,6 @@ export async function activate(context: ExtensionContext) {
     return process.env.SERVER_PATH_DEV ?? join(context.extensionPath, `./target/release/oxc_language_server${ext}`);
   }
 
-  const command = await findBinary();
-
   const nodePath = configService.vsCodeConfig.nodePath;
   const serverEnv: Record<string, string> = {
     ...process.env,
@@ -154,12 +152,25 @@ export async function activate(context: ExtensionContext) {
   if (nodePath) {
     serverEnv.PATH = `${nodePath}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`;
   }
-  const run: Executable = {
-    command: command!,
-    options: {
-      env: serverEnv,
-    },
-  };
+
+  const path = await findBinary();
+
+  const run: Executable =
+    process.env.OXLINT_LSP_TEST === 'true'
+      ? {
+          command: 'node',
+          args: [path!, '--lsp'],
+          options: {
+            env: serverEnv,
+          },
+        }
+      : {
+          command: path!,
+          options: {
+            env: serverEnv,
+          },
+        };
+
   const serverOptions: ServerOptions = {
     run,
     debug: run,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -243,6 +243,8 @@
     "watch": "pnpm run compile --watch",
     "package": "vsce package --no-dependencies -o oxc_language_server.vsix",
     "install-extension": "code --install-extension oxc_language_server.vsix --force",
+    "oxlint:build:debug": "pnpm -C ../../apps/oxlint build-napi-test && pnpm -C ../../apps/oxlint build-js",
+    "oxlint:build:release": "pnpm -C ../../apps/oxlint build-napi && pnpm -C ../../apps/oxlint build-js",
     "server:build:debug": "cross-env CARGO_TARGET_DIR=./target cargo build -p oxc_language_server",
     "server:build:release": "cross-env CARGO_TARGET_DIR=./target cargo build -p oxc_language_server --release",
     "test": "cross-env TEST=true pnpm run compile && vscode-test",

--- a/editors/vscode/tests/e2e_server_formatter.spec.ts
+++ b/editors/vscode/tests/e2e_server_formatter.spec.ts
@@ -1,0 +1,69 @@
+import { strictEqual } from 'assert';
+import {
+  commands,
+  Uri,
+  window,
+  workspace,
+} from 'vscode';
+import {
+  activateExtension,
+  fixturesWorkspaceUri,
+  loadFixture,
+  sleep,
+} from './test-helpers';
+
+suiteSetup(async () => {
+  await activateExtension();
+});
+
+teardown(async () => {
+  await workspace.getConfiguration('oxc').update('fmt.experimental', undefined);
+  await workspace.getConfiguration('oxc').update('fmt.configPath', undefined);
+  await workspace.getConfiguration('editor').update('defaultFormatter', undefined);
+  await workspace.saveAll();
+});
+
+suite('E2E Server Formatter', () => {
+    // Skip tests if formatter tests are disabled
+    if (process.env.SKIP_FORMATTER_TEST === 'true') {
+      return;
+    }
+
+    test('formats code with `oxc.fmt.experimental`', async () => {
+      await workspace.getConfiguration('oxc').update('fmt.experimental', true);
+      await workspace.getConfiguration('editor').update('defaultFormatter', 'oxc.oxc-vscode');
+      await loadFixture('formatting');
+
+      await sleep(500);
+
+      const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'formatting.ts');
+
+      const document = await workspace.openTextDocument(fileUri);
+      await window.showTextDocument(document);
+      await commands.executeCommand('editor.action.formatDocument');
+      await workspace.saveAll();
+      const content = await workspace.fs.readFile(fileUri);
+
+      strictEqual(content.toString(), "class X {\n  foo() {\n    return 42;\n  }\n}\n");
+    });
+
+    test('formats code with `oxc.fmt.configPath`', async () => {
+      await loadFixture('formatting_with_config');
+
+      await workspace.getConfiguration('oxc').update('fmt.experimental', true);
+      await workspace.getConfiguration('oxc').update('fmt.configPath', './fixtures/formatter.json');
+      await workspace.getConfiguration('editor').update('defaultFormatter', 'oxc.oxc-vscode');
+
+      await sleep(500); // wait for the server to pick up the new config
+      const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'formatting.ts');
+
+      const document = await workspace.openTextDocument(fileUri);
+      await window.showTextDocument(document);
+      await commands.executeCommand('editor.action.formatDocument');
+      await workspace.saveAll();
+      const content = await workspace.fs.readFile(fileUri);
+
+      strictEqual(content.toString(), "class X {\n  foo() {\n    return 42\n  }\n}\n");
+    });
+
+});

--- a/editors/vscode/tests/e2e_server_linter.spec.ts
+++ b/editors/vscode/tests/e2e_server_linter.spec.ts
@@ -42,7 +42,7 @@ teardown(async () => {
 });
 
 
-suite('E2E Diagnostics', () => {
+suite('E2E Server Linter', () => {
   test('simple debugger statement', async () => {
     await loadFixture('debugger');
     const diagnostics = await getDiagnostics('debugger.js');
@@ -276,42 +276,5 @@ suite('E2E Diagnostics', () => {
 
     const secondDiagnostics = await getDiagnostics('index.ts');
     strictEqual(secondDiagnostics.length, 1);
-  });
-
-  test('formats code with `oxc.fmt.experimental`', async () => {
-    await workspace.getConfiguration('oxc').update('fmt.experimental', true);
-    await workspace.getConfiguration('editor').update('defaultFormatter', 'oxc.oxc-vscode');
-    await loadFixture('formatting');
-
-    await sleep(500);
-
-    const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'formatting.ts');
-
-    const document = await workspace.openTextDocument(fileUri);
-    await window.showTextDocument(document);
-    await commands.executeCommand('editor.action.formatDocument');
-    await workspace.saveAll();
-    const content = await workspace.fs.readFile(fileUri);
-
-    strictEqual(content.toString(), "class X {\n  foo() {\n    return 42;\n  }\n}\n");
-  });
-
-  test('formats code with `oxc.fmt.configPath`', async () => {
-    await loadFixture('formatting_with_config');
-
-    await workspace.getConfiguration('oxc').update('fmt.experimental', true);
-    await workspace.getConfiguration('oxc').update('fmt.configPath', './fixtures/formatter.json');
-    await workspace.getConfiguration('editor').update('defaultFormatter', 'oxc.oxc-vscode');
-
-    await sleep(500); // wait for the server to pick up the new config
-    const fileUri = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'formatting.ts');
-
-    const document = await workspace.openTextDocument(fileUri);
-    await window.showTextDocument(document);
-    await commands.executeCommand('editor.action.formatDocument');
-    await workspace.saveAll();
-    const content = await workspace.fs.readFile(fileUri);
-
-    strictEqual(content.toString(), "class X {\n  foo() {\n    return 42\n  }\n}\n");
   });
 });

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -153,6 +153,8 @@ Arguments:
 ## Available options:
 - **`    --rules`** &mdash; 
   List all the rules that are currently registered
+- **`    --lsp`** &mdash; 
+  Start the language server
 - **`    --disable-nested-config`** &mdash; 
   Disable the automatic loading of nested configuration files
 - **`    --type-aware`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -93,6 +93,7 @@ Available positional items:
 
 Available options:
         --rules               List all the rules that are currently registered
+        --lsp                 Start the language server
         --disable-nested-config  Disable the automatic loading of nested configuration files
         --type-aware          Enable rules that require type information
     -h, --help                Prints help information


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/pull/15038 and https://github.com/oxc-project/oxc/issues/12251

> This PR adds a --lsp flag to the oxlint command-line tool that starts the language server directly, allowing for a unified binary that can function as both a linter and a language server. This addresses the need for a simpler deployment model where a single oxlint binary can be used in different modes.