### PR TITLE
refactor(oxfmt): Use stdout and stderr appropreately

### DIFF
--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -25,5 +25,6 @@ async fn main() -> CliRunResult {
     // stdio is blocked by LineWriter, use a BufWriter to reduce syscalls.
     // See `https://github.com/rust-lang/rust/issues/60673`.
     let mut stdout = BufWriter::new(std::io::stdout());
-    FormatRunner::new(command).run(&mut stdout)
+    let mut stderr = BufWriter::new(std::io::stderr());
+    FormatRunner::new(command).run(&mut stdout, &mut stderr)
 }

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -68,5 +68,8 @@ async fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) 
     // stdio is blocked by LineWriter, use a BufWriter to reduce syscalls.
     // See `https://github.com/rust-lang/rust/issues/60673`.
     let mut stdout = BufWriter::new(std::io::stdout());
-    FormatRunner::new(command).with_external_formatter(Some(external_formatter)).run(&mut stdout)
+    let mut stderr = BufWriter::new(std::io::stderr());
+    FormatRunner::new(command)
+        .with_external_formatter(Some(external_formatter))
+        .run(&mut stdout, &mut stderr)
 }

--- a/apps/oxfmt/test/__snapshots__/config_file.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/config_file.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/config_file/nested
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 deep/test.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -23,6 +24,7 @@ working directory: fixtures/config_file/nested/deep
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 test.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -39,6 +41,7 @@ working directory: fixtures/config_file
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 nested/deep/test.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -55,6 +58,7 @@ working directory: fixtures/config_file
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 nested/deep/test.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -68,6 +72,7 @@ working directory: fixtures/config_file
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 nested/deep/test.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -80,9 +85,9 @@ arguments: --check --config NOT_EXISTS.json
 working directory: fixtures/config_file
 exit code: 1
 --- STDOUT ---------
+
+--- STDERR ---------
 Failed to load configuration file.
 Failed to read config <cwd>/NOT_EXISTS.json: File not found
---- STDERR ---------
-
 --------------------"
 `;

--- a/apps/oxfmt/test/__snapshots__/config_ignore_patterns.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/config_ignore_patterns.test.ts.snap
@@ -8,9 +8,8 @@ exit code: 1
 --- STDOUT ---------
 Checking formatting...
 
-Expected at least one target file
 --- STDERR ---------
-
+Expected at least one target file
 --------------------
 --------------------
 arguments: --check --config fmtrc.jsonc
@@ -19,8 +18,7 @@ exit code: 1
 --- STDOUT ---------
 Checking formatting...
 
-Expected at least one target file
 --- STDERR ---------
-
+Expected at least one target file
 --------------------"
 `;

--- a/apps/oxfmt/test/__snapshots__/ignore_and_override.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/ignore_and_override.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/ignore_and_override
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 should_format/ok.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -21,9 +22,8 @@ exit code: 1
 --- STDOUT ---------
 Checking formatting...
 
-Expected at least one target file
 --- STDERR ---------
-
+Expected at least one target file
 --------------------
 --------------------
 arguments: --check --ignore-path ignore1 should_format/ok.js
@@ -31,6 +31,7 @@ working directory: fixtures/ignore_and_override
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 should_format/ok.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -44,6 +45,7 @@ working directory: fixtures/ignore_and_override
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 should_format/ok.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.

--- a/apps/oxfmt/test/__snapshots__/ignore_patterns.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/ignore_patterns.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/ignore_patterns
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 ignored/should-be-ignored.js (<variable>ms)
 ignored/should-be-ignored.ts (<variable>ms)
 
@@ -21,6 +22,7 @@ working directory: fixtures/ignore_patterns
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 not-formatted/bad.js (<variable>ms)
 not-formatted/bad.ts (<variable>ms)
 
@@ -46,9 +48,9 @@ arguments: --check --ignore-path nonexistent.ignore
 working directory: fixtures/ignore_patterns
 exit code: 1
 --- STDOUT ---------
+
+--- STDERR ---------
 Failed to parse target paths or ignore settings.
 Failed to add ignore file: <cwd>/nonexistent.ignore
---- STDERR ---------
-
 --------------------"
 `;

--- a/apps/oxfmt/test/__snapshots__/ignore_symlink.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/ignore_symlink.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/symlink_dirs
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 foo/file.js (<variable>ms)
 root.js (<variable>ms)
 

--- a/apps/oxfmt/test/__snapshots__/multiple_files.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/multiple_files.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/multiple_files
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 arrow.js (<variable>ms)
 simple.js (<variable>ms)
 
@@ -21,6 +22,7 @@ working directory: fixtures/multiple_files
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 app.tsx (<variable>ms)
 arrow.js (<variable>ms)
 component.jsx (<variable>ms)
@@ -39,6 +41,7 @@ working directory: fixtures/multiple_files
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 app.tsx (<variable>ms)
 arrow.js (<variable>ms)
 component.jsx (<variable>ms)
@@ -57,6 +60,7 @@ working directory: fixtures/multiple_files
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 app.tsx (<variable>ms)
 arrow.js (<variable>ms)
 component.jsx (<variable>ms)
@@ -75,6 +79,7 @@ working directory: fixtures/multiple_files
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 arrow.js (<variable>ms)
 component.jsx (<variable>ms)
 simple.js (<variable>ms)

--- a/apps/oxfmt/test/__snapshots__/no_error_on_unmatched_pattern.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/no_error_on_unmatched_pattern.test.ts.snap
@@ -8,10 +8,9 @@ exit code: 0
 --- STDOUT ---------
 Checking formatting...
 
-No files found matching the given patterns.
 Finished in <variable>ms on 0 files using 1 threads.
 --- STDERR ---------
-
+No files found matching the given patterns.
 --------------------
 --------------------
 arguments: --check __non__existent__file.js
@@ -20,8 +19,7 @@ exit code: 1
 --- STDOUT ---------
 Checking formatting...
 
-Expected at least one target file
 --- STDERR ---------
-
+Expected at least one target file
 --------------------"
 `;

--- a/apps/oxfmt/test/__snapshots__/node_modules_dirs.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/node_modules_dirs.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/node_modules_dirs
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 regular_dir/test.js (<variable>ms)
 root.js (<variable>ms)
 
@@ -21,6 +22,7 @@ working directory: fixtures/node_modules_dirs
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 node_modules/test.js (<variable>ms)
 regular_dir/node_modules/test.js (<variable>ms)
 regular_dir/test.js (<variable>ms)

--- a/apps/oxfmt/test/__snapshots__/single_file.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/single_file.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/single_file
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 simple.js (<variable>ms)
 
 Format issues found in above 1 files. Run without \`--check\` to fix.
@@ -20,7 +21,6 @@ working directory: fixtures/single_file
 exit code: 1
 --- STDOUT ---------
 simple.js
-
 --- STDERR ---------
 
 --------------------"

--- a/apps/oxfmt/test/__snapshots__/vcs_dirs.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/vcs_dirs.test.ts.snap
@@ -7,6 +7,7 @@ working directory: fixtures/vcs_dirs
 exit code: 1
 --- STDOUT ---------
 Checking formatting...
+
 regular_dir/test.js (<variable>ms)
 root.js (<variable>ms)
 


### PR DESCRIPTION
Until now, everything was displayed to `stdout`.

This caused inconveniences when combining pipes in the CLI.
For example, the following does not work properly in some situation.

```sh
oxfmt dir_with_parse_error --list-different | wc -l
```

Because the graphical parse error flows along with the paths that has updated.

This PR solves this.