### PR TITLE
fix(formatter): measuring multiline text in `fits_text` is incorrect

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -412,8 +412,10 @@ impl Width {
 /// that it is a multiline text if it contains a line feed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TextWidth {
+    /// Single-line text width
     Width(Width),
-    Multiline,
+    /// Multi-line text whose `width` is from the start of the text to the first line break
+    Multiline(Width),
 }
 
 impl TextWidth {
@@ -424,7 +426,7 @@ impl TextWidth {
         for c in text.chars() {
             let char_width = match c {
                 '\t' => indent_width.value(),
-                '\n' => return TextWidth::Multiline,
+                '\n' => return Self::Multiline(Width::new(width)),
                 #[expect(clippy::cast_possible_truncation)]
                 c => c.width().unwrap_or(0) as u8,
             };
@@ -444,14 +446,7 @@ impl TextWidth {
         TextWidth::Width(Width::new(len as u32))
     }
 
-    pub const fn width(self) -> Option<Width> {
-        match self {
-            TextWidth::Width(width) => Some(width),
-            TextWidth::Multiline => None,
-        }
-    }
-
     pub(crate) const fn is_multiline(self) -> bool {
-        matches!(self, TextWidth::Multiline)
+        matches!(self, TextWidth::Multiline(_))
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js
@@ -23,3 +23,7 @@ describe.only("Describe only", () => {});
 it.only("It only", () => {});
 
 test(code.replace((c) => ""), () => {});
+
+expect(content)
+  .toMatch(`props: /*@__PURE__*/_mergeDefaults(['foo', 'bar', 'baz'], {
+})`)

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
@@ -27,6 +27,11 @@ describe.only("Describe only", () => {});
 it.only("It only", () => {});
 
 test(code.replace((c) => ""), () => {});
+
+expect(content)
+  .toMatch(`props: /*@__PURE__*/_mergeDefaults(['foo', 'bar', 'baz'], {
+})`)
+
 ==================== Output ====================
 // Test patterns with multiple levels should not break incorrectly
 test.describe.serial("My test suite", () => {
@@ -56,5 +61,9 @@ test(
   code.replace((c) => ""),
   () => {},
 );
+
+expect(content)
+  .toMatch(`props: /*@__PURE__*/_mergeDefaults(['foo', 'bar', 'baz'], {
+})`);
 
 ===================== End =====================


### PR DESCRIPTION
Regressed by #15372. The changes are made to match previous behavior. In `fits_text`, once the text width is multiple lines, we should check whether the current line width plus the width of the text to the first line break is greater than the allowed line width to take action, but previously, we didn't include `plus the width of the text to the first line break`.