### PR TITLE
refactor(formatter): remove dead import

### DIFF
--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -61,7 +61,6 @@ use oxc_ast::{
     ast::{CallExpression, NewExpression},
 };
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::comment_node;
 
 use crate::write;
 


### PR DESCRIPTION
Pure refactor. `CommentNodeId` was introduced in #11214, but we didn't end up using it. We'll remove it entirely when we put `NodeId`s in AST nodes.

This import is dead code, so remove it.