### PR TITLE
docs(linter): Add config docs for no-restricted-globals rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
 use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -17,8 +18,12 @@ fn no_restricted_globals(global_name: &str, suffix: &str, span: Span) -> OxcDiag
     OxcDiagnostic::warn(warn_text).with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoRestrictedGlobals {
+    /// Objects in the format
+    /// `{ "name": "event", "message": "Use local parameter instead." }`, which define what globals
+    /// are restricted from use.
     restricted_globals: Box<FxHashMap<String, String>>,
 }
 
@@ -54,6 +59,7 @@ declare_oxc_lint!(
     NoRestrictedGlobals,
     eslint,
     restriction,
+    config = NoRestrictedGlobals,
 );
 
 impl Rule for NoRestrictedGlobals {

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -38,7 +38,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "eslint/no-else-return",
         "eslint/no-empty-function",
         "eslint/no-fallthrough",
-        "eslint/no-restricted-globals",
         "eslint/no-restricted-imports",
         "eslint/no-warning-comments",
         "eslint/yoda",


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md

## Configuration

This rule accepts a configuration object with the following properties:

### restrictedGlobals

type: `Record<string, string>`

default: `{}`

Objects in the format
`{ "name": "event", "message": "Use local parameter instead." }`, which define what globals
are restricted from use.
```

This is technically a positional argument and so should maybe be held back until we have a solution for documenting this kind of configuration option?