### PR TITLE
refactor(data_structures): add `PhantomData` field to `Stack` and `NonEmptyStack`

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -1,4 +1,5 @@
 use std::{
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -76,6 +77,8 @@ pub struct NonEmptyStack<T> {
     start: NonNull<T>,
     /// Pointer to end of allocation
     end: NonNull<T>,
+    /// Inform compiler that `NonEmptyStack<T>` owns `T`s
+    _marker: PhantomData<T>,
 }
 
 impl<T> StackCapacity<T> for NonEmptyStack<T> {}
@@ -211,7 +214,7 @@ impl<T> NonEmptyStack<T> {
         unsafe { start.as_ptr().write(initial_value) };
 
         // `cursor` is positioned at start i.e. pointing at initial value
-        Self { cursor: start, start, end }
+        Self { cursor: start, start, end, _marker: PhantomData }
     }
 
     /// Get reference to first value on stack.

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -1,4 +1,5 @@
 use std::{
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -49,6 +50,8 @@ pub struct Stack<T> {
     start: NonNull<T>,
     /// Pointer to end of allocation containing stack
     end: NonNull<T>,
+    /// Inform compiler that `Stack<T>` owns `T`s
+    _marker: PhantomData<T>,
 }
 
 impl<T> Default for Stack<T> {
@@ -115,7 +118,7 @@ impl<T> Stack<T> {
 
         // Create stack with equal `start` and `end`
         let dangling = NonNull::dangling();
-        Self { cursor: dangling, start: dangling, end: dangling }
+        Self { cursor: dangling, start: dangling, end: dangling, _marker: PhantomData }
     }
 
     /// Create new `Stack` with pre-allocated capacity for `capacity` entries.
@@ -180,7 +183,7 @@ impl<T> Stack<T> {
         let (start, end) = unsafe { Self::allocate(capacity_bytes) };
 
         // `cursor` is positioned at start
-        Self { cursor: start, start, end }
+        Self { cursor: start, start, end, _marker: PhantomData }
     }
 
     // Note: There is no need to implement `first` and `first_mut` methods.


### PR DESCRIPTION
Data structures which own `T`s should contain a `PhantomData<T>` field to signal to compiler the ownership semantics. For example `std::vec::Vec` does this.

Add `PhantomData` field to `Stack` and `NonEmptyStack`.

It's unclear to me if this is actually required for soundness or not. In the case of `std::vec::Vec`, it definitely is, but `Vec` uses `#[may_dangle]` in its `Drop` impl. Ideally we would use `#[may_dangle]` in these `Stack` types too, to loosen the borrow-checker's restrictions, but we're not able to as it's not available in stable Rust.

Given that we're not using `#[may_dangle]`, maybe `PhantomData` is not required either, but it costs nothing, so it's better to be on safe side and add it.