### PR TITLE
refactor(linter/plugins): improve types for `options`

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -7,7 +7,7 @@ import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
 export type * as ESTree from './generated/types.d.ts';
 export type { Context, LanguageOptions } from './plugins/context.ts';
 export type { Fix, Fixer, FixFn } from './plugins/fix.ts';
-export type { CreateOnceRule, CreateRule, Plugin, Rule } from './plugins/load.ts';
+export type { CreateOnceRule, CreateRule, Options, Plugin, Rule } from './plugins/load.ts';
 export type { Diagnostic, Suggestion } from './plugins/report.ts';
 export type {
   Definition,

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -30,7 +30,7 @@ import { ast, initAst, SOURCE_CODE } from './source_code.js';
 import { report } from './report.js';
 import { settings, initSettings } from './settings.js';
 
-import type { RuleDetails } from './load.ts';
+import type { Options, RuleDetails } from './load.ts';
 import type { Diagnostic } from './report.ts';
 import type { Settings } from './settings.ts';
 import type { SourceCode } from './source_code.ts';
@@ -303,7 +303,7 @@ export interface Context extends FileContext {
   /**
    * Rule options for this rule on this file.
    */
-  options: unknown[];
+  options: Readonly<Options>;
   /**
    * Report an error/warning.
    */
@@ -350,7 +350,7 @@ export function createContext(fullRuleName: string, ruleDetails: RuleDetails): R
       return fullRuleName;
     },
     // Getter for rule options for this rule on this file
-    get options(): Readonly<unknown[]> {
+    get options(): Readonly<Options> {
       if (filePath === null) throw new Error('Cannot access `context.options` in `createOnce`');
       return ruleDetails.options;
     },

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -5,6 +5,7 @@ import { getErrorMessage } from './utils.js';
 
 import type { Writable } from 'type-fest';
 import type { Context } from './context.ts';
+import type { JsonValue } from './json.ts';
 import type { RuleMeta } from './rule_meta.ts';
 import type { AfterHook, BeforeHook, Visitor, VisitorWithHooks } from './types.ts';
 
@@ -37,6 +38,11 @@ export interface CreateOnceRule {
 }
 
 /**
+ * Options for a rule on a file.
+ */
+export type Options = JsonValue[];
+
+/**
  * Linter rule, context object, and other details of rule.
  * If `rule` has a `createOnce` method, the visitor it returns is stored in `visitor` property.
  */
@@ -49,7 +55,7 @@ interface RuleDetailsBase {
   readonly messages: Readonly<Record<string, string>> | null;
   // Updated for each file
   ruleIndex: number;
-  options: Readonly<unknown[]>;
+  options: Readonly<Options>;
 }
 
 interface CreateRuleDetails extends RuleDetailsBase {
@@ -77,7 +83,7 @@ export const registeredRules: RuleDetails[] = [];
 const neverRunBeforeHook: BeforeHook = () => false;
 
 // Default rule options
-const DEFAULT_OPTIONS: Readonly<unknown[]> = Object.freeze([]);
+const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 
 // Plugin details returned to Rust
 interface PluginDetails {


### PR DESCRIPTION
Similar to #15695. `options` is serialized from JSON, so can only contain a limited set of values.