### PR TITLE
fix(linter/plugins): add types for suggested fixes

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -7,7 +7,16 @@ export type * as ESTree from './generated/types.d.ts';
 export type { Context, LanguageOptions } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn } from './plugins/fix.ts';
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
-export type { Diagnostic, DiagnosticBase, DiagnosticWithLoc, DiagnosticWithNode } from './plugins/report.ts';
+export type {
+  Diagnostic,
+  DiagnosticBase,
+  DiagnosticWithLoc,
+  DiagnosticWithNode,
+  Suggestion,
+  SuggestionBase,
+  SuggestionWithDescription,
+  SuggestionWithMessageId,
+} from './plugins/report.ts';
 export type {
   Definition,
   DefinitionType,

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -25,6 +25,7 @@ export interface DiagnosticBase {
   messageId?: string | null | undefined;
   data?: Record<string, string | number> | null | undefined;
   fix?: FixFn;
+  suggest?: Suggestion[];
 }
 
 export interface DiagnosticWithNode extends DiagnosticBase {
@@ -33,6 +34,25 @@ export interface DiagnosticWithNode extends DiagnosticBase {
 
 export interface DiagnosticWithLoc extends DiagnosticBase {
   loc: Location;
+}
+
+/**
+ * Suggested fix.
+ * NOT IMPLEMENTED YET.
+ */
+export type Suggestion = SuggestionWithDescription | SuggestionWithMessageId;
+
+export interface SuggestionBase {
+  fix: FixFn;
+  data?: Record<string, string | number> | null | undefined;
+}
+
+export interface SuggestionWithDescription extends SuggestionBase {
+  desc: string;
+}
+
+export interface SuggestionWithMessageId extends SuggestionBase {
+  messageId: string;
 }
 
 // Diagnostic in form sent to Rust


### PR DESCRIPTION
Add `Suggestion` type, and `suggest` field to `Diagnostic`.

Suggestions are not implemented yet, but this completes the interface for diagnostics defined by ESLint's docs.