### PR TITLE
fix(ast): exclude comment end position from `is_inside_comment` check

### DIFF
--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -82,7 +82,7 @@ pub fn is_inside_comment(comments: &[Comment], pos: u32) -> bool {
         .binary_search_by(|c| {
             if pos < c.span.start {
                 Ordering::Greater
-            } else if pos > c.span.end {
+            } else if pos >= c.span.end {
                 Ordering::Less
             } else {
                 Ordering::Equal


### PR DESCRIPTION
Fixes an off-by-one bug where a position exactly at `comment.span.end` was incorrectly considered to be inside the comment. This caused `find_next_token_from` to skip tokens immediately following comments, leading to incorrect token searches in linter rules.
