### PR TITLE
fix(tools): make `just ast` work on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -129,7 +129,7 @@ codecov:
 # unless Rust code is generated first.
 # See: https://github.com/oxc-project/oxc/issues/15564
 ast:
-  cargo run -p oxc_ast_tools || (cargo run -p oxc_ast_tools --no-default-features && cargo run -p oxc_ast_tools)
+  cargo run -p oxc_ast_tools || { cargo run -p oxc_ast_tools --no-default-features && cargo run -p oxc_ast_tools; }
 
 # ==================== PARSER ====================
 


### PR DESCRIPTION
According to Claude, `just ast` in its current form will not work on Windows, as PowerShell does not support `( ... )` for command groupings. Switch to `{ ... }`.

This script was added in #15565. Copilot writes it, Claude critiques it!
