### PR TITLE
fix(semantic): error on `\00` in strict mode

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -361,7 +361,7 @@ pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
             if c == '\\' {
                 match chars.next() {
                     Some('0') => {
-                        if chars.peek().is_some_and(|c| ('1'..='9').contains(c)) {
+                        if chars.peek().is_some_and(char::is_ascii_digit) {
                             return ctx.error(legacy_octal(lit.span));
                         }
                     }

--- a/tasks/coverage/misc/fail/escape-00.js
+++ b/tasks/coverage/misc/fail/escape-00.js
@@ -1,0 +1,1 @@
+export const escape00 = "\00";

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 49/49 (100.00%)
 Positive Passed: 49/49 (100.00%)
-Negative Passed: 112/112 (100.00%)
+Negative Passed: 113/113 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -71,6 +71,13 @@ Negative Passed: 112/112 (100.00%)
         If you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code.
         If you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased.
         If you have nested conflicts, resolve the outermost conflict first.
+
+  × '0'-prefixed octal literals and octal escape sequences are deprecated
+   ╭─[misc/fail/escape-00.js:1:25]
+ 1 │ export const escape00 = "\00";
+   ·                         ─────
+   ╰────
+  help: for octal literals use the '0o' prefix instead
 
   × Expected `,` or `]` but found `const`
    ╭─[misc/fail/imbalanced-array-expr.js:2:1]


### PR DESCRIPTION
`\00` matches LegacyOctalEscapeSequence and should be an error in strict mode.
https://tc39.es/ecma262/2025/multipage/ecmascript-language-lexical-grammar.html#sec-string-literals-early-errors