### PR TITLE
fix(minifier): avoid generating invalid spans

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
@@ -2,7 +2,7 @@ use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{ContentEq, GetSpan};
+use oxc_span::{ContentEq, GetSpan, SPAN};
 
 use crate::ctx::Ctx;
 
@@ -55,7 +55,7 @@ impl<'a> PeepholeOptimizations {
         if left.operator != op {
             return None;
         }
-        let new_span = Span::new(left.right.span().start, expr.span.end);
+        let new_span = left.right.span().merge_within(expr.right.span(), expr.span).unwrap_or(SPAN);
         Self::try_compress_is_null_or_undefined_for_left_and_right(
             &mut left.right,
             &mut expr.right,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -409,7 +409,7 @@ impl<'a> PeepholeOptimizations {
         let Some(new_expr) = Self::try_compress_is_object_and_not_null_for_left_and_right(
             &left.right,
             &e.right,
-            Span::new(left.right.span().start, e.span.end),
+            left.right.span().merge_within(e.right.span(), e.span).unwrap_or(SPAN),
             ctx,
             inversed,
         ) else {

--- a/crates/oxc_minifier/tests/peephole/oxc.rs
+++ b/crates/oxc_minifier/tests/peephole/oxc.rs
@@ -67,6 +67,16 @@ fn integration() {
         ",
         "v = KEY === 'delete' || KEY === 'has' ? function () { return 1 } : function () { return 2 }",
     );
+
+    test_unused(
+        "
+        const a = 'a';
+        window.foo
+        const b = `b`;
+        console.log(a + b);
+        ",
+        "window.foo, console.log('ab');",
+    );
 }
 
 #[test]


### PR DESCRIPTION
This debug assertion failed
https://github.com/oxc-project/oxc/blob/ef4cc33b5cedde82d5b5f91355d7b39436bdbcd6/crates/oxc_span/src/span.rs#L169
when it's called by
https://github.com/oxc-project/oxc/blob/c023ba67e07283bad3a43ef9bcc0336c94aa42ae/crates/oxc_codegen/src/gen.rs#L2123
which was caused by 
https://github.com/oxc-project/oxc/blob/102365da3dd02f5cdd444eaf04f8bbf91c814886/crates/oxc_minifier/src/peephole/fold_constants.rs#L445

This PR fixes these kinds of issues. This PR adds a test but does not fail even without the change. I'll fail once #15787 is done.

