### PR TITLE
fix(linter): Improve docs, diagnostic message, and implementation of typescript/consistent-indexed-object-style rule.

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_consistent_indexed_object_style.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_indexed_object_style.snap
@@ -8,7 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -71,112 +71,112 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: string | Bar };
    ·              ───────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: boolean]: any };
    ·              ───────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { readonly [key: string]: any };
    ·              ───────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:22]
  1 │ type Foo = Generic<{ [key: boolean]: any }>;
    ·                      ───────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:22]
  1 │ type Foo = Generic<{ readonly [key: string]: any }>;
    ·                      ───────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:21]
  1 │ function foo(arg: { [key: string]: any }) {}
    ·                     ──────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(): { [key: string]: any } {}
    ·                   ──────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:21]
  1 │ function foo(arg: { readonly [key: string]: any }) {}
    ·                     ───────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(): { readonly [key: string]: any } {}
    ·                   ───────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): An index signature is preferred over a record.
    ╭─[consistent_indexed_object_style.tsx:1:12]
  1 │ type Foo = Record<string, any>;
    ·            ───────────────────
    ╰────
-  help: A index signature is preferred over an record.
+  help: Use an index signature like `{ [key: string]: unknown }` instead of a record type.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): An index signature is preferred over a record.
    ╭─[consistent_indexed_object_style.tsx:1:15]
  1 │ type Foo<T> = Record<string, T>;
    ·               ─────────────────
    ╰────
-  help: A index signature is preferred over an record.
+  help: Use an index signature like `{ [key: string]: unknown }` instead of a record type.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [k: string]: A.Foo };
    ·              ──────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: AnotherFoo };
    ·              ─────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: { [key: string]: Foo } };
    ·              ─────────────────────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: string } | Foo;
    ·              ─────────────────────
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -185,7 +185,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -194,7 +194,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
@@ -203,25 +203,25 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────
  4 │             }
    ╰────
-  help: A record is preferred over an index signature.
+  help: Use a record type like `Record<string, unknown>` instead of an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): An index signature is preferred over a record.
    ╭─[consistent_indexed_object_style.tsx:1:20]
  1 │ type Foo = Generic<Record<string, any>>;
    ·                    ───────────────────
    ╰────
-  help: A index signature is preferred over an record.
+  help: Use an index signature like `{ [key: string]: unknown }` instead of a record type.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): An index signature is preferred over a record.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(arg: Record<string, any>) {}
    ·                   ───────────────────
    ╰────
-  help: A index signature is preferred over an record.
+  help: Use an index signature like `{ [key: string]: unknown }` instead of a record type.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): An index signature is preferred over a record.
    ╭─[consistent_indexed_object_style.tsx:1:17]
  1 │ function foo(): Record<string, any> {}
    ·                 ───────────────────
    ╰────
-  help: A index signature is preferred over an record.
+  help: Use an index signature like `{ [key: string]: unknown }` instead of a record type.


### PR DESCRIPTION
Diagnostic messages are grammatically correct and also tell the user what to actually do now. And the implementation of the rule has been refactored a bit to ensure the enum is used for the config options rather than a boolean, which was confusing (especially in the generated docs).

Docs now look like this:

### What it does

Choose between requiring either `Record` type or indexed signature types.

These two types are equivalent, this rule enforces consistency in picking one style over the other:

```ts
type Foo = Record<string, unknown>;

type Foo = {
  [key: string]: unknown;
}
```

### Why is this bad?

Inconsistent style for indexed object types can harm readability in a project.

### Examples

Examples of **incorrect** code for this rule with
`consistent-indexed-object-style: ["error", "record"]` (default):

```ts
interface Foo {
  [key: string]: unknown;
}
type Foo = {
  [key: string]: unknown;
};
```

Examples of **correct** code for this rule with
`consistent-indexed-object-style: ["error", "record"]` (default):
```ts
type Foo = Record<string, unknown>;
```

Examples of **incorrect** code for this rule with
`consistent-indexed-object-style: ["error", "index-signature"]`:
```ts
type Foo = Record<string, unknown>;
```

Examples of **correct** code for this rule with
`consistent-indexed-object-style: ["error", "index-signature"]`:
```ts
interface Foo {
  [key: string]: unknown;
}
type Foo = {
  [key: string]: unknown;
};
```


## Configuration

This rule accepts a configuration object with the following properties:

### preferredStyle

type: `"record" | "index-signature"`

default: `"record"`

When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`.
When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`.
