### PR TITLE
fix(transformer/tagged-template-transform): handle `\n` escape sequences

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: c92c4919
 
-Passed: 198/329
+Passed: 200/331
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/escape-sequence/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/escape-sequence/input.js
@@ -1,0 +1,2 @@
+foo`</script>\n`
+bar`</script>\t`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/escape-sequence/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/escape-sequence/output.js
@@ -1,0 +1,4 @@
+var _templateObject;
+var _templateObject2;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral(["</script>\n"], ["</script>\\n"])));
+bar(_templateObject2 || (_templateObject2 = babelHelpers.taggedTemplateLiteral(["</script>\t"], ["</script>\\t"])));

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/invalid-escape/input.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/invalid-escape/input.js
@@ -1,0 +1,1 @@
+foo`</script>\u`

--- a/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/invalid-escape/output.js
+++ b/tasks/transform_conformance/tests/plugin-tagged-template-transform/test/fixtures/invalid-escape/output.js
@@ -1,0 +1,2 @@
+var _templateObject;
+foo(_templateObject || (_templateObject = babelHelpers.taggedTemplateLiteral([void 0], ["</script>\\u"])));


### PR DESCRIPTION
Fixes the issue identified in #15664 where the tagged template transform plugin incorrectly handled template literals containing escape sequences.

### Examples

```js
// Input
foo`</script>\n`
// Before (incorrect): 
foo(_t || (_t = taggedTemplateLiteral(["</script>\\n"])));
// After (correct):
foo(_t || (_t = taggedTemplateLiteral(["</script>\n"], ["</script>\\n"])));

// Input with invalid escape
foo`</script>\u`
// Before (syntax error):
foo(_t || (_t = taggedTemplateLiteral(["</script>\\u"])));
// After (correct):
foo(_t || (_t = taggedTemplateLiteral([void 0], ["</script>\\u"])));
