### PR TITLE
refactor(vscode): add `WorkspaceConfig` methods for different lsp tools

### DIFF
--- a/editors/vscode/client/WorkspaceConfig.ts
+++ b/editors/vscode/client/WorkspaceConfig.ts
@@ -269,6 +269,13 @@ export class WorkspaceConfig {
 
   public toLanguageServerConfig(): WorkspaceConfigInterface {
     return {
+      ...this.toOxlintConfig(),
+      ...this.toOxfmtConfig(),
+    };
+  }
+
+  public toOxlintConfig(): Omit<WorkspaceConfigInterface, 'fmt.experimental' | 'fmt.configPath'> {
+    return {
       run: this.runTrigger,
       configPath: this.configPath ?? null,
       tsConfigPath: this.tsConfigPath ?? null,
@@ -276,13 +283,18 @@ export class WorkspaceConfig {
       typeAware: this.typeAware,
       disableNestedConfig: this.disableNestedConfig,
       fixKind: this.fixKind,
-      ['fmt.experimental']: this.formattingExperimental,
-      ['fmt.configPath']: this.formattingConfigPath ?? null,
       // deprecated, kept for backward compatibility
       flags: {
         disable_nested_config: this.disableNestedConfig ? 'true' : 'false',
         ...(this.fixKind ? { fix_kind: this.fixKind } : {}),
       },
+    };
+  }
+
+  public toOxfmtConfig(): Pick<WorkspaceConfigInterface, 'fmt.experimental' | 'fmt.configPath'> {
+    return {
+      ['fmt.experimental']: this.formattingExperimental,
+      ['fmt.configPath']: this.formattingConfigPath ?? null,
     };
   }
 }

--- a/editors/vscode/tests/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/WorkspaceConfig.spec.ts
@@ -90,4 +90,72 @@ suite('WorkspaceConfig', () => {
     strictEqual(wsConfig.get('fmt.experimental'), true);
     strictEqual(wsConfig.get('fmt.configPath'), './oxfmt.json');
   });
+
+  test('toLanguageServerConfig method', async () => {
+    const config = new WorkspaceConfig(WORKSPACE_FOLDER);
+
+    await Promise.all([
+      config.updateRunTrigger('onSave'),
+      config.updateConfigPath('./somewhere'),
+      config.updateTsConfigPath('./tsconfig.json'),
+      config.updateUnusedDisableDirectives('deny'),
+      config.updateTypeAware(true),
+      config.updateDisableNestedConfig(true),
+      config.updateFixKind(FixKind.DangerousFix),
+      config.updateFormattingExperimental(true),
+      config.updateFormattingConfigPath('./oxfmt.json'),
+    ]);
+
+    const lsConfig = config.toLanguageServerConfig();
+
+    strictEqual(lsConfig.run, 'onSave');
+    strictEqual(lsConfig.configPath, './somewhere');
+    strictEqual(lsConfig.tsConfigPath, './tsconfig.json');
+    strictEqual(lsConfig.unusedDisableDirectives, 'deny');
+    strictEqual(lsConfig.typeAware, true);
+    strictEqual(lsConfig.disableNestedConfig, true);
+    strictEqual(lsConfig.fixKind, 'dangerous_fix');
+    strictEqual(lsConfig['fmt.experimental'], true);
+    strictEqual(lsConfig['fmt.configPath'], './oxfmt.json');
+  });
+
+  test('toOxlintConfig method', async () => {
+    const config = new WorkspaceConfig(WORKSPACE_FOLDER);
+
+    await Promise.all([
+      config.updateRunTrigger('onSave'),
+      config.updateConfigPath('./somewhere'),
+      config.updateTsConfigPath('./tsconfig.json'),
+      config.updateUnusedDisableDirectives('deny'),
+      config.updateTypeAware(true),
+      config.updateDisableNestedConfig(true),
+      config.updateFixKind(FixKind.DangerousFix),
+      config.updateFormattingExperimental(true),
+      config.updateFormattingConfigPath('./oxfmt.json'),
+    ]);
+
+    const oxlintConfig = config.toOxlintConfig();
+
+    strictEqual(oxlintConfig.run, 'onSave');
+    strictEqual(oxlintConfig.configPath, './somewhere');
+    strictEqual(oxlintConfig.tsConfigPath, './tsconfig.json');
+    strictEqual(oxlintConfig.unusedDisableDirectives, 'deny');
+    strictEqual(oxlintConfig.typeAware, true);
+    strictEqual(oxlintConfig.disableNestedConfig, true);
+    strictEqual(oxlintConfig.fixKind, 'dangerous_fix');
+  });
+
+  test('toOxfmtConfig method', async () => {
+    const config = new WorkspaceConfig(WORKSPACE_FOLDER);
+
+    await Promise.all([
+      config.updateFormattingExperimental(true),
+      config.updateFormattingConfigPath('./oxfmt.json'),
+    ]);
+
+    const oxfmtConfig = config.toOxfmtConfig();
+
+    strictEqual(oxfmtConfig['fmt.experimental'], true);
+    strictEqual(oxfmtConfig['fmt.configPath'], './oxfmt.json');
+  });
 });


### PR DESCRIPTION
In the future, the VSCode extension will call 2 language servers. 
Added a method to get different LSP configs for the different tools.