### PR TITLE
chore(linter): Add links pointing back to the oxlint-migrate codebase.

### DIFF
--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -31,8 +31,8 @@ pub use self::{
 };
 
 /// List of Jest rules that have Vitest equivalents.
-/// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
-/// See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
+// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
+// See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
 const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
     "consistent-test-it",
     "expect-expect",
@@ -72,8 +72,8 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
 ];
 
 /// List of Eslint rules that have TypeScript equivalents.
-/// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
-/// See https://github.com/oxc-project/oxlint-migrate/blob/659b461eaf5b2f8a7283822ae84a5e619c86fca3/src/constants.ts#L24
+// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
+// See https://github.com/oxc-project/oxlint-migrate/blob/659b461eaf5b2f8a7283822ae84a5e619c86fca3/src/constants.ts#L24
 const TYPESCRIPT_COMPATIBLE_ESLINT_RULES: [&str; 18] = [
     "class-methods-use-this",
     "default-param-last",

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -31,6 +31,8 @@ pub use self::{
 };
 
 /// List of Jest rules that have Vitest equivalents.
+/// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
+/// See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
 const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
     "consistent-test-it",
     "expect-expect",
@@ -69,7 +71,9 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
     "valid-expect",
 ];
 
-// List of Eslint rules that have Typescript equivalents.
+/// List of Eslint rules that have TypeScript equivalents.
+/// When adding a new rule to this list, please ensure oxlint-migrate is also updated.
+/// See https://github.com/oxc-project/oxlint-migrate/blob/659b461eaf5b2f8a7283822ae84a5e619c86fca3/src/constants.ts#L24
 const TYPESCRIPT_COMPATIBLE_ESLINT_RULES: [&str; 18] = [
     "class-methods-use-this",
     "default-param-last",


### PR DESCRIPTION
This will hopefully ensure we don't miss changes in the future for oxlint-migrate.