### PR TITLE
refactor(language_server): Add formatter and linter features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ oxc_traverse = { version = "0.98.0", path = "crates/oxc_traverse" } # AST traver
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
-oxc_language_server = { path = "crates/oxc_language_server" } # Language server
+oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
 oxc_tasks_common = { path = "tasks/common" } # Task utilities

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_diagnostics = { workspace = true }
-oxc_language_server = { workspace = true }
+oxc_language_server = { workspace = true, features = ["linter"] }
 oxc_linter = { workspace = true }
 oxc_span = { workspace = true }
 

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -25,8 +25,8 @@ doctest = false
 oxc_allocator = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
-oxc_formatter = { workspace = true }
-oxc_linter = { workspace = true }
+oxc_formatter = { workspace = true, optional = true }
+oxc_linter = { workspace = true, optional = true }
 oxc_parser = { workspace = true }
 
 #
@@ -43,3 +43,8 @@ tower-lsp-server = { workspace = true, features = ["proposed"] }
 
 [dev-dependencies]
 insta = { workspace = true }
+
+[features]
+default = ["linter", "formatter"]
+linter = ["dep:oxc_linter"]
+formatter = ["dep:oxc_formatter"]

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -4,7 +4,9 @@ use tower_lsp_server::{LspService, Server};
 mod backend;
 mod capabilities;
 mod file_system;
+#[cfg(feature = "formatter")]
 mod formatter;
+#[cfg(feature = "linter")]
 mod linter;
 mod options;
 mod tool;
@@ -12,7 +14,9 @@ mod utils;
 mod worker;
 
 use crate::backend::Backend;
+#[cfg(feature = "formatter")]
 pub use crate::formatter::ServerFormatterBuilder;
+#[cfg(feature = "linter")]
 pub use crate::linter::ServerLinterBuilder;
 pub use crate::tool::{Tool, ToolBuilder, ToolRestartChanges, ToolShutdownChanges};
 

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,8 +1,14 @@
 #[tokio::main]
 async fn main() {
-    oxc_language_server::run_server(vec![
-        Box::new(oxc_language_server::ServerFormatterBuilder),
-        Box::new(oxc_language_server::ServerLinterBuilder),
-    ])
-    .await;
+    #[expect(clippy::vec_init_then_push)]
+    let tools: Vec<Box<dyn oxc_language_server::ToolBuilder>> = {
+        let mut v: Vec<Box<dyn oxc_language_server::ToolBuilder>> = Vec::new();
+        #[cfg(feature = "formatter")]
+        v.push(Box::new(oxc_language_server::ServerFormatterBuilder));
+        #[cfg(feature = "linter")]
+        v.push(Box::new(oxc_language_server::ServerLinterBuilder));
+        v
+    };
+
+    oxc_language_server::run_server(tools).await;
 }


### PR DESCRIPTION
Currently, there is 2 ways to start LS for oxc apps.

- `oxc_language_server`
- `oxlint --lsp`
- (`oxfmt --lsp` will be added soon)


Having duplicates are fine for now, but `ServerFormatter` (and `oxc_formatter`) should not bundled in `oxlint --lsp` case.

This PR adds `linter` and `formatter` features to exclude.
For `oxc_language_server`, both features are enabled by default, keep it as-is.