### PR TITLE
fix(ci): run conformance test suite on JS dep changes

### DIFF
--- a/.github/scripts/check-conformance-changes.js
+++ b/.github/scripts/check-conformance-changes.js
@@ -30,6 +30,7 @@ const ALWAYS_RUN_PATHS = [
   'tasks/common/',
   'tasks/oxc_transform_conformance/',
   'tasks/oxc_prettier_conformance/',
+  'pnpm-lock.yaml',
 ];
 
 /**


### PR DESCRIPTION
Transformer CI runs node, and produces snapshots that include the dependency version inside the snapshot:

https://github.com/oxc-project/oxc/blob/82471c8d5a22e3a07c275eea79a07b61f8827875/tasks/transform_conformance/snapshots/babel_exec.snap.md#L51-L56

Therefore we should re-run conformance CI when these dependencies change to ensure the snapshots remain up to date.