### PR TITLE
docs(linter): `oxlint-disable` not `eslint-disable`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -403,7 +403,7 @@ impl EnablePlugins {
 #[derive(Debug, Clone, PartialEq, Eq, Bpaf)]
 pub enum ReportUnusedDirectives {
     WithoutSeverity(
-        /// Report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway.
+        /// Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
         // More information at <https://eslint.org/docs/latest/use/command-line-interface#--report-unused-disable-directives>
         #[bpaf(long("report-unused-disable-directives"), switch, hide_usage)]
         bool,

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -138,7 +138,7 @@ Arguments:
 
 ## Inline Configuration Comments
 - **`    --report-unused-disable-directives`** &mdash; 
-  Report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway.
+  Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
 - **`    --report-unused-disable-directives-severity`**=_`SEVERITY`_ &mdash; 
   Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -81,8 +81,8 @@ Miscellaneous
                               linting is performed and only config-related options are valid.
 
 Inline Configuration Comments
-        --report-unused-disable-directives  Report directive comments like `// eslint-disable-line`
-                              when no errors would have been reported on that line anyway.
+        --report-unused-disable-directives  Report directive comments like `// oxlint-disable-line`,
+                              when no errors would have been reported on that line anyway
         --report-unused-disable-directives-severity=SEVERITY  Same as
                               `--report-unused-disable-directives`, but allows you to specify the
                               severity level of the reported errors. Only one of these two options


### PR DESCRIPTION
Update doc comment. It's just a pride thing really. Feels weird to be referencing ESLint in Oxlint's docs, when Oxlint has the same feature.