### PR TITLE
feat(parser): improve `import source` `from` error message

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -154,13 +154,12 @@ impl<'a> ParserImpl<'a> {
                     has_default_specifier = true;
                     should_parse_specifiers = false;
                 }
-            } else if self.at(Kind::From) {
+            } else {
+                self.expect_without_advance(Kind::From);
                 // `import source something from ...`
                 identifier_after_import = Some(identifier_after_source);
                 phase = Some(ImportPhase::Source);
                 has_default_specifier = true;
-            } else {
-                return self.unexpected();
             }
         }
 

--- a/tasks/coverage/misc/fail/import-source-non-from.js
+++ b/tasks/coverage/misc/fail/import-source-non-from.js
@@ -1,0 +1,1 @@
+import source foo bar from 'module';

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 110/110 (100.00%)
+Negative Passed: 111/111 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -178,6 +178,13 @@ Negative Passed: 110/110 (100.00%)
  3 │ const bar = 1;
    · ──┬──
    ·   ╰── `,` or `]` expected
+   ╰────
+
+  × Expected `from` but found `Identifier`
+   ╭─[misc/fail/import-source-non-from.js:1:19]
+ 1 │ import source foo bar from 'module';
+   ·                   ─┬─
+   ·                    ╰── `from` expected
    ╰────
 
   × Unexpected JSX expression


### PR DESCRIPTION
Improved error message for `import source` + something + `from`.

**Before**
```
  x Unexpected token
   ,-[:1:19]
 1 | import source foo bar from 'module';
   :                   ^^^
   `----
```

**After**
```
  × Expected `from` but found `Identifier`
   ╭─[misc/fail/import-source-non-from.js:1:19]
 1 │ import source foo bar from 'module';
   ·                   ─┬─
   ·                    ╰── `from` expected
   ╰────
```
