### PR TITLE
chore(linter): Update the file extensions allowed for detection as a jest file.

### DIFF
--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -93,9 +93,13 @@ pub fn is_jest_file(ctx: &LintContext) -> bool {
     }
 
     let file_path = ctx.file_path().to_string_lossy();
-    ["spec.js", "spec.jsx", "spec.ts", "spec.tsx", "test.js", "test.jsx", "test.ts", "test.tsx"]
-        .iter()
-        .any(|ext| file_path.ends_with(ext))
+    [
+        "spec.js", "spec.jsx", "spec.ts", "spec.tsx", "spec.mjs", "spec.cjs", "spec.mts",
+        "spec.cts", "test.js", "test.jsx", "test.ts", "test.tsx", "test.mjs", "test.cjs",
+        "test.mts", "test.cts",
+    ]
+    .iter()
+    .any(|ext| file_path.ends_with(ext))
 }
 
 pub fn is_type_of_jest_fn_call<'a>(


### PR DESCRIPTION
Jest 30 adds all of these: https://jestjs.io/docs/upgrading-to-jest30#support-for-mts-and-cts-file-extensions

This `is_jest_file` method is only used in the no-export rule, I'm unsure if it's really worth keeping around in general, but if it is we should keep it up-to-date.