### PR TITLE
fix(linter): restores `oxlint --rules -f=json` functionality.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -22,7 +22,7 @@ use oxc_linter::{
 
 use crate::{
     cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
-    output_formatter::{LintCommandInfo, OutputFormatter, OutputFormat},
+    output_formatter::{LintCommandInfo, OutputFormat, OutputFormatter},
     walk::Walk,
 };
 use oxc_linter::LintIgnoreMatcher;
@@ -306,11 +306,10 @@ impl CliRunner {
         if self.options.list_rules {
             // Preserve previous behavior of `--rules` output when `-f` is set
             if self.options.output_options.format != OutputFormat::Default {
-                if let Some(output) = output_formatter.all_rules(){
+                if let Some(output) = output_formatter.all_rules() {
                     print_and_flush_stdout(stdout, &output);
                 }
-            }
-            else{
+            } else {
                 // Build the set of enabled builtin rule names from the resolved config.
                 let enabled: FxHashSet<&str> =
                     config_store.rules().iter().map(|(rule, _)| rule.name()).collect();
@@ -327,7 +326,6 @@ impl CliRunner {
                     format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
                 );
                 print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
-
             }
 
             return CliRunResult::None;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -22,7 +22,7 @@ use oxc_linter::{
 
 use crate::{
     cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
-    output_formatter::{LintCommandInfo, OutputFormatter},
+    output_formatter::{LintCommandInfo, OutputFormatter, OutputFormat},
     walk::Walk,
 };
 use oxc_linter::LintIgnoreMatcher;
@@ -304,28 +304,31 @@ impl CliRunner {
         // If the user requested `--rules`, print a CLI-specific table that
         // includes an "Enabled?" column based on the resolved configuration.
         if self.options.list_rules {
-            // Ensure the `all_rules` method is considered used in non-test builds so the
-            // `InternalFormatter::all_rules` default implementation doesn't produce a
-            // `dead_code` warning. This is a no-op call (the result is discarded) and
-            // is only compiled in non-test builds.
-            let _ = output_formatter.all_rules();
-
-            // Build the set of enabled builtin rule names from the resolved config.
-            let enabled: FxHashSet<&str> =
-                config_store.rules().iter().map(|(rule, _)| rule.name()).collect();
-
-            let table = RuleTable::default();
-            for section in &table.sections {
-                let md = section.render_markdown_table_cli(None, &enabled);
-                print_and_flush_stdout(stdout, &md);
-                print_and_flush_stdout(stdout, "\n");
+            // Preserve previous behavior of `--rules` output when `-f` is set
+            if self.options.output_options.format != OutputFormat::Default {
+                if let Some(output) = output_formatter.all_rules(){
+                    print_and_flush_stdout(stdout, &output);
+                }
             }
+            else{
+                // Build the set of enabled builtin rule names from the resolved config.
+                let enabled: FxHashSet<&str> =
+                    config_store.rules().iter().map(|(rule, _)| rule.name()).collect();
 
-            print_and_flush_stdout(
-                stdout,
-                format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
-            );
-            print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
+                let table = RuleTable::default();
+                for section in &table.sections {
+                    let md = section.render_markdown_table_cli(None, &enabled);
+                    print_and_flush_stdout(stdout, &md);
+                    print_and_flush_stdout(stdout, "\n");
+                }
+
+                print_and_flush_stdout(
+                    stdout,
+                    format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
+                );
+                print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
+
+            }
 
             return CliRunResult::None;
         }
@@ -1293,6 +1296,25 @@ mod test {
     #[test]
     fn test_dot_folder() {
         Tester::new().with_cwd("fixtures/dot_folder".into()).test_and_snapshot(&[]);
+    }
+
+    #[test]
+    fn test_rules_json_output() {
+        let args = &["--rules", "-f=json"];
+        let stdout = Tester::new().with_cwd("fixtures".into()).test_output(args);
+
+        // Parse output as JSON array. If parsing fails, the test will fail.
+        let rules: Vec<serde_json::Value> =
+            serde_json::from_str(&stdout).expect("Failed to parse JSON");
+        assert!(!rules.is_empty(), "The rules list should not be empty");
+
+        // Validate the structure of JSON objects.
+        for rule in &rules {
+            let rule_obj = rule.as_object().unwrap();
+            assert!(rule_obj.contains_key("scope"), "Rule should contain 'scope' field");
+            assert!(rule_obj.contains_key("value"), "Rule should contain 'value' field");
+            assert!(rule_obj.contains_key("category"), "Rule should contain 'category' field");
+        }
     }
 
     #[test]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -322,10 +322,9 @@ impl CliRunner {
                     format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
                 );
                 print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
-            } else if let Some(output) = output_formatter.all_rules(){
-                    print_and_flush_stdout(stdout, &output);
+            } else if let Some(output) = output_formatter.all_rules() {
+                print_and_flush_stdout(stdout, &output);
             }
-
 
             return CliRunResult::None;
         }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -322,8 +322,7 @@ impl CliRunner {
                     format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
                 );
                 print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
-            }
-            else if let Some(output) = output_formatter.all_rules(){
+            } else if let Some(output) = output_formatter.all_rules(){
                     print_and_flush_stdout(stdout, &output);
             }
 

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -305,12 +305,7 @@ impl CliRunner {
         // includes an "Enabled?" column based on the resolved configuration.
         if self.options.list_rules {
             // Preserve previous behavior of `--rules` output when `-f` is set
-            if self.options.output_options.format != OutputFormat::Default {
-                if let Some(output) = output_formatter.all_rules(){
-                    print_and_flush_stdout(stdout, &output);
-                }
-            }
-            else{
+            if self.options.output_options.format == OutputFormat::Default {
                 // Build the set of enabled builtin rule names from the resolved config.
                 let enabled: FxHashSet<&str> =
                     config_store.rules().iter().map(|(rule, _)| rule.name()).collect();
@@ -327,8 +322,11 @@ impl CliRunner {
                     format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
                 );
                 print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
-
             }
+            else if let Some(output) = output_formatter.all_rules(){
+                    print_and_flush_stdout(stdout, &output);
+            }
+
 
             return CliRunResult::None;
         }

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -108,10 +108,8 @@ impl OutputFormatter {
         }
     }
 
-    /// Return a rendered listing of all available rules (if supported by the
-    /// underlying formatter). This used to exist as a public helper; restoring
-    /// it eliminates the `dead_code` warning on the trait method without
-    /// resorting to allow attributes.
+    /// Print all available rules by oxlint
+    /// See [`InternalFormatter::all_rules`] for more details.
     pub fn all_rules(&self) -> Option<String> {
         self.internal.all_rules()
     }

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -35,6 +35,17 @@ impl Tester {
         let _ = CliRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
     }
 
+    pub fn test_output(&self, args: &[&str]) -> String {
+        let mut new_args = vec!["--silent"];
+        new_args.extend(args);
+
+        let options = lint_command().run_inner(new_args.as_slice()).unwrap();
+        let mut output = Vec::new();
+        let _ = CliRunner::new(options, None).with_cwd(self.cwd.clone()).run(&mut output);
+
+        String::from_utf8(output).unwrap()
+    }
+
     pub fn test_fix(file: &str, before: &str, after: &str) {
         use std::fs;
         #[expect(clippy::disallowed_methods)]


### PR DESCRIPTION
Addresses bug https://github.com/oxc-project/oxc/issues/15688

When `self.options.output_options.format` is any value other than `OutputFormat::Default` we will revert to using the previous method for reporting `--rules`.

This preserves the `enabled?` column in the CLI while ensuring the json format is correctly output.

I have also added a test for validating that when `--rules -f=json` is invoked we return a list of JSON objects with the expected structure, without creating a test that will fail as more rules are added.

To achieve this a `test_output` method was added which returns the stdout we generate, if there is a more desirable way to test the output I would be happy to remove this method and modify the test.