### PR TITLE
fix(formatter): regression case for test call

### DIFF
--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -69,7 +69,17 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
 
         if is_simple_module_import
             || call_expression.is_some_and(|call| {
-                is_commonjs_or_amd_call(self, call, f) || is_test_call_expression(call)
+                is_commonjs_or_amd_call(self, call, f)
+                    || ((self.len() != 2
+                        || matches!(
+                            arguments.first(),
+                            Some(
+                                Argument::StringLiteral(_)
+                                    | Argument::TemplateLiteral(_)
+                                    | Argument::TaggedTemplateExpression(_)
+                            )
+                        ))
+                        && is_test_call_expression(call))
             })
             || is_multiline_template_only_args(self, f.source_text())
             || is_react_hook_with_deps_array(self, f.comments())

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js
@@ -21,3 +21,5 @@ test.describe.only("Describe only", () => {});
 test.only("Test only", () => {});
 describe.only("Describe only", () => {});
 it.only("It only", () => {});
+
+test(code.replace((c) => ""), () => {});

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
@@ -25,6 +25,8 @@ test.describe.only("Describe only", () => {});
 test.only("Test only", () => {});
 describe.only("Describe only", () => {});
 it.only("It only", () => {});
+
+test(code.replace((c) => ""), () => {});
 ==================== Output ====================
 // Test patterns with multiple levels should not break incorrectly
 test.describe.serial("My test suite", () => {
@@ -49,5 +51,10 @@ test.describe.only("Describe only", () => {});
 test.only("Test only", () => {});
 describe.only("Describe only", () => {});
 it.only("It only", () => {});
+
+test(
+  code.replace((c) => ""),
+  () => {},
+);
 
 ===================== End =====================


### PR DESCRIPTION
I found this mismatch case in the oxc-ecosystem-ci. This is a regression that was introduced in https://github.com/oxc-project/oxc/pull/15238. In that PR, I mistakenly removed some checks related to test declaration.