### PR TITLE
feat(minify): add directives option

### DIFF
--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -54,6 +54,9 @@ pub struct CompressOptions {
 
     /// Limit the maximum number of iterations for debugging purpose.
     pub max_iterations: Option<u8>,
+
+    /// Remove redundant or non-standard directives
+    pub directives: bool,
 }
 
 impl Default for CompressOptions {
@@ -75,6 +78,7 @@ impl CompressOptions {
             treeshake: TreeShakeOptions::default(),
             drop_labels: FxHashSet::default(),
             max_iterations: None,
+            directives: true,
         }
     }
 
@@ -90,6 +94,7 @@ impl CompressOptions {
             treeshake: TreeShakeOptions::default(),
             drop_labels: FxHashSet::default(),
             max_iterations: None,
+            directives: true,
         }
     }
 
@@ -105,6 +110,7 @@ impl CompressOptions {
             treeshake: TreeShakeOptions::default(),
             drop_labels: FxHashSet::default(),
             max_iterations: None,
+            directives: true,
         }
     }
 }


### PR DESCRIPTION
https://terser.org/docs/options/ 

- directives (default: true) -- remove redundant or non-standard directives


When the js module is of the Module type, it may output from ejs to cjs. Therefore, we add this configuration to keep it similar to terser

It is possible to fix the related issues

https://github.com/rolldown/rolldown/issues/6880
https://github.com/rolldown/rolldown/issues/6879