### PR TITLE
refactor(linter/plugins): add unimplemented `Context#markVariableAsUsed` method

### DIFF
--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -265,3 +265,17 @@ export function getScope(node: ESTree.Node): Scope {
   // @ts-expect-error // TODO: Our types don't quite align yet
   return tsScopeManager.scopes[0];
 }
+
+/**
+ * Marks as used a variable with the given name in a scope indicated by the given reference node.
+ * This affects the `no-unused-vars` rule.
+ * @param name - Variable name
+ * @param refNode - Reference node
+ * @returns `true` if a variable with the given name was found and marked as used, otherwise `false`
+ */
+/* oxlint-disable no-unused-vars */
+export function markVariableAsUsed(name: string, refNode: ESTree.Node): boolean {
+  // TODO: Implement
+  throw new Error('`context.markVariableAsUsed` not implemented yet');
+}
+/* oxlint-enable no-unused-vars */

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -217,6 +217,7 @@ export const SOURCE_CODE = Object.freeze({
   isGlobalReference: scopeMethods.isGlobalReference,
   getDeclaredVariables: scopeMethods.getDeclaredVariables,
   getScope: scopeMethods.getScope,
+  markVariableAsUsed: scopeMethods.markVariableAsUsed,
 
   // Token methods
   getTokens: tokenMethods.getTokens,


### PR DESCRIPTION
Add `Context#markVariableAsUsed` method. It's unimplemented at present, so just throws an error saying "unimplemented". But that's better for user than "TypeError: context.markVariableAsUsed is not a function", and having the stub in codebase reminds us we need to implement it.