### PR TITLE
feat(linter): add react/jsx-props-no-spreading rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2284,6 +2284,12 @@ impl RuleRunner for crate::rules::react::jsx_props_no_spread_multi::JsxPropsNoSp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::jsx_props_no_spreading::JsxPropsNoSpreading {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXSpreadAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_array_index_key::NoArrayIndexKey {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -364,6 +364,7 @@ pub(crate) mod react {
     pub mod jsx_no_useless_fragment;
     pub mod jsx_pascal_case;
     pub mod jsx_props_no_spread_multi;
+    pub mod jsx_props_no_spreading;
     pub mod no_array_index_key;
     pub mod no_children_prop;
     pub mod no_danger;
@@ -1045,6 +1046,7 @@ oxc_macros::declare_all_lint_rules! {
     react::jsx_no_undef,
     react::jsx_no_useless_fragment,
     react::jsx_props_no_spread_multi,
+    react::jsx_props_no_spreading,
     react::no_namespace,
     react::no_array_index_key,
     react::no_children_prop,

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -41,6 +41,7 @@ pub struct JsxPropsNoSpreadingConfig {
     /// For example:
     /// - If `html` is set to `ignore`, an exception for `div` will enforce the rule on `<div>` elements.
     /// - If `custom` is set to `enforce`, an exception for `Foo` will ignore the rule on `<Foo>` components.
+    ///
     /// This allows you to override the general setting for individual components.
     exceptions: Vec<CompactStr>,
 }

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -98,10 +98,6 @@ impl Rule for JsxPropsNoSpreading {
             return;
         };
 
-        let ignore_html_tags = self.html == IgnoreEnforceOption::Ignore;
-        let ignore_custom_tags = self.custom == IgnoreEnforceOption::Ignore;
-        let ignore_explicit_spread = self.explicit_spread == IgnoreEnforceOption::Ignore;
-
         let AstKind::JSXOpeningElement(jsx_opening_element) =
             ctx.nodes().parent_node(node.id()).kind()
         else {
@@ -113,12 +109,16 @@ impl Rule for JsxPropsNoSpreading {
         let is_html_tag = !is_react_component_name(&tag_name);
         let is_custom_tag = !is_html_tag || tag_name.contains('.');
 
+        let ignore_html_tags = self.html == IgnoreEnforceOption::Ignore;
+
         if is_html_tag
             && ((ignore_html_tags && !is_exception(&tag_name, &self.exceptions))
                 || (!ignore_html_tags && is_exception(&tag_name, &self.exceptions)))
         {
             return;
         }
+
+        let ignore_custom_tags = self.custom == IgnoreEnforceOption::Ignore;
 
         if is_custom_tag
             && ((ignore_custom_tags && !is_exception(&tag_name, &self.exceptions))
@@ -127,7 +127,7 @@ impl Rule for JsxPropsNoSpreading {
             return;
         }
 
-        if ignore_explicit_spread
+        if self.explicit_spread == IgnoreEnforceOption::Ignore
             && let Expression::ObjectExpression(obj_expr) = &spread_attr.argument
             && obj_expr.properties.iter().all(|prop| !prop.is_spread())
         {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     JsxPropsNoSpreading,
     react,
     style,
+    config = JsxPropsNoSpreadingConfig
 );
 
 impl Rule for JsxPropsNoSpreading {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -127,7 +127,7 @@ impl Rule for JsxPropsNoSpreading {
         let tag_name = get_tag_name(&jsx_opening_element.name);
 
         let is_html_tag = !is_react_component_name(&tag_name);
-        let is_custom_tag = !is_html_tag || tag_name.contains(".");
+        let is_custom_tag = !is_html_tag || tag_name.contains('.');
 
         if is_html_tag
             && ((ignore_html_tags && !is_exception(&tag_name, &self.exceptions))

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -1,0 +1,427 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, JSXElementName, JSXMemberExpression, JSXMemberExpressionObject},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
+use serde_json::Value;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_react_component_name};
+
+fn jsx_props_no_spreading_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prop spreading is forbidden").with_label(span)
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum IgnoreEnforceOption {
+    Ignore,
+    #[default]
+    Enforce,
+}
+
+impl IgnoreEnforceOption {
+    fn parse_config(config: &Value, option: &str) -> Self {
+        config
+            .get(option)
+            .and_then(serde_json::Value::as_str)
+            .map(|mode| match mode {
+                "ignore" => IgnoreEnforceOption::Ignore,
+                _ => IgnoreEnforceOption::Enforce,
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Default, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct JsxPropsNoSpreadingConfig {
+    /// `html` set to `ignore` will ignore all html jsx tags like `div`, `img` etc. Default is set to `enforce`.
+    html: IgnoreEnforceOption,
+    /// `custom` set to `ignore` will ignore all custom jsx tags like `App`, `MyCustomComponent` etc. Default is set to `enforce`.
+    custom: IgnoreEnforceOption,
+    /// `explicitSpread` set to `ignore` will ignore spread operators that are explicitly listing all object properties within that spread. Default is set to `enforce`.
+    explicit_spread: IgnoreEnforceOption,
+    /// An "exception" will always flip the resulting `html` or `custom` setting for that component - ie, `html` set to `ignore`, with an exception of `div` will enforce on an `div`; custom set to `enforce` with an exception of `Foo` will ignore `Foo`.
+    exceptions: Vec<CompactStr>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsxPropsNoSpreading(Box<JsxPropsNoSpreadingConfig>);
+
+impl std::ops::Deref for JsxPropsNoSpreading {
+    type Target = JsxPropsNoSpreadingConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow JSX prop spreading
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Enforces that there is no spreading for any JSX attribute. This enhances readability of code by being more explicit about what props are received by the component.
+    /// It is also good for maintainability by avoiding passing unintentional extra props and allowing react to emit warnings when invalid HTML props are passed to HTML elements.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <App {...props} />
+    /// <MyCustomComponent {...props} some_other_prop={some_other_prop} />
+    /// <img {...props} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const {src, alt} = props;
+    /// const {one_prop, two_prop} = otherProps;
+    /// <MyCustomComponent one_prop={one_prop} two_prop={two_prop} />
+    /// <img src={src} alt={alt} />
+    /// ```
+    JsxPropsNoSpreading,
+    react,
+    style,
+);
+
+impl Rule for JsxPropsNoSpreading {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let Some(config) = value.get(0) else {
+            return Self::default();
+        };
+
+        let html = IgnoreEnforceOption::parse_config(config, "html");
+        let custom = IgnoreEnforceOption::parse_config(config, "custom");
+        let explicit_spread = IgnoreEnforceOption::parse_config(config, "explicitSpread");
+
+        let exceptions = config
+            .get("exceptions")
+            .and_then(serde_json::Value::as_array)
+            .map(|v| v.iter().filter_map(serde_json::Value::as_str).map(CompactStr::from).collect())
+            .unwrap_or_default();
+
+        Self(Box::new(JsxPropsNoSpreadingConfig { html, custom, explicit_spread, exceptions }))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXSpreadAttribute(spread_attr) = node.kind() else {
+            return;
+        };
+
+        let ignore_html_tags = self.html == IgnoreEnforceOption::Ignore;
+        let ignore_custom_tags = self.custom == IgnoreEnforceOption::Ignore;
+        let ignore_explicit_spread = self.explicit_spread == IgnoreEnforceOption::Ignore;
+
+        let AstKind::JSXOpeningElement(jsx_opening_element) =
+            ctx.nodes().parent_node(node.id()).kind()
+        else {
+            return;
+        };
+
+        let tag_name = get_tag_name(&jsx_opening_element.name);
+
+        let is_html_tag = !is_react_component_name(&tag_name);
+        let is_custom_tag = !is_html_tag || tag_name.contains(".");
+
+        if is_html_tag
+            && ((ignore_html_tags && !is_exception(&tag_name, &self.exceptions))
+                || (!ignore_html_tags && is_exception(&tag_name, &self.exceptions)))
+        {
+            return;
+        }
+
+        if is_custom_tag
+            && ((ignore_custom_tags && !is_exception(&tag_name, &self.exceptions))
+                || (!ignore_custom_tags && is_exception(&tag_name, &self.exceptions)))
+        {
+            return;
+        }
+
+        if ignore_explicit_spread
+            && let Expression::ObjectExpression(obj_expr) = &spread_attr.argument
+            && obj_expr.properties.iter().all(|prop| !prop.is_spread())
+        {
+            return;
+        }
+
+        ctx.diagnostic(jsx_props_no_spreading_diagnostic(spread_attr.span));
+    }
+}
+
+fn is_exception(tag: &CompactStr, exceptions: &[CompactStr]) -> bool {
+    exceptions.contains(tag)
+}
+
+fn get_tag_name(name: &JSXElementName<'_>) -> CompactStr {
+    match name {
+        JSXElementName::Identifier(ident) => ident.name.as_str().into(),
+        JSXElementName::IdentifierReference(ident) => ident.name.as_str().into(),
+        JSXElementName::MemberExpression(member_expr) => get_member_expr_tag_name(member_expr),
+        JSXElementName::NamespacedName(namespaced_name) => format!(
+            "{}:{}",
+            namespaced_name.namespace.name.as_str(),
+            namespaced_name.name.name.as_str()
+        )
+        .into(),
+        JSXElementName::ThisExpression(_) => "this".into(),
+    }
+}
+
+/// gets full component name, e.g. "components.Group" in <components.Group />
+fn get_member_expr_tag_name(member_expr: &JSXMemberExpression) -> CompactStr {
+    let object_name = match &member_expr.object {
+        JSXMemberExpressionObject::IdentifierReference(ident) => ident.name.as_str(),
+        JSXMemberExpressionObject::ThisExpression(_) => "this",
+        JSXMemberExpressionObject::MemberExpression(next_expr) => {
+            &get_member_expr_tag_name(next_expr)
+        }
+    };
+
+    format!("{}.{}", object_name, member_expr.property.name.as_str()).into()
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+			        const {one_prop, two_prop} = props;
+			        <App one_prop={one_prop} two_prop={two_prop}/>
+			      ",
+            None,
+        ),
+        (
+            "
+			        const {one_prop, two_prop} = props;
+			        <div one_prop={one_prop} two_prop={two_prop}></div>
+			      ",
+            None,
+        ),
+        (
+            "
+			        const newProps = {...props};
+			        <App one_prop={newProps.one_prop} two_prop={newProps.two_prop} style={{...styles}}/>
+			      ",
+            None,
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        <App>
+			           <Image {...props}/>
+			           <img {...props}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "exceptions": ["Image", "img"] }])),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <Image {...props}/>
+			           <img src={src} alt={alt}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "custom": "ignore" }])),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <Image {...props}/>
+			           <img {...props}/>
+			        </App>
+			      "#,
+            Some(
+                serde_json::json!([{ "custom": "enforce", "html": "ignore", "exceptions": ["Image"] }]),
+            ),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <img {...props}/>
+			           <Image src={src} alt={alt}/>
+			           <div {...someOtherProps}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "html": "ignore" }])),
+        ),
+        (
+            "
+			        <App>
+			          <Foo {...{ prop1, prop2, prop3 }} />
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "explicitSpread": "ignore" }])),
+        ),
+        (
+            "
+			        const props = {};
+			        <App>
+			           <components.Group {...props}/>
+			           <Nav.Item {...props}/>
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "exceptions": ["components.Group", "Nav.Item"] }])),
+        ),
+        (
+            "
+			        const props = {};
+			        <App>
+			           <components.Group {...props}/>
+			           <Nav.Item {...props}/>
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "custom": "ignore" }])),
+        ),
+        (
+            "
+			        const props = {};
+			        <App>
+			           <components.Group {...props}/>
+			           <Nav.Item {...props}/>
+			        </App>
+			      ",
+            Some(
+                serde_json::json!([        {          "custom": "enforce",          "html": "ignore",          "exceptions": ["components.Group", "Nav.Item"],        },      ]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+			        <App {...props}/>
+			      ",
+            None,
+        ),
+        (
+            "
+			        <div {...props}></div>
+			      ",
+            None,
+        ),
+        (
+            "
+			        <App {...props} some_other_prop={some_other_prop}/>
+			      ",
+            None,
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        <App>
+			           <Image {...props}/>
+			           <span {...props}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "exceptions": ["Image", "img"] }])),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <Image {...props}/>
+			           <img {...props}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "custom": "ignore" }])),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <Image {...props}/>
+			           <img {...props}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "html": "ignore", "exceptions": ["Image", "img"] }])),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <Image {...props}/>
+			           <img {...props}/>
+			           <div {...props}/>
+			        </App>
+			      "#,
+            Some(
+                serde_json::json!([{ "custom": "ignore", "html": "ignore", "exceptions": ["Image", "img"] }]),
+            ),
+        ),
+        (
+            r#"
+			        const props = {src: "dummy.jpg", alt: "dummy"};
+			        const { src, alt } = props;
+			        <App>
+			           <img {...props}/>
+			           <Image {...props}/>
+			        </App>
+			      "#,
+            Some(serde_json::json!([{ "html": "ignore" }])),
+        ),
+        (
+            "
+			        <App>
+			          <Foo {...{ prop1, prop2, prop3 }} />
+			        </App>
+			      ",
+            None,
+        ),
+        (
+            "
+			        <App>
+			          <Foo {...{ prop1, ...rest }} />
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "explicitSpread": "ignore" }])),
+        ),
+        (
+            "
+			        <App>
+			          <Foo {...{ ...props }} />
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "explicitSpread": "ignore" }])),
+        ),
+        (
+            "
+			        <App>
+			          <Foo {...props } />
+			        </App>
+			      ",
+            Some(serde_json::json!([{ "explicitSpread": "ignore" }])),
+        ),
+        (
+            "
+			        const props = {};
+			        <App>
+			           <components.Group {...props}/>
+			           <Nav.Item {...props}/>
+			        </App>
+			      ",
+            Some(
+                serde_json::json!([{ "exceptions": ["components.DropdownIndicator", "Nav.Item"] }]),
+            ),
+        ),
+    ];
+
+    Tester::new(JsxPropsNoSpreading::NAME, JsxPropsNoSpreading::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
@@ -1,0 +1,114 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:2:17]
+ 1 │ 
+ 2 │                     <App {...props}/>
+   ·                          ──────────
+ 3 │                   
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:2:17]
+ 1 │ 
+ 2 │                     <div {...props}></div>
+   ·                          ──────────
+ 3 │                   
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:2:17]
+ 1 │ 
+ 2 │                     <App {...props} some_other_prop={some_other_prop}/>
+   ·                          ──────────
+ 3 │                   
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:5:21]
+ 4 │                        <Image {...props}/>
+ 5 │                        <span {...props}/>
+   ·                              ──────────
+ 6 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:6:20]
+ 5 │                        <Image {...props}/>
+ 6 │                        <img {...props}/>
+   ·                             ──────────
+ 7 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:6:20]
+ 5 │                        <Image {...props}/>
+ 6 │                        <img {...props}/>
+   ·                             ──────────
+ 7 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:5:22]
+ 4 │                     <App>
+ 5 │                        <Image {...props}/>
+   ·                               ──────────
+ 6 │                        <img {...props}/>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:6:20]
+ 5 │                        <Image {...props}/>
+ 6 │                        <img {...props}/>
+   ·                             ──────────
+ 7 │                        <div {...props}/>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:6:22]
+ 5 │                        <img {...props}/>
+ 6 │                        <Image {...props}/>
+   ·                               ──────────
+ 7 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:3:19]
+ 2 │                     <App>
+ 3 │                       <Foo {...{ prop1, prop2, prop3 }} />
+   ·                            ────────────────────────────
+ 4 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:3:19]
+ 2 │                     <App>
+ 3 │                       <Foo {...{ prop1, ...rest }} />
+   ·                            ───────────────────────
+ 4 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:3:19]
+ 2 │                     <App>
+ 3 │                       <Foo {...{ ...props }} />
+   ·                            ─────────────────
+ 4 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:3:19]
+ 2 │                     <App>
+ 3 │                       <Foo {...props } />
+   ·                            ───────────
+ 4 │                     </App>
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
+   ╭─[jsx_props_no_spreading.tsx:4:33]
+ 3 │                     <App>
+ 4 │                        <components.Group {...props}/>
+   ·                                          ──────────
+ 5 │                        <Nav.Item {...props}/>
+   ╰────


### PR DESCRIPTION
added `react/jsx-props-no-spreading` rule, issue #1022

[rule doc](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md)
[rule source](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-props-no-spreading.js)