### PR TITLE
docs(linter): fix error in `curly` `"all"` example

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -99,10 +99,14 @@ declare_oxc_lint!(
     /// ```js
     /// /* curly: ["error", "all"] */
     ///
-    /// if (foo) { foo++; }
-    /// while (bar) { bar--; }
+    /// if (foo) {
+    ///   foo++;
+    /// }
+    /// while (bar) {
+    ///   bar--;
+    /// }
     /// do { foo(); } while (bar);
-    ///```
+    /// ```
     ///
     /// #### `"multi"`
     /// Examples of **incorrect** code for this rule with the `"multi"` option:


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-project.github.io/pull/642/files

Co-authored-by: Jacob Carpenter <jacobcarpenter@users.noreply.github.com>