### PR TITLE
refactor(linter/plugins): improve `Diagnostic` + `Suggestion` types

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -7,16 +7,7 @@ export type * as ESTree from './generated/types.d.ts';
 export type { Context, LanguageOptions } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn } from './plugins/fix.ts';
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
-export type {
-  Diagnostic,
-  DiagnosticBase,
-  DiagnosticWithLoc,
-  DiagnosticWithNode,
-  Suggestion,
-  SuggestionBase,
-  SuggestionWithDescription,
-  SuggestionWithMessageId,
-} from './plugins/report.ts';
+export type { Diagnostic, Suggestion } from './plugins/report.ts';
 export type {
   Definition,
   DefinitionType,

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -39,7 +39,9 @@ export default defineConfig([
   {
     entry: 'src-js/index.ts',
     ...commonConfig,
-    dts: true,
+    dts: {
+      resolve: true,
+    },
     attw: true,
   },
 ]);


### PR DESCRIPTION
Improve `Diagnostic` and `Suggestion` types, by using `RequireAtLeastOne` utility type from `type-fest` package, to enforce that:

* Either `message` or `messageId` property must be provided.
* Either `node` or `loc` property must be provided.

Change to TSDown config `dts: { resolve: true }` is get it to bundle `type-fest` into the `.d.ts` file.