### PR TITLE
perf(oxfmt): Use simdutf8 based read_to_string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "rayon",
+ "simdutf8",
  "tracing-subscriber",
 ]
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -38,6 +38,7 @@ cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 miette = { workspace = true }
 rayon = { workspace = true }
+simdutf8 = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 # NAPI dependencies (conditional on napi feature)

--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, sync::mpsc, time::Instant};
+use std::{fs, io, path::Path, sync::mpsc, time::Instant};
 
 use cow_utils::CowUtils;
 use rayon::prelude::*;
@@ -77,7 +77,7 @@ impl FormatService {
         let source_type = enable_jsx_source_type(entry.source_type);
 
         let allocator = self.allocator_pool.get();
-        let source_text = fs::read_to_string(path).expect("Failed to read file");
+        let source_text = read_to_string(path).expect("Failed to read file");
 
         let ret = Parser::new(&allocator, &source_text, source_type)
             .with_options(get_parse_options())
@@ -147,4 +147,18 @@ impl FormatService {
             tx_error.send(vec![diagnostic.into()]).unwrap();
         }
     }
+}
+
+fn read_to_string(path: &Path) -> io::Result<String> {
+    // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
+    let bytes = fs::read(path)?;
+    if simdutf8::basic::from_utf8(&bytes).is_err() {
+        // Same error as `fs::read_to_string` produces (using `io::ErrorKind::InvalidData`)
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "stream did not contain valid UTF-8",
+        ));
+    }
+    // SAFETY: `simdutf8` has ensured it's a valid UTF-8 string
+    Ok(unsafe { String::from_utf8_unchecked(bytes) })
 }


### PR DESCRIPTION
Like `oxlint` does.

Run outline benchmark locally a few times and roughly shows:

```
## BEFORE (main)
Time (mean ± σ):      75.4 ms ±   0.9 ms    [User: 253.2 ms, System: 74.7 ms]
Range (min … max):    74.5 ms …  77.3 ms    10 runs

## AFTER (this PR)
Time (mean ± σ):      75.0 ms ±   0.5 ms    [User: 252.7 ms, System: 75.2 ms]
Range (min … max):    74.3 ms …  75.9 ms    10 runs
```