### PR TITLE
[DO NOT MERGE] Update config object for return-await to fix tsgolint upgrade

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/return_await.rs
+++ b/crates/oxc_linter/src/rules/typescript/return_await.rs
@@ -4,12 +4,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Clone)]
-pub struct ReturnAwait(Box<ReturnAwaitOption>);
+#[derive(Debug, Default, Clone)]
+pub struct ReturnAwait(Box<ReturnAwaitConfig>);
 
-impl Default for ReturnAwait {
+#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ReturnAwaitConfig {
+    option: ReturnAwaitOption,
+}
+
+impl Default for ReturnAwaitConfig {
     fn default() -> Self {
-        Self(Box::new(ReturnAwaitOption::InTryCatch))
+        Self { option: ReturnAwaitOption::InTryCatch }
     }
 }
 
@@ -97,13 +103,13 @@ declare_oxc_lint!(
     typescript,
     pedantic,
     pending,
-    config = ReturnAwaitOption,
+    config = ReturnAwaitConfig,
 );
 
 impl Rule for ReturnAwait {
     fn from_configuration(value: serde_json::Value) -> Self {
         Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<ReturnAwaitOption>>(value)
+            serde_json::from_value::<DefaultRuleConfig<ReturnAwaitConfig>>(value)
                 .unwrap_or_default()
                 .into_inner(),
         ))

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "emnapi": "1.6.0",
     "oxfmt": "^0.13.0",
     "oxlint": "^1.25.0",
-    "oxlint-tsgolint": "0.6.0",
+    "oxlint-tsgolint": "0.7.0",
     "publint": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 0.13.0
       oxlint:
         specifier: ^1.25.0
-        version: 1.28.0(oxlint-tsgolint@0.6.0)
+        version: 1.28.0(oxlint-tsgolint@0.7.0)
       oxlint-tsgolint:
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.7.0
+        version: 0.7.0
       publint:
         specifier: 'catalog:'
         version: 0.3.15
@@ -1497,33 +1497,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.6.0':
-    resolution: {integrity: sha512-avIT0fnAQ52jqRWqmyhIdgk18Fw0leaWAxdBYpeJihw1Jr+NWDXebxQNk+NV1krOLHQTj7SWM5JroRe08x3Wgg==}
+  '@oxlint-tsgolint/darwin-arm64@0.7.0':
+    resolution: {integrity: sha512-izoi/CWxaWNQ0mx30C5XOHj/2bQgCCOrI/NANhwvTF57x4ucrDs4QBOe9mmVXs7UWKdEJnIIVWFkOkBL+AeSXw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.6.0':
-    resolution: {integrity: sha512-+cZLAv+mpiNHoJLZA0TcKeO+rJFCAWSMkk0TJov0GvIg0HGM04XaoUFxzpFZS6+lNipzlTxq2s8ZFoz1FPCTyQ==}
+  '@oxlint-tsgolint/darwin-x64@0.7.0':
+    resolution: {integrity: sha512-e44m6SAlPi0x3Mw26NUqNDv/KhoLbOr2acanP8ESkgENx1AE+rGg11XONQTbBgah0VXg/Vrmn+RAbW0+Awc4HQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.6.0':
-    resolution: {integrity: sha512-cUuxWybs52R4c3SFUS0mhqwxyJlxLBnGTNjQaB6Zn6oFalCA/rZiip9zfpNR0/BjKJG8fvgtiw28MEf4Y8E66w==}
+  '@oxlint-tsgolint/linux-arm64@0.7.0':
+    resolution: {integrity: sha512-ry7cFVmFH0d5qR79V5D/JWCQnEOP3ykwYMTzKi0fNX5TBrRS1mza81DsEZiLzZCcftgKbv/FfZ4x3ZYuBdNlsw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.6.0':
-    resolution: {integrity: sha512-4kuLLjC3Pd3p346xanpl1NjOAQ8WPDOn40af+GspdClS4mwzfQLCp/3jGxzO8ehLPgpqbck1fDGIXM0TdHSOOQ==}
+  '@oxlint-tsgolint/linux-x64@0.7.0':
+    resolution: {integrity: sha512-SdBnhInM2YyEo68fNAR02Fc21TiUJn52huxuGqJtZVhXmxgDPKXqlv5+gcUTeSkLlurJCS75PTr+VCTvIPPJpQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.6.0':
-    resolution: {integrity: sha512-akPpoQ3MX6Y0MTCD2Wm/fBne8QO2b4A1avk8gXiZoeQi5j5Q6gn17NHk49pjPflShBAfvFwrY39KSQu1UhCHqQ==}
+  '@oxlint-tsgolint/win32-arm64@0.7.0':
+    resolution: {integrity: sha512-CcqZAbd0QNfppd3hHHaGFZsIAeEsk55BP6ful7ooosQGKt+IS3RNNbsLtiJwv6BE3I8Msc8xR5y5tp7CidioRQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.6.0':
-    resolution: {integrity: sha512-NkUOLye7P8lesLKcHBD3BUl3VF61I8m9d1NK0dLtchNRaM4Y6dY6IC8o9BceeyKoAOcm9rv4L4Dstbe/bu4ZVg==}
+  '@oxlint-tsgolint/win32-x64@0.7.0':
+    resolution: {integrity: sha512-wSUqtNB3SmqcM7OFI55ixQCEqXJz2W756KydQMExHoOzDJfjtacuo/anSdSkRdbpL/Sb7p0z7DeEki/hiPIz6g==}
     cpu: [x64]
     os: [win32]
 
@@ -3218,8 +3218,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.6.0:
-    resolution: {integrity: sha512-kb6T36Zht1pu0P35iNc3dRFtKwdzvoDuAKNwypbQMwk5tCREeO9jD6343O7oIO6hBSQ3FOr0B8dAqQbVL9IM/Q==}
+  oxlint-tsgolint@0.7.0:
+    resolution: {integrity: sha512-/bQym+gjssCWyKBJ30U0vJxojPx5fJQ2DFCARdjibvB0/DGbCRzZhJU5gZVs1gMnr9nBDz0+OUo1LZVZl3LDPw==}
     hasBin: true
 
   oxlint@1.28.0:
@@ -5227,22 +5227,22 @@ snapshots:
   '@oxfmt/win32-x64@0.13.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.6.0':
+  '@oxlint-tsgolint/darwin-arm64@0.7.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.6.0':
+  '@oxlint-tsgolint/darwin-x64@0.7.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.6.0':
+  '@oxlint-tsgolint/linux-arm64@0.7.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.6.0':
+  '@oxlint-tsgolint/linux-x64@0.7.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.6.0':
+  '@oxlint-tsgolint/win32-arm64@0.7.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.6.0':
+  '@oxlint-tsgolint/win32-x64@0.7.0':
     optional: true
 
   '@oxlint/darwin-arm64@1.28.0':
@@ -6970,16 +6970,16 @@ snapshots:
       '@oxfmt/win32-arm64': 0.13.0
       '@oxfmt/win32-x64': 0.13.0
 
-  oxlint-tsgolint@0.6.0:
+  oxlint-tsgolint@0.7.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.6.0
-      '@oxlint-tsgolint/darwin-x64': 0.6.0
-      '@oxlint-tsgolint/linux-arm64': 0.6.0
-      '@oxlint-tsgolint/linux-x64': 0.6.0
-      '@oxlint-tsgolint/win32-arm64': 0.6.0
-      '@oxlint-tsgolint/win32-x64': 0.6.0
+      '@oxlint-tsgolint/darwin-arm64': 0.7.0
+      '@oxlint-tsgolint/darwin-x64': 0.7.0
+      '@oxlint-tsgolint/linux-arm64': 0.7.0
+      '@oxlint-tsgolint/linux-x64': 0.7.0
+      '@oxlint-tsgolint/win32-arm64': 0.7.0
+      '@oxlint-tsgolint/win32-x64': 0.7.0
 
-  oxlint@1.28.0(oxlint-tsgolint@0.6.0):
+  oxlint@1.28.0(oxlint-tsgolint@0.7.0):
     optionalDependencies:
       '@oxlint/darwin-arm64': 1.28.0
       '@oxlint/darwin-x64': 1.28.0
@@ -6989,7 +6989,7 @@ snapshots:
       '@oxlint/linux-x64-musl': 1.28.0
       '@oxlint/win32-arm64': 1.28.0
       '@oxlint/win32-x64': 1.28.0
-      oxlint-tsgolint: 0.6.0
+      oxlint-tsgolint: 0.7.0
 
   p-limit@3.1.0:
     dependencies:


### PR DESCRIPTION
I think a mistake was made in the return-await implementation which results in Go treating the config option as being defined via an object with an `option` value, rather than it being just a string value you pass instead of an object.

`["error", { "option": "in-try-catch" }]` vs `["error", "in-try-catch"]`, where the latter is what it should actually be implemented as on the Go side, probably? But I know even less Go than I do Rust :)

Anyway, this rule should either be disabled temporarily, or fixed in the go side I assume.

Opening this just because I was trying to understand how to fix it, and it'll probably be useful for someone else

See also https://github.com/oxc-project/tsgolint/blob/d8d1ca10195efa8f8523bc3da3d6addc61f97d4e/internal/rules/return_await/return_await.go#L65-L79