### PR TITLE
feat(linter): implement prefer-const

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -900,7 +900,8 @@ impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignmen
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_const::PreferConst {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -899,6 +899,11 @@ impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignmen
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::prefer_const::PreferConst {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::prefer_destructuring::PreferDestructuring {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::AssignmentExpression,

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -174,6 +174,7 @@ pub(crate) mod eslint {
     pub mod no_warning_comments;
     pub mod no_with;
     pub mod operator_assignment;
+    pub mod prefer_const;
     pub mod prefer_destructuring;
     pub mod prefer_exponentiation_operator;
     pub mod prefer_numeric_literals;
@@ -802,6 +803,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_warning_comments,
     eslint::no_with,
     eslint::operator_assignment,
+    eslint::prefer_const,
     eslint::prefer_template,
     eslint::prefer_destructuring,
     eslint::prefer_promise_reject_errors,

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -708,7 +708,7 @@ fn test() {
 			}",
             None,
         ),
-        ("/*oxlint unicorn/no-useless-undefined:error*/ let foo = undefined;", None),
+        ("let foo = undefined;", None),
         ("let a = 1; class C { static { a; } }", None), // { "ecmaVersion": 2022 },
         ("class C { static { a; } } let a = 1;", None), // { "ecmaVersion": 2022 },
         ("class C { static { let a = 1; } }", None),    // { "ecmaVersion": 2022 },

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -423,9 +423,9 @@ fn test() {
         // 	};",
         //     None,
         // ),
-        // ("let x; x = 0;", None),
+        ("let x; x = 0;", None),
         // ("switch (a) { case 0: let x; x = 0; }", None),
-        // ("(function() { let x; x = 1; })();", None),
+        ("(function() { let x; x = 1; })();", None),
         // (
         //     "let {a = 0, b} = obj; b = 0; foo(a, b);",
         //     Some(serde_json::json!([{ "destructuring": "any" }])),

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -106,7 +106,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferConst {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(value.get(0).and_then(|v| serde_json::from_value(v.clone()).ok()).unwrap_or_default())
+        Self(value.get(0).and_then(|v| PreferConstConfig::deserialize(v).ok()).unwrap_or_default())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -597,6 +597,7 @@ fn test() {
         ("let x;", None),
         ("let x; { x = 0; } foo(x);", None),
         ("/* let foo = 'bar'; */ const baz = undefined;", None),
+        ("/*let*/ foo = 'bar';", None),
         ("let x = 0; x = 1;", None),
         ("using resource = fn();", None), // { "sourceType": "module", "ecmaVersion": 2026 },
         ("await using resource = fn();", None), // { "sourceType": "module", "ecmaVersion": 2026 },

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -257,9 +257,10 @@ impl PreferConst {
                 if let Some(reference_id) = ident.reference_id.get()
                     && let Some(symbol_id) =
                         ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                    && !self.can_identifier_be_const(symbol_id, symbol_table, ctx) {
-                        return false;
-                    }
+                    && !self.can_identifier_be_const(symbol_id, symbol_table, ctx)
+                {
+                    return false;
+                }
             }
         }
         true
@@ -283,9 +284,10 @@ impl PreferConst {
                     if let Some(reference_id) = ident.binding.reference_id.get()
                         && let Some(symbol_id) =
                             ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                        && !self.can_identifier_be_const(symbol_id, symbol_table, ctx) {
-                            return false;
-                        }
+                        && !self.can_identifier_be_const(symbol_id, symbol_table, ctx)
+                    {
+                        return false;
+                    }
                 }
                 AssignmentTargetProperty::AssignmentTargetPropertyProperty(_) => {
                     // For complex properties, we can't easily check, so allow it

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -952,6 +952,7 @@ fn test() {
             Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 }
         (
+            // This being a violation is a difference in behavior from ESLint, but I think it's correct.
             "for (let seen = new Set(); Math.random() < 0.5;) {
                seen.add('foo');
              }",

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -248,8 +248,7 @@ impl PreferConst {
                         // (one is the destructuring assignment itself)
                         let references: Vec<_> =
                             symbol_table.get_resolved_references(symbol_id).collect();
-                        let write_count =
-                            references.iter().filter(|r| r.is_write()).count();
+                        let write_count = references.iter().filter(|r| r.is_write()).count();
                         if write_count > 1 {
                             return false;
                         }
@@ -316,8 +315,7 @@ impl PreferConst {
                             // (one is the destructuring assignment itself)
                             let references: Vec<_> =
                                 symbol_table.get_resolved_references(symbol_id).collect();
-                            let write_count =
-                                references.iter().filter(|r| r.is_write()).count();
+                            let write_count = references.iter().filter(|r| r.is_write()).count();
                             if write_count > 1 {
                                 return false;
                             }

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -543,6 +543,7 @@ impl PreferConst {
                 | AstKind::DoWhileStatement(_)
                 | AstKind::ForStatement(_)
                 | AstKind::ConditionalExpression(_)
+                | AstKind::LogicalExpression(_)
                 | AstKind::TryStatement(_) => {
                     // Check if the variable's scope is a descendant of this control flow's scope
                     // If yes, the variable is declared inside the control flow
@@ -694,6 +695,15 @@ fn test() {
             "class C { static { () => a; let a = 1; } };",
             Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 }
+        (
+            // const must be initialized with a value, so this cannot become a const
+            "function example() {
+               let value; // declared, not initialized
+               return someCheck() && (value = getValue());
+             }
+            ",
+            None,
+        )
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -588,6 +588,7 @@ fn test() {
         ("var x = 0;", None),
         ("let x;", None),
         ("let x; { x = 0; } foo(x);", None),
+        ("/* let foo = 'bar'; */ const baz = undefined;", None),
         ("let x = 0; x = 1;", None),
         ("using resource = fn();", None), // { "sourceType": "module", "ecmaVersion": 2026 },
         ("await using resource = fn();", None), // { "sourceType": "module", "ecmaVersion": 2026 },
@@ -700,6 +701,9 @@ fn test() {
         ("for (let i in [1,2,3]) { foo(i); }", None),
         ("for (let x of [1,2,3]) { foo(x); }", None),
         ("let [x = -1, y] = [1,2]; y = 0;", None),
+        // Ensure a "reassignment" in a comment does not count
+        ("let foo = 'bar'; /* foo = 'baz'; */", None),
+        ("let foo = 'bar'; // foo = 'baz';", None),
         ("let {a: x = -1, b: y} = {a:1,b:2}; y = 0;", None),
         ("(function() { let x = 1; foo(x); })();", None),
         ("(function() { for (let i in [1,2,3]) { foo(i); } })();", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -16,7 +16,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_const_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is never reassigned"))
-        .with_help("Use 'const' instead".to_string())
+        .with_help("Use 'const' instead")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -426,22 +426,22 @@ fn test() {
         ("let x; x = 0;", None),
         // ("switch (a) { case 0: let x; x = 0; }", None),
         ("(function() { let x; x = 1; })();", None),
-        // (
-        //     "let {a = 0, b} = obj; b = 0; foo(a, b);",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ),
-        // (
-        //     "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ),
-        // (
-        //     "let {a: {b, c}} = {a: {b: 1, c: 2}}",
-        //     Some(serde_json::json!([{ "destructuring": "all" }])),
-        // ),
-        // (
-        //     "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ),
+        (
+            "let {a = 0, b} = obj; b = 0; foo(a, b);",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ),
+        (
+            "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ),
+        (
+            "let {a: {b, c}} = {a: {b: 1, c: 2}}",
+            Some(serde_json::json!([{ "destructuring": "all" }])),
+        ),
+        (
+            "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ),
         ("let {a = 0, b} = obj; foo(a, b);", Some(serde_json::json!([{ "destructuring": "all" }]))),
         ("let [a] = [1]", Some(serde_json::json!([]))),
         ("let {a} = obj", Some(serde_json::json!([]))),
@@ -449,57 +449,57 @@ fn test() {
             "let a, b; ({a = 0, b} = obj); foo(a, b);",
             Some(serde_json::json!([{ "destructuring": "all" }])),
         ),
-        // (
-        //     "let {a = 0, b} = obj, c = a; b = a;",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ),
-        // (
-        //     "let {a = 0, b} = obj, c = a; b = a;",
-        //     Some(serde_json::json!([{ "destructuring": "all" }])),
-        // ),
-        // (
-        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ), // { "ecmaVersion": 2018 },
-        // (
-        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
-        // ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling
-        ("/*eslint custom/use-x:error*/ let x = 1", None), // {				"parserOptions": { "ecmaFeatures": { "globalReturn": true } },			},
-        ("/*eslint custom/use-x:error*/ { let x = 1 }", None),
-        // ("let [a] = [1]", Some(serde_json::json!([]))),
-        // ("let {a} = obj", Some(serde_json::json!([]))),
-        // (
-        //     "let a, b; ({a = 0, b} = obj); foo(a, b);",
-        //     Some(serde_json::json!([{ "destructuring": "all" }])),
-        // ),
-        // (
-        //     "let {a = 0, b} = obj, c = a; b = a;",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ),
-        // (
-        //     "let {a = 0, b} = obj, c = a; b = a;",
-        //     Some(serde_json::json!([{ "destructuring": "all" }])),
-        // ),
-        // (
-        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ), // { "ecmaVersion": 2018 },
-        // (
-        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
-        //     Some(serde_json::json!([{ "destructuring": "any" }])),
-        // ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
-        // ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling (duplicate entry)
+        (
+            "let {a = 0, b} = obj, c = a; b = a;",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ),
+        (
+            "let {a = 0, b} = obj, c = a; b = a;",
+            Some(serde_json::json!([{ "destructuring": "all" }])),
+        ),
+        (
+            "let { name, ...otherStuff } = obj; otherStuff = {};",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ), // { "ecmaVersion": 2018 },
+        (
+            "let { name, ...otherStuff } = obj; otherStuff = {};",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
+        ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling
+        ("let x = 1", None), // {				"parserOptions": { "ecmaFeatures": { "globalReturn": true } },			},
+        ("{ let x = 1 }", None),
+        ("let [a] = [1]", Some(serde_json::json!([]))),
+        ("let {a} = obj", Some(serde_json::json!([]))),
+        (
+            "let a, b; ({a = 0, b} = obj); foo(a, b);",
+            Some(serde_json::json!([{ "destructuring": "all" }])),
+        ),
+        (
+            "let {a = 0, b} = obj, c = a; b = a;",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ),
+        (
+            "let {a = 0, b} = obj, c = a; b = a;",
+            Some(serde_json::json!([{ "destructuring": "all" }])),
+        ),
+        (
+            "let { name, ...otherStuff } = obj; otherStuff = {};",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ), // { "ecmaVersion": 2018 },
+        (
+            "let { name, ...otherStuff } = obj; otherStuff = {};",
+            Some(serde_json::json!([{ "destructuring": "any" }])),
+        ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
+        ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling (duplicate entry)
         ("/*eslint custom/use-x:error*/ let x = 1", None), // {				"parserOptions": { "ecmaFeatures": { "globalReturn": true } },			},
         ("/*eslint custom/use-x:error*/ { let x = 1 }", None),
         ("let { foo, bar } = baz;", None),
         ("const x = [1,2]; let [,y] = x;", None),
         ("const x = [1,2,3]; let [y,,z] = x;", None),
         // TODO: These require destructuring assignment analysis
-        // ("let predicate; [, {foo:returnType, predicate}] = foo();", None), // { "ecmaVersion": 2018 },
-        // ("let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();", None), // { "ecmaVersion": 2018 },
-        // ("let predicate; [, {foo:returnType, ...predicate} ] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, {foo:returnType, predicate}] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, {foo:returnType, ...predicate} ] = foo();", None), // { "ecmaVersion": 2018 },
         ("let x = 'x', y = 'y';", None),
         ("let x = 'x', y = 'y'; x = 1", None),
         ("let x = 1, y = 'y'; let z = 1;", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -227,60 +227,52 @@ impl PreferConst {
 
         // In "all" mode, check if ALL identifiers in the destructuring can be const
         if matches!(self.0.destructuring, Destructuring::All) {
-            for elem in &array_target.elements {
-                if let Some(target) = elem {
-                    if let AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(ident) = target
+            for target in array_target.elements.iter().flatten() {
+                if let AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(ident) = target {
+                    // Get the symbol for this identifier
+                    if let Some(reference_id) = ident.reference_id.get()
+                        && let Some(symbol_id) =
+                            ctx.semantic().scoping().get_reference(reference_id).symbol_id()
                     {
-                        // Get the symbol for this identifier
-                        if let Some(reference_id) = ident.reference_id.get() {
-                            if let Some(symbol_id) =
-                                ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                            {
-                                // Check if this symbol is a parameter
-                                // Parameters can't be changed to const
-                                let decl_node = symbol_table.symbol_declaration(symbol_id);
-                                if matches!(
-                                    ctx.nodes().kind(decl_node),
-                                    oxc_ast::AstKind::FormalParameter(_)
-                                ) {
-                                    return false;
-                                }
+                        // Check if this symbol is a parameter
+                        // Parameters can't be changed to const
+                        let decl_node = symbol_table.symbol_declaration(symbol_id);
+                        if matches!(
+                            ctx.nodes().kind(decl_node),
+                            oxc_ast::AstKind::FormalParameter(_)
+                        ) {
+                            return false;
+                        }
 
-                                // Check if this variable has more than one write
-                                // (one is the destructuring assignment itself)
-                                let references: Vec<_> =
-                                    symbol_table.get_resolved_references(symbol_id).collect();
-                                let write_count =
-                                    references.iter().filter(|r| r.is_write()).count();
-                                if write_count > 1 {
-                                    return false;
-                                }
-                            }
+                        // Check if this variable has more than one write
+                        // (one is the destructuring assignment itself)
+                        let references: Vec<_> =
+                            symbol_table.get_resolved_references(symbol_id).collect();
+                        let write_count =
+                            references.iter().filter(|r| r.is_write()).count();
+                        if write_count > 1 {
+                            return false;
                         }
                     }
                 }
             }
         } else {
             // In "any" mode, just check if any identifier is a parameter
-            for elem in &array_target.elements {
-                if let Some(target) = elem {
-                    if let AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(ident) = target
+            for target in array_target.elements.iter().flatten() {
+                if let AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(ident) = target {
+                    // Get the symbol for this identifier
+                    if let Some(reference_id) = ident.reference_id.get()
+                        && let Some(symbol_id) =
+                            ctx.semantic().scoping().get_reference(reference_id).symbol_id()
                     {
-                        // Get the symbol for this identifier
-                        if let Some(reference_id) = ident.reference_id.get() {
-                            if let Some(symbol_id) =
-                                ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                            {
-                                // Check if this symbol is a parameter
-                                // Parameters can't be changed to const
-                                let decl_node = symbol_table.symbol_declaration(symbol_id);
-                                if matches!(
-                                    ctx.nodes().kind(decl_node),
-                                    oxc_ast::AstKind::FormalParameter(_)
-                                ) {
-                                    return false;
-                                }
-                            }
+                        // Check if this symbol is a parameter
+                        // Parameters can't be changed to const
+                        let decl_node = symbol_table.symbol_declaration(symbol_id);
+                        if matches!(
+                            ctx.nodes().kind(decl_node),
+                            oxc_ast::AstKind::FormalParameter(_)
+                        ) {
+                            return false;
                         }
                     }
                 }
@@ -306,29 +298,28 @@ impl PreferConst {
                 match prop {
                     AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
                         // Get the symbol for this identifier
-                        if let Some(reference_id) = ident.binding.reference_id.get() {
-                            if let Some(symbol_id) =
+                        if let Some(reference_id) = ident.binding.reference_id.get()
+                            && let Some(symbol_id) =
                                 ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                            {
-                                // Check if this symbol is a parameter
-                                // Parameters can't be changed to const
-                                let decl_node = symbol_table.symbol_declaration(symbol_id);
-                                if matches!(
-                                    ctx.nodes().kind(decl_node),
-                                    oxc_ast::AstKind::FormalParameter(_)
-                                ) {
-                                    return false;
-                                }
+                        {
+                            // Check if this symbol is a parameter
+                            // Parameters can't be changed to const
+                            let decl_node = symbol_table.symbol_declaration(symbol_id);
+                            if matches!(
+                                ctx.nodes().kind(decl_node),
+                                oxc_ast::AstKind::FormalParameter(_)
+                            ) {
+                                return false;
+                            }
 
-                                // Check if this variable has more than one write
-                                // (one is the destructuring assignment itself)
-                                let references: Vec<_> =
-                                    symbol_table.get_resolved_references(symbol_id).collect();
-                                let write_count =
-                                    references.iter().filter(|r| r.is_write()).count();
-                                if write_count > 1 {
-                                    return false;
-                                }
+                            // Check if this variable has more than one write
+                            // (one is the destructuring assignment itself)
+                            let references: Vec<_> =
+                                symbol_table.get_resolved_references(symbol_id).collect();
+                            let write_count =
+                                references.iter().filter(|r| r.is_write()).count();
+                            if write_count > 1 {
+                                return false;
                             }
                         }
                     }
@@ -344,19 +335,18 @@ impl PreferConst {
                 match prop {
                     AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
                         // Get the symbol for this identifier
-                        if let Some(reference_id) = ident.binding.reference_id.get() {
-                            if let Some(symbol_id) =
+                        if let Some(reference_id) = ident.binding.reference_id.get()
+                            && let Some(symbol_id) =
                                 ctx.semantic().scoping().get_reference(reference_id).symbol_id()
-                            {
-                                // Check if this symbol is a parameter
-                                // Parameters can't be changed to const
-                                let decl_node = symbol_table.symbol_declaration(symbol_id);
-                                if matches!(
-                                    ctx.nodes().kind(decl_node),
-                                    oxc_ast::AstKind::FormalParameter(_)
-                                ) {
-                                    return false;
-                                }
+                        {
+                            // Check if this symbol is a parameter
+                            // Parameters can't be changed to const
+                            let decl_node = symbol_table.symbol_declaration(symbol_id);
+                            if matches!(
+                                ctx.nodes().kind(decl_node),
+                                oxc_ast::AstKind::FormalParameter(_)
+                            ) {
+                                return false;
                             }
                         }
                     }
@@ -933,6 +923,7 @@ fn test() {
         ), // { "ecmaVersion": 2022 }
     ];
 
+    // TODO: Implement the fixer and enable these tests.
     // let fix = vec![
     //     ("let x = 1; foo(x);", "const x = 1; foo(x);", None),
     //     ("for (let i in [1,2,3]) { foo(i); }", "for (const i in [1,2,3]) { foo(i); }", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -166,8 +166,7 @@ impl Rule for PreferConst {
             } else {
                 // "any" mode (default): check each binding identifier independently
                 for ident in binding_identifiers {
-                    let symbol_id = ident.symbol_id();
-                    if self.should_be_const(symbol_id, has_init, is_for_in_of_init, ctx) {
+                    if self.should_be_const(ident.symbol_id(), has_init, is_for_in_of_init, ctx) {
                         ctx.diagnostic(prefer_const_diagnostic(ident.name.as_str(), ident.span));
                     }
                 }
@@ -771,7 +770,9 @@ fn test() {
         ),
         // Function is hoisted and reads x before the assignment
         (
-            "function foo() { bar(x); } let x = 0;",
+            "function square(n) { x * x }
+             let x = 5;
+             console.log(square(4));",
             Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
         ),
     ];
@@ -956,10 +957,20 @@ fn test() {
              }",
             None,
         ),
-        // No read before assignment due to hoisting
+        // Hoisting tests
         (
-            "let x; x = 0; function foo() { bar(x); }",
-            Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
+            "function square(n) { x * x }
+             let x = 5;
+             console.log(square(4));",
+            Some(serde_json::json!([{ "ignoreReadBeforeAssign": false }])),
+        ),
+        (
+            "function foo() { bar(x); } let x = 0;",
+            Some(serde_json::json!([{ "ignoreReadBeforeAssign": false }])),
+        ),
+        (
+            "let x = 0; function foo() { bar(x); }",
+            Some(serde_json::json!([{ "ignoreReadBeforeAssign": false }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -496,7 +496,6 @@ fn test() {
         ("let { foo, bar } = baz;", None),
         ("const x = [1,2]; let [,y] = x;", None),
         ("const x = [1,2,3]; let [y,,z] = x;", None),
-        // TODO: These require destructuring assignment analysis
         ("let predicate; [, {foo:returnType, predicate}] = foo();", None), // { "ecmaVersion": 2018 },
         ("let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();", None), // { "ecmaVersion": 2018 },
         ("let predicate; [, {foo:returnType, ...predicate} ] = foo();", None), // { "ecmaVersion": 2018 },
@@ -527,49 +526,47 @@ fn test() {
         ("class C { static { let a = 1; } }", None),    // { "ecmaVersion": 2022 },
         ("class C { static { if (foo) { let a = 1; } } }", None), // { "ecmaVersion": 2022 },
         ("class C { static { let a = 1; if (foo) { a; } } }", None), // { "ecmaVersion": 2022 },
-                                                        // TODO: Requires scope analysis to determine if assignment is in same scope as declaration
-                                                        // ("class C { static { if (foo) { let a; a = 1; } } }", None), // { "ecmaVersion": 2022 },
-                                                        // ("class C { static { let a; a = 1; } }", None), // { "ecmaVersion": 2022 },
-                                                        // TODO: Requires destructuring assignment analysis
-                                                        // ("class C { static { let { a, b } = foo; } }", None), // { "ecmaVersion": 2022 },
-                                                        // ("class C { static { let a, b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
-                                                        // ("class C { static { let a; let b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
-                                                        // ("class C { static { let a; a = 0; console.log(a); } }", None), // { "ecmaVersion": 2022 },
-                                                        // (
-                                                        //     "
-                                                        // 	            let { itemId, list } = {},
-                                                        // 	            obj = [],
-                                                        // 	            total = 0;
-                                                        // 	            total = 9;
-                                                        // 	            console.log(itemId, list, obj, total);
-                                                        // 	            ",
-                                                        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
-                                                        // ), // { "ecmaVersion": 2022 },
-                                                        // (
-                                                        //     "
-                                                        // 	            let { itemId, list } = {},
-                                                        // 	            obj = [];
-                                                        // 	            console.log(itemId, list, obj);
-                                                        // 	            ",
-                                                        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
-                                                        // ), // { "ecmaVersion": 2022 },
-                                                        // (
-                                                        //     "
-                                                        // 	            let [ itemId, list ] = [],
-                                                        // 	            total = 0;
-                                                        // 	            total = 9;
-                                                        // 	            console.log(itemId, list, total);
-                                                        // 	            ",
-                                                        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
-                                                        // ), // { "ecmaVersion": 2022 },
-                                                        // (
-                                                        //     "
-                                                        // 	            let [ itemId, list ] = [],
-                                                        // 	            obj = [];
-                                                        // 	            console.log(itemId, list, obj);
-                                                        // 	            ",
-                                                        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
-                                                        // ), // { "ecmaVersion": 2022 }
+        // ("class C { static { if (foo) { let a; a = 1; } } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; a = 1; } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let { a, b } = foo; } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a, b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; let b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; a = 0; console.log(a); } }", None), // { "ecmaVersion": 2022 },
+        (
+            "
+        	            let { itemId, list } = {},
+        	            obj = [],
+        	            total = 0;
+        	            total = 9;
+        	            console.log(itemId, list, obj, total);
+        	            ",
+            Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+        	            let { itemId, list } = {},
+        	            obj = [];
+        	            console.log(itemId, list, obj);
+        	            ",
+            Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+        	            let [ itemId, list ] = [],
+        	            total = 0;
+        	            total = 9;
+        	            console.log(itemId, list, total);
+        	            ",
+            Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+        	            let [ itemId, list ] = [],
+        	            obj = [];
+        	            console.log(itemId, list, obj);
+        	            ",
+            Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        ), // { "ecmaVersion": 2022 }
     ];
 
     // let fix = vec![

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -104,7 +104,7 @@ impl Rule for PreferConst {
             return;
         };
 
-        // Only check `let` declarations (not `var` or `const`)
+        // Skip if not a `let` declaration (we do not check `var` or `const`)
         if decl.kind != VariableDeclarationKind::Let {
             return;
         }

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -703,11 +703,10 @@ fn test() {
         ("let x; for (x of array) { x; }", None),
         ("let {a, b} = obj; b = 0;", Some(serde_json::json!([{ "destructuring": "all" }]))),
         ("let a, b; ({a, b} = obj); b++;", Some(serde_json::json!([{ "destructuring": "all" }]))),
-        // TODO: Rest spread patterns may not be included in binding_identifiers
-        // (
-        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
-        //     Some(serde_json::json!([{ "destructuring": "all" }])),
-        // ), // { "ecmaVersion": 2018 },
+        (
+            "let { name, ...otherStuff } = obj; otherStuff = {};",
+            Some(serde_json::json!([{ "destructuring": "all" }])),
+        ), // { "ecmaVersion": 2018 },
         ("let predicate; [typeNode.returnType, predicate] = foo();", None), // { "ecmaVersion": 2018 },
         ("let predicate; [typeNode.returnType, ...predicate] = foo();", None), // { "ecmaVersion": 2018 },
         ("let predicate; [typeNode.returnType,, predicate] = foo();", None), // { "ecmaVersion": 2018 },

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_const_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is never reassigned"))
-        .with_help("Use 'const' instead")
+    OxcDiagnostic::warn(format!("`{name}` is never reassigned."))
+        .with_help("Use `const` instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::{AssignmentTarget, VariableDeclarationKind}};
+use oxc_ast::{
+    AstKind,
+    ast::{AssignmentTarget, VariableDeclarationKind},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
@@ -495,7 +498,7 @@ fn test() {
             "let { name, ...otherStuff } = obj; otherStuff = {};",
             Some(serde_json::json!([{ "destructuring": "any" }])),
         ), // { "parser": require(fixtureParser("babel-eslint5/destructuring-object-spread"), ), },
-        ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling
+        ("let x; function foo() { bar(x); } x = 0;", None),
         ("let x = 1", None), // { "parserOptions": { "ecmaFeatures": { "globalReturn": true } }, },
         ("{ let x = 1 }", None),
         ("let [a] = [1]", Some(serde_json::json!([]))),
@@ -520,9 +523,9 @@ fn test() {
             "let { name, ...otherStuff } = obj; otherStuff = {};",
             Some(serde_json::json!([{ "destructuring": "any" }])),
         ), // { "parser": require(fixtureParser("babel-eslint5/destructuring-object-spread"), ), },
-        ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling (duplicate entry)
-        ("/*eslint custom/use-x:error*/ let x = 1", None), // { "parserOptions": { "ecmaFeatures": { "globalReturn": true } }, },
-        ("/*eslint custom/use-x:error*/ { let x = 1 }", None),
+        ("let x; function foo() { bar(x); } x = 0;", None),
+        ("let x = 1", None), // { "parserOptions": { "ecmaFeatures": { "globalReturn": true } }, },
+        ("{ let x = 1 }", None),
         ("let { foo, bar } = baz;", None),
         ("const x = [1,2]; let [,y] = x;", None),
         ("const x = [1,2,3]; let [y,,z] = x;", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -1,0 +1,602 @@
+use oxc_ast::{AstKind, ast::VariableDeclarationKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::SymbolId;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_const_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{name}' is never reassigned"))
+        .with_help(format!("Use 'const' instead"))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename_all = "camelCase", default)]
+struct PreferConstConfig {
+    destructuring: Destructuring,
+    ignore_read_before_assign: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(untagged, rename_all = "kebab-case")]
+enum Destructuring {
+    #[default]
+    Any,
+    All,
+}
+
+impl Default for PreferConstConfig {
+    fn default() -> Self {
+        Self {
+            destructuring: Destructuring::Any,
+            ignore_read_before_assign: false,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct PreferConst(PreferConstConfig);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires `const` declarations for variables that are never reassigned after declared.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// If a variable is never reassigned, using the `const` declaration is better.
+    /// `const` declaration tells readers, "this variable is never reassigned," reducing cognitive load and improving maintainability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// let a = 3;
+    /// console.log(a);
+    ///
+    /// let b;
+    /// b = 0;
+    /// console.log(b);
+    ///
+    /// for (let i in [1,2,3]) {
+    ///   console.log(i);
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const a = 0;
+    ///
+    /// let a;
+    /// a = 0;
+    /// a = 1;
+    ///
+    /// let a;
+    /// if (true) {
+    ///   a = 0;
+    /// }
+    ///
+    /// for (const i in [1,2,3]) {
+    ///   console.log(i);
+    /// }
+    /// ```
+    PreferConst,
+    eslint,
+    style,
+    pending,
+    config = PreferConstConfig,
+);
+
+impl Rule for PreferConst {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(
+            value
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default(),
+        )
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclaration(decl) = node.kind() else {
+            return;
+        };
+
+        // Only check `let` declarations (not `var` or `const`)
+        if decl.kind != VariableDeclarationKind::Let {
+            return;
+        }
+
+        // Get parent to check if we're in a for-in or for-of loop initializer
+        let parent = ctx.nodes().parent_node(node.id());
+        let is_for_in_of_init =
+            matches!(parent.kind(), AstKind::ForInStatement(_) | AstKind::ForOfStatement(_));
+
+        // For regular for loops (for (let i = 0, j = 1; ...)), we need special handling
+        // If ANY variable in the declaration is reassigned, we can't fix the whole declaration
+        let is_for_statement_init = matches!(parent.kind(), AstKind::ForStatement(_));
+
+        if is_for_statement_init && decl.declarations.len() > 1 {
+            // Check if any declarator is reassigned
+            let any_reassigned = decl.declarations.iter().any(|declarator| {
+                let has_init = declarator.init.is_some();
+                declarator.id.get_binding_identifiers().iter().any(|ident| {
+                    let symbol_id = ident.symbol_id();
+                    !should_be_const(symbol_id, has_init, is_for_in_of_init, ctx)
+                })
+            });
+
+            // If any variable is reassigned, we can't convert any of them
+            if any_reassigned {
+                return;
+            }
+        }
+
+        for declarator in &decl.declarations {
+            // Check each binding identifier
+            for ident in declarator.id.get_binding_identifiers() {
+                let symbol_id = ident.symbol_id();
+                if should_be_const(symbol_id, declarator.init.is_some(), is_for_in_of_init, ctx) {
+                    ctx.diagnostic(prefer_const_diagnostic(ident.name.as_str(), ident.span));
+                }
+            }
+        }
+    }
+}
+
+/// Check if a variable should be declared as const
+fn should_be_const(
+    symbol_id: SymbolId,
+    has_init: bool,
+    is_for_in_of: bool,
+    ctx: &LintContext<'_>,
+) -> bool {
+    let symbol_table = ctx.scoping();
+
+    // Get all references to this symbol
+    let references = symbol_table.get_resolved_references(symbol_id);
+
+    // Count write references (assignments)
+    let write_count = references.filter(|r| r.is_write()).count();
+
+    // For for-in and for-of loops, the variable gets a new binding on each iteration
+    // If it's never reassigned in the loop body, it should be const
+    if is_for_in_of && write_count == 0 {
+        return true;
+    }
+
+    // If has initializer and no writes, it should be const
+    if has_init && write_count == 0 {
+        return true;
+    }
+
+    // For variables without initializers, we need more sophisticated checks
+    // to determine if they should be const. For now, be conservative and
+    // only flag if there are no writes at all (which shouldn't happen in practice)
+    // TODO: Implement proper scope analysis to handle cases like:
+    // - `let x; x = 0;` (should be const)
+    // - `let x; { x = 0; }` (should NOT be const - different scope)
+    // - `let x; if (foo) { x = 0; }` (should NOT be const - conditional)
+
+    false
+}
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var x = 0;", None),
+        ("let x;", None),
+        ("let x; { x = 0; } foo(x);", None),
+        ("let x = 0; x = 1;", None),
+        ("using resource = fn();", None), // {				"sourceType": "module",				"ecmaVersion": 2026,			},
+        ("await using resource = fn();", None), // {				"sourceType": "module",				"ecmaVersion": 2026,			},
+        ("const x = 0;", None),
+        ("for (let i = 0, end = 10; i < end; ++i) {}", None),
+        ("for (let i in [1,2,3]) { i = 0; }", None),
+        ("for (let x of [1,2,3]) { x = 0; }", None),
+        ("(function() { var x = 0; })();", None),
+        ("(function() { let x; })();", None),
+        ("(function() { let x; { x = 0; } foo(x); })();", None),
+        ("(function() { let x = 0; x = 1; })();", None),
+        ("(function() { const x = 0; })();", None),
+        ("(function() { for (let i = 0, end = 10; i < end; ++i) {} })();", None),
+        ("(function() { for (let i in [1,2,3]) { i = 0; } })();", None),
+        ("(function() { for (let x of [1,2,3]) { x = 0; } })();", None),
+        ("(function(x = 0) { })();", None),
+        ("let a; while (a = foo());", None),
+        ("let a; do {} while (a = foo());", None),
+        ("let a; for (; a = foo(); );", None),
+        ("let a; for (;; ++a);", None),
+        ("let a; for (const {b = ++a} in foo());", None),
+        ("let a; for (const {b = ++a} of foo());", None),
+        ("let a; for (const x of [1,2,3]) { if (a) {} a = foo(); }", None),
+        ("let a; for (const x of [1,2,3]) { a = a || foo(); bar(a); }", None),
+        ("let a; for (const x of [1,2,3]) { foo(++a); }", None),
+        ("let a; function foo() { if (a) {} a = bar(); }", None),
+        ("let a; function foo() { a = a || bar(); baz(a); }", None),
+        ("let a; function foo() { bar(++a); }", None),
+        (
+            "let id;
+			function foo() {
+			    if (typeof id !== 'undefined') {
+			        return;
+			    }
+			    id = setInterval(() => {}, 250);
+			}
+			foo();
+			",
+            None,
+        ),
+        // NOTE: Oxc does not support the `/*exported*/` directive
+        // ("/*exported a*/ let a; function init() { a = foo(); }", None),
+        // ("/*exported a*/ let a = 1", None),
+        ("let a; if (true) a = 0; foo(a);", None),
+        (
+            "
+			        (function (a) {
+			            let b;
+			            ({ a, b } = obj);
+			        })();
+			        ",
+            None,
+        ),
+        (
+            "
+			        (function (a) {
+			            let b;
+			            ([ a, b ] = obj);
+			        })();
+			        ",
+            None,
+        ),
+        ("var a; { var b; ({ a, b } = obj); }", None),
+        ("let a; { let b; ({ a, b } = obj); }", None),
+        ("var a; { var b; ([ a, b ] = obj); }", None),
+        ("let a; { let b; ([ a, b ] = obj); }", None),
+        ("let x; { x = 0; foo(x); }", None),
+        ("(function() { let x; { x = 0; foo(x); } })();", None),
+        ("let x; for (const a of [1,2,3]) { x = foo(); bar(x); }", None),
+        ("(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();", None),
+        ("let x; for (x of array) { x; }", None),
+        // ("let {a, b} = obj; b = 0;", Some(serde_json::json!([{ "destructuring": "all" }]))),
+        // ("let a, b; ({a, b} = obj); b++;", Some(serde_json::json!([{ "destructuring": "all" }]))),
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ), // { "ecmaVersion": 2018 },
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
+        ("let predicate; [typeNode.returnType, predicate] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [typeNode.returnType, ...predicate] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [typeNode.returnType,, predicate] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [typeNode.returnType=5, predicate] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [[typeNode.returnType=5], predicate] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [[typeNode.returnType, predicate]] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [typeNode.returnType, [predicate]] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, [typeNode.returnType, predicate]] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, {foo:typeNode.returnType, predicate}] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let predicate; [, {foo:typeNode.returnType, ...predicate}] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let a; const b = {}; ({ a, c: b.c } = func());", None), // { "ecmaVersion": 2018 },
+        // (
+        //     "let x; function foo() { bar(x); } x = 0;",
+        //     Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
+        // ),
+        ("const x = [1,2]; let y; [,y] = x; y = 0;", None),
+        ("const x = [1,2,3]; let y, z; [y,,z] = x; y = 0; z = 0;", None),
+        ("class C { static { let a = 1; a = 2; } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; a = 1; a = 2; } }", None), // { "ecmaVersion": 2022 },
+        ("let a; class C { static { a = 1; } }", None),     // { "ecmaVersion": 2022 },
+        ("class C { static { let a; if (foo) { a = 1; } } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a; if (foo) a = 1; } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a, b; if (foo) { ({ a, b } = foo); } } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a, b; if (foo) ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
+        // (
+        //     "class C { static { a; } } let a = 1; ",
+        //     Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 },
+        // (
+        //     "class C { static { () => a; let a = 1; } };",
+        //     Some(serde_json::json!([{ "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 }
+    ];
+
+    let fail = vec![
+        ("let x = 1; foo(x);", None),
+        ("for (let i in [1,2,3]) { foo(i); }", None),
+        ("for (let x of [1,2,3]) { foo(x); }", None),
+        ("let [x = -1, y] = [1,2]; y = 0;", None),
+        ("let {a: x = -1, b: y} = {a:1,b:2}; y = 0;", None),
+        ("(function() { let x = 1; foo(x); })();", None),
+        ("(function() { for (let i in [1,2,3]) { foo(i); } })();", None),
+        ("(function() { for (let x of [1,2,3]) { foo(x); } })();", None),
+        ("(function() { let [x = -1, y] = [1,2]; y = 0; })();", None),
+        ("let f = (function() { let g = x; })(); f = 1;", None),
+        ("(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();", None),
+        ("let x = 0; { let x = 1; foo(x); } x = 0;", None),
+        ("for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }", None),
+        ("for (let i in [1,2,3]) { let x = 1; foo(x); }", None),
+        // TODO: These require sophisticated scope analysis for `let x; x = 0;` patterns
+        // (
+        //     "var foo = function() {
+        // 	    for (const b of c) {
+        // 	       let a;
+        // 	       a = 1;
+        // 	   }
+        // 	};",
+        //     None,
+        // ),
+        // (
+        //     "var foo = function() {
+        // 	    for (const b of c) {
+        // 	       let a;
+        // 	       ({a} = 1);
+        // 	   }
+        // 	};",
+        //     None,
+        // ),
+        // ("let x; x = 0;", None),
+        // ("switch (a) { case 0: let x; x = 0; }", None),
+        // ("(function() { let x; x = 1; })();", None),
+        // (
+        //     "let {a = 0, b} = obj; b = 0; foo(a, b);",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ),
+        // (
+        //     "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ),
+        // (
+        //     "let {a: {b, c}} = {a: {b: 1, c: 2}}",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ),
+        // (
+        //     "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ),
+        // ("let {a = 0, b} = obj; foo(a, b);", Some(serde_json::json!([{ "destructuring": "all" }]))),
+        ("let [a] = [1]", Some(serde_json::json!([]))),
+        ("let {a} = obj", Some(serde_json::json!([]))),
+        // (
+        //     "let a, b; ({a = 0, b} = obj); foo(a, b);",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ),
+        // (
+        //     "let {a = 0, b} = obj, c = a; b = a;",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ),
+        // (
+        //     "let {a = 0, b} = obj, c = a; b = a;",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ),
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ), // { "ecmaVersion": 2018 },
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
+        // ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling
+        ("/*eslint custom/use-x:error*/ let x = 1", None), // {				"parserOptions": { "ecmaFeatures": { "globalReturn": true } },			},
+        ("/*eslint custom/use-x:error*/ { let x = 1 }", None),
+        // ("let [a] = [1]", Some(serde_json::json!([]))),
+        // ("let {a} = obj", Some(serde_json::json!([]))),
+        // (
+        //     "let a, b; ({a = 0, b} = obj); foo(a, b);",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ),
+        // (
+        //     "let {a = 0, b} = obj, c = a; b = a;",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ),
+        // (
+        //     "let {a = 0, b} = obj, c = a; b = a;",
+        //     Some(serde_json::json!([{ "destructuring": "all" }])),
+        // ),
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ), // { "ecmaVersion": 2018 },
+        // (
+        //     "let { name, ...otherStuff } = obj; otherStuff = {};",
+        //     Some(serde_json::json!([{ "destructuring": "any" }])),
+        // ), // {				"parser": require(					fixtureParser("babel-eslint5/destructuring-object-spread"),				),			},
+        // ("let x; function foo() { bar(x); } x = 0;", None),  // TODO: ignoreReadBeforeAssign handling (duplicate entry)
+        ("/*eslint custom/use-x:error*/ let x = 1", None), // {				"parserOptions": { "ecmaFeatures": { "globalReturn": true } },			},
+        ("/*eslint custom/use-x:error*/ { let x = 1 }", None),
+        ("let { foo, bar } = baz;", None),
+        ("const x = [1,2]; let [,y] = x;", None),
+        ("const x = [1,2,3]; let [y,,z] = x;", None),
+        // TODO: These require destructuring assignment analysis
+        // ("let predicate; [, {foo:returnType, predicate}] = foo();", None), // { "ecmaVersion": 2018 },
+        // ("let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();", None), // { "ecmaVersion": 2018 },
+        // ("let predicate; [, {foo:returnType, ...predicate} ] = foo();", None), // { "ecmaVersion": 2018 },
+        ("let x = 'x', y = 'y';", None),
+        ("let x = 'x', y = 'y'; x = 1", None),
+        ("let x = 1, y = 'y'; let z = 1;", None),
+        ("let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;", None),
+        ("let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }", None),
+        ("let someFunc = () => { let a = 1, b = 2; foo(a, b) }", None),
+        ("let {a, b} = c, d;", None),
+        ("let {a, b, c} = {}, e, f;", None),
+        (
+            "function a() {
+			let foo = 0,
+			  bar = 1;
+			foo = 1;
+			}
+			function b() {
+			let foo = 0,
+			  bar = 2;
+			foo = 2;
+			}",
+            None,
+        ),
+        ("/*oxlint unicorn/no-useless-undefined:error*/ let foo = undefined;", None),
+        ("let a = 1; class C { static { a; } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { a; } } let a = 1;", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a = 1; } }", None),    // { "ecmaVersion": 2022 },
+        ("class C { static { if (foo) { let a = 1; } } }", None), // { "ecmaVersion": 2022 },
+        ("class C { static { let a = 1; if (foo) { a; } } }", None), // { "ecmaVersion": 2022 },
+        // TODO: Requires scope analysis to determine if assignment is in same scope as declaration
+        // ("class C { static { if (foo) { let a; a = 1; } } }", None), // { "ecmaVersion": 2022 },
+        // ("class C { static { let a; a = 1; } }", None), // { "ecmaVersion": 2022 },
+        // TODO: Requires destructuring assignment analysis
+        // ("class C { static { let { a, b } = foo; } }", None), // { "ecmaVersion": 2022 },
+        // ("class C { static { let a, b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
+        // ("class C { static { let a; let b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
+        // ("class C { static { let a; a = 0; console.log(a); } }", None), // { "ecmaVersion": 2022 },
+        // (
+        //     "
+        // 	            let { itemId, list } = {},
+        // 	            obj = [],
+        // 	            total = 0;
+        // 	            total = 9;
+        // 	            console.log(itemId, list, obj, total);
+        // 	            ",
+        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 },
+        // (
+        //     "
+        // 	            let { itemId, list } = {},
+        // 	            obj = [];
+        // 	            console.log(itemId, list, obj);
+        // 	            ",
+        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 },
+        // (
+        //     "
+        // 	            let [ itemId, list ] = [],
+        // 	            total = 0;
+        // 	            total = 9;
+        // 	            console.log(itemId, list, total);
+        // 	            ",
+        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 },
+        // (
+        //     "
+        // 	            let [ itemId, list ] = [],
+        // 	            obj = [];
+        // 	            console.log(itemId, list, obj);
+        // 	            ",
+        //     Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
+        // ), // { "ecmaVersion": 2022 }
+    ];
+
+    // let fix = vec![
+    //     ("let x = 1; foo(x);", "const x = 1; foo(x);", None),
+    //     ("for (let i in [1,2,3]) { foo(i); }", "for (const i in [1,2,3]) { foo(i); }", None),
+    //     ("for (let x of [1,2,3]) { foo(x); }", "for (const x of [1,2,3]) { foo(x); }", None),
+    //     (
+    //         "(function() { let x = 1; foo(x); })();",
+    //         "(function() { const x = 1; foo(x); })();",
+    //         None,
+    //     ),
+    //     (
+    //         "(function() { for (let i in [1,2,3]) { foo(i); } })();",
+    //         "(function() { for (const i in [1,2,3]) { foo(i); } })();",
+    //         None,
+    //     ),
+    //     (
+    //         "(function() { for (let x of [1,2,3]) { foo(x); } })();",
+    //         "(function() { for (const x of [1,2,3]) { foo(x); } })();",
+    //         None,
+    //     ),
+    //     (
+    //         "let f = (function() { let g = x; })(); f = 1;",
+    //         "let f = (function() { const g = x; })(); f = 1;",
+    //         None,
+    //     ),
+    //     (
+    //         "let x = 0; { let x = 1; foo(x); } x = 0;",
+    //         "let x = 0; { const x = 1; foo(x); } x = 0;",
+    //         None,
+    //     ),
+    //     (
+    //         "for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
+    //         "for (let i = 0; i < 10; ++i) { const x = 1; foo(x); }",
+    //         None,
+    //     ),
+    //     (
+    //         "for (let i in [1,2,3]) { let x = 1; foo(x); }",
+    //         "for (const i in [1,2,3]) { const x = 1; foo(x); }",
+    //         None,
+    //     ),
+    //     (
+    //         "let {a: {b, c}} = {a: {b: 1, c: 2}}",
+    //         "const {a: {b, c}} = {a: {b: 1, c: 2}}",
+    //         Some(serde_json::json!([{ "destructuring": "all" }])),
+    //     ),
+    //     (
+    //         "let {a = 0, b} = obj; foo(a, b);",
+    //         "const {a = 0, b} = obj; foo(a, b);",
+    //         Some(serde_json::json!([{ "destructuring": "all" }])),
+    //     ),
+    //     ("let [a] = [1]", "const [a] = [1]", Some(serde_json::json!([]))),
+    //     ("let {a} = obj", "const {a} = obj", Some(serde_json::json!([]))),
+    //     (
+    //         "/*eslint custom/use-x:error*/ let x = 1",
+    //         "/*eslint custom/use-x:error*/ const x = 1",
+    //         None,
+    //     ),
+    //     (
+    //         "/*eslint custom/use-x:error*/ { let x = 1 }",
+    //         "/*eslint custom/use-x:error*/ { const x = 1 }",
+    //         None,
+    //     ),
+    //     ("let { foo, bar } = baz;", "const { foo, bar } = baz;", None),
+    //     ("const x = [1,2]; let [,y] = x;", "const x = [1,2]; const [,y] = x;", None),
+    //     ("const x = [1,2,3]; let [y,,z] = x;", "const x = [1,2,3]; const [y,,z] = x;", None),
+    //     ("let x = 'x', y = 'y';", "const x = 'x', y = 'y';", None),
+    //     ("let x = 1, y = 'y'; let z = 1;", "const x = 1, y = 'y'; const z = 1;", None),
+    //     (
+    //         "let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;",
+    //         "const { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;",
+    //         None,
+    //     ),
+    //     (
+    //         "let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }",
+    //         "const x = 'x', y = 'y'; function someFunc() { const a = 1, b = 2; foo(a, b) }",
+    //         None,
+    //     ),
+    //     (
+    //         "let someFunc = () => { let a = 1, b = 2; foo(a, b) }",
+    //         "const someFunc = () => { let a = 1, b = 2; foo(a, b) }",
+    //         None,
+    //     ),
+    //     (
+    //         "/*eslint no-undef-init:error*/ let foo = undefined;",
+    //         "/*eslint no-undef-init:error*/ const foo = undefined;",
+    //         None,
+    //     ),
+    //     ("let a = 1; class C { static { a; } }", "const a = 1; class C { static { a; } }", None),
+    //     ("class C { static { a; } } let a = 1;", "class C { static { a; } } const a = 1;", None),
+    //     ("class C { static { let a = 1; } }", "class C { static { const a = 1; } }", None),
+    //     (
+    //         "class C { static { if (foo) { let a = 1; } } }",
+    //         "class C { static { if (foo) { const a = 1; } } }",
+    //         None,
+    //     ),
+    //     (
+    //         "class C { static { let a = 1; if (foo) { a; } } }",
+    //         "class C { static { const a = 1; if (foo) { a; } } }",
+    //         None,
+    //     ),
+    //     (
+    //         "class C { static { let { a, b } = foo; } }",
+    //         "class C { static { const { a, b } = foo; } }",
+    //         None,
+    //     ),
+    // ];
+    Tester::new(PreferConst::NAME, PreferConst::PLUGIN, pass, fail)
+        // .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/prefer_const.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_const.rs
@@ -915,38 +915,30 @@ fn test() {
         ("class C { static { let a; let b; ({ a, b } = foo); } }", None), // { "ecmaVersion": 2022 },
         ("class C { static { let a; a = 0; console.log(a); } }", None), // { "ecmaVersion": 2022 },
         (
-            "
-        	            let { itemId, list } = {},
-        	            obj = [],
-        	            total = 0;
-        	            total = 9;
-        	            console.log(itemId, list, obj, total);
-        	            ",
+            "let { itemId, list } = {},
+             obj = [],
+             total = 0;
+             total = 9;
+             console.log(itemId, list, obj, total);",
             Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 },
         (
-            "
-        	            let { itemId, list } = {},
-        	            obj = [];
-        	            console.log(itemId, list, obj);
-        	            ",
+            "let { itemId, list } = {},
+             obj = [];
+             console.log(itemId, list, obj);",
             Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 },
         (
-            "
-        	            let [ itemId, list ] = [],
-        	            total = 0;
-        	            total = 9;
-        	            console.log(itemId, list, total);
-        	            ",
+            "let [ itemId, list ] = [],
+             total = 0;
+             total = 9;
+             console.log(itemId, list, total);",
             Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 },
         (
-            "
-        	            let [ itemId, list ] = [],
-        	            obj = [];
-        	            console.log(itemId, list, obj);
-        	            ",
+            "let [ itemId, list ] = [],
+             obj = [];
+             console.log(itemId, list, obj);",
             Some(serde_json::json!([{ "destructuring": "any", "ignoreReadBeforeAssign": true }])),
         ), // { "ecmaVersion": 2022 }
         (

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -108,6 +108,20 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(prefer-const): 'a' is never reassigned
    ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a = 0, b} = obj; foo(a, b);
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:13]
+ 1 │ let {a = 0, b} = obj; foo(a, b);
+   ·             ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
  1 │ let [a] = [1]
    ·      ─
    ╰────
@@ -117,6 +131,20 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a} = obj
    ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:8]
+ 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
+   ·        ─
    ╰────
   help: Use 'const' instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -1,816 +1,816 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 1; foo(x);
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'i' is never reassigned
+  ⚠ eslint(prefer-const): `i` is never reassigned.
    ╭─[prefer_const.tsx:1:10]
  1 │ for (let i in [1,2,3]) { foo(i); }
    ·          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:10]
  1 │ for (let x of [1,2,3]) { foo(x); }
    ·          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let [x = -1, y] = [1,2]; y = 0;
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'foo' is never reassigned
+  ⚠ eslint(prefer-const): `foo` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let foo = 'bar'; /* foo = 'baz'; */
    ·     ───
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'foo' is never reassigned
+  ⚠ eslint(prefer-const): `foo` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let foo = 'bar'; // foo = 'baz';
    ·     ───
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:9]
  1 │ let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
    ·         ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:19]
  1 │ (function() { let x = 1; foo(x); })();
    ·                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'i' is never reassigned
+  ⚠ eslint(prefer-const): `i` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:20]
  1 │ (function() { let [x = -1, y] = [1,2]; y = 0; })();
    ·                    ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'g' is never reassigned
+  ⚠ eslint(prefer-const): `g` is never reassigned.
    ╭─[prefer_const.tsx:1:27]
  1 │ let f = (function() { let g = x; })(); f = 1;
    ·                           ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:23]
  1 │ (function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
    ·                       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:18]
  1 │ let x = 0; { let x = 1; foo(x); } x = 0;
    ·                  ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:36]
  1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
    ·                                    ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'i' is never reassigned
+  ⚠ eslint(prefer-const): `i` is never reassigned.
    ╭─[prefer_const.tsx:1:10]
  1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
    ·          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:30]
  1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
    ·                              ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:3:21]
  2 │                 for (const b of c) {
  3 │                    let a;
    ·                        ─
  4 │                    a = 1;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:3:21]
  2 │                 for (const b of c) {
  3 │                    let a;
    ·                        ─
  4 │                    ({a} = 1);
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x; x = 0;
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:26]
  1 │ switch (a) { case 0: let x; x = 0; }
    ·                          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:19]
  1 │ (function() { let x; x = 1; })();
    ·                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj; b = 0; foo(a, b);
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:13]
  1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
    ·             ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:10]
  1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
    ·          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:13]
  1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
    ·             ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj; foo(a, b);
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:13]
  1 │ let {a = 0, b} = obj; foo(a, b);
    ·             ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let [a] = [1]
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a} = obj
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:8]
  1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
    ·        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:23]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·                       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:23]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·                       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'name' is never reassigned
+  ⚠ eslint(prefer-const): `name` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { name, ...otherStuff } = obj; otherStuff = {};
    ·       ────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'name' is never reassigned
+  ⚠ eslint(prefer-const): `name` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { name, ...otherStuff } = obj; otherStuff = {};
    ·       ────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x; function foo() { bar(x); } x = 0;
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 1
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ { let x = 1 }
    ·       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let [a] = [1]
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a} = obj
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:8]
  1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
    ·        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:23]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·                       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:23]
  1 │ let {a = 0, b} = obj, c = a; b = a;
    ·                       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'name' is never reassigned
+  ⚠ eslint(prefer-const): `name` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { name, ...otherStuff } = obj; otherStuff = {};
    ·       ────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'name' is never reassigned
+  ⚠ eslint(prefer-const): `name` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { name, ...otherStuff } = obj; otherStuff = {};
    ·       ────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x; function foo() { bar(x); } x = 0;
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 1
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ { let x = 1 }
    ·       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'foo' is never reassigned
+  ⚠ eslint(prefer-const): `foo` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { foo, bar } = baz;
    ·       ───
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'bar' is never reassigned
+  ⚠ eslint(prefer-const): `bar` is never reassigned.
    ╭─[prefer_const.tsx:1:12]
  1 │ let { foo, bar } = baz;
    ·            ───
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ const x = [1,2]; let [,y] = x;
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:25]
  1 │ const x = [1,2,3]; let [y,,z] = x;
    ·                         ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'z' is never reassigned
+  ⚠ eslint(prefer-const): `z` is never reassigned.
    ╭─[prefer_const.tsx:1:28]
  1 │ const x = [1,2,3]; let [y,,z] = x;
    ·                            ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+  ⚠ eslint(prefer-const): `predicate` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let predicate; [, {foo:returnType, predicate}] = foo();
    ·     ─────────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+  ⚠ eslint(prefer-const): `predicate` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
    ·     ─────────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+  ⚠ eslint(prefer-const): `predicate` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let predicate; [, {foo:returnType, ...predicate} ] = foo();
    ·     ─────────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 'x', y = 'y';
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:14]
  1 │ let x = 'x', y = 'y';
    ·              ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:14]
  1 │ let x = 'x', y = 'y'; x = 1
    ·              ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 1, y = 'y'; let z = 1;
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:12]
  1 │ let x = 1, y = 'y'; let z = 1;
    ·            ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'z' is never reassigned
+  ⚠ eslint(prefer-const): `z` is never reassigned.
    ╭─[prefer_const.tsx:1:25]
  1 │ let x = 1, y = 'y'; let z = 1;
    ·                         ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
    ·       ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:10]
  1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
    ·          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:13]
  1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
    ·             ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:32]
  1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
    ·                                ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'z' is never reassigned
+  ⚠ eslint(prefer-const): `z` is never reassigned.
    ╭─[prefer_const.tsx:1:35]
  1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
    ·                                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'y' is never reassigned
+  ⚠ eslint(prefer-const): `y` is never reassigned.
    ╭─[prefer_const.tsx:1:14]
  1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
    ·              ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:49]
  1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
    ·                                                 ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:56]
  1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
    ·                                                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'someFunc' is never reassigned
+  ⚠ eslint(prefer-const): `someFunc` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
    ·     ────────
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:28]
  1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
    ·                            ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:35]
  1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
    ·                                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a, b} = c, d;
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:9]
  1 │ let {a, b} = c, d;
    ·         ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a, b, c} = {}, e, f;
    ·      ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:9]
  1 │ let {a, b, c} = {}, e, f;
    ·         ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'c' is never reassigned
+  ⚠ eslint(prefer-const): `c` is never reassigned.
    ╭─[prefer_const.tsx:1:12]
  1 │ let {a, b, c} = {}, e, f;
    ·            ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'bar' is never reassigned
+  ⚠ eslint(prefer-const): `bar` is never reassigned.
    ╭─[prefer_const.tsx:3:6]
  2 │             let foo = 0,
  3 │               bar = 1;
    ·               ───
  4 │             foo = 1;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'bar' is never reassigned
+  ⚠ eslint(prefer-const): `bar` is never reassigned.
    ╭─[prefer_const.tsx:8:6]
  7 │             let foo = 0,
  8 │               bar = 2;
    ·               ───
  9 │             foo = 2;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'foo' is never reassigned
+  ⚠ eslint(prefer-const): `foo` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let foo = undefined;
    ·     ───
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
  1 │ let a = 1; class C { static { a; } }
    ·     ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:31]
  1 │ class C { static { a; } } let a = 1;
    ·                               ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a = 1; } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:35]
  1 │ class C { static { if (foo) { let a = 1; } } }
    ·                                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a = 1; if (foo) { a; } } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:35]
  1 │ class C { static { if (foo) { let a; a = 1; } } }
    ·                                   ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a; a = 1; } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:26]
  1 │ class C { static { let { a, b } = foo; } }
    ·                          ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:29]
  1 │ class C { static { let { a, b } = foo; } }
    ·                             ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a, b; ({ a, b } = foo); } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:27]
  1 │ class C { static { let a, b; ({ a, b } = foo); } }
    ·                           ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a; let b; ({ a, b } = foo); } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'b' is never reassigned
+  ⚠ eslint(prefer-const): `b` is never reassigned.
    ╭─[prefer_const.tsx:1:31]
  1 │ class C { static { let a; let b; ({ a, b } = foo); } }
    ·                               ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'a' is never reassigned
+  ⚠ eslint(prefer-const): `a` is never reassigned.
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a; a = 0; console.log(a); } }
    ·                        ─
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+  ⚠ eslint(prefer-const): `itemId` is never reassigned.
    ╭─[prefer_const.tsx:2:28]
  1 │ 
  2 │                         let { itemId, list } = {},
    ·                               ──────
  3 │                         obj = [],
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'list' is never reassigned
+  ⚠ eslint(prefer-const): `list` is never reassigned.
    ╭─[prefer_const.tsx:2:36]
  1 │ 
  2 │                         let { itemId, list } = {},
    ·                                       ────
  3 │                         obj = [],
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'obj' is never reassigned
+  ⚠ eslint(prefer-const): `obj` is never reassigned.
    ╭─[prefer_const.tsx:3:22]
  2 │                         let { itemId, list } = {},
  3 │                         obj = [],
    ·                         ───
  4 │                         total = 0;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+  ⚠ eslint(prefer-const): `itemId` is never reassigned.
    ╭─[prefer_const.tsx:2:28]
  1 │ 
  2 │                         let { itemId, list } = {},
    ·                               ──────
  3 │                         obj = [];
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'list' is never reassigned
+  ⚠ eslint(prefer-const): `list` is never reassigned.
    ╭─[prefer_const.tsx:2:36]
  1 │ 
  2 │                         let { itemId, list } = {},
    ·                                       ────
  3 │                         obj = [];
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'obj' is never reassigned
+  ⚠ eslint(prefer-const): `obj` is never reassigned.
    ╭─[prefer_const.tsx:3:22]
  2 │                         let { itemId, list } = {},
  3 │                         obj = [];
    ·                         ───
  4 │                         console.log(itemId, list, obj);
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+  ⚠ eslint(prefer-const): `itemId` is never reassigned.
    ╭─[prefer_const.tsx:2:28]
  1 │ 
  2 │                         let [ itemId, list ] = [],
    ·                               ──────
  3 │                         total = 0;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'list' is never reassigned
+  ⚠ eslint(prefer-const): `list` is never reassigned.
    ╭─[prefer_const.tsx:2:36]
  1 │ 
  2 │                         let [ itemId, list ] = [],
    ·                                       ────
  3 │                         total = 0;
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+  ⚠ eslint(prefer-const): `itemId` is never reassigned.
    ╭─[prefer_const.tsx:2:28]
  1 │ 
  2 │                         let [ itemId, list ] = [],
    ·                               ──────
  3 │                         obj = [];
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'list' is never reassigned
+  ⚠ eslint(prefer-const): `list` is never reassigned.
    ╭─[prefer_const.tsx:2:36]
  1 │ 
  2 │                         let [ itemId, list ] = [],
    ·                                       ────
  3 │                         obj = [];
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.
 
-  ⚠ eslint(prefer-const): 'obj' is never reassigned
+  ⚠ eslint(prefer-const): `obj` is never reassigned.
    ╭─[prefer_const.tsx:3:22]
  2 │                         let [ itemId, list ] = [],
  3 │                         obj = [];
    ·                         ───
  4 │                         console.log(itemId, list, obj);
    ╰────
-  help: Use 'const' instead
+  help: Use `const` instead.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -122,6 +122,41 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(prefer-const): 'a' is never reassigned
    ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a = 0, b} = obj; b = 0; foo(a, b);
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:13]
+ 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
+   ·             ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
+   ·          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:13]
+ 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
+   ·             ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj; foo(a, b);
    ·      ─
    ╰────
@@ -162,17 +197,129 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use 'const' instead
 
-  ⚠ eslint(prefer-const): 'x' is never reassigned
-   ╭─[prefer_const.tsx:1:35]
- 1 │ /*eslint custom/use-x:error*/ let x = 1
-   ·                                   ─
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:23]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·                       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:23]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·                       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'name' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
+   ·       ────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'name' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
+   ·       ────
    ╰────
   help: Use 'const' instead
 
   ⚠ eslint(prefer-const): 'x' is never reassigned
-   ╭─[prefer_const.tsx:1:37]
- 1 │ /*eslint custom/use-x:error*/ { let x = 1 }
-   ·                                     ─
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x; function foo() { bar(x); } x = 0;
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 1
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ { let x = 1 }
+   ·       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let [a] = [1]
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a} = obj
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:8]
+ 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
+   ·        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:23]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·                       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:23]
+ 1 │ let {a = 0, b} = obj, c = a; b = a;
+   ·                       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'name' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
+   ·       ────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'name' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
+   ·       ────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x; function foo() { bar(x); } x = 0;
+   ·     ─
    ╰────
   help: Use 'const' instead
 
@@ -222,6 +369,27 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_const.tsx:1:28]
  1 │ const x = [1,2,3]; let [y,,z] = x;
    ·                            ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let predicate; [, {foo:returnType, predicate}] = foo();
+   ·     ─────────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
+   ·     ─────────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'predicate' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let predicate; [, {foo:returnType, ...predicate} ] = foo();
+   ·     ─────────
    ╰────
   help: Use 'const' instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -132,6 +132,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Use 'const' instead
 
   ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:26]
+ 1 │ switch (a) { case 0: let x; x = 0; }
+   ·                          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
    ╭─[prefer_const.tsx:1:19]
  1 │ (function() { let x; x = 1; })();
    ·                   ─
@@ -629,6 +636,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_const.tsx:1:24]
  1 │ class C { static { let a = 1; if (foo) { a; } } }
    ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ class C { static { if (foo) { let a; a = 1; } } }
+   ·                                   ─
    ╰────
   help: Use 'const' instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -823,8 +823,24 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `x` is never reassigned.
+   ╭─[prefer_const.tsx:2:18]
+ 1 │ function square(n) { x * x }
+ 2 │              let x = 5;
+   ·                  ─
+ 3 │              console.log(square(4));
+   ╰────
+  help: Use `const` instead.
+
+  ⚠ eslint(prefer-const): `x` is never reassigned.
+   ╭─[prefer_const.tsx:1:32]
+ 1 │ function foo() { bar(x); } let x = 0;
+   ·                                ─
+   ╰────
+  help: Use `const` instead.
+
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:5]
- 1 │ let x; x = 0; function foo() { bar(x); }
+ 1 │ let x = 0; function foo() { bar(x); }
    ·     ─
    ╰────
   help: Use `const` instead.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -106,6 +106,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use 'const' instead
 
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x; x = 0;
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:19]
+ 1 │ (function() { let x; x = 1; })();
+   ·                   ─
+   ╰────
+  help: Use 'const' instead
+
   ⚠ eslint(prefer-const): 'a' is never reassigned
    ╭─[prefer_const.tsx:1:6]
  1 │ let {a = 0, b} = obj; foo(a, b);

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -324,16 +324,16 @@ source: crates/oxc_linter/src/tester.rs
   help: Use 'const' instead
 
   ⚠ eslint(prefer-const): 'x' is never reassigned
-   ╭─[prefer_const.tsx:1:35]
- 1 │ /*eslint custom/use-x:error*/ let x = 1
-   ·                                   ─
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 1
+   ·     ─
    ╰────
   help: Use 'const' instead
 
   ⚠ eslint(prefer-const): 'x' is never reassigned
-   ╭─[prefer_const.tsx:1:37]
- 1 │ /*eslint custom/use-x:error*/ { let x = 1 }
-   ·                                     ─
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ { let x = 1 }
+   ·       ─
    ╰────
   help: Use 'const' instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -613,3 +613,158 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─
    ╰────
   help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a; a = 1; } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:26]
+ 1 │ class C { static { let { a, b } = foo; } }
+   ·                          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:29]
+ 1 │ class C { static { let { a, b } = foo; } }
+   ·                             ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a, b; ({ a, b } = foo); } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:27]
+ 1 │ class C { static { let a, b; ({ a, b } = foo); } }
+   ·                           ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:31]
+ 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
+   ·                               ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a; a = 0; console.log(a); } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+   ╭─[prefer_const.tsx:2:28]
+ 1 │ 
+ 2 │                         let { itemId, list } = {},
+   ·                               ──────
+ 3 │                         obj = [],
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'list' is never reassigned
+   ╭─[prefer_const.tsx:2:36]
+ 1 │ 
+ 2 │                         let { itemId, list } = {},
+   ·                                       ────
+ 3 │                         obj = [],
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'obj' is never reassigned
+   ╭─[prefer_const.tsx:3:22]
+ 2 │                         let { itemId, list } = {},
+ 3 │                         obj = [],
+   ·                         ───
+ 4 │                         total = 0;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+   ╭─[prefer_const.tsx:2:28]
+ 1 │ 
+ 2 │                         let { itemId, list } = {},
+   ·                               ──────
+ 3 │                         obj = [];
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'list' is never reassigned
+   ╭─[prefer_const.tsx:2:36]
+ 1 │ 
+ 2 │                         let { itemId, list } = {},
+   ·                                       ────
+ 3 │                         obj = [];
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'obj' is never reassigned
+   ╭─[prefer_const.tsx:3:22]
+ 2 │                         let { itemId, list } = {},
+ 3 │                         obj = [];
+   ·                         ───
+ 4 │                         console.log(itemId, list, obj);
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+   ╭─[prefer_const.tsx:2:28]
+ 1 │ 
+ 2 │                         let [ itemId, list ] = [],
+   ·                               ──────
+ 3 │                         total = 0;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'list' is never reassigned
+   ╭─[prefer_const.tsx:2:36]
+ 1 │ 
+ 2 │                         let [ itemId, list ] = [],
+   ·                                       ────
+ 3 │                         total = 0;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'itemId' is never reassigned
+   ╭─[prefer_const.tsx:2:28]
+ 1 │ 
+ 2 │                         let [ itemId, list ] = [],
+   ·                               ──────
+ 3 │                         obj = [];
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'list' is never reassigned
+   ╭─[prefer_const.tsx:2:36]
+ 1 │ 
+ 2 │                         let [ itemId, list ] = [],
+   ·                                       ────
+ 3 │                         obj = [];
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'obj' is never reassigned
+   ╭─[prefer_const.tsx:3:22]
+ 2 │                         let [ itemId, list ] = [],
+ 3 │                         obj = [];
+   ·                         ───
+ 4 │                         console.log(itemId, list, obj);
+   ╰────
+  help: Use 'const' instead

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -724,101 +724,93 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `itemId` is never reassigned.
-   ╭─[prefer_const.tsx:2:28]
- 1 │ 
- 2 │                         let { itemId, list } = {},
-   ·                               ──────
- 3 │                         obj = [],
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { itemId, list } = {},
+   ·       ──────
+ 2 │              obj = [],
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `list` is never reassigned.
-   ╭─[prefer_const.tsx:2:36]
- 1 │ 
- 2 │                         let { itemId, list } = {},
-   ·                                       ────
- 3 │                         obj = [],
+   ╭─[prefer_const.tsx:1:15]
+ 1 │ let { itemId, list } = {},
+   ·               ────
+ 2 │              obj = [],
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `obj` is never reassigned.
-   ╭─[prefer_const.tsx:3:22]
- 2 │                         let { itemId, list } = {},
- 3 │                         obj = [],
-   ·                         ───
- 4 │                         total = 0;
+   ╭─[prefer_const.tsx:2:14]
+ 1 │ let { itemId, list } = {},
+ 2 │              obj = [],
+   ·              ───
+ 3 │              total = 0;
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `itemId` is never reassigned.
-   ╭─[prefer_const.tsx:2:28]
- 1 │ 
- 2 │                         let { itemId, list } = {},
-   ·                               ──────
- 3 │                         obj = [];
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { itemId, list } = {},
+   ·       ──────
+ 2 │              obj = [];
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `list` is never reassigned.
-   ╭─[prefer_const.tsx:2:36]
- 1 │ 
- 2 │                         let { itemId, list } = {},
-   ·                                       ────
- 3 │                         obj = [];
+   ╭─[prefer_const.tsx:1:15]
+ 1 │ let { itemId, list } = {},
+   ·               ────
+ 2 │              obj = [];
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `obj` is never reassigned.
-   ╭─[prefer_const.tsx:3:22]
- 2 │                         let { itemId, list } = {},
- 3 │                         obj = [];
-   ·                         ───
- 4 │                         console.log(itemId, list, obj);
+   ╭─[prefer_const.tsx:2:14]
+ 1 │ let { itemId, list } = {},
+ 2 │              obj = [];
+   ·              ───
+ 3 │              console.log(itemId, list, obj);
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `itemId` is never reassigned.
-   ╭─[prefer_const.tsx:2:28]
- 1 │ 
- 2 │                         let [ itemId, list ] = [],
-   ·                               ──────
- 3 │                         total = 0;
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let [ itemId, list ] = [],
+   ·       ──────
+ 2 │              total = 0;
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `list` is never reassigned.
-   ╭─[prefer_const.tsx:2:36]
- 1 │ 
- 2 │                         let [ itemId, list ] = [],
-   ·                                       ────
- 3 │                         total = 0;
+   ╭─[prefer_const.tsx:1:15]
+ 1 │ let [ itemId, list ] = [],
+   ·               ────
+ 2 │              total = 0;
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `itemId` is never reassigned.
-   ╭─[prefer_const.tsx:2:28]
- 1 │ 
- 2 │                         let [ itemId, list ] = [],
-   ·                               ──────
- 3 │                         obj = [];
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let [ itemId, list ] = [],
+   ·       ──────
+ 2 │              obj = [];
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `list` is never reassigned.
-   ╭─[prefer_const.tsx:2:36]
- 1 │ 
- 2 │                         let [ itemId, list ] = [],
-   ·                                       ────
- 3 │                         obj = [];
+   ╭─[prefer_const.tsx:1:15]
+ 1 │ let [ itemId, list ] = [],
+   ·               ────
+ 2 │              obj = [];
    ╰────
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `obj` is never reassigned.
-   ╭─[prefer_const.tsx:3:22]
- 2 │                         let [ itemId, list ] = [],
- 3 │                         obj = [];
-   ·                         ───
- 4 │                         console.log(itemId, list, obj);
+   ╭─[prefer_const.tsx:2:14]
+ 1 │ let [ itemId, list ] = [],
+ 2 │              obj = [];
+   ·              ───
+ 3 │              console.log(itemId, list, obj);
    ╰────
   help: Use `const` instead.
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -106,6 +106,24 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use 'const' instead
 
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:3:21]
+ 2 │                 for (const b of c) {
+ 3 │                    let a;
+   ·                        ─
+ 4 │                    a = 1;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:3:21]
+ 2 │                 for (const b of c) {
+ 3 │                    let a;
+   ·                        ─
+ 4 │                    ({a} = 1);
+   ╰────
+  help: Use 'const' instead
+
   ⚠ eslint(prefer-const): 'x' is never reassigned
    ╭─[prefer_const.tsx:1:5]
  1 │ let x; x = 0;

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -29,6 +29,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use 'const' instead
 
+  ⚠ eslint(prefer-const): 'foo' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let foo = 'bar'; /* foo = 'baz'; */
+   ·     ───
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'foo' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let foo = 'bar'; // foo = 'baz';
+   ·     ───
+   ╰────
+  help: Use 'const' instead
+
   ⚠ eslint(prefer-const): 'x' is never reassigned
    ╭─[prefer_const.tsx:1:9]
  1 │ let {a: x = -1, b: y} = {a:1,b:2}; y = 0;

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -598,9 +598,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Use 'const' instead
 
   ⚠ eslint(prefer-const): 'foo' is never reassigned
-   ╭─[prefer_const.tsx:1:51]
- 1 │ /*oxlint unicorn/no-useless-undefined:error*/ let foo = undefined;
-   ·                                                   ───
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let foo = undefined;
+   ·     ───
    ╰────
   help: Use 'const' instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -1,0 +1,405 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 1; foo(x);
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'i' is never reassigned
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ for (let i in [1,2,3]) { foo(i); }
+   ·          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ for (let x of [1,2,3]) { foo(x); }
+   ·          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let [x = -1, y] = [1,2]; y = 0;
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:9]
+ 1 │ let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
+   ·         ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:19]
+ 1 │ (function() { let x = 1; foo(x); })();
+   ·                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'i' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:20]
+ 1 │ (function() { let [x = -1, y] = [1,2]; y = 0; })();
+   ·                    ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'g' is never reassigned
+   ╭─[prefer_const.tsx:1:27]
+ 1 │ let f = (function() { let g = x; })(); f = 1;
+   ·                           ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:23]
+ 1 │ (function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
+   ·                       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:18]
+ 1 │ let x = 0; { let x = 1; foo(x); } x = 0;
+   ·                  ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:36]
+ 1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
+   ·                                    ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'i' is never reassigned
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
+   ·          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:30]
+ 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
+   ·                              ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let [a] = [1]
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a} = obj
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ /*eslint custom/use-x:error*/ let x = 1
+   ·                                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:37]
+ 1 │ /*eslint custom/use-x:error*/ { let x = 1 }
+   ·                                     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ /*eslint custom/use-x:error*/ let x = 1
+   ·                                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:37]
+ 1 │ /*eslint custom/use-x:error*/ { let x = 1 }
+   ·                                     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'foo' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { foo, bar } = baz;
+   ·       ───
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'bar' is never reassigned
+   ╭─[prefer_const.tsx:1:12]
+ 1 │ let { foo, bar } = baz;
+   ·            ───
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ const x = [1,2]; let [,y] = x;
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:25]
+ 1 │ const x = [1,2,3]; let [y,,z] = x;
+   ·                         ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'z' is never reassigned
+   ╭─[prefer_const.tsx:1:28]
+ 1 │ const x = [1,2,3]; let [y,,z] = x;
+   ·                            ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 'x', y = 'y';
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:14]
+ 1 │ let x = 'x', y = 'y';
+   ·              ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:14]
+ 1 │ let x = 'x', y = 'y'; x = 1
+   ·              ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 1, y = 'y'; let z = 1;
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:12]
+ 1 │ let x = 1, y = 'y'; let z = 1;
+   ·            ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'z' is never reassigned
+   ╭─[prefer_const.tsx:1:25]
+ 1 │ let x = 1, y = 'y'; let z = 1;
+   ·                         ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:7]
+ 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
+   ·       ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
+   ·          ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:13]
+ 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
+   ·             ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:32]
+ 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
+   ·                                ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'z' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
+   ·                                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'x' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'y' is never reassigned
+   ╭─[prefer_const.tsx:1:14]
+ 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
+   ·              ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:49]
+ 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
+   ·                                                 ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:56]
+ 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
+   ·                                                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'someFunc' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
+   ·     ────────
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:28]
+ 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
+   ·                            ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
+   ·                                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a, b} = c, d;
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:9]
+ 1 │ let {a, b} = c, d;
+   ·         ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:6]
+ 1 │ let {a, b, c} = {}, e, f;
+   ·      ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'b' is never reassigned
+   ╭─[prefer_const.tsx:1:9]
+ 1 │ let {a, b, c} = {}, e, f;
+   ·         ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'c' is never reassigned
+   ╭─[prefer_const.tsx:1:12]
+ 1 │ let {a, b, c} = {}, e, f;
+   ·            ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'bar' is never reassigned
+   ╭─[prefer_const.tsx:3:6]
+ 2 │             let foo = 0,
+ 3 │               bar = 1;
+   ·               ───
+ 4 │             foo = 1;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'bar' is never reassigned
+   ╭─[prefer_const.tsx:8:6]
+ 7 │             let foo = 0,
+ 8 │               bar = 2;
+   ·               ───
+ 9 │             foo = 2;
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'foo' is never reassigned
+   ╭─[prefer_const.tsx:1:51]
+ 1 │ /*oxlint unicorn/no-useless-undefined:error*/ let foo = undefined;
+   ·                                                   ───
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let a = 1; class C { static { a; } }
+   ·     ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:31]
+ 1 │ class C { static { a; } } let a = 1;
+   ·                               ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a = 1; } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:35]
+ 1 │ class C { static { if (foo) { let a = 1; } } }
+   ·                                   ─
+   ╰────
+  help: Use 'const' instead
+
+  ⚠ eslint(prefer-const): 'a' is never reassigned
+   ╭─[prefer_const.tsx:1:24]
+ 1 │ class C { static { let a = 1; if (foo) { a; } } }
+   ·                        ─
+   ╰────
+  help: Use 'const' instead

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -370,6 +370,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `const` instead.
 
   ⚠ eslint(prefer-const): `x` is never reassigned.
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x: string; x = 'hello'; console.log(x);
+   ·     ─────────
+   ╰────
+  help: Use `const` instead.
+
+  ⚠ eslint(prefer-const): `x` is never reassigned.
    ╭─[prefer_const.tsx:1:7]
  1 │ { let x = 1 }
    ·       ─
@@ -812,5 +819,13 @@ source: crates/oxc_linter/src/tester.rs
  3 │                         obj = [];
    ·                         ───
  4 │                         console.log(itemId, list, obj);
+   ╰────
+  help: Use `const` instead.
+
+  ⚠ eslint(prefer-const): `seen` is never reassigned.
+   ╭─[prefer_const.tsx:1:10]
+ 1 │ for (let seen = new Set(); Math.random() < 0.5;) {
+   ·          ────
+ 2 │                seen.add('foo');
    ╰────
   help: Use `const` instead.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_const.snap
@@ -821,3 +821,10 @@ source: crates/oxc_linter/src/tester.rs
  2 │                seen.add('foo');
    ╰────
   help: Use `const` instead.
+
+  ⚠ eslint(prefer-const): `x` is never reassigned.
+   ╭─[prefer_const.tsx:1:5]
+ 1 │ let x; x = 0; function foo() { bar(x); }
+   ·     ─
+   ╰────
+  help: Use `const` instead.


### PR DESCRIPTION
Taking a stab at implementing prefer-const, but I could probably use someone else's help to finish this up.

This was primarily implemented on a whim a few weeks ago, using GitHub Copilot and Claude Sonnet 4.5. I've gotten all the tests passing, so I think this is ready for review. Unfortunately as a Rust noob I have little ability to tell whether this code is following best practices (it almost certainly isn't, it feels a bit janky even as someone unfamiliar with Rust). I've done some refactoring based on code smells I've noticed, but it's still pretty smelly.

I did test it on the mastodon repo as well to ensure it detects problematic code correctly, and it gets identical results to what the eslint rule reports: https://github.com/oxc-project/oxc/pull/15707#issuecomment-3537083686

Fixes #12645.
