### PR TITLE
docs(linter): remove "experimental" from description of stable features

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -105,7 +105,7 @@ impl LintCommand {
 /// Basic Configuration
 #[derive(Debug, Clone, Bpaf)]
 pub struct BasicOptions {
-    /// Oxlint configuration file (experimental)
+    /// Oxlint configuration file
     ///  * only `.json` extension is supported
     ///  * you can use comments in configuration files.
     ///  * tries to be compatible with ESLint v8's format
@@ -268,8 +268,8 @@ pub struct EnablePlugins {
     )]
     pub typescript_plugin: OverrideToggle,
 
-    /// Enable the experimental import plugin and detect ESM problems.
-    /// It is recommended to use along side with the `--tsconfig` option.
+    /// Enable import plugin and detect ESM problems.
+    /// It is recommended to use alongside the `--tsconfig` option.
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub import_plugin: OverrideToggle,
 
@@ -277,7 +277,7 @@ pub struct EnablePlugins {
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub react_plugin: OverrideToggle,
 
-    /// Enable the experimental jsdoc plugin and detect JSDoc problems
+    /// Enable jsdoc plugin and detect JSDoc problems
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub jsdoc_plugin: OverrideToggle,
 

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -12,7 +12,7 @@ search: false
 
 ## Basic Configuration
 - **`-c`**, **`--config`**=_`<./.oxlintrc.json>`_ &mdash; 
-  Oxlint configuration file (experimental)
+  Oxlint configuration file
 * only `.json` extension is supported
 * you can use comments in configuration files.
 * tries to be compatible with ESLint v8's format
@@ -59,11 +59,11 @@ Arguments:
 - **`    --disable-typescript-plugin`** &mdash; 
   Disable TypeScript plugin, which is turned on by default
 - **`    --import-plugin`** &mdash; 
-  Enable the experimental import plugin and detect ESM problems. It is recommended to use along side with the `--tsconfig` option.
+  Enable import plugin and detect ESM problems. It is recommended to use alongside the `--tsconfig` option.
 - **`    --react-plugin`** &mdash; 
   Enable react plugin, which is turned off by default
 - **`    --jsdoc-plugin`** &mdash; 
-  Enable the experimental jsdoc plugin and detect JSDoc problems
+  Enable jsdoc plugin and detect JSDoc problems
 - **`    --jest-plugin`** &mdash; 
   Enable the Jest plugin and detect test problems
 - **`    --vitest-plugin`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -5,7 +5,7 @@ expression: snapshot
 Usage: [-c=<./.oxlintrc.json>] [PATH]...
 
 Basic Configuration
-    -c, --config=<./.oxlintrc.json>  Oxlint configuration file (experimental)
+    -c, --config=<./.oxlintrc.json>  Oxlint configuration file
                               * only `.json` extension is supported
                               * you can use comments in configuration files.
                               * tries to be compatible with ESLint v8's format
@@ -35,10 +35,10 @@ Enable/Disable Plugins
         --disable-unicorn-plugin  Disable unicorn plugin, which is turned on by default
         --disable-oxc-plugin  Disable oxc unique rules, which is turned on by default
         --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
-        --import-plugin       Enable the experimental import plugin and detect ESM problems. It is
-                              recommended to use along side with the `--tsconfig` option.
+        --import-plugin       Enable import plugin and detect ESM problems. It is recommended to use
+                              alongside the `--tsconfig` option.
         --react-plugin        Enable react plugin, which is turned off by default
-        --jsdoc-plugin        Enable the experimental jsdoc plugin and detect JSDoc problems
+        --jsdoc-plugin        Enable jsdoc plugin and detect JSDoc problems
         --jest-plugin         Enable the Jest plugin and detect test problems
         --vitest-plugin       Enable the Vitest plugin and detect test problems
         --jsx-a11y-plugin     Enable the JSX-a11y plugin and detect accessibility problems


### PR DESCRIPTION
I don't believe these features are experimental any more:

* `--config` CLI flag
* `import` plugin
* `jsdoc` plugin

Remove the word "experimental" from doc comments related to these features.

Also, improve grammar in description of `import` plugin.

I believe this will also update docs on website (https://oxc.rs/docs/guide/usage/linter/cli.html#enable-plugins).