### PR TITLE
perf(linter/typescript): avoid searching source text unless required

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -67,10 +67,9 @@ impl Rule for PreferNamespaceKeyword {
             return;
         }
 
-        let Some(offset) = ctx.find_next_token_from(module.span.start, "module") else { return };
-
         ctx.diagnostic_with_fix(prefer_namespace_keyword_diagnostic(module.span), |fixer| {
-            let span_start = module.span.start + offset;
+            let mut span_start = module.span.start;
+            span_start += ctx.find_next_token_from(span_start, "module").unwrap();
             fixer.replace(Span::sized(span_start, 6), "namespace")
         });
     }


### PR DESCRIPTION
Follow-on after #15715 and #15716. Small perf optimizations.

* `typescript/prefer-namespace-keyword`: Don't search for token unless it's needed (fixes are enabled).
* `typescript/no-namespace`: De-duplicate code.
