### PR TITLE
feat(transformer): support tagged template expression with `</script` transformation

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -168,6 +168,7 @@ pub enum Helper {
     DecorateParam,
     DecorateMetadata,
     UsingCtx,
+    TaggedTemplateLiteral,
 }
 
 impl Helper {
@@ -201,6 +202,7 @@ impl Helper {
             Self::DecorateParam => "decorateParam",
             Self::DecorateMetadata => "decorateMetadata",
             Self::UsingCtx => "usingCtx",
+            Self::TaggedTemplateLiteral => "taggedTemplateLiteral",
         }
     }
 

--- a/crates/oxc_transformer/src/options/babel/plugins.rs
+++ b/crates/oxc_transformer/src/options/babel/plugins.rs
@@ -77,6 +77,7 @@ pub struct BabelPlugins {
     pub legacy_decorator: Option<DecoratorOptions>,
     // Built-in plugins
     pub styled_components: Option<StyledComponentsOptions>,
+    pub tagged_template_escape: bool,
 }
 
 impl TryFrom<PluginPresetEntries> for BabelPlugins {
@@ -171,6 +172,9 @@ impl TryFrom<PluginPresetEntries> for BabelPlugins {
                         .value::<StyledComponentsOptions>()
                         .map_err(|err| p.errors.push(err))
                         .ok();
+                }
+                "tagged-template-transform" => {
+                    p.tagged_template_escape = true;
                 }
                 s => p.unsupported.push(s.to_string()),
             }

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -87,7 +87,10 @@ impl TransformOptions {
             },
             env: EnvOptions::enable_all(/* include_unfinished_plugins */ false),
             proposals: ProposalOptions::default(),
-            plugins: PluginsOptions { styled_components: Some(StyledComponentsOptions::default()) },
+            plugins: PluginsOptions {
+                styled_components: Some(StyledComponentsOptions::default()),
+                tagged_template_transform: true,
+            },
             helper_loader: HelperLoaderOptions {
                 mode: HelperLoaderMode::Runtime,
                 ..Default::default()
@@ -264,6 +267,7 @@ impl TryFrom<&BabelOptions> for TransformOptions {
         if let Some(styled_components) = &options.plugins.styled_components {
             plugins.styled_components = Some(styled_components.clone());
         }
+        plugins.tagged_template_transform = options.plugins.tagged_template_escape;
 
         Ok(Self {
             cwd: options.cwd.clone().unwrap_or_default(),

--- a/crates/oxc_transformer/src/plugins/mod.rs
+++ b/crates/oxc_transformer/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 mod options;
 mod styled_components;
+mod tagged_template_transform;
 
 pub use options::PluginsOptions;
 use oxc_ast::ast::*;
@@ -8,12 +9,15 @@ pub use styled_components::StyledComponentsOptions;
 
 use crate::{
     context::{TransformCtx, TraverseCtx},
-    plugins::styled_components::StyledComponents,
+    plugins::{
+        styled_components::StyledComponents, tagged_template_transform::TaggedTemplateTransform,
+    },
     state::TransformState,
 };
 
 pub struct Plugins<'a, 'ctx> {
     styled_components: Option<StyledComponents<'a, 'ctx>>,
+    tagged_template_escape: Option<TaggedTemplateTransform<'a, 'ctx>>,
 }
 
 impl<'a, 'ctx> Plugins<'a, 'ctx> {
@@ -22,6 +26,11 @@ impl<'a, 'ctx> Plugins<'a, 'ctx> {
             styled_components: options
                 .styled_components
                 .map(|options| StyledComponents::new(options, ctx)),
+            tagged_template_escape: if options.tagged_template_transform {
+                Some(TaggedTemplateTransform::new(ctx))
+            } else {
+                None
+            },
         }
     }
 }
@@ -50,6 +59,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for Plugins<'a, '_> {
     ) {
         if let Some(styled_components) = &mut self.styled_components {
             styled_components.enter_expression(node, ctx);
+        }
+        if let Some(tagged_template_escape) = &mut self.tagged_template_escape {
+            tagged_template_escape.enter_expression(node, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/plugins/options.rs
+++ b/crates/oxc_transformer/src/plugins/options.rs
@@ -3,4 +3,5 @@ use super::StyledComponentsOptions;
 #[derive(Default, Debug, Clone)]
 pub struct PluginsOptions {
     pub styled_components: Option<StyledComponentsOptions>,
+    pub tagged_template_transform: bool,
 }

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -1,0 +1,214 @@
+//! Tagged Template Transform
+//!
+//! This plugin transforms tagged template expressions containing `</script` tags
+//! to use a helper function call instead, preventing script tag issues in browser environments.
+//!
+//! ## Background
+//!
+//! Tagged template literals containing `</script` can break when the code is embedded
+//! directly in HTML script tags, because the browser will incorrectly parse `</script` as
+//! the end of the script tag.
+//!
+//! Additionally, String.raw`</script>` !== String.raw`<\/script>` due to how tagged
+//! template literals preserve the raw string values.
+//!
+//! ## Solution
+//!
+//! This plugin transforms tagged template expressions containing `</script` to use
+//! a cached template object with a helper function, matching esbuild's behavior.
+//!
+//! ## Example
+//!
+//! Input:
+//! ```js
+//! foo`</script>`
+//! foo`<script>${content}</script>`
+//! ```
+//!
+//! Output:
+//! ```js
+//! var _foo;
+//! var _foo2;
+//! foo(_foo || (_foo = babelHelpers.taggedTemplateLiteral(["<\/script>"])));
+//! foo(_foo2 || (_foo2 = babelHelpers.taggedTemplateLiteral(["<script>", "<\/script>"])), content);
+//! ```
+//!
+//! ## References
+//!
+//! - esbuild implementation: <https://github.com/evanw/esbuild/blob/d6427c91edab734da686c4c5d29ed580b08b9fd5/internal/js_parser/js_parser.go#L13894-L13907>
+//! - Issue: <https://github.com/oxc-project/oxc/issues/15306>
+
+use std::iter;
+
+use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_ast::ast::*;
+use oxc_semantic::SymbolFlags;
+use oxc_span::SPAN;
+use oxc_traverse::{BoundIdentifier, Traverse};
+
+use crate::{
+    common::helper_loader::Helper,
+    context::{TransformCtx, TraverseCtx},
+    state::TransformState,
+};
+
+pub struct TaggedTemplateTransform<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
+}
+
+impl<'a> Traverse<'a, TransformState<'a>> for TaggedTemplateTransform<'a, '_> {
+    // `#[inline]` because it is a hot path and it is directly delegated to `transform_tagged_template`
+    #[inline]
+    fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.transform_tagged_template(expr, ctx);
+    }
+}
+
+impl<'a, 'ctx> TaggedTemplateTransform<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
+        Self { ctx }
+    }
+
+    /// Check if the template literal contains a `</script` tag; note it is case-insensitive.
+    fn contains_closing_script_tag(quasi: &TemplateLiteral) -> bool {
+        const SCRIPT_TAG: &[u8] = b"</script";
+
+        quasi.quasis.iter().any(|quasi| {
+            let raw = &quasi.value.raw;
+
+            // The raw string must be at least as long as the script tag
+            if raw.len() < SCRIPT_TAG.len() {
+                return false;
+            }
+
+            let raw_bytes = raw.as_bytes();
+            // Get the bytes up to the last possible starting position of the script tag
+            let max_remain_len = raw_bytes.len().saturating_sub(SCRIPT_TAG.len());
+            let raw_bytes_iter = raw_bytes[..=max_remain_len].iter().copied().enumerate();
+            for (idx, byte) in raw_bytes_iter {
+                if byte == b'<'
+                    && SCRIPT_TAG
+                        .iter()
+                        .zip(raw_bytes[idx..].iter())
+                        .all(|(a, b)| *a == b.to_ascii_lowercase())
+                {
+                    return true;
+                }
+            }
+
+            false
+        })
+    }
+
+    /// Transform a tagged template expression to use the [`Helper::TaggedTemplateLiteral`] helper function
+    // `#[inline]` so that compiler can see `expr` should be a `TaggedTemplateExpression` and reduce redundant checks
+    #[inline]
+    fn transform_tagged_template(&self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if !matches!(expr, Expression::TaggedTemplateExpression(tagged) if Self::contains_closing_script_tag(&tagged.quasi))
+        {
+            return;
+        }
+
+        let Expression::TaggedTemplateExpression(tagged) = expr.take_in(ctx.ast) else {
+            unreachable!();
+        };
+
+        *expr = self.transform_tagged_template_impl(tagged.unbox(), ctx);
+    }
+
+    fn transform_tagged_template_impl(
+        &self,
+        expr: TaggedTemplateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let TaggedTemplateExpression { span, tag, quasi, type_arguments } = expr;
+
+        let binding = self.create_top_level_binding(ctx);
+        let arguments = self.transform_template_literal(&binding, quasi, ctx);
+        ctx.ast.expression_call(span, tag, type_arguments, arguments, false)
+    }
+
+    /// Transform [`TemplateLiteral`] to build the arguments for the tagged template call
+    ///
+    /// Handle its fields as follows:
+    ///   quasis:
+    ///     - Create an array expression containing the raw string literals
+    ///     - Call the helper function with the array expression
+    ///     - Create a logical OR expression to cache the result in the binding
+    ///     - Wrap the logical OR expression as the first argument
+    ///   expressions:
+    ///     - Add each expression as the remaining arguments
+    ///
+    /// Final arguments: `(binding || (binding = babelHelpers.taggedTemplateLiteral([<...quasis>])), <...expressions>)`
+    fn transform_template_literal(
+        &self,
+        binding: &BoundIdentifier<'a>,
+        quasi: TemplateLiteral<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> ArenaVec<'a, Argument<'a>> {
+        // `([<...quasis>])` (e.g. `["first", "second", "third"]`)
+        let elements = ctx.ast.vec_from_iter(quasi.quasis.iter().map(|quasi| {
+            let string = ctx.ast.expression_string_literal(SPAN, quasi.value.raw, None);
+            ArrayExpressionElement::from(string)
+        }));
+        let template_arguments =
+            ctx.ast.vec1(Argument::from(ctx.ast.expression_array(SPAN, elements)));
+
+        // `babelHelpers.taggedTemplateLiteral([<...quasis>])`
+        let template_call =
+            self.ctx.helper_call_expr(Helper::TaggedTemplateLiteral, SPAN, template_arguments, ctx);
+        // `binding || (binding = babelHelpers.taggedTemplateLiteral([<...quasis>]))`
+        let template_call =
+            Argument::from(Self::create_logical_or_expression(binding, template_call, ctx));
+
+        // `(binding || (binding = babelHelpers.taggedTemplateLiteral([<...quasis>])), <...expressions>)`
+        ctx.ast.vec_from_iter(
+            // Add the template expressions as the remaining arguments
+            iter::once(template_call).chain(quasi.expressions.into_iter().map(Argument::from)),
+        )
+    }
+
+    /// `binding || (binding = expr)`
+    fn create_logical_or_expression(
+        binding: &BoundIdentifier<'a>,
+        expr: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let left = binding.create_read_expression(ctx);
+        let right = ctx.ast.expression_assignment(
+            SPAN,
+            AssignmentOperator::Assign,
+            binding.create_write_target(ctx),
+            expr,
+        );
+        ctx.ast.expression_logical(SPAN, left, LogicalOperator::Or, right)
+    }
+
+    /// Creates a `var binding;` variable declaration at the top level and returns the binding
+    fn create_top_level_binding(&self, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
+        let binding = ctx.generate_uid(
+            "templateObject",
+            ctx.scoping().root_scope_id(),
+            SymbolFlags::FunctionScopedVariable,
+        );
+
+        let variable = ctx.ast.variable_declarator(
+            SPAN,
+            VariableDeclarationKind::Var,
+            binding.create_binding_pattern(ctx),
+            None,
+            false,
+        );
+
+        let stmt = Statement::from(ctx.ast.declaration_variable(
+            SPAN,
+            VariableDeclarationKind::Var,
+            ctx.ast.vec1(variable),
+            false,
+        ));
+
+        self.ctx.top_level_statements.insert_statement(stmt);
+
+        binding
+    }
+}

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -337,6 +337,7 @@ export declare function moduleRunnerTransformSync(filename: string, sourceText: 
 
 export interface PluginsOptions {
   styledComponents?: StyledComponentsOptions
+  taggedTemplateEscape?: boolean
 }
 
 export interface ReactRefreshOptions {

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -467,6 +467,7 @@ pub struct StyledComponentsOptions {
 #[derive(Default)]
 pub struct PluginsOptions {
     pub styled_components: Option<StyledComponentsOptions>,
+    pub tagged_template_escape: Option<bool>,
 }
 
 impl From<PluginsOptions> for oxc::transformer::PluginsOptions {
@@ -475,6 +476,7 @@ impl From<PluginsOptions> for oxc::transformer::PluginsOptions {
             styled_components: options
                 .styled_components
                 .map(oxc::transformer::StyledComponentsOptions::from),
+            tagged_template_transform: options.tagged_template_escape.unwrap_or(false),
         }
     }
 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 777ded79
 
-Passed: 188/319
+Passed: 198/329
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -18,6 +18,7 @@ Passed: 188/319
 * babel-plugin-transform-react-jsx-self
 * babel-plugin-transform-react-jsx-source
 * regexp
+* plugin-tagged-template-transform
 
 
 # babel-plugin-transform-explicit-resource-management (2/4)

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 777ded79
 
 node: v24.10.0
 
-Passed: 9 of 11 (81.82%)
+Passed: 10 of 12 (83.33%)
 
 Failures:
 

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -64,6 +64,7 @@ pub const PLUGINS: &[&str] = &[
     "legacy-decorators",
     // Built-in third-party plugins
     "plugin-styled-components",
+    "plugin-tagged-template-transform",
 ];
 
 pub const PLUGINS_NOT_SUPPORTED_YET: &[&str] = &[

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/basic/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/basic/input.js
@@ -1,0 +1,1 @@
+foo`</script>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/basic/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/basic/output.js
@@ -1,0 +1,2 @@
+var _templateObject;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/script>"])));

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/mixed-case/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/mixed-case/input.js
@@ -1,0 +1,1 @@
+foo`</ScRiPt>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/mixed-case/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/mixed-case/output.js
@@ -1,0 +1,2 @@
+var _templateObject;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/ScRiPt>"])));

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple-expressions/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple-expressions/input.js
@@ -1,0 +1,1 @@
+foo`<script>${a}${b}</script>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple-expressions/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple-expressions/output.js
@@ -1,0 +1,7 @@
+var _templateObject;
+foo(
+  _templateObject ||
+    (_templateObject = babelHelpers.taggedTemplateLiteral(["<script>", "", "<\/script>"])),
+  a,
+  b,
+);

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple/input.js
@@ -1,0 +1,2 @@
+foo`</script>`
+bar`</script>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/multiple/output.js
@@ -1,0 +1,4 @@
+var _templateObject;
+var _templateObject2;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/script>"])));
+bar(_templateObject2 || (_templateObject2 = babelHelpers.taggedTemplateLiteral(["<\/script>"])));

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/nested-scope/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/nested-scope/input.js
@@ -1,0 +1,7 @@
+function f() {
+  if (true) {
+    return function() {
+      return foo`</script>`;
+    };
+  }
+}

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/nested-scope/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/nested-scope/output.js
@@ -1,0 +1,8 @@
+var _templateObject;
+function f() {
+  if (true) {
+    return function() {
+      return foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/script>"])));
+    };
+  }
+}

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/no-script-tag/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/no-script-tag/input.js
@@ -1,0 +1,1 @@
+foo`hello world`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/no-script-tag/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/no-script-tag/output.js
@@ -1,0 +1,1 @@
+foo`hello world`;

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/opening-and-closing/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/opening-and-closing/input.js
@@ -1,0 +1,1 @@
+foo`<script></script>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/opening-and-closing/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/opening-and-closing/output.js
@@ -1,0 +1,4 @@
+var _templateObject;
+foo(
+  _templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<script><\/script>"])),
+);

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    [
+      "tagged-template-transform"
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/exec.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/exec.js
@@ -1,0 +1,2 @@
+expect(String.raw`</script>` === String.raw`</script>`).toBe(true);
+expect(String.raw`</script>` !== String.raw`<\/script>`).toBe(true);

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/input.js
@@ -1,0 +1,2 @@
+expect(String.raw`</script>` === String.raw`</script>`).toBe(true);
+expect(String.raw`</script>` !== String.raw`<\/script>`).toBe(true);

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/string-raw/output.js
@@ -1,0 +1,5 @@
+var _templateObject;
+var _templateObject2;
+var _templateObject3;
+expect(String.raw(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/script>"]))) === String.raw(_templateObject2 || (_templateObject2 = babelHelpers.taggedTemplateLiteral(["<\/script>"])))).toBe(true);
+expect(String.raw(_templateObject3 || (_templateObject3 = babelHelpers.taggedTemplateLiteral(["<\/script>"]))) !== String.raw`<\/script>`).toBe(true);

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/uppercase/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/uppercase/input.js
@@ -1,0 +1,1 @@
+foo`</SCRIPT>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/uppercase/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/uppercase/output.js
@@ -1,0 +1,2 @@
+var _templateObject;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/SCRIPT>"])));

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/with-expression/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/with-expression/input.js
@@ -1,0 +1,1 @@
+foo`<script>${content}</script>`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/with-expression/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/with-expression/output.js
@@ -1,0 +1,6 @@
+var _templateObject;
+foo(
+  _templateObject ||
+    (_templateObject = babelHelpers.taggedTemplateLiteral(["<script>", "<\/script>"])),
+  content,
+);


### PR DESCRIPTION
 Implement a transformation plugin for tagged template expressions containing </script> tags to prevent script tag issues in browser environments.

  This plugin transforms tagged template literals containing `</script` (case-insensitive) to use a helper function call with template caching, matching esbuild's behavior.

 ### Example

  Transforms tagged templates to use cached template objects with a helper function:

  Input:
```js
foo`</script>`
bar`<script>${content}</script>`
```
  Output:
```js
var _templateObject, _templateObject2;
foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["<\/script>"])));
bar(_templateObject2 || (_templateObject2 = babelHelpers.taggedTemplateLiteral(["<script>", "<\/script>"])), content);
```

 Closes #15306