### PR TITLE
feat(linter): implement config for all tsgolint rules supporting options

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -1016,7 +1016,7 @@ mod test {
         let base_rules = vec![
             (RuleEnum::EslintCurly(EslintCurly::default()), AllowWarnDeny::Deny),
             (
-                RuleEnum::TypescriptNoMisusedPromises(TypescriptNoMisusedPromises),
+                RuleEnum::TypescriptNoMisusedPromises(TypescriptNoMisusedPromises::default()),
                 AllowWarnDeny::Deny,
             ),
         ];

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -1,9 +1,25 @@
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::rule::Rule;
+use crate::rule::{DefaultRuleConfig, Rule};
 
 #[derive(Debug, Default, Clone)]
-pub struct NoConfusingVoidExpression;
+pub struct NoConfusingVoidExpression(Box<NoConfusingVoidExpressionConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoConfusingVoidExpressionConfig {
+    /// Whether to ignore arrow function shorthand that returns void.
+    /// When true, allows expressions like `() => someVoidFunction()`.
+    pub ignore_arrow_shorthand: bool,
+    /// Whether to ignore expressions using the void operator.
+    /// When true, allows `void someExpression`.
+    pub ignore_void_operator: bool,
+    /// Whether to ignore calling functions that are declared to return void.
+    /// When true, allows expressions like `x = voidReturningFunction()`.
+    pub ignore_void_returning_functions: bool,
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -53,6 +69,19 @@ declare_oxc_lint!(
     typescript,
     pedantic,
     pending,
+    config = NoConfusingVoidExpressionConfig,
 );
 
-impl Rule for NoConfusingVoidExpression {}
+impl Rule for NoConfusingVoidExpression {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<NoConfusingVoidExpressionConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        ))
+    }
+
+    fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
+        Some(serde_json::to_value(&*self.0))
+    }
+}

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -1,9 +1,22 @@
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::rule::Rule;
+use crate::rule::{DefaultRuleConfig, Rule};
 
 #[derive(Debug, Default, Clone)]
-pub struct NoDuplicateTypeConstituents;
+pub struct NoDuplicateTypeConstituents(Box<NoDuplicateTypeConstituentsConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoDuplicateTypeConstituentsConfig {
+    /// Whether to ignore duplicate types in intersection types.
+    /// When true, allows `type T = A & A`.
+    pub ignore_intersections: bool,
+    /// Whether to ignore duplicate types in union types.
+    /// When true, allows `type T = A | A`.
+    pub ignore_unions: bool,
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -51,6 +64,19 @@ declare_oxc_lint!(
     typescript,
     correctness,
     pending,
+    config = NoDuplicateTypeConstituentsConfig,
 );
 
-impl Rule for NoDuplicateTypeConstituents {}
+impl Rule for NoDuplicateTypeConstituents {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<NoDuplicateTypeConstituentsConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        ))
+    }
+
+    fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
+        Some(serde_json::to_value(&*self.0))
+    }
+}

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -2,7 +2,10 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::rule::{DefaultRuleConfig, Rule};
+use crate::{
+    rule::{DefaultRuleConfig, Rule},
+    utils::TypeOrValueSpecifier,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoFloatingPromises(Box<NoFloatingPromisesConfig>);
@@ -21,111 +24,6 @@ pub struct NoFloatingPromisesConfig {
     pub ignore_iife: bool,
     /// Ignore Promises that are void expressions.
     pub ignore_void: bool,
-}
-
-/// Type or value specifier for matching specific declarations
-///
-/// Supports four types of specifiers:
-///
-/// 1. **String specifier** (deprecated): Universal match by name
-///    ```json
-///    "Promise"
-///    ```
-///
-/// 2. **File specifier**: Match types/values declared in local files
-///    ```json
-///    { "from": "file", "name": "MyType" }
-///    { "from": "file", "name": ["Type1", "Type2"] }
-///    { "from": "file", "name": "MyType", "path": "./types.ts" }
-///    ```
-///
-/// 3. **Lib specifier**: Match TypeScript built-in lib types
-///    ```json
-///    { "from": "lib", "name": "Promise" }
-///    { "from": "lib", "name": ["Promise", "PromiseLike"] }
-///    ```
-///
-/// 4. **Package specifier**: Match types/values from npm packages
-///    ```json
-///    { "from": "package", "name": "Observable", "package": "rxjs" }
-///    { "from": "package", "name": ["Observable", "Subject"], "package": "rxjs" }
-///    ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum TypeOrValueSpecifier {
-    /// Universal string specifier - matches all types and values with this name regardless of declaration source.
-    /// Not recommended - will be removed in a future major version.
-    String(String),
-    /// Describes specific types or values declared in local files.
-    File(FileSpecifier),
-    /// Describes specific types or values declared in TypeScript's built-in lib.*.d.ts types.
-    Lib(LibSpecifier),
-    /// Describes specific types or values imported from packages.
-    Package(PackageSpecifier),
-}
-
-/// Describes specific types or values declared in local files.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct FileSpecifier {
-    /// Must be "file"
-    from: FileFrom,
-    /// The name(s) of the type or value to match
-    name: NameSpecifier,
-    /// Optional file path to specify where the types or values must be declared.
-    /// If omitted, all files will be matched.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum FileFrom {
-    File,
-}
-
-/// Describes specific types or values declared in TypeScript's built-in lib.*.d.ts types.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct LibSpecifier {
-    /// Must be "lib"
-    from: LibFrom,
-    /// The name(s) of the lib type or value to match
-    name: NameSpecifier,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum LibFrom {
-    Lib,
-}
-
-/// Describes specific types or values imported from packages.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PackageSpecifier {
-    /// Must be "package"
-    from: PackageFrom,
-    /// The name(s) of the type or value to match
-    name: NameSpecifier,
-    /// The package name to match
-    package: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum PackageFrom {
-    Package,
-}
-
-/// Name specifier that can be a single string or array of strings
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum NameSpecifier {
-    /// Single name
-    Single(String),
-    /// Multiple names
-    Multiple(Vec<String>),
 }
 
 impl Default for NoFloatingPromisesConfig {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -1,9 +1,89 @@
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::rule::Rule;
+use crate::{
+    rule::{DefaultRuleConfig, Rule},
+    utils::default_true,
+};
+
+fn default_checks_void_return() -> ChecksVoidReturn {
+    ChecksVoidReturn::Boolean(true)
+}
 
 #[derive(Debug, Default, Clone)]
-pub struct NoMisusedPromises;
+pub struct NoMisusedPromises(Box<NoMisusedPromisesConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+#[expect(clippy::struct_field_names)]
+pub struct NoMisusedPromisesConfig {
+    /// Whether to check if Promises are used in conditionals.
+    /// When true, disallows using Promises in conditions where a boolean is expected.
+    #[serde(default = "default_true")]
+    pub checks_conditionals: bool,
+    /// Whether to check if Promises are used in spread syntax.
+    /// When true, disallows spreading Promise values.
+    #[serde(default = "default_true")]
+    pub checks_spreads: bool,
+    /// Configuration for checking if Promises are returned in contexts expecting void.
+    /// Can be a boolean to enable/disable all checks, or an object for granular control.
+    #[serde(default = "default_checks_void_return")]
+    pub checks_void_return: ChecksVoidReturn,
+}
+
+impl Default for NoMisusedPromisesConfig {
+    fn default() -> Self {
+        Self {
+            checks_conditionals: true,
+            checks_spreads: true,
+            checks_void_return: ChecksVoidReturn::Boolean(true),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ChecksVoidReturn {
+    Boolean(bool),
+    Options(ChecksVoidReturnOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ChecksVoidReturnOptions {
+    /// Whether to check Promise-returning functions passed as arguments to void-returning functions.
+    #[serde(default = "default_true")]
+    pub arguments: bool,
+    /// Whether to check Promise-returning functions in JSX attributes expecting void.
+    #[serde(default = "default_true")]
+    pub attributes: bool,
+    /// Whether to check Promise-returning methods that override void-returning inherited methods.
+    #[serde(default = "default_true")]
+    pub inherited_methods: bool,
+    /// Whether to check Promise-returning functions assigned to object properties expecting void.
+    #[serde(default = "default_true")]
+    pub properties: bool,
+    /// Whether to check Promise values returned from void-returning functions.
+    #[serde(default = "default_true")]
+    pub returns: bool,
+    /// Whether to check Promise-returning functions assigned to variables typed as void-returning.
+    #[serde(default = "default_true")]
+    pub variables: bool,
+}
+
+impl Default for ChecksVoidReturnOptions {
+    fn default() -> Self {
+        Self {
+            arguments: true,
+            attributes: true,
+            inherited_methods: true,
+            properties: true,
+            returns: true,
+            variables: true,
+        }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -55,6 +135,19 @@ declare_oxc_lint!(
     typescript,
     pedantic,
     pending,
+    config = NoMisusedPromisesConfig,
 );
 
-impl Rule for NoMisusedPromises {}
+impl Rule for NoMisusedPromises {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<NoMisusedPromisesConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        ))
+    }
+
+    fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
+        Some(serde_json::to_value(&*self.0))
+    }
+}

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -1,9 +1,40 @@
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::rule::Rule;
+use crate::{
+    rule::{DefaultRuleConfig, Rule},
+    utils::default_true,
+};
 
 #[derive(Debug, Default, Clone)]
-pub struct NoUnnecessaryBooleanLiteralCompare;
+pub struct NoUnnecessaryBooleanLiteralCompare(Box<NoUnnecessaryBooleanLiteralCompareConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoUnnecessaryBooleanLiteralCompareConfig {
+    /// Whether to allow comparing nullable boolean expressions to `false`.
+    /// When false, `x === false` where x is `boolean | null` will be flagged.
+    #[serde(default = "default_true")]
+    pub allow_comparing_nullable_booleans_to_false: bool,
+    /// Whether to allow comparing nullable boolean expressions to `true`.
+    /// When false, `x === true` where x is `boolean | null` will be flagged.
+    #[serde(default = "default_true")]
+    pub allow_comparing_nullable_booleans_to_true: bool,
+    /// Whether to allow this rule to run without `strictNullChecks` enabled.
+    /// This is not recommended as the rule may produce incorrect results.
+    pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
+}
+
+impl Default for NoUnnecessaryBooleanLiteralCompareConfig {
+    fn default() -> Self {
+        Self {
+            allow_comparing_nullable_booleans_to_false: true,
+            allow_comparing_nullable_booleans_to_true: true,
+            allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: false,
+        }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -61,6 +92,21 @@ declare_oxc_lint!(
     typescript,
     suspicious,
     pending,
+    config = NoUnnecessaryBooleanLiteralCompareConfig,
 );
 
-impl Rule for NoUnnecessaryBooleanLiteralCompare {}
+impl Rule for NoUnnecessaryBooleanLiteralCompare {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryBooleanLiteralCompareConfig>>(
+                value,
+            )
+            .unwrap_or_default()
+            .into_inner(),
+        ))
+    }
+
+    fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
+        Some(serde_json::to_value(&*self.0))
+    }
+}

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -1,9 +1,57 @@
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::rule::Rule;
+use crate::{
+    rule::{DefaultRuleConfig, Rule},
+    utils::default_true,
+};
 
 #[derive(Debug, Default, Clone)]
-pub struct StrictBooleanExpressions;
+pub struct StrictBooleanExpressions(Box<StrictBooleanExpressionsConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct StrictBooleanExpressionsConfig {
+    /// Whether to allow `any` type in boolean contexts.
+    pub allow_any: bool,
+    /// Whether to allow nullable boolean types (e.g., `boolean | null`) in boolean contexts.
+    pub allow_nullable_boolean: bool,
+    /// Whether to allow nullable number types (e.g., `number | null`) in boolean contexts.
+    pub allow_nullable_number: bool,
+    /// Whether to allow nullable string types (e.g., `string | null`) in boolean contexts.
+    pub allow_nullable_string: bool,
+    /// Whether to allow nullable enum types in boolean contexts.
+    pub allow_nullable_enum: bool,
+    /// Whether to allow nullable object types in boolean contexts.
+    #[serde(default = "default_true")]
+    pub allow_nullable_object: bool,
+    /// Whether to allow string types in boolean contexts (checks for non-empty strings).
+    #[serde(default = "default_true")]
+    pub allow_string: bool,
+    /// Whether to allow number types in boolean contexts (checks for non-zero numbers).
+    #[serde(default = "default_true")]
+    pub allow_number: bool,
+    /// Whether to allow this rule to run without `strictNullChecks` enabled.
+    /// This is not recommended as the rule may produce incorrect results.
+    pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
+}
+
+impl Default for StrictBooleanExpressionsConfig {
+    fn default() -> Self {
+        Self {
+            allow_any: false,
+            allow_nullable_boolean: false,
+            allow_nullable_number: false,
+            allow_nullable_string: false,
+            allow_nullable_enum: false,
+            allow_nullable_object: true,
+            allow_string: true,
+            allow_number: true,
+            allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: false,
+        }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -81,6 +129,19 @@ declare_oxc_lint!(
     typescript,
     pedantic,
     pending,
+    config = StrictBooleanExpressionsConfig,
 );
 
-impl Rule for StrictBooleanExpressions {}
+impl Rule for StrictBooleanExpressions {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<StrictBooleanExpressionsConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        ))
+    }
+
+    fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
+        Some(serde_json::to_value(&*self.0))
+    }
+}

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -19,6 +19,7 @@ mod promise;
 mod react;
 mod react_perf;
 mod regex;
+mod typescript;
 mod unicorn;
 mod url;
 mod vitest;
@@ -26,7 +27,7 @@ mod vue;
 
 pub use self::{
     comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
-    react_perf::*, regex::*, unicorn::*, url::*, vitest::*, vue::*,
+    react_perf::*, regex::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Jest rules that have Vitest equivalents.

--- a/crates/oxc_linter/src/utils/typescript.rs
+++ b/crates/oxc_linter/src/utils/typescript.rs
@@ -1,0 +1,109 @@
+//! Shared TypeScript utilities and types for linter rules
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Type or value specifier for matching specific declarations
+///
+/// Supports four types of specifiers:
+///
+/// 1. **String specifier** (deprecated): Universal match by name
+///    ```json
+///    "Promise"
+///    ```
+///
+/// 2. **File specifier**: Match types/values declared in local files
+///    ```json
+///    { "from": "file", "name": "MyType" }
+///    { "from": "file", "name": ["Type1", "Type2"] }
+///    { "from": "file", "name": "MyType", "path": "./types.ts" }
+///    ```
+///
+/// 3. **Lib specifier**: Match TypeScript built-in lib types
+///    ```json
+///    { "from": "lib", "name": "Promise" }
+///    { "from": "lib", "name": ["Promise", "PromiseLike"] }
+///    ```
+///
+/// 4. **Package specifier**: Match types/values from npm packages
+///    ```json
+///    { "from": "package", "name": "Observable", "package": "rxjs" }
+///    { "from": "package", "name": ["Observable", "Subject"], "package": "rxjs" }
+///    ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum TypeOrValueSpecifier {
+    /// Universal string specifier - matches all types and values with this name regardless of declaration source.
+    /// Not recommended - will be removed in a future major version.
+    String(String),
+    /// Describes specific types or values declared in local files.
+    File(FileSpecifier),
+    /// Describes specific types or values declared in TypeScript's built-in lib.*.d.ts types.
+    Lib(LibSpecifier),
+    /// Describes specific types or values imported from packages.
+    Package(PackageSpecifier),
+}
+
+/// Describes specific types or values declared in local files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FileSpecifier {
+    /// Must be "file"
+    pub from: FileFrom,
+    /// The name(s) of the type or value to match
+    pub name: NameSpecifier,
+    /// Optional file path to specify where the types or values must be declared.
+    /// If omitted, all files will be matched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum FileFrom {
+    File,
+}
+
+/// Describes specific types or values declared in TypeScript's built-in lib.*.d.ts types.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LibSpecifier {
+    /// Must be "lib"
+    pub from: LibFrom,
+    /// The name(s) of the lib type or value to match
+    pub name: NameSpecifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LibFrom {
+    Lib,
+}
+
+/// Describes specific types or values imported from packages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageSpecifier {
+    /// Must be "package"
+    pub from: PackageFrom,
+    /// The name(s) of the type or value to match
+    pub name: NameSpecifier,
+    /// The package name to match
+    pub package: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageFrom {
+    Package,
+}
+
+/// Name specifier that can be a single string or array of strings
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum NameSpecifier {
+    /// Single name
+    Single(String),
+    /// Multiple names
+    Multiple(Vec<String>),
+}


### PR DESCRIPTION
NOTE: This was largely generated by AI. I've looked over its work and it seems mostly correct, but please do apply some additional scrutiny. This is implementing the boilerplate to add all of the config parsing and docs generation code so we can fully support configuring these rules for tsgolint.