### PR TITLE
fix(parser): reject `import something 'source'`

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -178,6 +178,10 @@ impl<'a> ParserImpl<'a> {
                     None => unreachable!(),
                 }
             } else {
+                if has_default_specifier {
+                    // `import something 'source'`
+                    self.expect_without_advance(Kind::From);
+                }
                 None
             }
         } else {

--- a/tasks/coverage/misc/fail/import-defer-without-from.js
+++ b/tasks/coverage/misc/fail/import-defer-without-from.js
@@ -1,0 +1,1 @@
+import defer 'module';

--- a/tasks/coverage/misc/fail/import-from-str.js
+++ b/tasks/coverage/misc/fail/import-from-str.js
@@ -1,0 +1,1 @@
+import from 'module';

--- a/tasks/coverage/misc/fail/import-source-without-from.js
+++ b/tasks/coverage/misc/fail/import-source-without-from.js
@@ -1,0 +1,1 @@
+import source 'module';

--- a/tasks/coverage/misc/fail/import-type-without-from.ts
+++ b/tasks/coverage/misc/fail/import-type-without-from.ts
@@ -1,0 +1,1 @@
+import type 'module';

--- a/tasks/coverage/misc/fail/import-without-from.js
+++ b/tasks/coverage/misc/fail/import-without-from.js
@@ -1,0 +1,1 @@
+import unknown 'module';

--- a/tasks/coverage/misc/pass/import-from-from.js
+++ b/tasks/coverage/misc/pass/import-from-from.js
@@ -1,0 +1,1 @@
+import from from 'module';

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 49/49 (100.00%)
-Positive Passed: 49/49 (100.00%)
+AST Parsed     : 50/50 (100.00%)
+Positive Passed: 50/50 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 49/49 (100.00%)
-Positive Passed: 49/49 (100.00%)
+AST Parsed     : 50/50 (100.00%)
+Positive Passed: 50/50 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 49/49 (100.00%)
-Positive Passed: 49/49 (100.00%)
-Negative Passed: 113/113 (100.00%)
+AST Parsed     : 50/50 (100.00%)
+Positive Passed: 50/50 (100.00%)
+Negative Passed: 118/118 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -187,10 +187,45 @@ Negative Passed: 113/113 (100.00%)
    ·   ╰── `,` or `]` expected
    ╰────
 
+  × Expected `from` but found `string`
+   ╭─[misc/fail/import-defer-without-from.js:1:14]
+ 1 │ import defer 'module';
+   ·              ────┬───
+   ·                  ╰── `from` expected
+   ╰────
+
+  × Expected `from` but found `string`
+   ╭─[misc/fail/import-from-str.js:1:13]
+ 1 │ import from 'module';
+   ·             ────┬───
+   ·                 ╰── `from` expected
+   ╰────
+
   × Expected `from` but found `Identifier`
    ╭─[misc/fail/import-source-non-from.js:1:19]
  1 │ import source foo bar from 'module';
    ·                   ─┬─
+   ·                    ╰── `from` expected
+   ╰────
+
+  × Expected `from` but found `string`
+   ╭─[misc/fail/import-source-without-from.js:1:15]
+ 1 │ import source 'module';
+   ·               ────┬───
+   ·                   ╰── `from` expected
+   ╰────
+
+  × Expected `from` but found `string`
+   ╭─[misc/fail/import-type-without-from.ts:1:13]
+ 1 │ import type 'module';
+   ·             ────┬───
+   ·                 ╰── `from` expected
+   ╰────
+
+  × Expected `from` but found `string`
+   ╭─[misc/fail/import-without-from.js:1:16]
+ 1 │ import unknown 'module';
+   ·                ────┬───
    ·                    ╰── `from` expected
    ╰────
 

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 49/49 (100.00%)
-Positive Passed: 31/49 (63.27%)
+AST Parsed     : 50/50 (100.00%)
+Positive Passed: 32/50 (64.00%)
 semantic Error: tasks/coverage/misc/pass/oxc-11593.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 49/49 (100.00%)
-Positive Passed: 49/49 (100.00%)
+AST Parsed     : 50/50 (100.00%)
+Positive Passed: 50/50 (100.00%)


### PR DESCRIPTION
```js
import something 'source'
```
was not rejected but this should be rejected.
https://tc39.es/ecma262/2025/multipage/ecmascript-language-scripts-and-modules.html#prod-ImportDeclaration
