### PR TITLE
feat(parser): improve error message when JSX is found while not enabled

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -101,6 +101,13 @@ pub fn merge_conflict_marker(
 }
 
 #[cold]
+pub fn jsx_in_non_jsx(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected JSX expression")
+        .with_label(span)
+        .with_help("JSX syntax is disabled and should be enabled via the parser options")
+}
+
+#[cold]
 pub fn expect_token(x0: &str, x1: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Expected `{x0}` but found `{x1}`"))
         .with_label(span.label(format!("`{x0}` expected")))

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1082,7 +1082,16 @@ impl<'a> ParserImpl<'a> {
                 if self.is_ts {
                     return self.parse_ts_type_assertion();
                 }
-                self.unexpected()
+
+                let checkpoint = self.checkpoint_with_error_recovery();
+                let start = self.start_span();
+                self.parse_jsx_expression();
+                if self.fatal_error.is_none() {
+                    self.fatal_error(diagnostics::jsx_in_non_jsx(self.end_span(start)))
+                } else {
+                    self.rewind(checkpoint);
+                    self.unexpected()
+                }
             }
             Kind::Await if self.is_await_expression() => self.parse_await_expression(lhs_span),
             _ => self.parse_update_expression(lhs_span),

--- a/tasks/coverage/misc/fail/jsx-in-js.js
+++ b/tasks/coverage/misc/fail/jsx-in-js.js
@@ -1,0 +1,1 @@
+export const foo = <Foo />;

--- a/tasks/coverage/misc/fail/jsx-like-in-js.js
+++ b/tasks/coverage/misc/fail/jsx-like-in-js.js
@@ -1,0 +1,1 @@
+export const foo = <Foo;

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12607,19 +12607,21 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·        ────
    ╰────
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/input.js:3:5]
  2 │   return (
  3 │     <>Hello</>
-   ·     ─
+   ·     ──────────
  4 │   );
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/input.js:1:1]
  1 │ <div>{name}</div>
-   · ─
+   · ─────────────────
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:1:1]
@@ -12627,18 +12629,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    · ─
    ╰────
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/input.js:1:1]
  1 │ <div></div>
-   · ─
+   · ───────────
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/input.js:1:1]
- 1 │ <
-   · ─
- 2 │   𠮷
+ 1 │ ╭─▶ <
+ 2 │ │     𠮷
+ 3 │ │   ></
+ 4 │ │     𠮷
+ 5 │ ╰─▶ >
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected token. Did you mean `{'>'}` or `&gt;`?
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/unclosed-jsx-element/input.js:1:10]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 108/108 (100.00%)
+Negative Passed: 110/110 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -178,6 +178,19 @@ Negative Passed: 108/108 (100.00%)
  3 │ const bar = 1;
    · ──┬──
    ·   ╰── `,` or `]` expected
+   ╰────
+
+  × Unexpected JSX expression
+   ╭─[misc/fail/jsx-in-js.js:1:20]
+ 1 │ export const foo = <Foo />;
+   ·                    ───────
+   ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
+
+  × Unexpected token
+   ╭─[misc/fail/jsx-like-in-js.js:1:20]
+ 1 │ export const foo = <Foo;
+   ·                    ─
    ╰────
 
   × Expected `:` but found `EOF`

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -9435,11 +9435,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·  ─
    ╰────
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash2.ts:1:2]
  1 │ ~<></> <
-   ·  ─
+   ·  ─────
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash3.ts:1:2]


### PR DESCRIPTION
Improved the error message when JSX syntax is found while not enabled.

The idea came from esbuild's error message ([esbuild try](https://esbuild.github.io/try/#dAAwLjI3LjAAAGV4cG9ydCBjb25zdCBmb28gPSA8Rm9vIC8+Ow)).

**Before**
```
  x Unexpected token
   ,-[:1:20]
 1 | export const foo = <Foo />;
   :                    ^
   `----
```

**After**
```
  × Unexpected JSX expression
   ╭─[misc/fail/jsx-in-js.js:1:20]
 1 │ export const foo = <Foo />;
   ·                    ───────
   ╰────
  help: JSX syntax is disabled and should be enabled via the parser options
```
