### PR TITLE
feat(linter): add unicorn/prefer-response-static-json rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3654,6 +3654,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_regexp_test::PreferRegexpTest 
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_response_static_json::PreferResponseStaticJson {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::prefer_set_has::PreferSetHas {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::VariableDeclarator]));

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -490,6 +490,7 @@ pub(crate) mod unicorn {
     pub mod prefer_query_selector;
     pub mod prefer_reflect_apply;
     pub mod prefer_regexp_test;
+    pub mod prefer_response_static_json;
     pub mod prefer_set_has;
     pub mod prefer_set_size;
     pub mod prefer_spread;
@@ -1212,6 +1213,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::numeric_separators_style,
     unicorn::prefer_classlist_toggle,
     unicorn::prefer_class_fields,
+    unicorn::prefer_response_static_json,
     unicorn::prefer_top_level_await,
     unicorn::prefer_at,
     unicorn::prefer_global_this,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
@@ -1,0 +1,133 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    ast_util::{is_method_call, is_new_expression},
+    context::LintContext,
+    rule::Rule,
+};
+
+fn prefer_response_static_json_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer using `Response.json(…)` over `JSON.stringify()`.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferResponseStaticJson;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of `Response.json()` over `new Response(JSON.stringify())`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `Response.json()` is a more concise and semantically clear way to create JSON responses.
+    /// It automatically sets the correct `Content-Type` header (`application/json`) and handles
+    /// serialization, making the code more maintainable and less error-prone.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// const response = new Response(JSON.stringify(data));
+    /// const response = new Response(JSON.stringify(data), { status: 200 });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const response = Response.json(data);
+    /// const response = Response.json(data, { status: 200 });
+    /// ```
+    PreferResponseStaticJson,
+    unicorn,
+    style,
+    pending,
+);
+
+impl Rule for PreferResponseStaticJson {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::NewExpression(new_expr) = node.kind() else {
+            return;
+        };
+
+        if !is_new_expression(new_expr, &["Response"], Some(1), None) {
+            return;
+        }
+
+        let Some(argument) = new_expr.arguments.first() else {
+            return;
+        };
+
+        let Some(argument_expr) = argument.as_expression() else {
+            return;
+        };
+
+        let Expression::CallExpression(call_expr) = argument_expr.get_inner_expression() else {
+            return;
+        };
+
+        if !is_method_call(call_expr, Some(&["JSON"]), Some(&["stringify"]), Some(1), Some(1)) {
+            return;
+        }
+
+        if stringify_has_spread_arguments(call_expr) {
+            return;
+        }
+
+        ctx.diagnostic(prefer_response_static_json_diagnostic(call_expr.callee.span()));
+    }
+}
+
+fn stringify_has_spread_arguments(call_expr: &CallExpression) -> bool {
+    call_expr.arguments.iter().any(oxc_ast::ast::Argument::is_spread)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "Response.json(data)",
+        "Response(JSON.stringify(data))",
+        "new Response()",
+        "new NotResponse(JSON.stringify(data))",
+        "new Response(JSON.stringify(...data))",
+        "new Response(JSON.stringify())",
+        "new Response(JSON.stringify(data, extraArgument))",
+        "new Response(JSON.stringify?.(data))",
+        "new Response(JSON?.stringify(data))",
+        "new Response(new JSON.stringify(data))",
+        "new Response(JSON.not_stringify(data))",
+        "new Response(NOT_JSON.stringify(data))",
+        "new Response(data(JSON.stringify))",
+        r#"new Response("" + JSON.stringify(data))"#,
+    ];
+
+    let fail = vec![
+        "new Response(JSON.stringify(data))",
+        "new Response(JSON.stringify(data), extraArgument)",
+        "new Response( (( JSON.stringify( (( 0, data )), ) )), )",
+        "function foo() {
+				return new // comment
+					Response(JSON.stringify(data))
+			}",
+        "new Response(JSON.stringify(data), {status: 200})",
+        "foo
+			new (( Response ))(JSON.stringify(data))",
+        "foo;
+			new (( Response ))(JSON.stringify(data))",
+        "foo;
+			(( new (( Response ))(JSON.stringify(data)) ))",
+        "foo
+			(( new (( Response ))(JSON.stringify(data)) ))",
+    ];
+
+    Tester::new(PreferResponseStaticJson::NAME, PreferResponseStaticJson::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_response_static_json.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_response_static_json.snap
@@ -1,0 +1,62 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:1:14]
+ 1 │ new Response(JSON.stringify(data))
+   ·              ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:1:14]
+ 1 │ new Response(JSON.stringify(data), extraArgument)
+   ·              ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:1:18]
+ 1 │ new Response( (( JSON.stringify( (( 0, data )), ) )), )
+   ·                  ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:3:15]
+ 2 │                 return new // comment
+ 3 │                     Response(JSON.stringify(data))
+   ·                              ──────────────
+ 4 │             }
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:1:14]
+ 1 │ new Response(JSON.stringify(data), {status: 200})
+   ·              ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:2:23]
+ 1 │ foo
+ 2 │             new (( Response ))(JSON.stringify(data))
+   ·                                ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:2:23]
+ 1 │ foo;
+ 2 │             new (( Response ))(JSON.stringify(data))
+   ·                                ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:2:26]
+ 1 │ foo;
+ 2 │             (( new (( Response ))(JSON.stringify(data)) ))
+   ·                                   ──────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
+   ╭─[prefer_response_static_json.tsx:2:26]
+ 1 │ foo
+ 2 │             (( new (( Response ))(JSON.stringify(data)) ))
+   ·                                   ──────────────
+   ╰────


### PR DESCRIPTION
This PR adds unicorn/prefer-response-static-json rule, issue #684

[rule doc](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-response-static-json.md)
[rule source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-response-static-json.js)