### PR TITLE
fix(parser): forbid invalid modifiers on `module` and `global`

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -334,6 +334,12 @@ impl<'a> ParserImpl<'a> {
             self.asi();
             None
         };
+        self.verify_modifiers(
+            modifiers,
+            ModifierFlags::DECLARE,
+            true,
+            diagnostics::modifier_cannot_be_used_here,
+        );
         self.ast.alloc_ts_module_declaration(
             self.end_span(span),
             id,
@@ -392,6 +398,13 @@ impl<'a> ParserImpl<'a> {
         let keyword_span = self.end_span(keyword_span_start);
 
         let body = self.parse_ts_module_block().unbox();
+
+        self.verify_modifiers(
+            modifiers,
+            ModifierFlags::DECLARE,
+            true,
+            diagnostics::modifier_cannot_be_used_here,
+        );
 
         self.ast.alloc_ts_global_declaration(
             self.end_span(span),

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -9671,6 +9671,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  327 │     namespace m2 {
      ╰────
 
+  × 'export' modifier cannot be used here.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:326:9]
+ 325 │ 
+ 326 │ declare export module "anotherParseError2" {
+     ·         ──────
+ 327 │     namespace m2 {
+     ╰────
+  help: Only 'declare' modifier is allowed here.
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/privateNameJsx.tsx:4:22]
  3 │     render() {


### PR DESCRIPTION
Error on invalid modifiers before `module` and `global` declarations.

Previously illegal syntax like this would be parsed without error:

```ts
protected accessor readonly async declare global {}
protected accessor readonly async global {}
protected accessor readonly async module "foo" {}
```

Discovered this bug while working on #15712.

Similar to #11713.
