### PR TITLE
fix(formatter): inconsistent CallExpression and NewExpression around member chain and logical expression

### DIFF
--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -162,8 +162,8 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
                 parent.parent(),
                 AstNodes::ReturnStatement(_)
                     | AstNodes::ThrowStatement(_)
-                    // TODO(prettier): Why not include `NewExpression` ???
                     | AstNodes::CallExpression(_)
+                    | AstNodes::NewExpression(_)
                     | AstNodes::ImportExpression(_)
                     | AstNodes::MetaProperty(_)
             ),

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -82,6 +82,7 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
             AstNodes::CallExpression(call) if call.is_argument_span(self.span()) => {
                 WrapState::NoWrap
             }
+            AstNodes::NewExpression(new) if new.is_argument_span(self.span()) => WrapState::NoWrap,
             AstNodes::ExpressionStatement(stmt) => {
                 // `() => <div></div>`
                 //        ^^^^^^^^^^^

--- a/crates/oxc_formatter/src/write/member_expression.rs
+++ b/crates/oxc_formatter/src/write/member_expression.rs
@@ -150,7 +150,7 @@ fn layout<'a>(
     }
 
     match first_non_static_member_ancestor {
-        AstNodes::NewExpression(expr) if expr.is_argument_span(node.span()) => {
+        AstNodes::NewExpression(expr) if expr.callee.span().contains_inclusive(node.span()) => {
             StaticMemberLayout::NoBreak
         }
         AstNodes::AssignmentExpression(assignment) => {

--- a/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
@@ -17,7 +17,7 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
     options.singleRun
       ? "Infinity"
       : (options.cacheLifetime?.glob ??
-        DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
+          DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
   );
 }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/static-members/argument.ts.snap
@@ -20,9 +20,8 @@ TelemetryTrustedValue(
 );
 
 new TelemetryTrustedValue(
-  instance.capabilities.get(
-    TerminalCapability?.PromptTypeDetection,
-  )?.promptType,
+  instance.capabilities.get(TerminalCapability?.PromptTypeDetection)
+    ?.promptType,
 );
 
 ===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 707/758 (93.27%)
+js compatibility: 711/758 (93.80%)
 
 # Failed
 
@@ -28,9 +28,6 @@ js compatibility: 707/758 (93.27%)
 | js/if/if_comments.js | 💥 | 76.00% |
 | js/if/trailing_comment.js | 💥 | 91.43% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
-| js/logical-assignment/inside-call/18171.js | 💥 | 90.20% |
-| js/method-chain/18171.js | 💥 | 82.76% |
-| js/new-expression/with-member-expression.js | 💥 | 73.91% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
 | js/quote-props/classes.js | 💥💥✨✨ | 47.06% |
 | js/quote-props/objects.js | 💥💥✨✨ | 45.10% |
@@ -52,6 +49,5 @@ js compatibility: 707/758 (93.27%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/parentheses/argument.js | 💥 | 68.00% |
 | jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 543/601 (90.35%)
+ts compatibility: 545/601 (90.68%)
 
 # Failed
 
@@ -7,7 +7,6 @@ ts compatibility: 543/601 (90.35%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/parentheses/argument.js | 💥 | 68.00% |
 | jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
@@ -50,7 +49,6 @@ ts compatibility: 543/601 (90.35%)
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/mapped-type/break-mode/break-mode.ts | 💥 | 68.75% |
 | typescript/multiparser-css/issue-6259.ts | 💥 | 57.14% |
-| typescript/new/with-member-expression.ts | 💥 | 52.00% |
 | typescript/non-null/optional-chain.ts | 💥 | 72.22% |
 | typescript/object-multiline/multiline.ts | 💥✨ | 23.21% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |


### PR DESCRIPTION
Follow up https://github.com/prettier/prettier/issues/18171