### PR TITLE
test(linter/plugins): remove unused imports from fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -1,5 +1,3 @@
-import { sep } from 'node:path';
-
 import type { Node, Plugin, Rule } from '../../../dist/index.js';
 
 const SPAN: Node = {

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -1,5 +1,3 @@
-import { sep } from 'node:path';
-
 import type { Node, Plugin, Rule } from '../../../dist/index.js';
 
 const SPAN: Node = {

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -1,4 +1,3 @@
-import { sep } from 'node:path';
 import { definePlugin } from '../../../dist/index.js';
 
 import type { Node, Rule } from '../../../dist/index.js';

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -1,4 +1,3 @@
-import { sep } from 'node:path';
 import { definePlugin, defineRule } from '../../../dist/index.js';
 
 import type { Node } from '../../../dist/index.js';

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -1,4 +1,3 @@
-import { sep } from 'node:path';
 import { defineRule } from '../../../dist/index.js';
 
 import type { Node } from '../../../dist/index.js';


### PR DESCRIPTION
Pure refactor to tests. These imports are no longer used. Remove them.