### PR TITLE
feat(parser): improve error message for missing namespace/module names

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -482,6 +482,11 @@ pub fn identifier_expected(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn ts_identifier_expected(span: Span) -> OxcDiagnostic {
+    ts_error("1003", "Identifier expected.").with_label(span)
+}
+
+#[cold]
 pub fn identifier_reserved_word(span: Span, reserved: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!(
         "Identifier expected. '{reserved}' is a reserved word that cannot be used here."
@@ -569,6 +574,16 @@ pub fn ts_empty_type_parameter_list(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn ts_empty_type_argument_list(span: Span) -> OxcDiagnostic {
     ts_error("1099", "Type argument list cannot be empty.").with_label(span)
+}
+
+#[cold]
+pub fn ts_namespace_missing_name(span: Span) -> OxcDiagnostic {
+    ts_error("1437", "Namespace must be given a name.").with_label(span)
+}
+
+#[cold]
+pub fn ts_module_missing_name(span: Span) -> OxcDiagnostic {
+    ts_error("1437", "Module must be given a name.").with_label(span)
 }
 
 #[cold]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -357,13 +357,13 @@ Negative Passed: 118/118 (100.00%)
    ·                        ╰── `}` expected
    ╰────
 
-  × Unexpected token
+  × TS(1003): Identifier expected.
    ╭─[misc/fail/oxc-11592-1.ts:1:11]
  1 │ namespace "a" {}
    ·           ───
    ╰────
 
-  × Unexpected token
+  × TS(1003): Identifier expected.
    ╭─[misc/fail/oxc-11592-2.ts:1:11]
  1 │ namespace "a";
    ·           ───

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2871,13 +2871,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·          ──
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/anonymousModules.ts:1:7]
+  × TS(1437): Module must be given a name.
+   ╭─[typescript/tests/cases/compiler/anonymousModules.ts:1:8]
  1 │ module {
-   ·       ▲
+   ·        ─
  2 │     export var foo = 1;
    ╰────
-  help: Try inserting a semicolon here
 
   × Identifier `myFn` has already been declared
    ╭─[typescript/tests/cases/compiler/anyDeclare.ts:3:9]
@@ -6392,13 +6391,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  17 │         public pe:string;
     ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/externModule.ts:1:8]
+  × TS(1437): Module must be given a name.
+   ╭─[typescript/tests/cases/compiler/externModule.ts:1:16]
  1 │ declare module {
-   ·        ▲
+   ·                ─
  2 │     export class XDate {
    ╰────
-  help: Try inserting a semicolon here
 
   × Expected `,` or `)` but found `=>`
    ╭─[typescript/tests/cases/compiler/fatarrowfunctionsErrors.ts:2:8]
@@ -6947,23 +6945,21 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │ }
    ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/innerModExport1.ts:5:11]
+  × TS(1437): Module must be given a name.
+   ╭─[typescript/tests/cases/compiler/innerModExport1.ts:5:12]
  4 │     var non_export_var: number;
  5 │     module {
-   ·           ▲
+   ·            ─
  6 │         var non_export_var = 0;
    ╰────
-  help: Try inserting a semicolon here
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[typescript/tests/cases/compiler/innerModExport2.ts:5:11]
+  × TS(1437): Module must be given a name.
+   ╭─[typescript/tests/cases/compiler/innerModExport2.ts:5:12]
  4 │     var non_export_var: number;
  5 │     module {
-   ·           ▲
+   ·            ─
  6 │         var non_export_var = 0;
    ╰────
-  help: Try inserting a semicolon here
 
   × TS(1099): Type argument list cannot be empty.
    ╭─[typescript/tests/cases/compiler/instantiateTypeParameter.ts:2:13]


### PR DESCRIPTION
**BEFORE:**
When parsing `declare namespace {` or `module {`, oxc reported:
```
  "Expected a semicolon or an implicit semicolon after a statement, but found none"
```
This was confusing because the actual issue is a missing name, not a semicolon.

**AFTER:**
Now reports TypeScript-compatible error TS(1437):
```
  "Namespace must be given a name."
  "Module must be given a name."
```