### PR TITLE
perf(linter/plugins): avoid implicit boolean coercion in `initLines`

### DIFF
--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -78,7 +78,7 @@ export function initLines(): void {
   let lastOffset = 0,
     offset,
     match;
-  while ((match = LINE_BREAK_PATTERN.exec(sourceText))) {
+  while ((match = LINE_BREAK_PATTERN.exec(sourceText)) !== null) {
     offset = match.index;
     lines.push(sourceText.slice(lastOffset, offset));
     lineStartOffsets.push((lastOffset = offset + match[0].length));


### PR DESCRIPTION
Tiny perf optimization. Explicitly check `!== null` instead of incurring cost of implicit boolean coercion.