### PR TITLE
chore(vscode): second language server connection for `oxfmt`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
+  // "oxc.path.oxlint": "apps/oxlint/dist/cli.js", // debug with local oxlint build
   "oxc.typeAware": true,
   "oxc.configPath": "oxlintrc.json",
   "oxc.unusedDisableDirectives": "deny",
+
+  // "oxc.path.oxfmt": "apps/oxfmt/dist/cli.js", // debug with local oxfmt build
   "oxc.fmt.experimental": true,
   "oxc.fmt.configPath": "oxfmtrc.jsonc",
   "[javascript]": {

--- a/editors/vscode/client/StatusBarItemHandler.ts
+++ b/editors/vscode/client/StatusBarItemHandler.ts
@@ -34,7 +34,9 @@ export default class StatusBarItemHandler {
   }
 
   private updateFullTooltip(): void {
-    const text = Array.from(this.tooltipSections.values()).join("\n\n");
+    const text = [this.tooltipSections.get("linter"), this.tooltipSections.get("formatter")]
+      .filter(Boolean)
+      .join("\n\n---\n\n");
 
     if (!(this.statusBarItem.tooltip instanceof MarkdownString)) {
       this.statusBarItem.tooltip = new MarkdownString("", true);

--- a/editors/vscode/client/VSCodeConfig.ts
+++ b/editors/vscode/client/VSCodeConfig.ts
@@ -5,6 +5,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
   private _enable!: boolean;
   private _trace!: TraceLevel;
   private _binPathOxlint: string | undefined;
+  private _binPathOxfmt: string | undefined;
   private _nodePath: string | undefined;
   private _requireConfig!: boolean;
 
@@ -25,6 +26,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
     this._enable = this.configuration.get<boolean>("enable") ?? true;
     this._trace = this.configuration.get<TraceLevel>("trace.server") || "off";
     this._binPathOxlint = binPathOxlint;
+    this._binPathOxfmt = this.configuration.get<string>("path.oxfmt");
     this._nodePath = this.configuration.get<string>("path.node");
     this._requireConfig = this.configuration.get<boolean>("requireConfig") ?? false;
   }
@@ -54,6 +56,15 @@ export class VSCodeConfig implements VSCodeConfigInterface {
   updateBinPathOxlint(value: string | undefined): PromiseLike<void> {
     this._binPathOxlint = value;
     return this.configuration.update("path.oxlint", value);
+  }
+
+  get binPathOxfmt(): string | undefined {
+    return this._binPathOxfmt;
+  }
+
+  updateBinPathOxfmt(value: string | undefined): PromiseLike<void> {
+    this._binPathOxfmt = value;
+    return this.configuration.update("path.oxfmt", value);
   }
 
   get nodePath(): string | undefined {

--- a/editors/vscode/client/WorkspaceConfig.ts
+++ b/editors/vscode/client/WorkspaceConfig.ts
@@ -100,6 +100,16 @@ export interface WorkspaceConfigInterface {
   ["fmt.configPath"]?: string | null;
 }
 
+export type OxlintWorkspaceConfigInterface = Omit<
+  WorkspaceConfigInterface,
+  "fmt.experimental" | "fmt.configPath"
+>;
+
+export type OxfmtWorkspaceConfigInterface = Pick<
+  WorkspaceConfigInterface,
+  "fmt.experimental" | "fmt.configPath"
+>;
+
 export class WorkspaceConfig {
   private _configPath: string | null = null;
   private _tsConfigPath: string | null = null;
@@ -297,7 +307,7 @@ export class WorkspaceConfig {
     };
   }
 
-  public toOxlintConfig(): Omit<WorkspaceConfigInterface, "fmt.experimental" | "fmt.configPath"> {
+  public toOxlintConfig(): OxlintWorkspaceConfigInterface {
     return {
       run: this.runTrigger,
       configPath: this.configPath ?? null,
@@ -314,7 +324,7 @@ export class WorkspaceConfig {
     };
   }
 
-  public toOxfmtConfig(): Pick<WorkspaceConfigInterface, "fmt.experimental" | "fmt.configPath"> {
+  public toOxfmtConfig(): OxfmtWorkspaceConfigInterface {
     return {
       ["fmt.experimental"]: this.formattingExperimental,
       ["fmt.configPath"]: this.formattingConfigPath ?? null,

--- a/editors/vscode/client/commands.ts
+++ b/editors/vscode/client/commands.ts
@@ -1,9 +1,15 @@
 const commandPrefix = "oxc";
 
 export const enum OxcCommands {
-  ShowOutputChannel = `${commandPrefix}.showOutputChannel`,
+  // always available, even if no tool is active
+  ShowOutputChannelLint = `${commandPrefix}.showOutputChannel`,
+  ShowOutputChannelFmt = `${commandPrefix}.showOutputChannelFormatter`,
+
   // only for linter.ts usage
-  RestartServer = `${commandPrefix}.restartServer`,
-  ToggleEnable = `${commandPrefix}.toggleEnable`,
+  RestartServerLint = `${commandPrefix}.restartServer`, // without `Linter` suffix for backward compatibility
+  ToggleEnableLint = `${commandPrefix}.toggleEnable`, // without `Linter` suffix for backward compatibility
   ApplyAllFixesFile = `${commandPrefix}.applyAllFixesFile`,
+
+  // only for formatter.ts usage
+  RestartServerFmt = `${commandPrefix}.restartServerFormatter`,
 }

--- a/editors/vscode/client/tools/formatter.ts
+++ b/editors/vscode/client/tools/formatter.ts
@@ -1,0 +1,245 @@
+import { promises as fsPromises } from "node:fs";
+
+import {
+  commands,
+  ConfigurationChangeEvent,
+  ExtensionContext,
+  LogOutputChannel,
+  Uri,
+  window,
+  workspace,
+} from "vscode";
+
+import { ConfigurationParams, ShowMessageNotification } from "vscode-languageclient";
+
+import {
+  Executable,
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
+
+import { OxcCommands } from "../commands";
+import { ConfigService } from "../ConfigService";
+import StatusBarItemHandler from "../StatusBarItemHandler";
+import { onClientNotification, runExecutable } from "./lsp_helper";
+import ToolInterface from "./ToolInterface";
+
+const languageClientName = "oxc";
+
+export default class FormatterTool implements ToolInterface {
+  // LSP client instance
+  private client: LanguageClient | undefined;
+
+  async getBinary(
+    _context: ExtensionContext,
+    outputChannel: LogOutputChannel,
+    configService: ConfigService,
+  ): Promise<string | undefined> {
+    const bin = await configService.getOxfmtServerBinPath();
+    if (workspace.isTrusted && bin) {
+      try {
+        await fsPromises.access(bin);
+        return bin;
+      } catch (e) {
+        outputChannel.error(`Invalid bin path: ${bin}`, e);
+      }
+    }
+    return process.env.SERVER_PATH_DEV;
+  }
+
+  async activate(
+    context: ExtensionContext,
+    binaryPath: string,
+    outputChannel: LogOutputChannel,
+    configService: ConfigService,
+    statusBarItemHandler: StatusBarItemHandler,
+  ) {
+    const restartCommand = commands.registerCommand(OxcCommands.RestartServerFmt, async () => {
+      await this.restartClient();
+    });
+
+    outputChannel.info(`Using server binary at: ${binaryPath}`);
+
+    const run: Executable = runExecutable(binaryPath, configService.vsCodeConfig.nodePath);
+
+    const serverOptions: ServerOptions = {
+      run,
+      debug: run,
+    };
+
+    // This list is not used as-is for implementation to determine whether formatting processing is possible.
+    const supportedExtensions = [
+      "cjs",
+      "cts",
+      "js",
+      "jsx",
+      "mjs",
+      "mts",
+      "ts",
+      "tsx",
+      // https://github.com/oxc-project/oxc/blob/f3e9913f534e36195b9b5a6244dd21076ed8715e/crates/oxc_formatter/src/service/parse_utils.rs#L24-L45
+      "_js",
+      "bones",
+      "es",
+      "es6",
+      "gs",
+      "jake",
+      "javascript",
+      "jsb",
+      "jscad",
+      "jsfl",
+      "jslib",
+      "jsm",
+      "jspre",
+      "jss",
+      "njs",
+      "pac",
+      "sjs",
+      "ssjs",
+      "xsjs",
+      "xsjslib",
+      // https://github.com/oxc-project/oxc/blob/f3e9913f534e36195b9b5a6244dd21076ed8715e/crates/oxc_formatter/src/service/parse_utils.rs#L73
+      // allow `*.start.frag` and `*.end.frag`,
+      "frag",
+    ];
+
+    // Special filenames that are valid JS files
+    // https://github.com/oxc-project/oxc/blob/f3e9913f534e36195b9b5a6244dd21076ed8715e/crates/oxc_formatter/src/service/parse_utils.rs#L47C4-L52
+    const specialFilenames = [
+      "Jakefile",
+
+      // covered by the "frag" extension above
+      // "start.frag",
+      // "end.frag",
+    ];
+
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+      // Register the server for plain text documents
+      documentSelector: [
+        {
+          pattern: `**/*.{${supportedExtensions.join(",")}}`,
+          scheme: "file",
+        },
+        ...specialFilenames.map((filename) => ({
+          pattern: `**/${filename}`,
+          scheme: "file",
+        })),
+      ],
+      initializationOptions: configService.formatterServerConfig,
+      outputChannel,
+      traceOutputChannel: outputChannel,
+      middleware: {
+        workspace: {
+          configuration: (params: ConfigurationParams) => {
+            return params.items.map((item) => {
+              if (item.section !== "oxc_language_server") {
+                return null;
+              }
+              if (item.scopeUri === undefined) {
+                return null;
+              }
+
+              return (
+                configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxfmtConfig() ?? null
+              );
+            });
+          },
+        },
+      },
+    };
+
+    // Create the language client and start the client.
+    this.client = new LanguageClient(languageClientName, serverOptions, clientOptions);
+
+    const onNotificationDispose = this.client.onNotification(
+      ShowMessageNotification.type,
+      (params) => {
+        onClientNotification(params, outputChannel);
+      },
+    );
+
+    context.subscriptions.push(restartCommand, onNotificationDispose);
+
+    updateStatsBar(statusBarItemHandler, configService);
+    if (configService.vsCodeConfig.enable) {
+      await this.client.start();
+    }
+  }
+
+  async deactivate(): Promise<void> {
+    if (!this.client) {
+      return undefined;
+    }
+    await this.client.stop();
+    this.client = undefined;
+  }
+
+  async restartClient(): Promise<void> {
+    if (this.client === undefined) {
+      window.showErrorMessage("oxc client not found");
+      return;
+    }
+
+    try {
+      if (this.client.isRunning()) {
+        await this.client.restart();
+        window.showInformationMessage("oxc server restarted.");
+      } else {
+        await this.client.start();
+      }
+    } catch (err) {
+      this.client.error("Restarting client failed", err, "force");
+    }
+  }
+
+  async toggleClient(configService: ConfigService): Promise<void> {
+    if (this.client === undefined) {
+      return;
+    }
+
+    if (this.client.isRunning()) {
+      if (!configService.vsCodeConfig.enable) {
+        await this.client.stop();
+      }
+    } else {
+      if (configService.vsCodeConfig.enable) {
+        await this.client.start();
+      }
+    }
+  }
+
+  async onConfigChange(
+    event: ConfigurationChangeEvent,
+    configService: ConfigService,
+    statusBarItemHandler: StatusBarItemHandler,
+  ): Promise<void> {
+    updateStatsBar(statusBarItemHandler, configService);
+
+    if (this.client === undefined) {
+      return;
+    }
+
+    // update the initializationOptions for a possible restart
+    this.client.clientOptions.initializationOptions = configService.formatterServerConfig;
+
+    if (configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
+      await this.client.sendNotification("workspace/didChangeConfiguration", {
+        settings: configService.formatterServerConfig,
+      });
+    }
+  }
+}
+
+function updateStatsBar(statusBarItemHandler: StatusBarItemHandler, configService: ConfigService) {
+  let text = configService.vsCodeConfig.enable ? `**oxfmt enabled**\n\n` : `**oxfmt disabled**\n\n`;
+
+  text +=
+    `[$(terminal) Open Output](command:${OxcCommands.ShowOutputChannelFmt})\n\n` +
+    `[$(refresh) Restart Server](command:${OxcCommands.RestartServerFmt})\n\n`;
+
+  statusBarItemHandler.updateToolTooltip("formatter", text);
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -41,7 +41,12 @@
     "commands": [
       {
         "command": "oxc.restartServer",
-        "title": "Restart Oxc Server",
+        "title": "Restart oxlint Server",
+        "category": "Oxc"
+      },
+      {
+        "command": "oxc.restartServerFormatter",
+        "title": "Restart oxfmt Server",
         "category": "Oxc"
       },
       {
@@ -51,7 +56,12 @@
       },
       {
         "command": "oxc.showOutputChannel",
-        "title": "Show Output Channel",
+        "title": "Show Output Channel (Linter)",
+        "category": "Oxc"
+      },
+      {
+        "command": "oxc.showOutputChannelFormatter",
+        "title": "Show Output Channel (Formatter)",
         "category": "Oxc"
       },
       {
@@ -204,6 +214,11 @@
           "scope": "window",
           "markdownDescription": "Path to an Oxc linter binary. Will be used by the language server instead of the bundled one."
         },
+        "oxc.path.oxfmt": {
+          "type": "string",
+          "scope": "window",
+          "markdownDescription": "Path to an Oxc formatter binary. Will be used by the language server instead of the bundled one."
+        },
         "oxc.path.node": {
           "type": "string",
           "scope": "window",
@@ -239,7 +254,9 @@
       "supported": "limited",
       "description": "The Extension will always use the Language Server shipped with the Extension.",
       "restrictedConfigurations": [
-        "oxc.path.server"
+        "oxc.path.server",
+        "oxc.path.oxlint",
+        "oxc.path.oxfmt"
       ]
     }
   },

--- a/editors/vscode/tests/ConfigService.spec.ts
+++ b/editors/vscode/tests/ConfigService.spec.ts
@@ -7,13 +7,13 @@ const conf = workspace.getConfiguration('oxc');
 
 suite('ConfigService', () => {
   setup(async () => {
-    const keys = ['path.server'];
+    const keys = ['path.server', 'path.oxlint', 'path.oxfmt'];
 
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
 
   teardown(async () => {
-    const keys = ['path.server'];
+    const keys = ['path.server', 'path.oxlint', 'path.oxfmt'];
 
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
@@ -29,6 +29,47 @@ suite('ConfigService', () => {
     return workspace_path;
   };
 
+  suite('getOxfmtServerBinPath', () => {
+    testSingleFolderMode('resolves relative server path with workspace folder', async () => {
+      const service = new ConfigService();
+      const nonDefinedServerPath = await service.getOxfmtServerBinPath();
+
+      strictEqual(nonDefinedServerPath, undefined);
+
+      await conf.update('path.oxfmt', '/absolute/oxfmt');
+      const absoluteServerPath = await service.getOxfmtServerBinPath();
+
+      strictEqual(absoluteServerPath, '/absolute/oxfmt');
+
+      await conf.update('path.oxfmt', './relative/oxfmt');
+      const relativeServerPath = await service.getOxfmtServerBinPath();
+
+      const workspace_path = getWorkspaceFolderPlatformSafe();
+      strictEqual(relativeServerPath, `${workspace_path}/relative/oxfmt`);
+    });
+
+    testSingleFolderMode('returns undefined for unsafe server path', async () => {
+      const service = new ConfigService();
+      await conf.update('path.oxfmt', '../unsafe/oxfmt');
+      const unsafeServerPath = await service.getOxfmtServerBinPath();
+
+      strictEqual(unsafeServerPath, undefined);
+    });
+
+    testSingleFolderMode('returns backslashes path on Windows', async () => {
+      if (process.platform !== 'win32') {
+        return;
+      }
+      const service = new ConfigService();
+      await conf.update('path.oxfmt', './relative/oxfmt');
+      const relativeServerPath = await service.getOxfmtServerBinPath();
+      const workspace_path = getWorkspaceFolderPlatformSafe();
+
+      strictEqual(workspace_path[1], ':', 'The test workspace folder must be an absolute path with a drive letter on Windows');
+      strictEqual(relativeServerPath, `${workspace_path}\\relative\\oxfmt`);
+    });
+  });
+
   suite('getUserServerBinPath', () => {
     testSingleFolderMode('resolves relative server path with workspace folder', async () => {
       const service = new ConfigService();
@@ -36,37 +77,37 @@ suite('ConfigService', () => {
 
       strictEqual(nonDefinedServerPath, undefined);
 
-      await conf.update('path.server', '/absolute/oxc_language_server');
+      await conf.update('path.oxlint', '/absolute/oxlint');
       const absoluteServerPath = service.getUserServerBinPath();
 
-      strictEqual(absoluteServerPath, '/absolute/oxc_language_server');
+      strictEqual(absoluteServerPath, '/absolute/oxlint');
 
-      await conf.update('path.server', './relative/oxc_language_server');
+      await conf.update('path.oxlint', './relative/oxlint');
       const relativeServerPath = service.getUserServerBinPath();
 
       const workspace_path = getWorkspaceFolderPlatformSafe();
-      strictEqual(relativeServerPath, `${workspace_path}/relative/oxc_language_server`);
+      strictEqual(relativeServerPath, `${workspace_path}/relative/oxlint`);
     });
 
     testSingleFolderMode('returns undefined for unsafe server path', async () => {
       const service = new ConfigService();
-      await conf.update('path.server', '../unsafe/oxc_language_server');
+      await conf.update('path.oxlint', '../unsafe/oxlint');
       const unsafeServerPath = service.getUserServerBinPath();
 
       strictEqual(unsafeServerPath, undefined);
     });
 
-   testSingleFolderMode('returns backslashes path on Windows', async () => {
+    testSingleFolderMode('returns backslashes path on Windows', async () => {
       if (process.platform !== 'win32') {
         return;
       }
       const service = new ConfigService();
-      await conf.update('path.server', './relative/oxc_language_server');
+      await conf.update('path.oxlint', './relative/oxlint');
       const relativeServerPath = service.getUserServerBinPath();
       const workspace_path = getWorkspaceFolderPlatformSafe();
 
       strictEqual(workspace_path[1], ':', 'The test workspace folder must be an absolute path with a drive letter on Windows');
-      strictEqual(relativeServerPath, `${workspace_path}\\relative\\oxc_language_server`);
+      strictEqual(relativeServerPath, `${workspace_path}\\relative\\oxlint`);
     });
   });
 });

--- a/editors/vscode/tests/VSCodeConfig.spec.ts
+++ b/editors/vscode/tests/VSCodeConfig.spec.ts
@@ -6,7 +6,7 @@ import { testSingleFolderMode } from './test-helpers.js';
 const conf = workspace.getConfiguration('oxc');
 
 suite('VSCodeConfig', () => {
-  const keys = ['enable', 'requireConfig', 'trace.server', 'path.server', 'path.oxlint', 'path.node'];
+  const keys = ['enable', 'requireConfig', 'trace.server', 'path.server', 'path.oxlint', 'path.oxfmt', 'path.node'];
   setup(async () => {
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
@@ -22,6 +22,7 @@ suite('VSCodeConfig', () => {
     strictEqual(config.requireConfig, false);
     strictEqual(config.trace, 'off');
     strictEqual(config.binPathOxlint, '');
+    strictEqual(config.binPathOxfmt, '');
     strictEqual(config.nodePath, '');
   });
 
@@ -40,6 +41,7 @@ suite('VSCodeConfig', () => {
       config.updateRequireConfig(true),
       config.updateTrace('messages'),
       config.updateBinPathOxlint('./binary'),
+      config.updateBinPathOxfmt('./formatter'),
       config.updateNodePath('./node'),
     ]);
 
@@ -49,6 +51,7 @@ suite('VSCodeConfig', () => {
     strictEqual(wsConfig.get('requireConfig'), true);
     strictEqual(wsConfig.get('trace.server'), 'messages');
     strictEqual(wsConfig.get('path.oxlint'), './binary');
+    strictEqual(wsConfig.get('path.oxfmt'), './formatter');
     strictEqual(wsConfig.get('path.node'), './node');
   });
 });

--- a/editors/vscode/tests/commands.spec.ts
+++ b/editors/vscode/tests/commands.spec.ts
@@ -31,31 +31,55 @@ suite('commands', () => {
   testSingleFolderMode('listed commands', async () => {
     const oxcCommands = (await commands.getCommands(true)).filter(x => x.startsWith('oxc.'));
 
-    const extraCommands = process.env.SKIP_LINTER_TEST === 'true' ? [] : [
-      'oxc.fixAll',
+    const expectedCommands = [
+      'oxc.showOutputChannel',
+      'oxc.showOutputChannelFormatter',
     ];
 
-    deepStrictEqual([
-      'oxc.showOutputChannel',
-      'oxc.restartServer',
-      'oxc.toggleEnable',
-      'oxc.applyAllFixesFile', // TODO: only if linter tests are enabled
-      ...extraCommands,
-    ], oxcCommands);
+    if (process.env.SKIP_LINTER_TEST !== 'true') {
+      expectedCommands.push(
+        'oxc.restartServer',
+        'oxc.toggleEnable',
+        'oxc.applyAllFixesFile',
+        'oxc.fixAll',
+      );
+    }
+
+    if (process.env.SKIP_FORMATTER_TEST !== 'true' && !process.env.SERVER_PATH_DEV?.includes('oxc_language_server')) {
+      expectedCommands.push(
+        'oxc.restartServerFormatter',
+      );
+    }
+
+    deepStrictEqual(expectedCommands, oxcCommands);
   });
 
   testSingleFolderMode('oxc.showOutputChannel', async () => {
     await commands.executeCommand('oxc.showOutputChannel');
-    await sleep(500);
+    await sleep(250);
 
     notEqual(window.activeTextEditor, undefined);
     const { uri } = window.activeTextEditor!.document;
-    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc');
+    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Lint%29');
+
+    await commands.executeCommand('workbench.action.closeActiveEditor');
+  });
+
+  testSingleFolderMode('oxc.showOutputChannelFormatter', async () => {
+    await commands.executeCommand('oxc.showOutputChannelFormatter');
+    await sleep(250);
+
+    notEqual(window.activeTextEditor, undefined);
+    const { uri } = window.activeTextEditor!.document;
+    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Fmt%29');
 
     await commands.executeCommand('workbench.action.closeActiveEditor');
   });
 
   testSingleFolderMode('oxc.toggleEnable', async () => {
+    if (process.env.SKIP_LINTER_TEST === 'true') {
+      return;
+    }
     const isEnabledBefore = workspace.getConfiguration('oxc').get<boolean>('enable');
     strictEqual(isEnabledBefore, true);
 


### PR DESCRIPTION
This PR implements a second language server connection only for `oxfmt`. Currently, it still uses the shipped `oxc_language_server` binary for formatting. When defining a custom `oxc.path.oxlint` (or `oxc.path.server`), it will start the search process for `node_modules/.bin/oxfmt` or uses `oxc.path.oxfmt`. 

This should be **not** a breaking change. When `node_modules/.bin/oxfmt` should be required for formatting, the `ConfigService.useOxcLanguageServerForFormatting` must not be modified. I would love to wait for the correct search implementation for `.node_modules/.bin/oxlint` before breaking the server detection (and probably removing the shipped server too).

### Default / with `oxfmt` installed:
Using the internal language server (once)

### with `oxc.path.oxlint`:
Using the oxlint path server for linting.
Searching for `oxfmt` inside `node_modules/.bin`

### with `oxc.path.fmt`:
Using the internal language server for linting.
Using `oxc.path.fmt` binary


<img width="257" height="233" alt="grafik" src="https://github.com/user-attachments/assets/0776920d-76cd-49cf-9357-fae2ea4a0eb8" />

<img width="193" height="238" alt="grafik" src="https://github.com/user-attachments/assets/c3b2670d-559e-4d0a-96b2-b420e868e1a1" />

<img width="174" height="258" alt="grafik" src="https://github.com/user-attachments/assets/63f9a265-cae9-4971-9c21-86adeacaf35d" />
