### PR TITLE
feat(oxfmt): `oxfmt --lsp` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,10 +2524,12 @@ dependencies = [
  "oxc_allocator",
  "oxc_diagnostics",
  "oxc_formatter",
+ "oxc_language_server",
  "oxc_parser",
  "oxc_span",
  "rayon",
  "simdutf8",
+ "tokio",
  "tracing-subscriber",
 ]
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -30,6 +30,7 @@ doctest = false
 oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
+oxc_language_server = { workspace = true, default-features = false, features = ["formatter"] }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 
@@ -39,6 +40,7 @@ ignore = { workspace = true, features = ["simd-accel"] }
 miette = { workspace = true }
 rayon = { workspace = true }
 simdutf8 = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 
 # NAPI dependencies (conditional on napi feature)

--- a/apps/oxfmt/src/command.rs
+++ b/apps/oxfmt/src/command.rs
@@ -75,6 +75,9 @@ pub struct IgnoreOptions {
 /// Miscellaneous
 #[derive(Debug, Clone, Bpaf)]
 pub struct MiscOptions {
+    /// Start language server protocol (LSP) server
+    #[bpaf(switch, hide_usage)]
+    pub lsp: bool,
     /// Do not exit with error when pattern is unmatched
     #[bpaf(switch, hide_usage)]
     pub no_error_on_unmatched_pattern: bool,

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -1,6 +1,7 @@
 mod command;
 mod format;
 mod init;
+mod lsp;
 mod reporter;
 mod result;
 mod service;
@@ -10,6 +11,7 @@ mod walk;
 pub use command::format_command;
 pub use format::FormatRunner;
 pub use init::{init_miette, init_tracing};
+pub use lsp::run_lsp;
 pub use result::CliRunResult;
 
 // Only include code to run formatter when the `napi` feature is enabled.

--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -1,0 +1,6 @@
+use oxc_language_server::{ServerFormatterBuilder, run_server};
+
+/// Run the language server
+pub async fn run_lsp() {
+    run_server(vec![Box::new(ServerFormatterBuilder)]).await;
+}

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,16 +1,24 @@
 use std::io::BufWriter;
 
-use oxfmt::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing};
+use oxfmt::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing, run_lsp};
 
 // Pure Rust CLI entry point.
 // For JS CLI entry point, see `run.rs` exported by `lib.rs`.
 
-fn main() -> CliRunResult {
-    init_tracing();
-    init_miette();
-
+#[tokio::main]
+async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = format_command().run();
+
+    // Handle LSP mode
+    if command.misc_options.lsp {
+        run_lsp().await;
+        return CliRunResult::None;
+    }
+
+    // Otherwise, CLI mode
+    init_tracing();
+    init_miette();
 
     command.handle_threads();
 

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     io::BufWriter,
     process::{ExitCode, Termination},
 };
@@ -9,6 +10,7 @@ use crate::{
     command::format_command,
     format::FormatRunner,
     init::{init_miette, init_tracing},
+    lsp::run_lsp,
     prettier_plugins::{JsFormatEmbeddedCb, create_external_formatter},
     result::CliRunResult,
 };
@@ -27,17 +29,16 @@ use crate::{
 #[allow(clippy::trailing_empty_array, clippy::unused_async)] // https://github.com/napi-rs/napi-rs/issues/2758
 #[napi]
 pub async fn format(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> bool {
-    format_impl(args, format_embedded_cb).report() == ExitCode::SUCCESS
+    format_impl(args, format_embedded_cb).await.report() == ExitCode::SUCCESS
 }
 
 /// Run the formatter.
-#[expect(clippy::needless_pass_by_value)]
-fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> CliRunResult {
-    init_tracing();
-    init_miette();
+async fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> CliRunResult {
+    // Convert String args to OsString for compatibility with bpaf
+    let args: Vec<OsString> = args.into_iter().map(OsString::from).collect();
 
     // Use `run_inner()` to report errors instead of panicking.
-    let command = match format_command().run_inner(args.as_slice()) {
+    let command = match format_command().run_inner(&*args) {
         Ok(cmd) => cmd,
         Err(e) => {
             e.print_message(100);
@@ -48,6 +49,16 @@ fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> Cli
             };
         }
     };
+
+    // Handle LSP mode
+    if command.misc_options.lsp {
+        run_lsp().await;
+        return CliRunResult::None;
+    }
+
+    // Otherwise, CLI mode
+    init_tracing();
+    init_miette();
 
     command.handle_threads();
 


### PR DESCRIPTION
Support `--lsp`, fixes #15739 

- Implementation still lives in `oxc_language_server`
  - The same as `oxlint --lsp`
  - But now we can remove `oxc_language_server`'s `bin`
- For Rust CLI, `.await` with `tokio`
- For JS CLI, `napi-rs` automatically wraps with `tokio`

---

Now I'm seeing 2 problems:

- For JS CLI, `node ./dist/cli.js --lsp` does not work
  - Instead of waiting LSP message, just panics with error
  - `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}`
  - `import process2 from "process";` in bundled file makes this happen, but I don't know why
  - 👉🏻 Fixed by import `prettier` lazily...
- `oxc_linter` is also bundled with `oxfmt`
  - via `oxc_language_server`
  - 👉🏻 #15767