### PR TITLE
fix(linter/plugins): pin `@typescript-eslint/scope-manager` dependency

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -20,7 +20,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "devDependencies": {
-    "@typescript-eslint/scope-manager": "^8.46.2",
+    "@typescript-eslint/scope-manager": "8.46.2",
     "@types/esquery": "^1.5.4",
     "@types/estree": "^1.0.8",
     "eslint": "^9.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       '@typescript-eslint/scope-manager':
-        specifier: ^8.46.2
+        specifier: 8.46.2
         version: 8.46.2(patch_hash=08ab34b5f27480602bc518186b717a8915aa4d6b2b5df1adc747320ba25b1f8b)
       eslint:
         specifier: ^9.36.0


### PR DESCRIPTION
#15214 added a patch to `@typescript-eslint/scope-manager` dependency.

Pin that dependency, so the patch continues to work.
