### PR TITLE
feat(oxlint,oxfmt): Allow comments and also commas for vscode-json-ls

### DIFF
--- a/crates/oxc_formatter/tests/schema.rs
+++ b/crates/oxc_formatter/tests/schema.rs
@@ -8,7 +8,15 @@ use project_root::get_project_root;
 #[test]
 fn test_schema_json() {
     let path = get_project_root().unwrap().join("npm/oxfmt/configuration_schema.json");
-    let schema = schemars::schema_for!(Oxfmtrc);
+    let mut schema = schemars::schema_for!(Oxfmtrc);
+    // Allow comments and trailing commas for vscode-json-languageservice
+    // NOTE: This is NOT part of standard JSON Schema specification
+    // https://github.com/microsoft/vscode-json-languageservice/blob/fb83547762901f32d8449d57e24666573016b10c/src/jsonLanguageTypes.ts#L151-L159
+    schema.schema.extensions.insert("allowComments".to_string(), serde_json::Value::Bool(true));
+    schema
+        .schema
+        .extensions
+        .insert("allowTrailingCommas".to_string(), serde_json::Value::Bool(true));
     let json = serde_json::to_string_pretty(&schema).unwrap();
     let existing_json = fs::read_to_string(&path).unwrap_or_default();
     if existing_json.trim() != json.trim() {

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -174,6 +174,8 @@ expression: json
       ]
     }
   },
+  "allowComments": true,
+  "allowTrailingCommas": true,
   "definitions": {
     "ArrowParensConfig": {
       "type": "string",

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -204,9 +204,14 @@ impl Oxlintrc {
     /// Panics if the schema generation fails.
     pub fn generate_schema_json() -> String {
         let mut schema = schema_for!(Oxlintrc);
-        // setting `allowComments` to true to allow comments in JSON schema files
-        // https://github.com/microsoft/vscode-json-languageservice/blob/356d5dd980d49c6ac09ec8446614a6f94016dcea/src/jsonLanguageTypes.ts#L127-L131
+        // Allow comments and trailing commas for vscode-json-languageservice
+        // NOTE: This is NOT part of standard JSON Schema specification
+        // https://github.com/microsoft/vscode-json-languageservice/blob/fb83547762901f32d8449d57e24666573016b10c/src/jsonLanguageTypes.ts#L151-L159
         schema.schema.extensions.insert("allowComments".to_string(), serde_json::Value::Bool(true));
+        schema
+            .schema
+            .extensions
+            .insert("allowTrailingCommas".to_string(), serde_json::Value::Bool(true));
         serde_json::to_string_pretty(&schema).unwrap()
     }
 

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -127,6 +127,7 @@ expression: json
     }
   },
   "allowComments": true,
+  "allowTrailingCommas": true,
   "definitions": {
     "AllowWarnDeny": {
       "oneOf": [

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -170,6 +170,8 @@
       ]
     }
   },
+  "allowComments": true,
+  "allowTrailingCommas": true,
   "definitions": {
     "ArrowParensConfig": {
       "type": "string",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -123,6 +123,7 @@
     }
   },
   "allowComments": true,
+  "allowTrailingCommas": true,
   "definitions": {
     "AllowWarnDeny": {
       "oneOf": [


### PR DESCRIPTION
Fixes #15588 

Add vscode specific extension of `allowComments` and `allowTrailingCommas` for both `oxlint` and `oxfmt`.