### PR TITLE
feat(oxc_minify_napi): expose `TreeShakeOptions`

### DIFF
--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -25,7 +25,7 @@ use oxc_span::SourceType;
 
 pub use crate::options::{
     CodegenOptions, CompressOptions, CompressOptionsKeepNames, MangleOptions,
-    MangleOptionsKeepNames, MinifyOptions,
+    MangleOptionsKeepNames, MinifyOptions, TreeShakeOptions,
 };
 
 #[derive(Default)]


### PR DESCRIPTION
Similar to #13288. I wonder if it's possible to ensure the types are exposed.