### PR TITLE
refactor(linter/plugins): move location-related types into `location.ts`

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1,7 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
 
-import { Span, Comment } from '../plugins/types.ts';
+import { Span } from '../plugins/location.ts';
+import { Comment } from '../plugins/types.ts';
 export { Span, Comment };
 
 export interface Program extends Span {

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -33,17 +33,13 @@ export type {
   RuleReplacedByInfo,
   RuleReplacedByExternalSpecifier,
 } from './plugins/rule_meta.ts';
+export type { LineColumn, Location, Range, Ranged, Span } from './plugins/location.ts';
 export type {
   AfterHook,
   BeforeHook,
   Comment,
-  LineColumn,
-  Location,
   Node,
   NodeOrToken,
-  Range,
-  Ranged,
-  Span,
   Token,
   Visitor,
   VisitorWithHooks,

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -34,7 +34,7 @@ import { settings, initSettings } from './settings.js';
 import type { Fix, FixFn } from './fix.ts';
 import type { RuleDetails } from './load.ts';
 import type { SourceCode } from './source_code.ts';
-import type { Location, Ranged } from './types.ts';
+import type { Location, Ranged } from './location.ts';
 import type { ModuleKind } from '../generated/types.d.ts';
 
 const { hasOwn, keys: ObjectKeys, freeze, assign: ObjectAssign, create: ObjectCreate } = Object;

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -2,7 +2,7 @@ import { assertIs } from './utils.js';
 
 import type { Diagnostic } from './context.ts';
 import type { RuleDetails } from './load.ts';
-import type { Range, Ranged } from './types.ts';
+import type { Range, Ranged } from './location.ts';
 
 const { prototype: ArrayPrototype, from: ArrayFrom } = Array,
   { getPrototypeOf, hasOwn, prototype: ObjectPrototype } = Object,

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -5,9 +5,47 @@
 
 import { initSourceText, sourceText } from './source_code.js';
 
-import type { LineColumn, Location, Node } from './types.ts';
+import type { Node } from './types.ts';
 
 const { defineProperty } = Object;
+
+/**
+ * Range of source offsets.
+ */
+export type Range = [number, number];
+
+/**
+ * Interface for any type which has `range` field.
+ */
+export interface Ranged {
+  range: Range;
+}
+
+/**
+ * Interface for any type which has location properties.
+ */
+export interface Span extends Ranged {
+  start: number;
+  end: number;
+  loc: Location;
+}
+
+/**
+ * Source code location.
+ */
+export interface Location {
+  start: LineColumn;
+  end: LineColumn;
+}
+
+/**
+ * Line number + column number pair.
+ * `line` is 1-indexed, `column` is 0-indexed.
+ */
+export interface LineColumn {
+  line: number;
+  column: number;
+}
 
 // Pattern for splitting source text into lines
 const LINE_BREAK_PATTERN = /\r\n|[\r\n\u2028\u2029]/gu;

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -20,7 +20,8 @@ import * as scopeMethods from './scope.js';
 import * as tokenMethods from './tokens.js';
 
 import type { Program } from '../generated/types.d.ts';
-import type { BufferWithArrays, Node, Ranged } from './types.ts';
+import type { Ranged } from './location.ts';
+import type { BufferWithArrays, Node } from './types.ts';
 import type { ScopeManager } from './scope.ts';
 
 const { max } = Math;

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -6,6 +6,8 @@ export interface Visitor {
 }
 */
 
+import type { Span } from './location.ts';
+
 import type { VisitorObject as Visitor } from '../generated/visitor.d.ts';
 export type { Visitor };
 
@@ -24,34 +26,6 @@ export interface VisitorWithHooks extends Visitor {
 
 // Visit function for a specific AST node type.
 export type VisitFn = (node: Node) => void;
-
-// Range of source offsets.
-export type Range = [number, number];
-
-// Interface for any type which has `range` field
-export interface Ranged {
-  range: Range;
-}
-
-// Interface for any type which has location properties.
-export interface Span extends Ranged {
-  start: number;
-  end: number;
-  loc: Location;
-}
-
-// Source code location.
-export interface Location {
-  start: LineColumn;
-  end: LineColumn;
-}
-
-// Line number + column number pair.
-// `line` is 1-indexed, `column` is 0-indexed.
-export interface LineColumn {
-  line: number;
-  column: number;
-}
 
 // AST node type.
 export interface Node extends Span {}

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -491,7 +491,8 @@ fn amend_oxlint_types(code: &str) -> String {
 
     #[rustfmt::skip]
     code.insert_str(0, "
-        import { Span, Comment } from '../plugins/types.ts';
+        import { Span } from '../plugins/location.ts';
+        import { Comment } from '../plugins/types.ts';
         export { Span, Comment };
 
     ");


### PR DESCRIPTION
Pure refactor.

Move TS type defs for location-related types into `location.ts`. `types.ts` is too crowded.

Also add JSDoc comments to these type defs.