### PR TITLE
refactor(oxfmt): simplify `wrap_format_embeded`

### DIFF
--- a/apps/oxfmt/src/prettier_plugins/external_formatter.rs
+++ b/apps/oxfmt/src/prettier_plugins/external_formatter.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use napi::{
     Status,
     bindgen_prelude::{FnArgs, Promise, block_on},
-    threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
+    threadsafe_function::ThreadsafeFunction,
 };
 use oxc_formatter::EmbeddedFormatterCallback;
 
@@ -51,43 +51,22 @@ impl ExternalFormatter {
 ///
 /// Uses a channel to capture the result from the JS callback.
 pub fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback {
-    let cb = Arc::new(cb);
     Arc::new(move |tag_name: &str, code: &str| {
-        let cb = Arc::clone(&cb);
-
-        // Use a channel to capture the result from the JS callback
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        let tag_name_str = tag_name.to_string();
-        let code_str = code.to_string();
-
-        // Call the JS function with separate arguments
-        let status = cb.call_with_return_value(
-            FnArgs::from((tag_name_str.clone(), code_str)),
-            ThreadsafeFunctionCallMode::Blocking,
-            move |result: Result<Promise<String>, napi::Error>, _env| {
-                // Send the result through the channel
-                let _ = tx.send(result);
-                Ok(())
-            },
-        );
-
-        if status != napi::Status::Ok {
-            return Err(format!(
-                "Failed to call JS formatter for tag '{tag_name_str}': {status:?}"
-            ));
-        }
-
-        // Wait for the result from the channel
-        match rx.recv() {
-            Ok(Ok(promise)) => block_on(promise).map_err(|e| {
-                format!("JS formatter promise rejected for tag '{tag_name_str}': {e}")
-            }),
-            Ok(Err(e)) => Err(format!("JS formatter failed for tag '{tag_name_str}': {e}")),
-            Err(_) => {
-                Err(format!("Failed to receive result from JS formatter for tag '{tag_name_str}'"))
+        block_on(async {
+            let status =
+                cb.call_async(FnArgs::from((tag_name.to_string(), code.to_string()))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(formatted_code) => Ok(formatted_code),
+                    Err(err) => {
+                        Err(format!("JS formatter promise rejected for tag '{tag_name}': {err}"))
+                    }
+                },
+                Err(err) => Err(format!(
+                    "Failed to call JS formatting callback for tag '{tag_name}': {err}"
+                )),
             }
-        }
+        })
     })
 }
 


### PR DESCRIPTION
`call_async` does the same thing as `call_with_return_value` + `channel`, so use `call_async` to simplify it and reduce some unnecessary overhead

### Benchmark

I benchmarked this PR locally, and the results indicate that it is 9% faster than before in the `Outline` repo.

EDIT: Maybe just a noise since `Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interference from other programs.` was displayed.

```shell

Setup complete! Run 'pnpm run bench' to start benchmarking.
=========================================
JavaScript/TypeScript Formatter Benchmark
=========================================

Formatters: Prettier, Biome, Oxfmt

Starting benchmark with:
- 3 warmup runs
- 10 benchmark runs
- Git reset before each run


=========================================
Benchmarking parser.ts (single large file)
=========================================
Benchmark 1: biome
  Time (mean ± σ):      69.5 ms ±   0.9 ms    [User: 55.4 ms, System: 9.7 ms]
  Range (min … max):    68.3 ms …  71.2 ms    10 runs
 
Benchmark 2: oxfmt-new
  Time (mean ± σ):      30.7 ms ±   0.3 ms    [User: 23.7 ms, System: 11.0 ms]
  Range (min … max):    30.3 ms …  31.3 ms    10 runs
 
Benchmark 3: oxfmt-old
  Time (mean ± σ):      30.4 ms ±   0.3 ms    [User: 23.6 ms, System: 10.6 ms]
  Range (min … max):    30.1 ms …  30.9 ms    10 runs
 
Summary
  oxfmt-old ran
    1.01 ± 0.01 times faster than oxfmt-new
    2.29 ± 0.04 times faster than biome

=========================================
Benchmarking Outline repository
=========================================
Benchmark 1: biome
  Time (mean ± σ):     154.6 ms ±   6.0 ms    [User: 825.2 ms, System: 555.8 ms]
  Range (min … max):   147.5 ms … 164.0 ms    10 runs
 
Benchmark 2: oxfmt-new
  Time (mean ± σ):      65.8 ms ±   2.3 ms    [User: 196.0 ms, System: 265.3 ms]
  Range (min … max):    60.7 ms …  68.8 ms    10 runs
 
Benchmark 3: oxfmt-old
  Time (mean ± σ):      72.0 ms ±  17.7 ms    [User: 195.0 ms, System: 277.3 ms]
  Range (min … max):    62.6 ms … 121.1 ms    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.
 
Summary
  oxfmt-new ran
    1.09 ± 0.27 times faster than oxfmt-old
    2.35 ± 0.12 times faster than biome
```