### PR TITLE
test(linter/plugins): simplify test case

### DIFF
--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
@@ -25,12 +25,12 @@
  3 | 
    `----
 
-  x scope-plugin(scope): getScope(topLevelFunction): type: function
+  x scope-plugin(scope): getScope(topLevelFunction):
+  | type: function
   | isStrict: true
-  | vars: [arguments, param, localConstant]
+  | variables: [arguments, param, localConstant]
   | through: [topLevelConstant, Math]
-  | upper: module
-  | 
+  | upper type: module
     ,-[files/index.js:4:1]
   3 |     
   4 | ,-> function topLevelFunction(param) {

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -1,24 +1,4 @@
-import assert from 'node:assert';
-
-import type { ESTree, Node, Plugin, Rule, Scope, Variable } from '../../../dist/index.js';
-
-type Program = ESTree.Program;
-
-type Identifier =
-  | ESTree.IdentifierName
-  | ESTree.IdentifierReference
-  | ESTree.BindingIdentifier
-  | ESTree.LabelIdentifier;
-
-const SPAN: Node = {
-  start: 0,
-  end: 0,
-  range: [0, 0],
-  loc: {
-    start: { line: 0, column: 0 },
-    end: { line: 0, column: 0 },
-  },
-};
+import type { Plugin, Rule } from '../../../dist/index.js';
 
 const rule: Rule = {
   create(context) {
@@ -33,24 +13,21 @@ const rule: Rule = {
         });
       },
       Identifier(node) {
-        const { name } = node;
-        const isGlobal = sourceCode.isGlobalReference(node);
         context.report({
-          message: `isGlobalReference(${name}): ${isGlobal}`,
+          message: `isGlobalReference(${node.name}): ${sourceCode.isGlobalReference(node)}`,
           node,
         });
       },
       FunctionDeclaration(node) {
         const scope = sourceCode.getScope(node);
-        let text = '';
-        text += `type: ${scope.type}\n`;
-        text += `isStrict: ${scope.isStrict}\n`;
-        text += `vars: [${scope.variables.map((v) => v.name).join(', ')}]\n`;
-        text += `through: [${scope.through.map((r) => (r.identifier as any).name).join(', ')}]\n`;
-        if (scope.upper) text += `upper: ${scope.upper.type}\n`;
-
         context.report({
-          message: `getScope(${node.id.name}): ${text}`,
+          message:
+            `getScope(${node.id.name}):\n` +
+            `type: ${scope.type}\n` +
+            `isStrict: ${scope.isStrict}\n` +
+            `variables: [${scope.variables.map((v) => v.name).join(', ')}]\n` +
+            `through: [${scope.through.map((r) => r.identifier.name).join(', ')}]\n` +
+            `upper type: ${scope.upper?.type}`,
           node,
         });
       },


### PR DESCRIPTION
Follow-on after #15214. Pure refactor of tests. Just simplify the plugin used in the test fixture, to make it easier to read, and remove dead code.