### PR TITLE
test(linter/switch-case-braces): add test for comment between case expression and colon

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -283,6 +283,18 @@ fn test() {
             }",
             None,
         ),
+        (
+            "switch(something) {
+                case 'a'/* Get a model by its ID */:
+                    doSomething({ a: b});
+            }",
+            "switch(something) {
+                case 'a'/* Get a model by its ID */: {
+                    doSomething({ a: b});
+                }
+            }",
+            None,
+        ),
     ];
 
     Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::PLUGIN, pass, fail)


### PR DESCRIPTION
Adds a test case to ensure the fixer correctly handles switch cases where a comment appears between the test expression and the colon, such as `case 'a'/* comment */:`. This regression test verifies the fix for the `is_inside_comment` off-by-one bug.