### PR TITLE
feat(vscode): support `oxlint --lsp`

### DIFF
--- a/editors/vscode/client/PathValidator.ts
+++ b/editors/vscode/client/PathValidator.ts
@@ -39,9 +39,12 @@ export function validateSafeBinaryPath(binary: string): boolean {
     }
   }
 
-  // Check if the filename contains `oxc_language_server`
+  // Check if the filename contains `oxc_language_server` or `oxlint`
   // Malicious projects might try to point to a different binary.
-  if (!binary.replaceAll('\\', '/').toLowerCase().split('/').pop()?.includes('oxc_language_server')) {
+  if (
+    !binary.replaceAll('\\', '/').toLowerCase().split('/').pop()?.includes('oxc_language_server') &&
+    !binary.replaceAll('\\', '/').toLowerCase().split('/').pop()?.includes('oxlint')
+  ) {
     return false;
   }
 

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -166,6 +166,7 @@ export async function activate(context: ExtensionContext) {
         }
       : {
           command: path!,
+          args: ['--lsp'],
           options: {
             env: serverEnv,
           },
@@ -175,6 +176,8 @@ export async function activate(context: ExtensionContext) {
     run,
     debug: run,
   };
+
+  outputChannel.info(`Using server binary at: ${path}`);
 
   // see https://github.com/oxc-project/oxc/blob/9b475ad05b750f99762d63094174be6f6fc3c0eb/crates/oxc_linter/src/loader/partial_loader/mod.rs#L17-L20
   const supportedExtensions = ['astro', 'cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'svelte', 'ts', 'tsx', 'vue'];


### PR DESCRIPTION
Hacked a bit to test if the `node_modules/.bin/oxlint --lsp` will work:
```
{
  "oxc.path.server": "/home/sysix/dev/oxc/node_modules/.bin/oxlint"
}
```
<img width="887" height="196" alt="grafik" src="https://github.com/user-attachments/assets/76088dd1-3ede-4b83-86b9-09527edb784a" />

"works" with windows + shell:
<img width="1556" height="123" alt="grafik" src="https://github.com/user-attachments/assets/9753bf44-05cd-471f-b8a1-7c48d3436491" />
