### PR TITLE
docs(allocator): use `allocator` as var name in examples

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -70,9 +70,9 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
-    /// let arena = Allocator::default();
+    /// let allocator = Allocator::default();
     ///
-    /// let mut vec: Vec<i32> = Vec::new_in(&arena);
+    /// let mut vec: Vec<i32> = Vec::new_in(&allocator);
     /// assert!(vec.is_empty());
     /// ```
     #[inline(always)]
@@ -103,9 +103,9 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
-    /// let arena = Allocator::default();
+    /// let allocator = Allocator::default();
     ///
-    /// let mut vec = Vec::with_capacity_in(10, &arena);
+    /// let mut vec = Vec::with_capacity_in(10, &allocator);
     ///
     /// // The vector contains no items, even though it has capacity for more
     /// assert_eq!(vec.len(), 0);
@@ -125,7 +125,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     ///
     /// // A vector of a zero-sized type will always over-allocate, since no
     /// // allocation is necessary
-    /// let vec_units = Vec::<()>::with_capacity_in(10, &arena);
+    /// let vec_units = Vec::<()>::with_capacity_in(10, &allocator);
     /// assert_eq!(vec_units.capacity(), usize::MAX);
     /// ```
     #[inline(always)]
@@ -203,9 +203,9 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
-    /// let arena = Allocator::default();
+    /// let allocator = Allocator::default();
     ///
-    /// let mut vec = Vec::from_iter_in([1, 2, 3], &arena);
+    /// let mut vec = Vec::from_iter_in([1, 2, 3], &allocator);
     /// let slice = vec.into_bump_slice();
     /// assert_eq!(slice, [1, 2, 3]);
     /// ```


### PR DESCRIPTION
Make the vars names in examples for `Vec` methods consistent.