### PR TITLE
feat(linter): Add an "Enabled" total to the bottom of the `--rules` output, and add `enabled` value to the json rules output.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -321,6 +321,7 @@ impl CliRunner {
                     stdout,
                     format!("Default: {}\n", table.turned_on_by_default_count).as_str(),
                 );
+                print_and_flush_stdout(stdout, format!("Enabled: {}\n", enabled.len()).as_str());
                 print_and_flush_stdout(stdout, format!("Total: {}\n", table.total).as_str());
             } else if let Some(output) = output_formatter.all_rules() {
                 print_and_flush_stdout(stdout, &output);

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -312,7 +312,7 @@ impl CliRunner {
 
                 let table = RuleTable::default();
                 for section in &table.sections {
-                    let md = section.render_markdown_table_cli(None, &enabled);
+                    let md = section.render_markdown_table(None, Some(&enabled));
                     print_and_flush_stdout(stdout, &md);
                     print_and_flush_stdout(stdout, "\n");
                 }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -303,14 +303,18 @@ impl CliRunner {
         // If the user requested `--rules`, print a CLI-specific table that
         // includes an "Enabled?" column based on the resolved configuration.
         if self.options.list_rules {
-            // Put together the enabled hashset if the format is default, otherwise None
-            let enabled: Option<FxHashSet<&str>> =
-                if self.options.output_options.format == OutputFormat::Default {
-                    // Build the set of enabled builtin rule names from the resolved config.
-                    Some(config_store.rules().iter().map(|(rule, _)| rule.name()).collect())
-                } else {
-                    None
-                };
+            // Put together the enabled hashset if the format is default or json, otherwise None
+            let is_format_with_enabled = matches!(
+                self.options.output_options.format,
+                OutputFormat::Default | OutputFormat::Json
+            );
+
+            let enabled: Option<FxHashSet<&str>> = if is_format_with_enabled {
+                // Build the set of enabled builtin rule names from the resolved config.
+                Some(config_store.rules().iter().map(|(rule, _)| rule.name()).collect())
+            } else {
+                None
+            };
 
             if let Some(output) = output_formatter.all_rules(enabled.as_ref()) {
                 print_and_flush_stdout(stdout, &output);
@@ -1327,6 +1331,7 @@ mod test {
             assert!(rule_obj.contains_key("scope"), "Rule should contain 'scope' field");
             assert!(rule_obj.contains_key("value"), "Rule should contain 'value' field");
             assert!(rule_obj.contains_key("category"), "Rule should contain 'category' field");
+            assert!(rule_obj.contains_key("enabled"), "Rule should contain 'enabled' field");
         }
     }
 

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -20,6 +20,9 @@ impl InternalFormatter for DefaultOutputFormatter {
             output.push('\n');
         }
         output.push_str(format!("Default: {}\n", table.turned_on_by_default_count).as_str());
+        if enabled.is_some() {
+            output.push_str(format!("Enabled: {}\n", enabled.unwrap().len()).as_str());
+        }
         output.push_str(format!("Total: {}\n", table.total).as_str());
         Some(output)
     }

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -6,16 +6,17 @@ use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult},
 };
 use oxc_linter::table::RuleTable;
+use rustc_hash::FxHashSet;
 
 #[derive(Debug)]
 pub struct DefaultOutputFormatter;
 
 impl InternalFormatter for DefaultOutputFormatter {
-    fn all_rules(&self) -> Option<String> {
+    fn all_rules(&self, enabled: Option<&FxHashSet<&str>>) -> Option<String> {
         let mut output = String::new();
         let table = RuleTable::default();
         for section in table.sections {
-            output.push_str(section.render_markdown_table(None).as_str());
+            output.push_str(section.render_markdown_table(None, enabled).as_str());
             output.push('\n');
         }
         output.push_str(format!("Default: {}\n", table.turned_on_by_default_count).as_str());
@@ -167,7 +168,7 @@ mod test {
     #[test]
     fn all_rules() {
         let formatter = DefaultOutputFormatter;
-        let result = formatter.all_rules();
+        let result = formatter.all_rules(None);
 
         assert!(result.is_some());
     }

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -20,8 +20,8 @@ impl InternalFormatter for DefaultOutputFormatter {
             output.push('\n');
         }
         output.push_str(format!("Default: {}\n", table.turned_on_by_default_count).as_str());
-        if enabled.is_some() {
-            output.push_str(format!("Enabled: {}\n", enabled.unwrap().len()).as_str());
+        if let Some(enabled) = enabled {
+            output.push_str(format!("Enabled: {}\n", enabled.len()).as_str());
         }
         output.push_str(format!("Total: {}\n", table.total).as_str());
         Some(output)

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -167,6 +167,7 @@ mod test {
         default::{DefaultOutputFormatter, GraphicalReporter},
     };
     use oxc_diagnostics::reporter::{DiagnosticReporter, DiagnosticResult};
+    use rustc_hash::FxHashSet;
 
     #[test]
     fn all_rules() {
@@ -174,6 +175,18 @@ mod test {
         let result = formatter.all_rules(None);
 
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn all_rules_with_enabled() {
+        let formatter = DefaultOutputFormatter;
+        // Pass in one enabled rule to make sure it renders fine:
+        let mut enabled = FxHashSet::default();
+        enabled.insert("no-unused-vars");
+        let result = formatter.all_rules(Some(&enabled));
+
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("Enabled: 1\n"));
     }
 
     #[test]

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use miette::JSONReportHandler;
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 
 use oxc_diagnostics::{
@@ -17,7 +18,7 @@ pub struct JsonOutputFormatter {
 }
 
 impl InternalFormatter for JsonOutputFormatter {
-    fn all_rules(&self) -> Option<String> {
+    fn all_rules(&self, _enabled: Option<&FxHashSet<&str>>) -> Option<String> {
         #[derive(Debug, Serialize)]
         struct RuleInfoJson<'a> {
             scope: &'a str,

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -18,18 +18,20 @@ pub struct JsonOutputFormatter {
 }
 
 impl InternalFormatter for JsonOutputFormatter {
-    fn all_rules(&self, _enabled: Option<&FxHashSet<&str>>) -> Option<String> {
+    fn all_rules(&self, enabled: Option<&FxHashSet<&str>>) -> Option<String> {
         #[derive(Debug, Serialize)]
         struct RuleInfoJson<'a> {
             scope: &'a str,
             value: &'a str,
             category: RuleCategory,
+            enabled: bool,
         }
 
         let rules_info = RULES.iter().map(|rule| RuleInfoJson {
             scope: rule.plugin_name(),
             value: rule.name(),
             category: rule.category(),
+            enabled: enabled.is_some_and(|enabled_set| enabled_set.contains(rule.name())),
         });
 
         Some(

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -15,6 +15,7 @@ use checkstyle::CheckStyleOutputFormatter;
 use github::GithubOutputFormatter;
 use gitlab::GitlabOutputFormatter;
 use junit::JUnitOutputFormatter;
+use rustc_hash::FxHashSet;
 use stylish::StylishOutputFormatter;
 use unix::UnixOutputFormatter;
 
@@ -72,7 +73,7 @@ pub struct LintCommandInfo {
 /// The Formatter is then managed by [`OutputFormatter`].
 trait InternalFormatter {
     /// Print all available rules by oxlint
-    fn all_rules(&self) -> Option<String> {
+    fn all_rules(&self, _enabled: Option<&FxHashSet<&str>>) -> Option<String> {
         None
     }
 
@@ -111,7 +112,7 @@ impl OutputFormatter {
     /// Print all available rules by oxlint
     /// See [`InternalFormatter::all_rules`] for more details.
     pub fn all_rules(&self) -> Option<String> {
-        self.internal.all_rules()
+        self.internal.all_rules(None)
     }
 
     /// At the end of the Lint command we may output extra information.

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -111,8 +111,8 @@ impl OutputFormatter {
 
     /// Print all available rules by oxlint
     /// See [`InternalFormatter::all_rules`] for more details.
-    pub fn all_rules(&self) -> Option<String> {
-        self.internal.all_rules(None)
+    pub fn all_rules(&self, enabled: Option<&FxHashSet<&str>>) -> Option<String> {
+        self.internal.all_rules(enabled)
     }
 
     /// At the end of the Lint command we may output extra information.

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -308,6 +308,7 @@ impl ConfigStore {
         Some(count)
     }
 
+    // TODO: fix this to return rules based on whether type_aware is enabled
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.base.rules
     }

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -228,7 +228,11 @@ impl RuleTableSection {
     ///
     /// Provide [`Some`] set of enabled rule names to include an "Enabled?" column.
     /// Provide [`None`] to omit the column.
-    pub fn render_markdown_table(&self, link_prefix: Option<&str>, enabled: Option<&FxHashSet<&str>>) -> String {
+    pub fn render_markdown_table(
+        &self,
+        link_prefix: Option<&str>,
+        enabled: Option<&FxHashSet<&str>>,
+    ) -> String {
         self.render_markdown_table_inner(link_prefix, enabled)
     }
 }

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -225,16 +225,11 @@ impl RuleTableSection {
     ///
     /// Provide [`Some`] prefix to render the rule name as a link. Provide
     /// [`None`] to just display the rule name as text.
-    pub fn render_markdown_table(&self, link_prefix: Option<&str>) -> String {
-        self.render_markdown_table_inner(link_prefix, None)
-    }
-
-    pub fn render_markdown_table_cli(
-        &self,
-        link_prefix: Option<&str>,
-        enabled: &FxHashSet<&str>,
-    ) -> String {
-        self.render_markdown_table_inner(link_prefix, Some(enabled))
+    ///
+    /// Provide [`Some`] set of enabled rule names to include an "Enabled?" column.
+    /// Provide [`None`] to omit the column.
+    pub fn render_markdown_table(&self, link_prefix: Option<&str>, enabled: Option<&FxHashSet<&str>>) -> String {
+        self.render_markdown_table_inner(link_prefix, enabled)
     }
 }
 
@@ -256,7 +251,7 @@ mod test {
     fn test_table_no_links() {
         let options = Options::gfm();
         for section in &table().sections {
-            let rendered_table = section.render_markdown_table(None);
+            let rendered_table = section.render_markdown_table(None, None);
             assert!(!rendered_table.is_empty());
             assert_eq!(rendered_table.split('\n').count(), 5 + section.rows.len());
 
@@ -274,7 +269,7 @@ mod test {
         let options = Options::gfm();
 
         for section in &table().sections {
-            let rendered_table = section.render_markdown_table(Some(PREFIX));
+            let rendered_table = section.render_markdown_table(Some(PREFIX), None);
             assert!(!rendered_table.is_empty());
             assert_eq!(rendered_table.split('\n').count(), 5 + section.rows.len());
 
@@ -296,7 +291,7 @@ mod test {
                 enabled.insert(first.name);
             }
 
-            let rendered_table = section.render_markdown_table_cli(Some(PREFIX), &enabled);
+            let rendered_table = section.render_markdown_table(Some(PREFIX), Some(&enabled));
             assert!(!rendered_table.is_empty());
             // same number of lines as other renderer (header + desc + separator + rows + trailing newline)
             assert_eq!(rendered_table.split('\n').count(), 5 + section.rows.len());

--- a/tasks/website_linter/src/rules/table.rs
+++ b/tasks/website_linter/src/rules/table.rs
@@ -14,7 +14,7 @@ pub fn render_rules_table(table: &RuleTable, docs_prefix: &str) -> String {
     let body = table
         .sections
         .iter()
-        .map(|s| s.render_markdown_table(Some(docs_prefix)))
+        .map(|s| s.render_markdown_table(Some(docs_prefix), None))
         .collect::<Vec<_>>()
         .join("\n");
 


### PR DESCRIPTION
This adds an enabled count to the `--rules` output alongside default and total:

```
Default: 103
Enabled: 76
Total: 616
```

For example, with this lint config:

```
{
  "$schema": "./node_modules/oxlint/configuration_schema.json",
  "plugins": ["import", "oxc", "node"],
  "categories": {
    "correctness": "error",
		"nursery": "warn"
  },
  "env": {
    "builtin": true
  },
  "ignorePatterns": [],
  "rules": {}
}
```

We get this output:

<details>
<summary>Output</summary>

```
## Correctness (196):
Code that is outright wrong or useless.
| Rule name                                           | Source     | Default | Enabled? | Fixable? |
| --------------------------------------------------- | ---------- | ------- | -------- | -------- |
| for-direction                                       | eslint     | ✅      | ✅       | ⚠️🛠️️       |
| no-async-promise-executor                           | eslint     | ✅      | ✅       |          |
| no-caller                                           | eslint     | ✅      | ✅       |          |
| no-class-assign                                     | eslint     | ✅      | ✅       |          |
| no-compare-neg-zero                                 | eslint     | ✅      | ✅       | 🛠️💡      |
| no-cond-assign                                      | eslint     | ✅      | ✅       |          |
| no-const-assign                                     | eslint     | ✅      | ✅       |          |
| no-constant-binary-expression                       | eslint     | ✅      | ✅       |          |
| no-constant-condition                               | eslint     | ✅      | ✅       |          |
| no-control-regex                                    | eslint     | ✅      | ✅       |          |
| no-debugger                                         | eslint     | ✅      | ✅       | 🛠️        |
| no-delete-var                                       | eslint     | ✅      | ✅       |          |
| no-dupe-class-members                               | eslint     | ✅      | ✅       |          |
| no-dupe-else-if                                     | eslint     | ✅      | ✅       |          |
| no-dupe-keys                                        | eslint     | ✅      | ✅       |          |
| no-duplicate-case                                   | eslint     | ✅      | ✅       |          |
| no-empty-character-class                            | eslint     | ✅      | ✅       |          |
| no-empty-pattern                                    | eslint     | ✅      | ✅       |          |
| no-empty-static-block                               | eslint     | ✅      | ✅       | 💡       |
| no-eval                                             | eslint     | ✅      | ✅       |          |
| no-ex-assign                                        | eslint     | ✅      | ✅       |          |
| no-extra-boolean-cast                               | eslint     | ✅      | ✅       | 🛠️💡      |
| no-func-assign                                      | eslint     | ✅      | ✅       |          |
| no-global-assign                                    | eslint     | ✅      | ✅       |          |
| no-import-assign                                    | eslint     | ✅      | ✅       |          |
| no-invalid-regexp                                   | eslint     | ✅      | ✅       |          |
| no-irregular-whitespace                             | eslint     | ✅      | ✅       |          |
| no-loss-of-precision                                | eslint     | ✅      | ✅       |          |
| no-new-native-nonconstructor                        | eslint     | ✅      | ✅       |          |
| no-nonoctal-decimal-escape                          | eslint     | ✅      | ✅       | 🚧       |
| no-obj-calls                                        | eslint     | ✅      | ✅       |          |
| no-self-assign                                      | eslint     | ✅      | ✅       |          |
| no-setter-return                                    | eslint     | ✅      | ✅       |          |
| no-shadow-restricted-names                          | eslint     | ✅      | ✅       |          |
| no-sparse-arrays                                    | eslint     | ✅      | ✅       |          |
| no-this-before-super                                | eslint     | ✅      | ✅       |          |
| no-unassigned-vars                                  | eslint     | ✅      | ✅       |          |
| no-unsafe-finally                                   | eslint     | ✅      | ✅       |          |
| no-unsafe-negation                                  | eslint     | ✅      | ✅       | 🛠️        |
| no-unsafe-optional-chaining                         | eslint     | ✅      | ✅       |          |
| no-unused-expressions                               | eslint     | ✅      | ✅       |          |
| no-unused-labels                                    | eslint     | ✅      | ✅       | 🛠️        |
| no-unused-private-class-members                     | eslint     | ✅      | ✅       |          |
| no-unused-vars                                      | eslint     | ✅      | ✅       | ⚠️💡      |
| no-useless-backreference                            | eslint     | ✅      | ✅       |          |
| no-useless-catch                                    | eslint     | ✅      | ✅       |          |
| no-useless-escape                                   | eslint     | ✅      | ✅       | 🛠️        |
| no-useless-rename                                   | eslint     | ✅      | ✅       |          |
| no-with                                             | eslint     | ✅      | ✅       |          |
| require-yield                                       | eslint     | ✅      | ✅       |          |
| use-isnan                                           | eslint     | ✅      | ✅       | 🛠️        |
| valid-typeof                                        | eslint     | ✅      | ✅       | 🛠️        |
| default                                             | import     |         | ✅       |          |
| namespace                                           | import     |         | ✅       |          |
| expect-expect                                       | jest       |         |          |          |
| no-conditional-expect                               | jest       |         |          |          |
| no-disabled-tests                                   | jest       |         |          |          |
| no-export                                           | jest       |         |          |          |
| no-focused-tests                                    | jest       |         |          | 🛠️        |
| no-standalone-expect                                | jest       |         |          |          |
| require-to-throw-message                            | jest       |         |          |          |
| valid-describe-callback                             | jest       |         |          |          |
| valid-expect                                        | jest       |         |          |          |
| valid-title                                         | jest       |         |          | 🛠️        |
| check-property-names                                | jsdoc      |         |          |          |
| check-tag-names                                     | jsdoc      |         |          |          |
| implements-on-classes                               | jsdoc      |         |          |          |
| no-defaults                                         | jsdoc      |         |          |          |
| require-property                                    | jsdoc      |         |          |          |
| require-property-description                        | jsdoc      |         |          |          |
| require-property-name                               | jsdoc      |         |          |          |
| require-property-type                               | jsdoc      |         |          |          |
| require-yields                                      | jsdoc      |         |          |          |
| alt-text                                            | jsx_a11y   |         |          |          |
| anchor-has-content                                  | jsx_a11y   |         |          | 💡       |
| anchor-is-valid                                     | jsx_a11y   |         |          |          |
| aria-activedescendant-has-tabindex                  | jsx_a11y   |         |          |          |
| aria-props                                          | jsx_a11y   |         |          | 🛠️        |
| aria-role                                           | jsx_a11y   |         |          |          |
| aria-unsupported-elements                           | jsx_a11y   |         |          | 🛠️        |
| autocomplete-valid                                  | jsx_a11y   |         |          |          |
| click-events-have-key-events                        | jsx_a11y   |         |          |          |
| heading-has-content                                 | jsx_a11y   |         |          |          |
| html-has-lang                                       | jsx_a11y   |         |          |          |
| iframe-has-title                                    | jsx_a11y   |         |          |          |
| img-redundant-alt                                   | jsx_a11y   |         |          |          |
| label-has-associated-control                        | jsx_a11y   |         |          |          |
| lang                                                | jsx_a11y   |         |          |          |
| media-has-caption                                   | jsx_a11y   |         |          |          |
| mouse-events-have-key-events                        | jsx_a11y   |         |          |          |
| no-access-key                                       | jsx_a11y   |         |          | 💡       |
| no-aria-hidden-on-focusable                         | jsx_a11y   |         |          | 🛠️        |
| no-autofocus                                        | jsx_a11y   |         |          | 🛠️        |
| no-distracting-elements                             | jsx_a11y   |         |          |          |
| no-noninteractive-tabindex                          | jsx_a11y   |         |          |          |
| no-redundant-roles                                  | jsx_a11y   |         |          | 🛠️        |
| prefer-tag-over-role                                | jsx_a11y   |         |          |          |
| role-has-required-aria-props                        | jsx_a11y   |         |          |          |
| role-supports-aria-props                            | jsx_a11y   |         |          |          |
| scope                                               | jsx_a11y   |         |          | 🛠️        |
| tabindex-no-positive                                | jsx_a11y   |         |          | ⚠️💡      |
| google-font-display                                 | nextjs     |         |          |          |
| google-font-preconnect                              | nextjs     |         |          |          |
| inline-script-id                                    | nextjs     |         |          |          |
| next-script-for-ga                                  | nextjs     |         |          |          |
| no-assign-module-variable                           | nextjs     |         |          |          |
| no-async-client-component                           | nextjs     |         |          |          |
| no-before-interactive-script-outside-document       | nextjs     |         |          |          |
| no-css-tags                                         | nextjs     |         |          |          |
| no-document-import-in-page                          | nextjs     |         |          |          |
| no-duplicate-head                                   | nextjs     |         |          |          |
| no-head-element                                     | nextjs     |         |          |          |
| no-head-import-in-document                          | nextjs     |         |          |          |
| no-html-link-for-pages                              | nextjs     |         |          |          |
| no-img-element                                      | nextjs     |         |          | 🚧       |
| no-page-custom-font                                 | nextjs     |         |          |          |
| no-script-component-in-head                         | nextjs     |         |          |          |
| no-styled-jsx-in-document                           | nextjs     |         |          |          |
| no-sync-scripts                                     | nextjs     |         |          |          |
| no-title-in-document-head                           | nextjs     |         |          |          |
| no-typos                                            | nextjs     |         |          | 🚧       |
| no-unwanted-polyfillio                              | nextjs     |         |          |          |
| bad-array-method-on-arguments                       | oxc        | ✅      | ✅       |          |
| bad-char-at-comparison                              | oxc        | ✅      | ✅       |          |
| bad-comparison-sequence                             | oxc        | ✅      | ✅       |          |
| bad-min-max-func                                    | oxc        | ✅      | ✅       |          |
| bad-object-literal-comparison                       | oxc        | ✅      | ✅       |          |
| bad-replace-all-arg                                 | oxc        | ✅      | ✅       |          |
| const-comparisons                                   | oxc        | ✅      | ✅       |          |
| double-comparisons                                  | oxc        | ✅      | ✅       | 🛠️        |
| erasing-op                                          | oxc        | ✅      | ✅       | ⚠️🛠️️       |
| missing-throw                                       | oxc        | ✅      | ✅       | 💡       |
| number-arg-out-of-range                             | oxc        | ✅      | ✅       |          |
| only-used-in-recursion                              | oxc        | ✅      | ✅       | ⚠️🛠️️       |
| uninvoked-array-callback                            | oxc        | ✅      | ✅       |          |
| no-callback-in-promise                              | promise    |         |          |          |
| no-new-statics                                      | promise    |         |          | 🛠️        |
| valid-params                                        | promise    |         |          |          |
| exhaustive-deps                                     | react      |         |          | ⚠️🛠️️💡     |
| forward-ref-uses-ref                                | react      |         |          | 💡       |
| jsx-key                                             | react      |         |          |          |
| jsx-no-duplicate-props                              | react      |         |          |          |
| jsx-no-undef                                        | react      |         |          |          |
| jsx-props-no-spread-multi                           | react      |         |          | 🛠️        |
| no-children-prop                                    | react      |         |          |          |
| no-danger-with-children                             | react      |         |          |          |
| no-direct-mutation-state                            | react      |         |          |          |
| no-find-dom-node                                    | react      |         |          |          |
| no-is-mounted                                       | react      |         |          |          |
| no-render-return-value                              | react      |         |          |          |
| no-string-refs                                      | react      |         |          |          |
| void-dom-elements-no-children                       | react      |         |          |          |
| await-thenable                                      | typescript | ✅      |          | 🚧       |
| no-array-delete                                     | typescript | ✅      |          | 🚧       |
| no-base-to-string                                   | typescript | ✅      |          | 🚧       |
| no-duplicate-enum-values                            | typescript | ✅      |          |          |
| no-duplicate-type-constituents                      | typescript | ✅      |          | 🚧       |
| no-extra-non-null-assertion                         | typescript | ✅      |          |          |
| no-floating-promises                                | typescript | ✅      |          | 🚧       |
| no-for-in-array                                     | typescript | ✅      |          | 🚧       |
| no-implied-eval                                     | typescript | ✅      |          | 🚧       |
| no-meaningless-void-operator                        | typescript | ✅      |          | 🚧       |
| no-misused-new                                      | typescript | ✅      |          |          |
| no-misused-spread                                   | typescript | ✅      |          | 🚧       |
| no-non-null-asserted-optional-chain                 | typescript | ✅      |          | 💡       |
| no-redundant-type-constituents                      | typescript | ✅      |          | 🚧       |
| no-this-alias                                       | typescript | ✅      |          |          |
| no-unnecessary-parameter-property-assignment        | typescript | ✅      |          | 💡       |
| no-unsafe-declaration-merging                       | typescript | ✅      |          |          |
| no-unsafe-unary-minus                               | typescript | ✅      |          | 🚧       |
| no-useless-empty-export                             | typescript | ✅      |          | 🛠️        |
| no-wrapper-object-types                             | typescript | ✅      |          | 🛠️        |
| prefer-as-const                                     | typescript | ✅      |          | 🛠️        |
| require-array-sort-compare                          | typescript | ✅      |          | 🚧       |
| restrict-template-expressions                       | typescript | ✅      |          | 🚧       |
| triple-slash-reference                              | typescript | ✅      |          |          |
| unbound-method                                      | typescript | ✅      |          | 🚧       |
| no-await-in-promise-methods                         | unicorn    | ✅      |          |          |
| no-empty-file                                       | unicorn    | ✅      |          |          |
| no-invalid-fetch-options                            | unicorn    | ✅      |          |          |
| no-invalid-remove-event-listener                    | unicorn    | ✅      |          |          |
| no-new-array                                        | unicorn    | ✅      |          | 🚧       |
| no-single-promise-in-promise-methods                | unicorn    | ✅      |          | 🛠️        |
| no-thenable                                         | unicorn    | ✅      |          |          |
| no-unnecessary-await                                | unicorn    | ✅      |          | 🛠️        |
| no-useless-fallback-in-spread                       | unicorn    | ✅      |          | 🛠️        |
| no-useless-length-check                             | unicorn    | ✅      |          | 🚧       |
| no-useless-spread                                   | unicorn    | ✅      |          | ⚠️🛠️️       |
| prefer-set-size                                     | unicorn    | ✅      |          | 🛠️        |
| prefer-string-starts-ends-with                      | unicorn    | ✅      |          | 🛠️        |
| no-conditional-tests                                | vitest     |         |          |          |
| require-local-test-context-for-concurrent-snapshots | vitest     |         |          | 🚧       |
| no-export-in-script-setup                           | vue        |         |          |          |
| prefer-import-from-vue                              | vue        |         |          | 🛠️        |
| valid-define-emits                                  | vue        |         |          | 🚧       |
| valid-define-props                                  | vue        |         |          | 🚧       |

## Perf (11):
Code that can be written to run faster.
| Rule name                   | Source     | Default | Enabled? | Fixable? |
| --------------------------- | ---------- | ------- | -------- | -------- |
| no-await-in-loop            | eslint     |         |          |          |
| no-useless-call             | eslint     |         |          |          |
| no-accumulating-spread      | oxc        |         |          |          |
| no-array-index-key          | react      |         |          |          |
| jsx-no-jsx-as-prop          | react_perf |         |          |          |
| jsx-no-new-array-as-prop    | react_perf |         |          |          |
| jsx-no-new-function-as-prop | react_perf |         |          |          |
| jsx-no-new-object-as-prop   | react_perf |         |          |          |
| prefer-array-find           | unicorn    |         |          | 🚧       |
| prefer-array-flat-map       | unicorn    |         |          | 🛠️        |
| prefer-set-has              | unicorn    |         |          | ⚠️🛠️️       |

## Restriction (78):
Lints which prevent the use of language and library features. Must not be enabled as a whole, should be considered on a case-by-case basis before enabling.
| Rule name                               | Source     | Default | Enabled? | Fixable? |
| --------------------------------------- | ---------- | ------- | -------- | -------- |
| class-methods-use-this                  | eslint     |         |          |          |
| default-case                            | eslint     |         |          |          |
| no-alert                                | eslint     |         |          |          |
| no-bitwise                              | eslint     |         |          |          |
| no-console                              | eslint     |         |          | 💡       |
| no-div-regex                            | eslint     |         |          | 🛠️        |
| no-empty                                | eslint     |         |          | 💡       |
| no-empty-function                       | eslint     |         |          |          |
| no-eq-null                              | eslint     |         |          | ⚠️🛠️️       |
| no-iterator                             | eslint     |         |          | 💡       |
| no-param-reassign                       | eslint     |         |          |          |
| no-plusplus                             | eslint     |         |          | 💡       |
| no-proto                                | eslint     |         |          | 🚧       |
| no-regex-spaces                         | eslint     |         |          | 🚧       |
| no-restricted-globals                   | eslint     |         |          |          |
| no-restricted-imports                   | eslint     |         |          |          |
| no-undefined                            | eslint     |         |          |          |
| no-var                                  | eslint     |         |          | 🛠️        |
| no-void                                 | eslint     |         |          | 💡       |
| unicode-bom                             | eslint     |         |          | 🛠️        |
| extensions                              | import     |         |          |          |
| no-amd                                  | import     |         |          |          |
| no-commonjs                             | import     |         |          |          |
| no-cycle                                | import     |         |          |          |
| no-default-export                       | import     |         |          |          |
| no-dynamic-require                      | import     |         |          |          |
| no-webpack-loader-syntax                | import     |         |          |          |
| unambiguous                             | import     |         |          |          |
| check-access                            | jsdoc      |         |          |          |
| empty-tags                              | jsdoc      |         |          |          |
| anchor-ambiguous-text                   | jsx_a11y   |         |          |          |
| no-new-require                          | node       |         |          |          |
| no-process-env                          | node       |         |          |          |
| bad-bitwise-operator                    | oxc        |         |          | 🚧       |
| no-async-await                          | oxc        |         |          |          |
| no-barrel-file                          | oxc        |         |          |          |
| no-const-enum                           | oxc        |         |          | 🛠️        |
| no-optional-chaining                    | oxc        |         |          |          |
| no-rest-spread-properties               | oxc        |         |          |          |
| catch-or-return                         | promise    |         |          |          |
| spec-only                               | promise    |         |          |          |
| button-has-type                         | react      |         |          |          |
| forbid-dom-props                        | react      |         |          |          |
| forbid-elements                         | react      |         |          |          |
| jsx-filename-extension                  | react      |         |          | 🚧       |
| no-danger                               | react      |         |          |          |
| no-unknown-property                     | react      |         |          | 🚧       |
| only-export-components                  | react      |         |          |          |
| explicit-function-return-type           | typescript |         |          |          |
| explicit-module-boundary-types          | typescript |         |          |          |
| no-dynamic-delete                       | typescript |         |          |          |
| no-empty-object-type                    | typescript |         |          |          |
| no-explicit-any                         | typescript |         |          | 🛠️        |
| no-import-type-side-effects             | typescript |         |          | 🛠️        |
| no-namespace                            | typescript |         |          |          |
| no-non-null-asserted-nullish-coalescing | typescript |         |          |          |
| no-non-null-assertion                   | typescript |         |          |          |
| no-require-imports                      | typescript |         |          | 🚧       |
| no-var-requires                         | typescript |         |          |          |
| non-nullable-type-assertion-style       | typescript |         |          | 🚧       |
| prefer-literal-enum-member              | typescript |         |          |          |
| promise-function-async                  | typescript |         |          | 🚧       |
| use-unknown-in-catch-callback-variable  | typescript |         |          | 🚧       |
| no-abusive-eslint-disable               | unicorn    |         |          |          |
| no-anonymous-default-export             | unicorn    |         |          |          |
| no-array-for-each                       | unicorn    |         |          | 🚧       |
| no-array-reduce                         | unicorn    |         |          |          |
| no-document-cookie                      | unicorn    |         |          |          |
| no-length-as-slice-end                  | unicorn    |         |          | 🛠️        |
| no-magic-array-flat-depth               | unicorn    |         |          |          |
| no-process-exit                         | unicorn    |         |          | 🚧       |
| no-useless-error-capture-stack-trace    | unicorn    |         |          | 🚧       |
| prefer-modern-math-apis                 | unicorn    |         |          | 🚧       |
| prefer-node-protocol                    | unicorn    |         |          | 🛠️        |
| prefer-number-properties                | unicorn    |         |          | ⚠️🛠️️       |
| max-props                               | vue        |         |          |          |
| no-import-compiler-macros               | vue        |         |          | ⚠️🛠️️       |
| no-multiple-slot-args                   | vue        |         |          | 🚧       |

## Suspicious (47):
code that is most likely wrong or useless.
| Rule name                              | Source     | Default | Enabled? | Fixable? |
| -------------------------------------- | ---------- | ------- | -------- | -------- |
| block-scoped-var                       | eslint     |         |          |          |
| no-extend-native                       | eslint     |         |          |          |
| no-extra-bind                          | eslint     |         |          | 🚧       |
| no-new                                 | eslint     |         |          |          |
| no-unexpected-multiline                | eslint     |         |          | ⚠️🛠️️       |
| no-unneeded-ternary                    | eslint     |         |          | ⚠️🛠️️       |
| no-useless-concat                      | eslint     |         |          |          |
| no-useless-constructor                 | eslint     |         |          | 🛠️        |
| preserve-caught-error                  | eslint     |         |          | 🛠️        |
| no-absolute-path                       | import     |         |          | 🚧       |
| no-empty-named-blocks                  | import     |         |          | 🛠️        |
| no-named-as-default                    | import     |         |          |          |
| no-named-as-default-member             | import     |         |          |          |
| no-self-import                         | import     |         |          |          |
| no-unassigned-import                   | import     |         |          |          |
| no-commented-out-tests                 | jest       |         |          |          |
| approx-constant                        | oxc        |         |          |          |
| misrefactored-assign-op                | oxc        |         |          | 🚧       |
| no-async-endpoint-handlers             | oxc        |         |          |          |
| always-return                          | promise    |         |          |          |
| no-multiple-resolved                   | promise    |         |          |          |
| no-promise-in-callback                 | promise    |         |          |          |
| iframe-missing-sandbox                 | react      |         |          | 🚧       |
| jsx-no-comment-textnodes               | react      |         |          |          |
| jsx-no-script-url                      | react      |         |          | 🚧       |
| no-namespace                           | react      |         |          |          |
| react-in-jsx-scope                     | react      |         |          |          |
| style-prop-object                      | react      |         |          |          |
| no-confusing-non-null-assertion        | typescript |         |          | 🚧       |
| no-extraneous-class                    | typescript |         |          | ⚠️💡      |
| no-unnecessary-boolean-literal-compare | typescript |         |          | 🚧       |
| no-unnecessary-template-expression     | typescript |         |          | 🚧       |
| no-unnecessary-type-arguments          | typescript |         |          | 🚧       |
| no-unnecessary-type-assertion          | typescript |         |          | 🚧       |
| no-unnecessary-type-constraint         | typescript |         |          |          |
| no-unsafe-enum-comparison              | typescript |         |          | 🚧       |
| no-unsafe-type-assertion               | typescript |         |          | 🚧       |
| consistent-function-scoping            | unicorn    |         |          | 🚧       |
| no-accessor-recursion                  | unicorn    |         |          |          |
| no-array-reverse                       | unicorn    |         |          | 🛠️        |
| no-array-sort                          | unicorn    |         |          | 🛠️        |
| no-instanceof-builtins                 | unicorn    |         |          | 🚧       |
| prefer-add-event-listener              | unicorn    |         |          | 🚧       |
| require-module-specifiers              | unicorn    |         |          | 🛠️        |
| require-post-message-target-origin     | unicorn    |         |          | 💡       |
| no-required-prop-with-default          | vue        |         |          | 🚧       |
| require-default-export                 | vue        |         |          |          |

## Pedantic (106):
Lints which are rather strict or have occasional false positives.
| Rule name                               | Source     | Default | Enabled? | Fixable? |
| --------------------------------------- | ---------- | ------- | -------- | -------- |
| array-callback-return                   | eslint     |         |          |          |
| eqeqeq                                  | eslint     |         |          | ⚠️🛠️️       |
| max-classes-per-file                    | eslint     |         |          |          |
| max-depth                               | eslint     |         |          |          |
| max-lines                               | eslint     |         |          |          |
| max-lines-per-function                  | eslint     |         |          |          |
| max-nested-callbacks                    | eslint     |         |          |          |
| no-array-constructor                    | eslint     |         |          | 🛠️        |
| no-case-declarations                    | eslint     |         |          |          |
| no-constructor-return                   | eslint     |         |          |          |
| no-else-return                          | eslint     |         |          | 🛠️        |
| no-fallthrough                          | eslint     |         |          | 🚧       |
| no-inner-declarations                   | eslint     |         |          |          |
| no-lonely-if                            | eslint     |         |          | 🚧       |
| no-negated-condition                    | eslint     |         |          | 🚧       |
| no-new-wrappers                         | eslint     |         |          | 🛠️        |
| no-object-constructor                   | eslint     |         |          | 🚧       |
| no-prototype-builtins                   | eslint     |         |          |          |
| no-redeclare                            | eslint     |         |          |          |
| no-self-compare                         | eslint     |         |          |          |
| no-throw-literal                        | eslint     |         |          | 💡       |
| no-warning-comments                     | eslint     |         |          |          |
| radix                                   | eslint     |         |          | ⚠️🛠️️       |
| require-await                           | eslint     |         |          | ⚠️🛠️️       |
| sort-vars                               | eslint     |         |          | 🚧       |
| symbol-description                      | eslint     |         |          |          |
| max-dependencies                        | import     |         |          |          |
| no-conditional-in-test                  | jest       |         |          |          |
| require-param                           | jsdoc      |         |          |          |
| require-param-description               | jsdoc      |         |          |          |
| require-param-name                      | jsdoc      |         |          |          |
| require-param-type                      | jsdoc      |         |          |          |
| require-returns                         | jsdoc      |         |          |          |
| require-returns-description             | jsdoc      |         |          |          |
| require-returns-type                    | jsdoc      |         |          |          |
| checked-requires-onchange-or-readonly   | react      |         |          |          |
| jsx-no-target-blank                     | react      |         |          |          |
| jsx-no-useless-fragment                 | react      |         |          | 💡       |
| no-unescaped-entities                   | react      |         |          |          |
| rules-of-hooks                          | react      |         |          |          |
| ban-ts-comment                          | typescript |         |          | 🛠️        |
| ban-types                               | typescript |         |          | 🚧       |
| no-confusing-void-expression            | typescript |         |          | 🚧       |
| no-deprecated                           | typescript |         |          |          |
| no-misused-promises                     | typescript |         |          | 🚧       |
| no-mixed-enums                          | typescript |         |          | 🚧       |
| no-unsafe-argument                      | typescript |         |          | 🚧       |
| no-unsafe-assignment                    | typescript |         |          | 🚧       |
| no-unsafe-call                          | typescript |         |          | 🚧       |
| no-unsafe-function-type                 | typescript |         |          |          |
| no-unsafe-member-access                 | typescript |         |          | 🚧       |
| no-unsafe-return                        | typescript |         |          | 🚧       |
| only-throw-error                        | typescript |         |          | 🚧       |
| prefer-enum-initializers                | typescript |         |          | 🚧       |
| prefer-includes                         | typescript |         |          | 🚧       |
| prefer-promise-reject-errors            | typescript |         |          | 🚧       |
| prefer-ts-expect-error                  | typescript |         |          | 🛠️        |
| related-getter-setter-pairs             | typescript |         |          | 🚧       |
| require-await                           | typescript |         |          | 🚧       |
| restrict-plus-operands                  | typescript |         |          | 🚧       |
| return-await                            | typescript |         |          | 🚧       |
| strict-boolean-expressions              | typescript |         |          | 🚧       |
| switch-exhaustiveness-check             | typescript |         |          | 🚧       |
| consistent-assert                       | unicorn    |         |          | 🛠️        |
| consistent-empty-array-spread           | unicorn    |         |          | 💡       |
| escape-case                             | unicorn    |         |          | 🛠️        |
| explicit-length-check                   | unicorn    |         |          | 🛠️        |
| new-for-builtins                        | unicorn    |         |          |          |
| no-array-callback-reference             | unicorn    |         |          | 🚧       |
| no-hex-escape                           | unicorn    |         |          | 🛠️        |
| no-instanceof-array                     | unicorn    |         |          | 🛠️        |
| no-lonely-if                            | unicorn    |         |          |          |
| no-negation-in-equality-check           | unicorn    |         |          | 🚧       |
| no-new-buffer                           | unicorn    |         |          | 🚧       |
| no-object-as-default-parameter          | unicorn    |         |          |          |
| no-static-only-class                    | unicorn    |         |          | ⚠️🛠️️       |
| no-this-assignment                      | unicorn    |         |          |          |
| no-typeof-undefined                     | unicorn    |         |          | 🚧       |
| no-unnecessary-array-flat-depth         | unicorn    |         |          | 🚧       |
| no-unnecessary-array-splice-count       | unicorn    |         |          | 🛠️        |
| no-unnecessary-slice-end                | unicorn    |         |          | 🛠️        |
| no-unreadable-iife                      | unicorn    |         |          |          |
| no-useless-promise-resolve-reject       | unicorn    |         |          | 🛠️        |
| no-useless-switch-case                  | unicorn    |         |          | 🚧       |
| no-useless-undefined                    | unicorn    |         |          | 🛠️        |
| prefer-array-flat                       | unicorn    |         |          | ⚠️🛠️️       |
| prefer-array-some                       | unicorn    |         |          | 🛠️        |
| prefer-at                               | unicorn    |         |          | ⚠️🛠️️       |
| prefer-blob-reading-methods             | unicorn    |         |          | 🚧       |
| prefer-code-point                       | unicorn    |         |          | 🛠️        |
| prefer-date-now                         | unicorn    |         |          | 🛠️        |
| prefer-dom-node-append                  | unicorn    |         |          | 🛠️        |
| prefer-dom-node-dataset                 | unicorn    |         |          | 🚧       |
| prefer-dom-node-remove                  | unicorn    |         |          |          |
| prefer-event-target                     | unicorn    |         |          |          |
| prefer-math-min-max                     | unicorn    |         |          | 🛠️        |
| prefer-math-trunc                       | unicorn    |         |          | 🚧       |
| prefer-native-coercion-functions        | unicorn    |         |          | 🚧       |
| prefer-prototype-methods                | unicorn    |         |          | 🛠️        |
| prefer-query-selector                   | unicorn    |         |          | 🛠️        |
| prefer-regexp-test                      | unicorn    |         |          | 🛠️        |
| prefer-string-replace-all               | unicorn    |         |          | 🛠️        |
| prefer-string-slice                     | unicorn    |         |          | 🛠️        |
| prefer-top-level-await                  | unicorn    |         |          |          |
| prefer-type-error                       | unicorn    |         |          | 🛠️        |
| require-number-to-fixed-digits-argument | unicorn    |         |          | 🛠️        |

## Style (167):
Code that should be written in a more idiomatic way.
| Rule name                            | Source     | Default | Enabled? | Fixable? |
| ------------------------------------ | ---------- | ------- | -------- | -------- |
| arrow-body-style                     | eslint     |         |          | 🚧       |
| curly                                | eslint     |         |          | 🛠️        |
| default-case-last                    | eslint     |         |          |          |
| default-param-last                   | eslint     |         |          |          |
| func-names                           | eslint     |         |          | 🛠️💡      |
| func-style                           | eslint     |         |          | 🚧       |
| grouped-accessor-pairs               | eslint     |         |          | 🚧       |
| guard-for-in                         | eslint     |         |          |          |
| id-length                            | eslint     |         |          |          |
| init-declarations                    | eslint     |         |          |          |
| max-params                           | eslint     |         |          |          |
| new-cap                              | eslint     |         |          | 🚧       |
| no-continue                          | eslint     |         |          |          |
| no-duplicate-imports                 | eslint     |         |          | 🚧       |
| no-extra-label                       | eslint     |         |          | 🛠️        |
| no-label-var                         | eslint     |         |          |          |
| no-labels                            | eslint     |         |          |          |
| no-lone-blocks                       | eslint     |         |          |          |
| no-magic-numbers                     | eslint     |         |          | 🚧       |
| no-multi-assign                      | eslint     |         |          |          |
| no-multi-str                         | eslint     |         |          |          |
| no-nested-ternary                    | eslint     |         |          |          |
| no-new-func                          | eslint     |         |          |          |
| no-return-assign                     | eslint     |         |          | 🚧       |
| no-script-url                        | eslint     |         |          |          |
| no-template-curly-in-string          | eslint     |         |          |          |
| no-ternary                           | eslint     |         |          |          |
| no-useless-computed-key              | eslint     |         |          | 🚧       |
| operator-assignment                  | eslint     |         |          | ⚠️🛠️️       |
| prefer-destructuring                 | eslint     |         |          | 🚧       |
| prefer-exponentiation-operator       | eslint     |         |          |          |
| prefer-numeric-literals              | eslint     |         |          | 🛠️        |
| prefer-object-has-own                | eslint     |         |          | 🛠️        |
| prefer-object-spread                 | eslint     |         |          | 🛠️        |
| prefer-promise-reject-errors         | eslint     |         |          |          |
| prefer-rest-params                   | eslint     |         |          |          |
| prefer-spread                        | eslint     |         |          |          |
| prefer-template                      | eslint     |         |          | 🚧       |
| sort-imports                         | eslint     |         |          | 🛠️        |
| sort-keys                            | eslint     |         |          | 🛠️        |
| vars-on-top                          | eslint     |         |          |          |
| yoda                                 | eslint     |         |          | 🛠️        |
| consistent-type-specifier-style      | import     |         |          | 🛠️        |
| exports-last                         | import     |         |          |          |
| first                                | import     |         |          | 🚧       |
| group-exports                        | import     |         |          |          |
| no-anonymous-default-export          | import     |         |          |          |
| no-duplicates                        | import     |         |          |          |
| no-mutable-exports                   | import     |         |          |          |
| no-named-default                     | import     |         |          |          |
| no-named-export                      | import     |         |          |          |
| no-namespace                         | import     |         |          | 🚧       |
| prefer-default-export                | import     |         |          |          |
| consistent-test-it                   | jest       |         |          | 🛠️        |
| max-expects                          | jest       |         |          |          |
| max-nested-describe                  | jest       |         |          |          |
| no-alias-methods                     | jest       |         |          | 🛠️        |
| no-confusing-set-timeout             | jest       |         |          |          |
| no-deprecated-functions              | jest       |         |          | 🛠️        |
| no-done-callback                     | jest       |         |          |          |
| no-duplicate-hooks                   | jest       |         |          |          |
| no-hooks                             | jest       |         |          |          |
| no-identical-title                   | jest       |         |          |          |
| no-interpolation-in-snapshots        | jest       |         |          |          |
| no-jasmine-globals                   | jest       |         |          | 🛠️        |
| no-large-snapshots                   | jest       |         |          |          |
| no-mocks-import                      | jest       |         |          |          |
| no-restricted-jest-methods           | jest       |         |          |          |
| no-restricted-matchers               | jest       |         |          |          |
| no-test-prefixes                     | jest       |         |          | 🛠️        |
| no-test-return-statement             | jest       |         |          |          |
| no-untyped-mock-factory              | jest       |         |          | 🛠️        |
| padding-around-test-blocks           | jest       |         |          | 🛠️        |
| prefer-called-with                   | jest       |         |          |          |
| prefer-comparison-matcher            | jest       |         |          | 🛠️        |
| prefer-each                          | jest       |         |          |          |
| prefer-equality-matcher              | jest       |         |          |          |
| prefer-expect-resolves               | jest       |         |          | 🛠️        |
| prefer-hooks-in-order                | jest       |         |          |          |
| prefer-hooks-on-top                  | jest       |         |          |          |
| prefer-jest-mocked                   | jest       |         |          | 🛠️        |
| prefer-lowercase-title               | jest       |         |          | 🛠️        |
| prefer-mock-promise-shorthand        | jest       |         |          | 🛠️        |
| prefer-spy-on                        | jest       |         |          | 🛠️        |
| prefer-strict-equal                  | jest       |         |          | 🛠️        |
| prefer-to-be                         | jest       |         |          | 🛠️        |
| prefer-to-contain                    | jest       |         |          |          |
| prefer-to-have-length                | jest       |         |          | 🛠️        |
| prefer-todo                          | jest       |         |          | 🛠️        |
| require-hook                         | jest       |         |          |          |
| require-top-level-describe           | jest       |         |          |          |
| no-exports-assign                    | node       |         |          | 🛠️        |
| avoid-new                            | promise    |         |          |          |
| no-nesting                           | promise    |         |          | 🚧       |
| no-return-wrap                       | promise    |         |          | 🚧       |
| param-names                          | promise    |         |          |          |
| prefer-await-to-callbacks            | promise    |         |          |          |
| prefer-await-to-then                 | promise    |         |          |          |
| prefer-catch                         | promise    |         |          | 🚧       |
| jsx-boolean-value                    | react      |         |          | 🛠️        |
| jsx-curly-brace-presence             | react      |         |          | 🛠️        |
| jsx-fragments                        | react      |         |          | 🛠️        |
| jsx-handler-names                    | react      |         |          |          |
| jsx-pascal-case                      | react      |         |          |          |
| no-set-state                         | react      |         |          |          |
| prefer-es6-class                     | react      |         |          |          |
| self-closing-comp                    | react      |         |          | 🛠️        |
| state-in-constructor                 | react      |         |          |          |
| adjacent-overload-signatures         | typescript |         |          |          |
| array-type                           | typescript |         |          | 🛠️        |
| ban-tslint-comment                   | typescript |         |          | 🛠️        |
| consistent-generic-constructors      | typescript |         |          | 🚧       |
| consistent-indexed-object-style      | typescript |         |          | 🛠️        |
| consistent-type-definitions          | typescript |         |          | 🛠️        |
| consistent-type-imports              | typescript |         |          | 🛠️        |
| no-empty-interface                   | typescript |         |          |          |
| no-inferrable-types                  | typescript |         |          | 🚧       |
| prefer-for-of                        | typescript |         |          | 🚧       |
| prefer-function-type                 | typescript |         |          | 🛠️        |
| prefer-namespace-keyword             | typescript |         |          | 🛠️        |
| prefer-reduce-type-parameter         | typescript |         |          | 🚧       |
| prefer-return-this-type              | typescript |         |          | 🚧       |
| catch-error-name                     | unicorn    |         |          | 🛠️        |
| consistent-date-clone                | unicorn    |         |          | 🛠️        |
| consistent-existence-index-check     | unicorn    |         |          | 🛠️        |
| empty-brace-spaces                   | unicorn    |         |          | 🛠️        |
| error-message                        | unicorn    |         |          |          |
| filename-case                        | unicorn    |         |          |          |
| no-array-method-this-argument        | unicorn    |         |          | 🚧       |
| no-await-expression-member           | unicorn    |         |          | ⚠️🛠️️       |
| no-console-spaces                    | unicorn    |         |          | 🛠️        |
| no-nested-ternary                    | unicorn    |         |          | 🛠️        |
| no-null                              | unicorn    |         |          | 🛠️        |
| no-unreadable-array-destructuring    | unicorn    |         |          |          |
| no-useless-collection-argument       | unicorn    |         |          | 🚧       |
| no-zero-fractions                    | unicorn    |         |          | 🛠️        |
| number-literal-case                  | unicorn    |         |          | 🛠️        |
| numeric-separators-style             | unicorn    |         |          | 🛠️        |
| prefer-array-index-of                | unicorn    |         |          | 🚧       |
| prefer-class-fields                  | unicorn    |         |          | 🛠️💡      |
| prefer-classlist-toggle              | unicorn    |         |          | 🛠️        |
| prefer-dom-node-text-content         | unicorn    |         |          | 🛠️        |
| prefer-global-this                   | unicorn    |         |          | 🚧       |
| prefer-includes                      | unicorn    |         |          | 🚧       |
| prefer-logical-operator-over-ternary | unicorn    |         |          | 🚧       |
| prefer-modern-dom-apis               | unicorn    |         |          | 🚧       |
| prefer-negative-index                | unicorn    |         |          | 🛠️        |
| prefer-object-from-entries           | unicorn    |         |          | 🚧       |
| prefer-optional-catch-binding        | unicorn    |         |          | 🛠️        |
| prefer-reflect-apply                 | unicorn    |         |          |          |
| prefer-response-static-json          | unicorn    |         |          | 🚧       |
| prefer-spread                        | unicorn    |         |          | 🛠️        |
| prefer-string-raw                    | unicorn    |         |          | 🛠️        |
| prefer-string-trim-start-end         | unicorn    |         |          | 🛠️        |
| prefer-structured-clone              | unicorn    |         |          | 💡       |
| require-array-join-separator         | unicorn    |         |          | 🛠️        |
| switch-case-braces                   | unicorn    |         |          | 🛠️        |
| text-encoding-identifier-case        | unicorn    |         |          | 🛠️        |
| throw-new-error                      | unicorn    |         |          | 🛠️        |
| no-import-node-test                  | vitest     |         |          | 🛠️        |
| prefer-to-be-falsy                   | vitest     |         |          | 🛠️        |
| prefer-to-be-object                  | vitest     |         |          | 🛠️        |
| prefer-to-be-truthy                  | vitest     |         |          | 🛠️        |
| define-emits-declaration             | vue        |         |          | 🚧       |
| define-props-declaration             | vue        |         |          |          |
| define-props-destructuring           | vue        |         |          |          |
| require-typed-ref                    | vue        |         |          |          |

## Nursery (11):
New lints that are still under development.
| Rule name                     | Source  | Default | Enabled? | Fixable? |
| ----------------------------- | ------- | ------- | -------- | -------- |
| constructor-super             | eslint  |         | ✅       |          |
| getter-return                 | eslint  |         | ✅       |          |
| no-misleading-character-class | eslint  |         | ✅       |          |
| no-undef                      | eslint  |         | ✅       |          |
| no-unreachable                | eslint  |         | ✅       |          |
| export                        | import  |         | ✅       |          |
| named                         | import  |         | ✅       |          |
| branches-sharing-code         | oxc     |         | ✅       |          |
| no-map-spread                 | oxc     |         | ✅       | 🛠️💡      |
| no-return-in-finally          | promise |         |          |          |
| require-render-return         | react   |         |          |          |

Default: 103
Enabled: 76
Total: 616
```
</details>

This also refactors the lint rules printing code to simplify it a bit, we previously had two near-identical copies of this code. The rule table for the website is also able to generate fine still, and does not include the enabled column.

It also exposes the `enabled` value to the json formatter, when running `oxlint --rules -f=json`, so we print json objects like this:

```json
  {
    "scope": "vue",
    "value": "valid-define-props",
    "category": "correctness",
    "enabled": false
  }
```