### PR TITLE
refactor(linter): remove feature flag `language_server`

### DIFF
--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -26,7 +26,7 @@ oxc_allocator = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
-oxc_linter = { workspace = true, features = ["language_server"] }
+oxc_linter = { workspace = true }
 oxc_parser = { workspace = true }
 
 #

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 [features]
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
-language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
 force_test_reporter = []
 
 [lints]

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -266,10 +266,6 @@ impl<'a> LintContext<'a> {
     /// Use [`LintContext::diagnostic_with_fix`] to provide an automatic fix.
     #[inline]
     pub fn diagnostic(&self, diagnostic: OxcDiagnostic) {
-        #[cfg(not(feature = "language_server"))]
-        self.add_diagnostic(Message::new(diagnostic, PossibleFixes::None));
-
-        #[cfg(feature = "language_server")]
         self.add_diagnostic(
             Message::new(diagnostic, PossibleFixes::None)
                 .with_section_offset(self.parent.current_sub_host().source_text_offset),
@@ -384,10 +380,6 @@ impl<'a> LintContext<'a> {
     {
         let (diagnostic, fix) = self.create_fix(fix_kind, fix, diagnostic);
         if let Some(fix) = fix {
-            #[cfg(not(feature = "language_server"))]
-            self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Single(fix)));
-
-            #[cfg(feature = "language_server")]
             self.add_diagnostic(
                 Message::new(diagnostic, PossibleFixes::Single(fix))
                     .with_section_offset(self.parent.current_sub_host().source_text_offset),
@@ -420,10 +412,6 @@ impl<'a> LintContext<'a> {
         if fixes_result.is_empty() {
             self.diagnostic(diagnostic);
         } else {
-            #[cfg(not(feature = "language_server"))]
-            self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Multiple(fixes_result)));
-
-            #[cfg(feature = "language_server")]
             self.add_diagnostic(
                 Message::new(diagnostic, PossibleFixes::Multiple(fixes_result))
                     .with_section_offset(self.parent.current_sub_host().source_text_offset),

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -223,7 +223,6 @@ pub struct Message {
     pub fixes: PossibleFixes,
     pub span: Span,
     fixed: bool,
-    #[cfg(feature = "language_server")]
     pub section_offset: u32,
 }
 
@@ -237,17 +236,9 @@ impl Message {
             .map(|span| Span::new(span.offset() as u32, (span.offset() + span.len()) as u32))
             .unwrap_or_default();
 
-        Self {
-            error,
-            span,
-            fixes,
-            fixed: false,
-            #[cfg(feature = "language_server")]
-            section_offset: 0,
-        }
+        Self { error, span, fixes, fixed: false, section_offset: 0 }
     }
 
-    #[cfg(feature = "language_server")]
     #[must_use]
     pub fn with_section_offset(mut self, section_offset: u32) -> Self {
         self.section_offset = section_offset;

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -6,18 +6,13 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
 use oxc_span::Span;
 
 use crate::{
-    AllowWarnDeny, DisableDirectives, FixKind, LintService, LintServiceOptions, Linter,
-    OsFileSystem, TsGoLintState,
+    AllowWarnDeny, DisableDirectives, FixKind, LintService, LintServiceOptions, Linter, Message,
+    OsFileSystem, PossibleFixes, TsGoLintState,
 };
-
-#[cfg(feature = "language_server")]
-use crate::{Message, PossibleFixes};
-#[cfg(feature = "language_server")]
-use oxc_diagnostics::OxcDiagnostic;
 
 /// Unified runner that orchestrates both regular (oxc) and type-aware (tsgolint) linting
 /// with centralized disable directives handling.
@@ -230,7 +225,6 @@ impl LintRunner {
     /// Run both regular and type-aware linting on files
     /// # Errors
     /// Returns an error if type-aware linting fails.
-    #[cfg(feature = "language_server")]
     pub fn run_source(
         &self,
         file: &Arc<OsStr>,

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -87,7 +87,6 @@ impl LintService {
         self.runtime.set_disable_directives_map(map);
     }
 
-    #[cfg(feature = "language_server")]
     pub fn run_source(
         &self,
         file_system: &(dyn RuntimeFileSystem + Sync + Send),

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -26,11 +26,8 @@ use oxc_resolver::Resolver;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{CompactStr, SourceType, VALID_EXTENSIONS};
 
-#[cfg(any(test, feature = "language_server"))]
-use crate::{Message, fixer::PossibleFixes};
-
 use crate::{
-    Fixer, Linter,
+    Fixer, Linter, Message, PossibleFixes,
     context::ContextSubHost,
     disable_directives::DisableDirectives,
     loader::{JavaScriptSource, LINT_PARTIAL_LOADER_EXTENSIONS, PartialLoader},
@@ -658,7 +655,6 @@ impl Runtime {
     // language_server: the language server needs line and character position
     // the struct not using `oxc_diagnostic::Error, because we are just collecting information
     // and returning it to the client to let him display it.
-    #[cfg(feature = "language_server")]
     pub(super) fn run_source(
         &self,
         file_system: &(dyn RuntimeFileSystem + Sync + Send),

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -14,9 +14,7 @@ use oxc_span::{SourceType, Span};
 
 use super::{AllowWarnDeny, ConfigStore, DisableDirectives, ResolvedLinterState, read_to_string};
 
-use crate::FixKind;
-#[cfg(feature = "language_server")]
-use crate::fixer::{CompositeFix, Message, PossibleFixes};
+use crate::{CompositeFix, FixKind, Message, PossibleFixes};
 
 /// State required to initialize the `tsgolint` linter.
 #[derive(Debug, Clone)]
@@ -329,7 +327,6 @@ impl TsGoLintState {
     ///
     /// # Errors
     /// A human-readable error message indicating why the linting failed.
-    #[cfg(feature = "language_server")]
     pub fn lint_source(
         &self,
         path: &Arc<OsStr>,
@@ -705,7 +702,6 @@ impl From<TsGoLintInternalDiagnostic> for OxcDiagnostic {
     }
 }
 
-#[cfg(feature = "language_server")]
 impl Message {
     /// Converts a `TsGoLintDiagnostic` into a `Message` with possible fixes.
     fn from_tsgo_lint_diagnostic(mut val: TsGoLintRuleDiagnostic, source_text: &str) -> Self {
@@ -1053,7 +1049,6 @@ pub fn try_find_tsgolint_executable(cwd: &Path) -> Result<PathBuf, String> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "language_server")]
 mod test {
     use oxc_diagnostics::{LabeledSpan, OxcCode, Severity};
     use oxc_span::Span;


### PR DESCRIPTION
With https://github.com/oxc-project/oxc/pull/15611 the language server is included in all package including `oxc_linter`.
Removing the feature flag because it is obsolete now.

<img width="1180" height="327" alt="graphic showing very small performance regression" src="https://github.com/user-attachments/assets/129bd94f-0392-41b0-a23f-ec70d174279e" />
