### PR TITLE
ci(labeler): label PRs with changes to `apps/oxlint/src-js` dir as `A-linter-plugins`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,10 @@ A-linter:
   - changed-files:
       - any-glob-to-any-file: ["crates/oxc_linter/**", "apps/oxlint/**"]
 
+A-linter-plugins:
+  - changed-files:
+      - any-glob-to-any-file: ["apps/oxlint/src-js/**"]
+
 A-minifier:
   - changed-files:
       - any-glob-to-any-file: ["crates/oxc_minifier/**", "napi/minify/**"]


### PR DESCRIPTION
Add `A-linter-plugins` label to any PR which alters files in `apps/oxlint/src-js`. It's tiresome adding the label by hand to loads of PRs.