### PR TITLE
docs(linter): add missing `perf` category

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -126,6 +126,7 @@ pub struct BasicOptions {
 
 // This is formatted according to
 // <https://docs.rs/bpaf/latest/bpaf/params/struct.NamedArg.html#method.help>
+//
 /// Allowing / Denying Multiple Lints
 ///
 /// Accumulate rules and categories from left to right on the command-line.
@@ -134,9 +135,10 @@ pub struct BasicOptions {
 ///   * `correctness` - code that is outright wrong or useless (default).
 ///   * `suspicious`  - code that is most likely wrong or useless.
 ///   * `pedantic`    - lints which are rather strict or have occasional false positives.
+///   * `perf`        - code that could be written in a more performant way.
 ///   * `style`       - code that should be written in a more idiomatic way.
-///   * `nursery`     - new lints that are still under development.
 ///   * `restriction` - lints which prevent the use of language and library features.
+///   * `nursery`     - new lints that are still under development.
 ///   * `all`         - all the categories listed above except nursery. Does not enable plugins automatically.
 ///
 /// Arguments:

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -34,9 +34,10 @@ Accumulate rules and categories from left to right on the command-line.
  * `correctness` - code that is outright wrong or useless (default).
  * `suspicious`  - code that is most likely wrong or useless.
  * `pedantic`    - lints which are rather strict or have occasional false positives.
+ * `perf`        - code that could be written in a more performant way.
  * `style`       - code that should be written in a more idiomatic way.
- * `nursery`     - new lints that are still under development.
  * `restriction` - lints which prevent the use of language and library features.
+ * `nursery`     - new lints that are still under development.
  * `all`         - all the categories listed above except nursery. Does not enable plugins automatically.
 
 Arguments:

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -21,9 +21,10 @@ Allowing / Denying Multiple Lints
    * `correctness` - code that is outright wrong or useless (default).
    * `suspicious`  - code that is most likely wrong or useless.
    * `pedantic`    - lints which are rather strict or have occasional false positives.
+   * `perf`        - code that could be written in a more performant way.
    * `style`       - code that should be written in a more idiomatic way.
-   * `nursery`     - new lints that are still under development.
    * `restriction` - lints which prevent the use of language and library features.
+   * `nursery`     - new lints that are still under development.
    * `all`         - all the categories listed above except nursery. Does not enable plugins
   automatically.
     -A, --allow=NAME          Allow the rule or category (suppress the lint)


### PR DESCRIPTION
`perf` category was missing from this list. Add it.

Also move `nursery` category to after `restriction`, to match the order listed in https://oxc.rs/docs/guide/usage/linter/config.html#enabling-groups-of-rules-categories

I believe this will fix same omission from website (https://oxc.rs/docs/guide/usage/linter/cli.html#allowing-denying-multiple-lints), because that file appears to be auto-generated from this comment.