### PR TITLE
feat(linter): Update linter JSON rule output to include extra information.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1349,6 +1349,10 @@ mod test {
             assert!(rule_obj.contains_key("scope"), "Rule should contain 'scope' field");
             assert!(rule_obj.contains_key("value"), "Rule should contain 'value' field");
             assert!(rule_obj.contains_key("category"), "Rule should contain 'category' field");
+            assert!(rule_obj.contains_key("type_aware"), "Rule should contain 'type_aware' field");
+            assert!(rule_obj.contains_key("fix"), "Rule should contain 'fix' field");
+            assert!(rule_obj.contains_key("default"), "Rule should contain 'default' field");
+            assert!(rule_obj.contains_key("docs_url"), "Rule should contain 'docs_url' field");
         }
     }
 

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -117,6 +117,29 @@ impl FixKind {
             }
         }
     }
+
+    /// Returns a string representation of the fix kind.
+    ///
+    /// This method returns a lowercase, underscore-separated string
+    /// representing all possible fix kind combinations.
+    pub fn to_string(self) -> &'static str {
+        if self.is_empty() {
+            return "none";
+        }
+        match self {
+            Self::Fix => "fix",
+            Self::Suggestion => "suggestion",
+            Self::Dangerous => "dangerous",
+            Self::SafeFixOrSuggestion => "safe_fix_or_suggestion",
+            Self::DangerousFix => "dangerous_fix",
+            Self::DangerousSuggestion => "dangerous_suggestion",
+            Self::DangerousFixOrSuggestion => "dangerous_fix_or_suggestion",
+            _ => {
+                debug_assert!(false, "Unhandled FixKind combination: {self:?}");
+                "unknown"
+            }
+        }
+    }
 }
 
 // TODO: rename
@@ -126,7 +149,7 @@ pub struct RuleFix {
     kind: FixKind,
     /// A suggestion message. Will be shown in editors via code actions.
     message: Option<Cow<'static, str>>,
-    /// The actual that will be applied to the source code.
+    /// The actual fix that will be applied to the source code.
     ///
     /// See: [`Fix`]
     fix: CompositeFix,
@@ -757,5 +780,31 @@ mod test {
     )]
     fn test_emojis_invalid() {
         FixKind::Dangerous.emoji();
+    }
+
+    #[test]
+    fn test_to_string() {
+        let tests = vec![
+            (FixKind::None, "none"),
+            (FixKind::Fix, "fix"),
+            (FixKind::Suggestion, "suggestion"),
+            (FixKind::Dangerous, "dangerous"),
+            (FixKind::SafeFixOrSuggestion, "safe_fix_or_suggestion"),
+            (FixKind::DangerousFix, "dangerous_fix"),
+            (FixKind::DangerousSuggestion, "dangerous_suggestion"),
+            (FixKind::DangerousFixOrSuggestion, "dangerous_fix_or_suggestion"),
+        ];
+
+        for (kind, expected) in tests {
+            assert_eq!(
+                kind.to_string(),
+                expected,
+                "Expected {kind:?} to have string '{expected}'."
+            );
+        }
+
+        // Test that aliases work correctly
+        assert_eq!(FixKind::SafeFix.to_string(), "fix"); // SafeFix is an alias for Fix
+        assert_eq!(FixKind::All.to_string(), "dangerous_fix_or_suggestion"); // All is an alias for DangerousFixOrSuggestion
     }
 }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -383,6 +383,17 @@ impl RuleFixMeta {
     }
 }
 
+impl fmt::Display for RuleFixMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::FixPending => write!(f, "pending"),
+            Self::Conditional(kind) => write!(f, "conditional_{}", kind.to_string()),
+            Self::Fixable(kind) => write!(f, "fixable_{}", kind.to_string()),
+        }
+    }
+}
+
 impl From<RuleFixMeta> for FixKind {
     fn from(value: RuleFixMeta) -> Self {
         value.fix_kind()


### PR DESCRIPTION
Partially addresses #12499.

When running `oxlint --rules -f=json`, the output JSON for each rule now includes:
- `docs_url`: A URL pointing to the documentation page for the rule.
- `fix`: A string indicating the type of fixer a rule has, if any.
- `type_aware`: A boolean indicating whether the rule is type-aware (meaning a tsgolint rule).

e.g:
```json

  {
    "scope": "vue",
    "value": "require-typed-ref",
    "category": "style",
    "type_aware": false,
    "fix": "none",
    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/require-typed-ref.html"
  },
  {
    "scope": "vue",
    "value": "valid-define-emits",
    "category": "correctness",
    "type_aware": false,
    "fix": "pending",
    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/valid-define-emits.html"
  },
```

You can see the full JSON output by this here: https://gist.github.com/connorshea/2a239e01f32740411f231c493bffb5ce

I don't know if including the docs for all the rules in this is necessarily a good idea, as it'd be pretty huge, but it would be possible to do if we want to. I think we should probably serialize something about the config options here in the future as well, but I didn't feel like bothering with that right now.