### PR TITLE
chore(oxfmt): Use workspace napi and its flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,8 +1450,6 @@ dependencies = [
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
- "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -42,11 +42,11 @@ simdutf8 = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 # NAPI dependencies (conditional on napi feature)
-napi = { version = "3", features = ["napi9", "async", "serde-json"], optional = true }
-napi-derive = { version = "3", optional = true }
+napi = { workspace = true, features = ["async"], optional = true }
+napi-derive = { workspace = true, optional = true }
 
 [build-dependencies]
-napi-build = "2.3.1"
+napi-build = { workspace = true }
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
@@ -56,8 +56,6 @@ mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_o
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls", "no_opt_arch"] }
-
-[dev-dependencies]
 
 [features]
 default = ["napi"]


### PR DESCRIPTION
Use workspace versions of `napi`, `napi_derive` and `napi_build`.

Also features are aligned with `oxlint`.