### PR TITLE
feat(linter): Handle config docs for string/enum values and add config option docs for various rules.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -2,8 +2,15 @@ use oxc_ast::{AstKind, ast::Statement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, ast_util::get_preceding_indent_str, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    ast_util::get_preceding_indent_str,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn switch_case_braces_diagnostic_empty_clause(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected braces in empty case clause.")
@@ -24,14 +31,22 @@ fn switch_case_braces_diagnostic_unnecessary_braces(span: Span) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone)]
-pub struct SwitchCaseBraces {
-    always_braces: bool,
-}
+pub struct SwitchCaseBraces(Box<SwitchCaseBracesConfig>);
 
 impl Default for SwitchCaseBraces {
     fn default() -> Self {
-        Self { always_braces: true }
+        Self(Box::new(SwitchCaseBracesConfig::Always))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SwitchCaseBracesConfig {
+    /// Always require braces in case clauses (except empty cases).
+    #[default]
+    Always,
+    /// Allow braces only when needed for scoping (e.g., variable or function declarations).
+    Avoid,
 }
 
 declare_oxc_lint!(
@@ -68,30 +83,24 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// ### Options
-    ///
-    /// `{ type: "always" | "avoid", default: "always" }`
-    ///
-    /// - `"always"`
-    ///   Always report when clause is not a `BlockStatement`.
-    ///
-    /// - `"avoid"`
-    ///   Allows braces only when needed for scoping (e.g., variable or function declarations).
-    ///
-    /// Example:
+    /// Example config:
     /// ```json
     /// "unicorn/switch-case-braces": ["error", "avoid"]
     /// ```
     SwitchCaseBraces,
     unicorn,
     style,
-    fix
+    fix,
+    config = SwitchCaseBracesConfig,
 );
 
 impl Rule for SwitchCaseBraces {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let always_braces = value.get(0).is_none_or(|v| v.as_str() != Some("avoid"));
-        Self { always_braces }
+        Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<SwitchCaseBracesConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        ))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -116,7 +125,7 @@ impl Rule for SwitchCaseBraces {
                         );
                         continue;
                     }
-                    if !self.always_braces
+                    if *self.0 == SwitchCaseBracesConfig::Avoid
                         && !block_stmt.body.iter().any(|stmt| {
                             matches!(
                                 stmt,
@@ -141,7 +150,7 @@ impl Rule for SwitchCaseBraces {
                 _ => true,
             };
 
-            if self.always_braces && missing_braces {
+            if *self.0 == SwitchCaseBracesConfig::Always && missing_braces {
                 let test_end = case.test.as_ref().map_or(case.span.start, |t| t.span().end);
                 let colon_offset = ctx.find_next_token_from(test_end, ":").unwrap();
                 let colon_pos = test_end + colon_offset;

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -53,7 +53,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "react/forbid-dom-props",
         "react/forbid-elements",
         "react/jsx-handler-names",
-        "react/prefer-es6-class",
         "react/state-in-constructor",
         // typescript
         "typescript/ban-ts-comment",
@@ -61,10 +60,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         // unicorn
         "unicorn/catch-error-name",
         "unicorn/filename-case",
-        "unicorn/switch-case-braces",
-        // vue
-        "vue/define-emits-declaration",
-        "vue/define-props-declaration",
     ];
 
     let exception_set: FxHashSet<&str> = exceptions.iter().copied().collect();


### PR DESCRIPTION
This allows rules like `return-await` to render their possible values accurately on the docs website. Fixes #15078. Also part of #14743.

Used GitHub Copilot + Claude Sonnet 4.5 for most of the json schema edits, after figuring out which parts needed modification to enable this.

Updates the following rules with config option docs and uses DefaultRuleConfig for configuration handling:
- `react/prefer-es6-class`
- `unicorn/switch-case-braces`
- `vue/define-emits-declaration`
- `vue/define-props-declaration`
- `typescript/consistent-indexed-object-style`

Generated docs are as follows.

For `typescript/consistent-indexed-object-style`:
```md
## Configuration

This rule accepts one of the following string values:

### `"record"`

When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`.


### `"index-signature"`

When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`.
```

For `typescript/return-await`:

```md
## Configuration

This rule accepts one of the following string values:

### `"in-try-catch"`

Require `await` when returning Promises inside try/catch/finally blocks.
This ensures proper error handling and stack traces.


### `"always"`

Require `await` before returning Promises in all cases.
Example: `return await Promise.resolve()` is required.


### `"error-handling-correctness-only"`

Require `await` only when it affects error handling correctness.
Only flags cases where omitting await would change error handling behavior.


### `"never"`

Disallow `await` before returning Promises in all cases.
Example: `return Promise.resolve()` is required (no await).
```

For `vue/define-emits-declaration`:

```md
## Configuration

This rule accepts one of the following string values:

### `"type-based"`



Enforce type-based declaration.


### `"type-literal"`



Enforce type-literal declaration.


### `"runtime"`



Enforce runtime declaration.
```

For `vue/define-props-declaration`:
```md
## Configuration

This rule accepts one of the following string values:

### `"type-based"`



Enforce type-based declaration.


### `"runtime"`



Enforce runtime declaration.
```

For `react/prefer-es6-class`:
```md
## Configuration

This rule accepts one of the following string values:

### `"always"`

Always prefer ES6 class-style components


### `"never"`

Do not allow ES6 class-style
```