### PR TITLE
docs(linter): fix grammar

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -108,7 +108,7 @@ pub struct BasicOptions {
     /// Oxlint configuration file (experimental)
     ///  * only `.json` extension is supported
     ///  * you can use comments in configuration files.
-    ///  * tries to be compatible with the ESLint v8's format
+    ///  * tries to be compatible with ESLint v8's format
     ///
     /// If not provided, Oxlint will look for `.oxlintrc.json` in the current working directory.
     #[bpaf(long, short, argument("./.oxlintrc.json"))]

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -15,7 +15,7 @@ search: false
   Oxlint configuration file (experimental)
 * only `.json` extension is supported
 * you can use comments in configuration files.
-* tries to be compatible with the ESLint v8's format
+* tries to be compatible with ESLint v8's format
 
   If not provided, Oxlint will look for `.oxlintrc.json` in the current working directory.
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -8,7 +8,7 @@ Basic Configuration
     -c, --config=<./.oxlintrc.json>  Oxlint configuration file (experimental)
                               * only `.json` extension is supported
                               * you can use comments in configuration files.
-                              * tries to be compatible with the ESLint v8's format
+                              * tries to be compatible with ESLint v8's format
         --tsconfig=<./tsconfig.json>  TypeScript `tsconfig.json` path for reading path alias and
                               project references for import plugin. If not provided, will look for
                               `tsconfig.json` in the current working directory.


### PR DESCRIPTION
Just remove an extraneous "the" from docs comment.

I *think* this will remove the same typo from website (https://oxc.rs/docs/guide/usage/linter/cli.html#basic-configuration), because that file appears to be auto-generated from this comment.