### PR TITLE
perf(ast_tools): derives only loop through structs and enums

### DIFF
--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     Codegen, Result, Runner,
     output::{Output, output_path},
     parse::attr::{AttrLocation, AttrPart, AttrPositions, attr_positions},
-    schema::{Def, FileId, Schema, StructOrEnum, TypeDef},
+    schema::{Def, FileId, Schema, StructOrEnum},
     utils::format_cow,
 };
 
@@ -156,14 +156,14 @@ pub trait Derive: Runner {
         let derive_id = codegen.get_derive_id_by_name(self.trait_name());
 
         let mut crate_contents = FxHashMap::<&str, CrateContent>::default();
-        for type_def in &schema.types {
+        for type_def in schema.structs_and_enums() {
             let (derived, file_id) = match type_def {
-                TypeDef::Struct(struct_def) if struct_def.generates_derive(derive_id) => {
-                    let derived = self.derive(StructOrEnum::Struct(struct_def), schema);
+                StructOrEnum::Struct(struct_def) if struct_def.generates_derive(derive_id) => {
+                    let derived = self.derive(type_def, schema);
                     (derived, struct_def.file_id)
                 }
-                TypeDef::Enum(enum_def) if enum_def.generates_derive(derive_id) => {
-                    let derived = self.derive(StructOrEnum::Enum(enum_def), schema);
+                StructOrEnum::Enum(enum_def) if enum_def.generates_derive(derive_id) => {
+                    let derived = self.derive(type_def, schema);
                     (derived, enum_def.file_id)
                 }
                 _ => continue,

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -93,7 +93,6 @@ impl Schema {
     }
 
     /// Get iterator over all structs and enums.
-    #[expect(dead_code)]
     pub fn structs_and_enums(&self) -> StructsAndEnums<'_> {
         StructsAndEnums::new(self)
     }


### PR DESCRIPTION
Every derive loops through all structs and enums. Use `StructsAndEnums` iterator for this, to avoid looping through `TypeDef`s for `Vec`s, `Option`s, `Box`es, primitives, etc, when they're all ignored anyway.

Has no effect on generated code.