### PR TITLE
chore(ast): Update `oxc_ast@0.98.0`/`CHANGELOG` to notify breaking change

### DIFF
--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## [0.98.0] - 2025-11-17
 
+### 💥 BREAKING CHANGES
+
+- b2af6b5 ast: [**BREAKING**] Remove AstKind for Argument (#13902) (taearls)
+
 ### 🚀 Features
 
 - 8a61cfd allocator, ast: Introduce `UnstableAddress` trait (#15700) (overlookmotel)


### PR DESCRIPTION
Added `AstKind::Argument` breaking change for version 0.98.0.

https://github.com/oxc-project/oxc/releases/tag/crates_v0.98.0 has updated too.