### PR TITLE
refactor(oxfmt): Arrange and fix main files

### DIFF
--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { format } from './bindings.js';
 import { formatEmbeddedCode } from './embedded.js';
 
@@ -8,4 +6,7 @@ const args = process.argv.slice(2);
 // Call the Rust formatter with our JS callback
 const success = await format(args, formatEmbeddedCode);
 
-process.exit(success ? 0 : 1);
+// NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
+// `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
+// https://nodejs.org/api/process.html#processexitcode
+if (!success) process.exitCode = 1;

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -14,11 +14,11 @@ pub use result::CliRunResult;
 
 // Only include code to run formatter when the `napi` feature is enabled.
 #[cfg(feature = "napi")]
+mod main_napi;
+#[cfg(feature = "napi")]
 mod prettier_plugins;
 #[cfg(feature = "napi")]
-mod run;
-#[cfg(feature = "napi")]
-pub use run::*;
+pub use main_napi::*;
 
 #[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]
 #[global_allocator]

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -2,6 +2,9 @@ use std::io::BufWriter;
 
 use oxfmt::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing};
 
+// Pure Rust CLI entry point.
+// For JS CLI entry point, see `run.rs` exported by `lib.rs`.
+
 fn main() -> CliRunResult {
     init_tracing();
     init_miette();

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -13,6 +13,9 @@ use crate::{
     result::CliRunResult,
 };
 
+// NAPI based JS CLI entry point.
+// For pure Rust CLI entry point, see `main.rs`.
+
 /// NAPI entry point.
 ///
 /// JS side passes in:
@@ -33,10 +36,8 @@ fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> Cli
     init_tracing();
     init_miette();
 
-    // Parse command line arguments
-    let command = match format_command()
-        .run_inner(args.iter().map(|s| s.as_ref() as &str).collect::<Vec<_>>().as_slice())
-    {
+    // Use `run_inner()` to report errors instead of panicking.
+    let command = match format_command().run_inner(args.as_slice()) {
         Ok(cmd) => cmd,
         Err(e) => {
             e.print_message(100);


### PR DESCRIPTION
- Rename `run.rs` to `main_napi.rs`
  - `main.rs` is the entrypoint for Rust CLI, and `main_napi.rs` is for JS CLI
- Fix up `cli.ts` to use `.exitCode`, rather than `.exit()`
