### PR TITLE
feat(minifier): disable removal of unnecessary `use strict` directives for DCE

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -33,8 +33,11 @@ impl<'a> Compressor<'a> {
         let max_iterations = options.max_iterations;
         let state = MinifierState::new(program.source_type, options);
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
-        let normalize_options =
-            NormalizeOptions { convert_while_to_fors: true, convert_const_to_let: true };
+        let normalize_options = NormalizeOptions {
+            convert_while_to_fors: true,
+            convert_const_to_let: true,
+            remove_unnecessary_use_strict: true,
+        };
         Normalize::new(normalize_options).build(program, &mut ctx);
         PeepholeOptimizations::new(max_iterations).run_in_loop(program, &mut ctx)
     }
@@ -54,8 +57,11 @@ impl<'a> Compressor<'a> {
         let max_iterations = options.max_iterations;
         let state = MinifierState::new(program.source_type, options);
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
-        let normalize_options =
-            NormalizeOptions { convert_while_to_fors: false, convert_const_to_let: false };
+        let normalize_options = NormalizeOptions {
+            convert_while_to_fors: false,
+            convert_const_to_let: false,
+            remove_unnecessary_use_strict: false,
+        };
         Normalize::new(normalize_options).build(program, &mut ctx);
         DeadCodeElimination::new(max_iterations).run_in_loop(program, &mut ctx)
     }

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -15,6 +15,7 @@ use crate::{
 pub struct NormalizeOptions {
     pub convert_while_to_fors: bool,
     pub convert_const_to_let: bool,
+    pub remove_unnecessary_use_strict: bool,
 }
 
 /// Normalize AST
@@ -53,7 +54,7 @@ impl<'a> Normalize {
 
 impl<'a> Traverse<'a, MinifierState<'a>> for Normalize {
     fn exit_program(&mut self, node: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        if node.source_type.is_module() {
+        if self.options.remove_unnecessary_use_strict && node.source_type.is_module() {
             node.directives.drain_filter(|d| d.directive.as_str() == "use strict");
         }
     }
@@ -118,7 +119,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for Normalize {
     }
 
     fn exit_function_body(&mut self, body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        Self::remove_unused_use_strict_directive(body, ctx);
+        if self.options.remove_unnecessary_use_strict {
+            Self::remove_unused_use_strict_directive(body, ctx);
+        }
     }
 }
 

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -404,3 +404,8 @@ fn drop_labels_with_vars() {
 
     test_with_options("PURE: { var x = 1; foo(x); }", "", options);
 }
+
+#[test]
+fn keep_use_strict_directives() {
+    test_same("'use strict'; export function foo() { 'use strict'; return 1; }");
+}


### PR DESCRIPTION
This is kind of a workaround. The target of this PR is to solve https://github.com/rolldown/rolldown/issues/6879 and https://github.com/rolldown/rolldown/issues/6880.

While the proper way to fix them is to use the proper `ModuleKind` (described in https://github.com/rolldown/rolldown/issues/7009), `ModuleKind::Unambiguous` doesn't work as expected and is blocked by https://github.com/oxc-project/oxc/issues/15541.

So for the meanwhile, this PR can solve those issues indirectly. We can revert this PR once the issues above are solved properly, but I guess it's also fine to keep it as I think there's less value to remove `use strict` directives in DCE.
