### PR TITLE
docs(linter): correct comment on what `EnablePlugins` does

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -240,7 +240,7 @@ pub struct OutputOptions {
     pub format: OutputFormat,
 }
 
-/// Enable Plugins
+/// Enable/Disable Plugins
 #[expect(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone, Bpaf)]
 pub struct EnablePlugins {

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -51,7 +51,7 @@ Arguments:
 
 
 
-## Enable Plugins
+## Enable/Disable Plugins
 - **`    --disable-unicorn-plugin`** &mdash; 
   Disable unicorn plugin, which is turned on by default
 - **`    --disable-oxc-plugin`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -31,7 +31,7 @@ Allowing / Denying Multiple Lints
     -W, --warn=NAME           Deny the rule or category (emit a warning)
     -D, --deny=NAME           Deny the rule or category (emit an error)
 
-Enable Plugins
+Enable/Disable Plugins
         --disable-unicorn-plugin  Disable unicorn plugin, which is turned on by default
         --disable-oxc-plugin  Disable oxc unique rules, which is turned on by default
         --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default


### PR DESCRIPTION
`EnablePlugins` also allows *disabling* plugins. Correct the doc comment to reflect that.

I believe this will correct section header in docs on website (https://oxc.rs/docs/guide/usage/linter/cli.html#enable-plugins), because that file appears to be auto-generated from this comment.

Note: There are no links on website that reference `#enable-plugins` anchor, so it shouldn't break any links when this anchor changes to `#enable-disable-plugins`.