### PR TITLE
refactor(linter/plugins): improve types for `settings`

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,5 +1,6 @@
 import type { Context, FileContext, LanguageOptions } from './plugins/context.ts';
 import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
+import type { Settings } from './plugins/settings.ts';
 import type { SourceCode } from './plugins/source_code.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 
@@ -17,6 +18,7 @@ export type {
   ScopeType,
   Variable,
 } from './plugins/scope.ts';
+export type { Settings } from './plugins/settings.ts';
 export type { SourceCode } from './plugins/source_code.ts';
 export type { CountOptions, FilterFn, RangeOptions, SkipOptions } from './plugins/tokens.ts';
 export type {
@@ -182,7 +184,7 @@ const FILE_CONTEXT: FileContext = freeze({
     throw new Error('Cannot access `context.languageOptions` in `createOnce`');
   },
 
-  get settings(): Record<string, unknown> {
+  get settings(): Readonly<Settings> {
     throw new Error('Cannot access `context.settings` in `createOnce`');
   },
 

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -32,6 +32,7 @@ import { settings, initSettings } from './settings.js';
 
 import type { RuleDetails } from './load.ts';
 import type { Diagnostic } from './report.ts';
+import type { Settings } from './settings.ts';
 import type { SourceCode } from './source_code.ts';
 import type { ModuleKind } from '../generated/types.d.ts';
 
@@ -247,7 +248,7 @@ const FILE_CONTEXT = freeze({
   /**
    * Settings for the file being linted.
    */
-  get settings(): Record<string, unknown> {
+  get settings(): Readonly<Settings> {
     if (filePath === null) throw new Error('Cannot access `context.settings` in `createOnce`');
     if (settings === null) initSettings();
     return settings;

--- a/apps/oxlint/src-js/plugins/json.ts
+++ b/apps/oxlint/src-js/plugins/json.ts
@@ -1,0 +1,42 @@
+/*
+ * Methods and types related to JSON.
+ */
+
+const { isArray } = Array,
+  { freeze } = Object;
+
+/**
+ * A JSON value.
+ */
+export type JsonValue = JsonObject | JsonValue[] | string | number | boolean | null;
+
+/**
+ * A JSON object.
+ */
+export type JsonObject = { [key: string]: JsonValue };
+
+/**
+ * Deep freeze a JSON value, recursively freezing all nested objects and arrays.
+ *
+ * Freezes the value in place, and returns `undefined`.
+ *
+ * @param value - The value to deep freeze
+ */
+export function deepFreezeJsonValue(value: JsonValue): undefined {
+  if (value === null || typeof value !== 'object') return;
+
+  // Circular references are not possible in JSON, so no need to handle them here
+  if (isArray(value)) {
+    for (let i = 0, len = value.length; i !== len; i++) {
+      deepFreezeJsonValue(value[i]);
+    }
+  } else {
+    // Symbol properties are not possible in JSON, so no need to handle them here.
+    // All properties are enumerable own properties, so can use simple `for..in` loop.
+    for (const key in value) {
+      deepFreezeJsonValue(value[key]);
+    }
+  }
+
+  freeze(value);
+}

--- a/apps/oxlint/src-js/plugins/settings.ts
+++ b/apps/oxlint/src-js/plugins/settings.ts
@@ -2,13 +2,22 @@
  * Methods related to settings.
  */
 
-const { isArray } = Array;
+import { deepFreezeJsonValue } from './json.js';
+
+import type { JsonObject } from './json.ts';
+
+/**
+ * Settings for the file being linted.
+ *
+ * Settings are deserialized from JSON, so can only contain JSON-compatible values.
+ */
+export type Settings = JsonObject;
 
 // Settings for current file.
 // `settingsJSON` is set before linting a file by `setSettingsForFile`.
 // `settings` is deserialized from `settingsJSON` lazily upon first access.
 let settingsJSON: string | null = null;
-export let settings: Record<string, unknown> | null = null;
+export let settings: Readonly<Settings> | null = null;
 
 /**
  * Updates the settings for the file.
@@ -18,44 +27,23 @@ export let settings: Record<string, unknown> | null = null;
  *
  * @param settingsJSONInput - Settings for the file as JSON
  */
-export function setSettingsForFile(settingsJSONInput: string) {
+export function setSettingsForFile(settingsJSONInput: string): undefined {
   settingsJSON = settingsJSONInput;
 }
 
 /**
  * Deserialize settings from JSON.
  */
-export function initSettings() {
+export function initSettings(): undefined {
   settings = JSON.parse(settingsJSON);
-  deepFreezeSettings(settings);
+  // Deep freeze the settings object, to prevent any mutation of the settings from plugins
+  deepFreezeJsonValue(settings);
 }
 
 /**
  * Reset settings.
  */
-export function resetSettings() {
+export function resetSettings(): undefined {
   settings = null;
   settingsJSON = null;
-}
-
-/**
- * Deep freeze the settings object, recursively freezing all nested objects and arrays.
- * This prevents any mutation of the settings from plugins.
- * @param obj - The object to deep freeze
- */
-function deepFreezeSettings(obj: unknown): undefined {
-  if (obj === null || typeof obj !== 'object') return;
-
-  if (isArray(obj)) {
-    for (let i = 0, len = obj.length; i < len; i++) {
-      deepFreezeSettings(obj[i]);
-    }
-  } else {
-    // We don't need to handle symbol properties or circular references because settings are deserialized from JSON
-    for (const key in obj) {
-      deepFreezeSettings((obj as unknown as Record<string, unknown>)[key]);
-    }
-  }
-
-  Object.freeze(obj);
 }


### PR DESCRIPTION
Improve types for `settings`. `settings` is deserialized from JSON, so can only contain a limited set of values.