### PR TITLE
feat(linter/plugins): implement deprecated `SourceCode#getJSDocComment` method

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -200,3 +200,17 @@ export function commentsExistBetween(nodeOrToken1: NodeOrToken, nodeOrToken2: No
     comments[firstCommentBetween].end <= nodeOrToken2.range[0]
   );
 }
+
+/**
+ * Retrieve the JSDoc comment for a given node.
+ *
+ * @deprecated
+ *
+ * @param node - The AST node to get the comment for.
+ * @returns The JSDoc comment for the given node, or `null` if not found.
+ */
+/* oxlint-disable no-unused-vars */
+export function getJSDocComment(node: Node): Comment | null {
+  throw new Error('`sourceCode.getJSDocComment` is not supported at present (and deprecated)'); // TODO
+}
+/* oxlint-enable no-unused-vars */

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -212,6 +212,7 @@ export const SOURCE_CODE = Object.freeze({
   getCommentsAfter: commentMethods.getCommentsAfter,
   getCommentsInside: commentMethods.getCommentsInside,
   commentsExistBetween: commentMethods.commentsExistBetween,
+  getJSDocComment: commentMethods.getJSDocComment,
 
   // Scope methods
   isGlobalReference: scopeMethods.isGlobalReference,


### PR DESCRIPTION
Add `SourceCode#getJSDocComment` method. It currently throws an "unimplemented" error.

This concludes the `Context` API additions. Every method, getter, and property listed in ESLint's [custom rules docs](https://eslint.org/docs/latest/extend/custom-rules) are now present in our API too.

Note: `Plugin` and `Rule` types may still be missing properties.