### PR TITLE
docs(data_structures): doc comments on fields of `Stack`

### DIFF
--- a/crates/oxc_data_structures/src/stack/sparse.rs
+++ b/crates/oxc_data_structures/src/stack/sparse.rs
@@ -37,7 +37,11 @@ use super::{NonEmptyStack, Stack};
 /// [`pop`]: SparseStack::pop
 /// [`NonEmptyStack<Option<T>>`]: NonEmptyStack
 pub struct SparseStack<T> {
+    /// Stack of `bool`s, indicating if entries have a value or not.
+    /// * `true` = has value.
+    /// * `false` = no value.
     has_values: NonEmptyStack<bool>,
+    /// The actual values for entries which have one
     values: Stack<T>,
 }
 

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -43,11 +43,11 @@ use super::{StackCapacity, StackCommon};
 /// [`NonEmptyStack::new`]: super::NonEmptyStack::new
 /// [`std`'s slice iterators]: std::slice::Iter
 pub struct Stack<T> {
-    // Pointer to *after* last entry on stack.
+    /// Pointer to *after* last entry on stack
     cursor: NonNull<T>,
-    // Pointer to start of allocation containing stack
+    /// Pointer to start of allocation containing stack
     start: NonNull<T>,
-    // Pointer to end of allocation containing stack
+    /// Pointer to end of allocation containing stack
     end: NonNull<T>,
 }
 


### PR DESCRIPTION
Convert normal comments on `Stack`'s struct fields to doc comments. Add doc comments on fields of `SparseStack`.