### PR TITLE
refactor(linter/plugins): simplify type for `analyzeOptions`

### DIFF
--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -11,6 +11,7 @@ import { ast, initAst } from './source_code.js';
 import { assertIs } from './utils.js';
 
 import type * as ESTree from '../generated/types.d.ts';
+import type { SetNullable } from './utils.ts';
 
 type Identifier =
   | ESTree.IdentifierName
@@ -26,11 +27,7 @@ let tsScopeManager: TSESLintScopeManager | null = null;
 
 // Options for TS-ESLint's `analyze` method.
 // `sourceType` property is set before calling `analyze`.
-interface AnalyzeOptionsWithNullableSourceType extends Omit<AnalyzeOptions, 'sourceType'> {
-  sourceType: AnalyzeOptions['sourceType'] | null;
-}
-
-const analyzeOptions: AnalyzeOptionsWithNullableSourceType = {
+const analyzeOptions: SetNullable<AnalyzeOptions, 'sourceType'> = {
   globalReturn: false,
   jsxFragmentName: null,
   jsxPragma: 'React',

--- a/apps/oxlint/src-js/plugins/utils.ts
+++ b/apps/oxlint/src-js/plugins/utils.ts
@@ -41,3 +41,17 @@ export function getErrorMessage(err: unknown): string {
  */
 // oxlint-disable-next-line no-unused-vars
 export function assertIs<T>(value: unknown): asserts value is T {}
+
+/**
+ * Utility type to make specified properties of a type nullable.
+ *
+ * @example
+ * ```ts
+ * type Foo = { str: string, num: number };
+ * type FooWithNullableNum = SetNullable<Foo, 'num'>;
+ * // { str: string, num: number | null }
+ * ```
+ */
+export type SetNullable<BaseType, Keys extends keyof BaseType = keyof BaseType> = {
+  [Key in keyof BaseType]: Key extends Keys ? BaseType[Key] | null : BaseType[Key];
+};


### PR DESCRIPTION
Simplify the type of `analyseOptions` object, by introducing a `SetNullable` utility type (oooh fancy!).

`SetNullable` is adapted from `SetNonNullable` [from `type-fest` package](https://github.com/sindresorhus/type-fest/blob/2300245cb6f0b28ee36c2bb852ade872254073b8/source/set-non-nullable.d.ts).