### PR TITLE
refactor(linter/plugins): make error message for `languageOptions.parser` getter consistent

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -103,7 +103,7 @@ const LANGUAGE_OPTIONS = freeze({
    * Parser used to parse the file being linted.
    */
   get parser(): Record<string, unknown> {
-    throw new Error('`context.languageOptions.parser` is not implemented yet.'); // TODO
+    throw new Error('`context.languageOptions.parser` not implemented yet.'); // TODO
   },
 
   /**


### PR DESCRIPTION
Nit. As the pedantic Mr Copilot pointed out in https://github.com/oxc-project/oxc/pull/15637#discussion_r2518858637, the pattern we use in error messages is "not implemented", not "is not implemented". Make the error message in `languageOptions.parser` getter consistent with this pattern.