### PR TITLE
refactor(formatter): Expose explicit detect_code_removal api

### DIFF
--- a/apps/oxfmt/src/service.rs
+++ b/apps/oxfmt/src/service.rs
@@ -113,6 +113,14 @@ impl FormatService {
 
         let code = formatter.build(&ret.program);
 
+        #[cfg(feature = "detect_code_removal")]
+        {
+            if let Some(diff) = oxc_formatter::detect_code_removal(&source_text, &code, source_type)
+            {
+                unreachable!("Code removal detected in `{}`:\n{diff}", path.to_string_lossy());
+            }
+        }
+
         let elapsed = start_time.elapsed();
         let is_changed = source_text != code;
 


### PR DESCRIPTION
- Before: `Formatter::new().build()` panics when detected
- After: Need to use `detect_code_removal()` api explicitly

It has also been adapted to use `oxfmt`.

This change allows `monitor-oxc` to retain the output of existing `FormatterRunner` while also enabling separate results for `FormatterDCRRunner`.