### PR TITLE
perf(formatter): reduce the size of `TextWidth` to 4 byte

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -4,7 +4,6 @@ pub mod tag;
 // #[cfg(target_pointer_width = "64")]
 // use biome_rowan::static_assert;
 use std::hash::{Hash, Hasher};
-use std::num::NonZeroU32;
 use std::ptr;
 use std::{borrow::Cow, ops::Deref, rc::Rc};
 
@@ -384,69 +383,161 @@ pub trait FormatElements {
     fn end_tag(&self, kind: TagKind) -> Option<&Tag>;
 }
 
-/// New-type wrapper for a single-line text unicode width.
-/// Mainly to prevent access to the inner value.
+/// New-type wrapper for a text Unicode width. Mainly to prevent access to the inner value.
 ///
 /// ## Representation
 ///
-/// Represents the width by adding 1 to the actual width so that the width can be represented by a [`NonZeroU32`],
-/// allowing [`TextWidth`] or [`Option<Width>`] fit in 4 bytes rather than 8.
+/// Uses a single `u32` to efficiently store both the width value and a multiline flag:
 ///
-/// This means that 2^32 can not be precisely represented and instead has the same value as 2^32-1.
-/// This imprecision shouldn't matter in practice because either text are longer than any configured line width
-/// and thus, the text should break.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Width(NonZeroU32);
-
-impl Width {
-    pub(crate) const fn new(width: u32) -> Self {
-        Width(NonZeroU32::MIN.saturating_add(width))
-    }
-
-    pub const fn value(self) -> u32 {
-        self.0.get() - 1
-    }
-}
-
-/// The pre-computed unicode width of a text if it is a single-line text or a marker
-/// that it is a multiline text if it contains a line feed.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TextWidth {
-    /// Single-line text width
-    Width(Width),
-    /// Multi-line text whose `width` is from the start of the text to the first line break
-    Multiline(Width),
-}
+/// - Bit 31: Multiline flag (1 = multiline, 0 = single line)
+/// - Bits 0-30: Width value (stored directly)
+///
+/// This encoding allows `TextWidth` to fit in 4 bytes while supporting both a width value
+/// and a boolean flag. The maximum representable width is 2^31 - 1 (0x7FFFFFFF).
+///
+/// The maximum value is sufficient in practice as texts that long would exceed any
+/// reasonable line width configuration (typically < 500 columns).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct TextWidth(u32);
 
 impl TextWidth {
+    /// Bit mask for the multiline flag (highest bit)
+    const MULTILINE_MASK: u32 = 1 << 31;
+
+    /// Bit mask for extracting the width value (all bits except the highest)
+    const WIDTH_MASK: u32 = Self::MULTILINE_MASK - 1;
+
+    /// Encodes width and multiline flag into a single u32.
+    const fn encode(width: u32, multiline: bool) -> u32 {
+        debug_assert!(width <= Self::WIDTH_MASK, "width exceeds maximum representable value");
+
+        // Set multiline flag if needed
+        if multiline { width | Self::MULTILINE_MASK } else { width }
+    }
+
+    /// Creates a single-line text width.
+    pub const fn single(width: u32) -> Self {
+        Self(Self::encode(width, false))
+    }
+
+    /// Creates a multi-line text width.
+    pub const fn multiline(width: u32) -> Self {
+        Self(Self::encode(width, true))
+    }
+
+    /// Returns the width value.
+    pub const fn value(self) -> u32 {
+        self.0 & Self::WIDTH_MASK
+    }
+
+    /// Calculates width from text, handling tabs, newlines, and Unicode.
+    ///
+    /// Returns early on newline detection for efficiency.
     pub fn from_text(text: &str, indent_width: IndentWidth) -> TextWidth {
+        // Fast path for empty text
+        if text.is_empty() {
+            return Self::single(0);
+        }
+
         let mut width = 0u32;
 
         #[expect(clippy::cast_lossless)]
         for c in text.chars() {
             let char_width = match c {
                 '\t' => indent_width.value(),
-                '\n' => return Self::Multiline(Width::new(width)),
+                '\n' => return Self::multiline(width),
                 #[expect(clippy::cast_possible_truncation)]
                 c => c.width().unwrap_or(0) as u8,
             };
             width += char_width as u32;
         }
 
-        Self::Width(Width::new(width))
+        Self::single(width)
     }
 
+    /// Creates width from a string known to not contain whitespace.
+    /// More efficient than `from_text` when whitespace is guaranteed absent.
     pub fn from_non_whitespace_str(name: &str) -> TextWidth {
         #[expect(clippy::cast_possible_truncation)]
-        Self::Width(Width::new(name.width() as u32))
+        Self::single(name.width() as u32)
     }
 
-    pub fn from_len(len: usize) -> TextWidth {
-        #[expect(clippy::cast_possible_truncation)]
-        TextWidth::Width(Width::new(len as u32))
-    }
-
+    /// Returns true if the text contains newlines.
     pub(crate) const fn is_multiline(self) -> bool {
-        matches!(self, TextWidth::Multiline(_))
+        (self.0 & Self::MULTILINE_MASK) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn indent_width(value: u8) -> IndentWidth {
+        IndentWidth::try_from(value).expect("valid indent width")
+    }
+
+    #[test]
+    fn single_width_round_trips_zero() {
+        let width = TextWidth::single(0);
+        debug_assert_eq!(width.value(), 0);
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn multiline_sets_flag_without_touching_width() {
+        let width = TextWidth::multiline(3);
+        debug_assert_eq!(width.value(), 3);
+        debug_assert!(width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_uses_indent_width_for_tabs() {
+        let width = TextWidth::from_text("\t", indent_width(4));
+        debug_assert_eq!(width.value(), 4);
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_marks_multiline_on_newline() {
+        let width = TextWidth::from_text("ab\nc", indent_width(2));
+        debug_assert_eq!(width.value(), 2);
+        debug_assert!(width.is_multiline());
+    }
+
+    #[test]
+    fn from_non_whitespace_and_len_match() {
+        let name = "hello";
+        #[expect(clippy::cast_possible_truncation)]
+        let name_len = name.len() as u32;
+        debug_assert_eq!(TextWidth::from_non_whitespace_str(name).value(), name_len);
+    }
+
+    #[test]
+    fn is_single_line_inverse_of_is_multiline() {
+        let single = TextWidth::single(10);
+        debug_assert!(!single.is_multiline());
+
+        let multi = TextWidth::multiline(10);
+        debug_assert!(multi.is_multiline());
+    }
+
+    #[test]
+    fn from_text_handles_unicode() {
+        // Emoji width
+        let width = TextWidth::from_text("👍", indent_width(2));
+        debug_assert_eq!(width.value(), 2); // Most emojis are width 2
+        debug_assert!(!width.is_multiline());
+
+        // Chinese characters
+        let width = TextWidth::from_text("你好", indent_width(2));
+        debug_assert_eq!(width.value(), 4); // Each CJK char is width 2
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_empty_returns_zero() {
+        let width = TextWidth::from_text("", indent_width(2));
+        debug_assert_eq!(width.value(), 0);
+        debug_assert!(!width.is_multiline());
     }
 }


### PR DESCRIPTION
* close: #15823

The size of `TextWidth` was increased in https://github.com/oxc-project/oxc/pull/15762, which caused a 2% performance regression; I am unsure why this occurred at the time. Now I understand that the `TextWidth` size increased from 4 bytes to 8 bytes, which caused the FormatElement enum size to become 24 bytes in a 32-bit system.

This PR changes the `TextWidth` enum to a struct that only stores a `u32` width and uses the 31st bit as a marker to represent whether it is a multiline or not. Although it is smaller than `NonZeroU32`, it is enough to store the text width.