### PR TITLE
chore(linter): Reword LSP fix message to distinguish from other option.

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -300,7 +300,7 @@ fn disable_for_this_section(
     let position = offset_to_position(rope, insert_offset, source_text);
 
     FixedContent {
-        message: Some(format!("Disable {rule_name} for this file")),
+        message: Some(format!("Disable {rule_name} for this whole file")),
         code: content,
         range: Range::new(position, position),
     }

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro@debugger.astro.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro@debugger.astro.snap
@@ -85,7 +85,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -136,7 +136,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -187,7 +187,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -238,7 +238,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@debugger.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@debugger.ts.snap
@@ -52,7 +52,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
@@ -35,7 +35,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-cycle for this file
+Title: Disable no-cycle for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
@@ -35,7 +35,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-cycle for this file
+Title: Disable no-cycle for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -42,7 +42,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-cycle for this file
+Title: Disable no-cycle for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
@@ -35,7 +35,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-console for this file
+Title: Disable no-console for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -56,7 +56,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -60,7 +60,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-extra-boolean-cast for this file
+Title: Disable no-extra-boolean-cast for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -94,7 +94,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-non-null-asserted-optional-chain for this file
+Title: Disable no-non-null-asserted-optional-chain for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_js_plugins@index.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_js_plugins@index.js.snap
@@ -52,7 +52,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
@@ -69,7 +69,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable forward-ref-uses-ref for this file
+Title: Disable forward-ref-uses-ref for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature@index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature@index.ts.snap
@@ -46,7 +46,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-control-regex for this file
+Title: Disable no-control-regex for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -97,7 +97,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-useless-escape for this file
+Title: Disable no-useless-escape for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte@debugger.svelte.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte@debugger.svelte.snap
@@ -57,7 +57,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-unassigned-vars for this file
+Title: Disable no-unassigned-vars for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -91,7 +91,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-unassigned-vars for this file
+Title: Disable no-unassigned-vars for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -142,7 +142,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
@@ -35,7 +35,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-cycle for this file
+Title: Disable no-cycle for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
@@ -90,7 +90,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-unused-expressions for this file
+Title: Disable no-unused-expressions for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -158,7 +158,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -226,7 +226,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -294,7 +294,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -362,7 +362,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -396,7 +396,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
@@ -46,7 +46,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -80,7 +80,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this file
+Title: Disable no-floating-promises for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -79,7 +79,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-console for this file
+Title: Disable no-console for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -130,7 +130,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue@debugger.vue.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue@debugger.vue.snap
@@ -63,7 +63,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {
@@ -114,7 +114,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-debugger for this file
+Title: Disable no-debugger for this whole file
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/editors/vscode/tests/code_actions.spec.ts
+++ b/editors/vscode/tests/code_actions.spec.ts
@@ -70,7 +70,7 @@ suite('code actions', () => {
         },
         {
           isPreferred: false,
-          title: 'Disable no-debugger for this file',
+          title: 'Disable no-debugger for this whole file',
         },
       ],
     );


### PR DESCRIPTION
The `Disable rule-name for this line` and `Disable rule-name for this file` options look very similar at a glance, I think simply distinguishing the option for the whole file vs. the line is a bit better developer experience.

Currently it looks like this:
<img width="414" height="188" alt="Screenshot 2025-11-14 at 9 52 07 PM" src="https://github.com/user-attachments/assets/f4b15b13-1773-43f4-92f1-a5f9a1a4bf3c" />

Initially, I didn't notice the difference and thought it was a bug where I was getting an option from the ESLint extension and another from oxlint :)

I'm marking this as a chore, but I guess it's technically a fix... or something? :shrug: