### PR TITLE
fix(formatter/sort-imports)!: Change default order to `natural` with `natord` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,6 +1496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,7 +1540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1937,6 +1943,7 @@ dependencies = [
  "cow-utils",
  "insta",
  "json-strip-comments",
+ "natord",
  "oxc-schemars",
  "oxc_allocator",
  "oxc_ast",
@@ -2933,7 +2940,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3028,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3316,7 +3323,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3847,7 +3854,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -30,6 +30,7 @@ oxc_syntax = { workspace = true }
 
 cow-utils = { workspace = true }
 json-strip-comments = { workspace = true }
+natord = "1.0.9"
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 schemars = { workspace = true }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -266,7 +266,8 @@ fn sort_imports(imports: &mut [SortableImport], options: &options::SortImports) 
         }
 
         // Within the same group, sort by source respecting the order option
-        let source_ord = imports[a].normalized_source.cmp(&imports[b].normalized_source);
+        let source_ord =
+            natord::compare(&imports[a].normalized_source, &imports[b].normalized_source);
         if options.order.is_desc() { source_ord.reverse() } else { source_ord }
     });
 

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -38,7 +38,7 @@ import * as c from "c";
 import d from "d";
 "#,
     );
-    // Alphabetical ASC order by default
+    // Natural ASC order by default
     assert_format(
         r#"
 import { log } from "./log";
@@ -49,9 +49,9 @@ import { log2 } from "./log2";
         r#"{ "experimentalSortImports": {} }"#,
         r#"
 import { log } from "./log";
-import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
+import { log10 } from "./log10";
 "#,
     );
     // Dynamic imports should not affect sorting
@@ -612,7 +612,7 @@ import B from "b";
 
 #[test]
 fn should_sort_by_order() {
-    // Z-A
+    // Z-A (natural order reversed)
     assert_format(
         r#"
 import { log } from "./log";
@@ -622,13 +622,13 @@ import { log2 } from "./log2";
 "#,
         r#"{ "experimentalSortImports": { "order": "desc" } }"#,
         r#"
+import { log10 } from "./log10";
 import { log2 } from "./log2";
 import { log1p } from "./log1p";
-import { log10 } from "./log10";
 import { log } from "./log";
 "#,
     );
-    // A-Z - default
+    // A-Z - default (natural order)
     assert_format(
         r#"
 import { log } from "./log";
@@ -639,9 +639,9 @@ import { log2 } from "./log2";
         r#"{ "experimentalSortImports": { "order": "asc" } }"#,
         r#"
 import { log } from "./log";
-import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
+import { log10 } from "./log10";
 "#,
     );
     assert_format(
@@ -654,9 +654,9 @@ import { log2 } from "./log2";
         r#"{ "experimentalSortImports": {} }"#,
         r#"
 import { log } from "./log";
-import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
+import { log10 } from "./log10";
 "#,
     );
 }


### PR DESCRIPTION
Part of #14253 

Change the default order type from `alphabetical` to `natural`.

In the original JS implementation, `alphabetical` sort uses the built-in `localeCompare()` function, but this does not exist in Rust.

I have therefore changed the default to `natural` because:

- Adding a crate to handle locale would be excessive
- `prettier-plugin-sort-imports` also uses natural sorting