### PR TITLE
docs(linter): reformat doc comments

### DIFF
--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -78,7 +78,7 @@ pub struct MiscOptions {
     /// Do not exit with error when pattern is unmatched
     #[bpaf(switch, hide_usage)]
     pub no_error_on_unmatched_pattern: bool,
-    /// Number of threads to use. Set to 1 for using only 1 CPU core
+    /// Number of threads to use. Set to 1 for using only 1 CPU core.
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,
 }

--- a/apps/oxlint/src/command/ignore.rs
+++ b/apps/oxlint/src/command/ignore.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use bpaf::{Bpaf, doc::Style};
 
 pub const NO_IGNORE_HELP: &[(&str, Style)] = &[
-    ("Disables excluding of files from .eslintignore files, ", Style::Text),
+    ("Disable excluding files from `.eslintignore` files, ", Style::Text),
     ("--ignore-path", Style::Literal),
     (" flags and ", Style::Text),
     ("--ignore-pattern", Style::Literal),
@@ -13,14 +13,14 @@ pub const NO_IGNORE_HELP: &[(&str, Style)] = &[
 /// Ignore Files
 #[derive(Debug, Clone, Bpaf)]
 pub struct IgnoreOptions {
-    /// Specify the file to use as your .eslintignore
+    /// Specify the file to use as your `.eslintignore`
     #[bpaf(argument("PATH"), fallback(".eslintignore".into()), hide_usage)]
     pub ignore_path: OsString,
 
-    /// Specify patterns of files to ignore (in addition to those in .eslintignore)
+    /// Specify patterns of files to ignore (in addition to those in `.eslintignore`)
     ///
-    /// The supported syntax is the same as for .eslintignore and .gitignore files
-    /// You should quote your patterns in order to avoid shell interpretation of glob patterns
+    /// The supported syntax is the same as for `.eslintignore` and `.gitignore` files.
+    /// You should quote your patterns in order to avoid shell interpretation of glob patterns.
     #[bpaf(argument("PAT"), many, hide_usage)]
     pub ignore_pattern: Vec<String>,
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -35,18 +35,18 @@ pub struct LintCommand {
     #[bpaf(external)]
     pub output_options: OutputOptions,
 
-    /// list all the rules that are currently registered
+    /// List all the rules that are currently registered
     #[bpaf(long("rules"), switch, hide_usage)]
     pub list_rules: bool,
 
     #[bpaf(external)]
     pub misc_options: MiscOptions,
 
-    /// Disables the automatic loading of nested configuration files.
+    /// Disable the automatic loading of nested configuration files
     #[bpaf(switch, hide_usage)]
     pub disable_nested_config: bool,
 
-    /// Enables rules that require type information.
+    /// Enable rules that require type information
     #[bpaf(switch, hide_usage)]
     pub type_aware: bool,
 
@@ -132,14 +132,14 @@ pub struct BasicOptions {
 /// Accumulate rules and categories from left to right on the command-line.
 ///   For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
 ///   The categories are:
-///   * `correctness` - code that is outright wrong or useless (default).
-///   * `suspicious`  - code that is most likely wrong or useless.
-///   * `pedantic`    - lints which are rather strict or have occasional false positives.
-///   * `perf`        - code that could be written in a more performant way.
-///   * `style`       - code that should be written in a more idiomatic way.
-///   * `restriction` - lints which prevent the use of language and library features.
-///   * `nursery`     - new lints that are still under development.
-///   * `all`         - all the categories listed above except nursery. Does not enable plugins automatically.
+///   * `correctness` - Code that is outright wrong or useless (default)
+///   * `suspicious`  - Code that is most likely wrong or useless
+///   * `pedantic`    - Lints which are rather strict or have occasional false positives
+///   * `perf`        - Code that could be written in a more performant way
+///   * `style`       - Code that should be written in a more idiomatic way
+///   * `restriction` - Lints which prevent the use of language and library features
+///   * `nursery`     - New lints that are still under development
+///   * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
 ///
 /// Arguments:
 //  ^ This shows up on the website but not from the cli's `--help`.
@@ -175,14 +175,14 @@ impl LintFilter {
 /// Fix Problems
 #[derive(Debug, Clone, Bpaf)]
 pub struct FixOptions {
-    /// Fix as many issues as possible. Only unfixed issues are reported in the output
+    /// Fix as many issues as possible. Only unfixed issues are reported in the output.
     #[bpaf(switch, hide_usage)]
     pub fix: bool,
     /// Apply auto-fixable suggestions. May change program behavior.
     #[bpaf(switch, hide_usage)]
     pub fix_suggestions: bool,
 
-    /// Apply dangerous fixes and suggestions.
+    /// Apply dangerous fixes and suggestions
     #[bpaf(switch, hide_usage)]
     pub fix_dangerously: bool,
 }

--- a/apps/oxlint/src/command/mod.rs
+++ b/apps/oxlint/src/command/mod.rs
@@ -22,7 +22,7 @@ pub struct MiscOptions {
     #[bpaf(switch, hide_usage)]
     pub silent: bool,
 
-    /// Number of threads to use. Set to 1 for using only 1 CPU core
+    /// Number of threads to use. Set to 1 for using only 1 CPU core.
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,
 

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -31,14 +31,14 @@ Accumulate rules and categories from left to right on the command-line.
 
  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
  The categories are:
- * `correctness` - code that is outright wrong or useless (default).
- * `suspicious`  - code that is most likely wrong or useless.
- * `pedantic`    - lints which are rather strict or have occasional false positives.
- * `perf`        - code that could be written in a more performant way.
- * `style`       - code that should be written in a more idiomatic way.
- * `restriction` - lints which prevent the use of language and library features.
- * `nursery`     - new lints that are still under development.
- * `all`         - all the categories listed above except nursery. Does not enable plugins automatically.
+ * `correctness` - Code that is outright wrong or useless (default)
+ * `suspicious`  - Code that is most likely wrong or useless
+ * `pedantic`    - Lints which are rather strict or have occasional false positives
+ * `perf`        - Code that could be written in a more performant way
+ * `style`       - Code that should be written in a more idiomatic way
+ * `restriction` - Lints which prevent the use of language and library features
+ * `nursery`     - New lints that are still under development
+ * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
 
 Arguments:
 
@@ -87,23 +87,23 @@ Arguments:
 
 ## Fix Problems
 - **`    --fix`** &mdash; 
-  Fix as many issues as possible. Only unfixed issues are reported in the output
+  Fix as many issues as possible. Only unfixed issues are reported in the output.
 - **`    --fix-suggestions`** &mdash; 
   Apply auto-fixable suggestions. May change program behavior.
 - **`    --fix-dangerously`** &mdash; 
-  Apply dangerous fixes and suggestions.
+  Apply dangerous fixes and suggestions
 
 
 
 ## Ignore Files
 - **`    --ignore-path`**=_`PATH`_ &mdash; 
-  Specify the file to use as your .eslintignore
+  Specify the file to use as your `.eslintignore`
 - **`    --ignore-pattern`**=_`PAT`_ &mdash; 
-  Specify patterns of files to ignore (in addition to those in .eslintignore)
+  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
 
-  The supported syntax is the same as for .eslintignore and .gitignore files You should quote your patterns in order to avoid shell interpretation of glob patterns
+  The supported syntax is the same as for `.eslintignore` and `.gitignore` files. You should quote your patterns in order to avoid shell interpretation of glob patterns.
 - **`    --no-ignore`** &mdash; 
-  Disables excluding of files from .eslintignore files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
+  Disable excluding files from `.eslintignore` files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
 
 
 
@@ -130,7 +130,7 @@ Arguments:
 - **`    --silent`** &mdash; 
   Do not display any diagnostics
 - **`    --threads`**=_`INT`_ &mdash; 
-  Number of threads to use. Set to 1 for using only 1 CPU core
+  Number of threads to use. Set to 1 for using only 1 CPU core.
 - **`    --print-config`** &mdash; 
   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
@@ -152,11 +152,11 @@ Arguments:
 
 ## Available options:
 - **`    --rules`** &mdash; 
-  list all the rules that are currently registered
+  List all the rules that are currently registered
 - **`    --disable-nested-config`** &mdash; 
-  Disables the automatic loading of nested configuration files.
+  Disable the automatic loading of nested configuration files
 - **`    --type-aware`** &mdash; 
-  Enables rules that require type information.
+  Enable rules that require type information
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -18,14 +18,14 @@ Allowing / Denying Multiple Lints
    Accumulate rules and categories from left to right on the command-line.
    For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
    The categories are:
-   * `correctness` - code that is outright wrong or useless (default).
-   * `suspicious`  - code that is most likely wrong or useless.
-   * `pedantic`    - lints which are rather strict or have occasional false positives.
-   * `perf`        - code that could be written in a more performant way.
-   * `style`       - code that should be written in a more idiomatic way.
-   * `restriction` - lints which prevent the use of language and library features.
-   * `nursery`     - new lints that are still under development.
-   * `all`         - all the categories listed above except nursery. Does not enable plugins
+   * `correctness` - Code that is outright wrong or useless (default)
+   * `suspicious`  - Code that is most likely wrong or useless
+   * `pedantic`    - Lints which are rather strict or have occasional false positives
+   * `perf`        - Code that could be written in a more performant way
+   * `style`       - Code that should be written in a more idiomatic way
+   * `restriction` - Lints which prevent the use of language and library features
+   * `nursery`     - New lints that are still under development
+   * `all`         - All categories listed above except `nursery`. Does not enable plugins
   automatically.
     -A, --allow=NAME          Allow the rule or category (suppress the lint)
     -W, --warn=NAME           Deny the rule or category (emit a warning)
@@ -52,15 +52,15 @@ Enable/Disable Plugins
 
 Fix Problems
         --fix                 Fix as many issues as possible. Only unfixed issues are reported in
-                              the output
+                              the output.
         --fix-suggestions     Apply auto-fixable suggestions. May change program behavior.
-        --fix-dangerously     Apply dangerous fixes and suggestions.
+        --fix-dangerously     Apply dangerous fixes and suggestions
 
 Ignore Files
-        --ignore-path=PATH    Specify the file to use as your .eslintignore
+        --ignore-path=PATH    Specify the file to use as your `.eslintignore`
         --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in
-                              .eslintignore)
-        --no-ignore           Disables excluding of files from .eslintignore files, --ignore-path
+                              `.eslintignore`)
+        --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path
                               flags and --ignore-pattern flags
 
 Handle Warnings
@@ -76,7 +76,7 @@ Output
 
 Miscellaneous
         --silent              Do not display any diagnostics
-        --threads=INT         Number of threads to use. Set to 1 for using only 1 CPU core
+        --threads=INT         Number of threads to use. Set to 1 for using only 1 CPU core.
         --print-config        This option outputs the configuration to be used. When present, no
                               linting is performed and only config-related options are valid.
 
@@ -92,8 +92,8 @@ Available positional items:
     PATH                      Single file, single path or list of paths
 
 Available options:
-        --rules               list all the rules that are currently registered
-        --disable-nested-config  Disables the automatic loading of nested configuration files.
-        --type-aware          Enables rules that require type information.
+        --rules               List all the rules that are currently registered
+        --disable-nested-config  Disable the automatic loading of nested configuration files
+        --type-aware          Enable rules that require type information
     -h, --help                Prints help information
     -V, --version             Prints version information


### PR DESCRIPTION
Really anal style nits for CLI options. Standardize formatting based on the following rules:

* Capitalized first letter.
* No full stops on end, unless comment contains multiple sentences (in which case, always full stop).
* Quote filenames and technical names in backticks (e.g. `.eslintignore`, `nursery`).
* Imperative style ("Disable" not "Disables").

These are the existing stylistic conventions, which comments mostly followed. This PR just corrects the few which didn't, to bring all the doc comments into line stylistically.

Main purpose is to clean up the docs on website: https://oxc.rs/docs/guide/usage/linter/cli.html