### PR TITLE
fix(ast): include rest properties when using `get_binding_identifiers`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1321,14 +1321,24 @@ impl<'a> BindingPatternKind<'a> {
         match self {
             Self::BindingIdentifier(ident) => idents.push(ident),
             Self::AssignmentPattern(assign) => assign.left.kind.append_binding_identifiers(idents),
-            Self::ArrayPattern(pattern) => pattern
-                .elements
-                .iter()
-                .filter_map(|item| item.as_ref())
-                .for_each(|item| item.kind.append_binding_identifiers(idents)),
-            Self::ObjectPattern(pattern) => pattern.properties.iter().for_each(|item| {
-                item.value.kind.append_binding_identifiers(idents);
-            }),
+            Self::ArrayPattern(pattern) => {
+                pattern
+                    .elements
+                    .iter()
+                    .filter_map(|item| item.as_ref())
+                    .for_each(|item| item.kind.append_binding_identifiers(idents));
+                if let Some(rest) = &pattern.rest {
+                    rest.argument.kind.append_binding_identifiers(idents);
+                }
+            }
+            Self::ObjectPattern(pattern) => {
+                pattern.properties.iter().for_each(|item| {
+                    item.value.kind.append_binding_identifiers(idents);
+                });
+                if let Some(rest) = &pattern.rest {
+                    rest.argument.kind.append_binding_identifiers(idents);
+                }
+            }
         }
     }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -246,10 +246,8 @@ impl RuleRunner for crate::rules::eslint::no_console::NoConsole {
 }
 
 impl RuleRunner for crate::rules::eslint::no_const_assign::NoConstAssign {
-    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
-        AstType::BindingRestElement,
-        AstType::VariableDeclarator,
-    ]));
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclarator]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -58,11 +58,6 @@ impl Rule for NoConstAssign {
                     check_symbol_id(ident.symbol_id(), ctx);
                 }
             }
-            AstKind::BindingRestElement(rest) => {
-                for ident in rest.argument.get_binding_identifiers() {
-                    check_symbol_id(ident.symbol_id(), ctx);
-                }
-            }
             _ => {}
         }
     }

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -444,6 +444,8 @@ mod test {
         test("for (const x in y);", "for (let x in y);");
         // TypeError: Assignment to constant variable.
         test_same("for (const i = 0; i < 1; i++);");
+        test_same("{ const { a, ...b } = foo; b = 123; }");
+        test_same("{ const [a, ...b] = foo; b = 123; }");
         test_same("for (const x in [1, 2, 3]) x++");
         test_same("for (const x of [1, 2, 3]) x++");
         test("{ let foo; const bar = undefined; }", "{ let foo, bar; }");


### PR DESCRIPTION
previously, the rest param of an `ArrayPattern`​ inside a `BindingPattern` would never be visited, this meant it had to be manually visited inside the linter. It also meant that the minifier incorrectly transformed `{ const { a, ...b } = {}; b = {} }`​ to `{ let const { a, ...b } = {} }` which is a difference in runtime behvaiour (before is a `TypeError`​, after is not.

