### PR TITLE
refactor(oxlint): hoist import

### DIFF
--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -1,14 +1,11 @@
-use std::fmt::Debug;
+use std::{error::Error, fmt::Debug};
 
 use serde::Deserialize;
 
 use oxc_allocator::Allocator;
 
 pub type ExternalLinterLoadPluginCb = Box<
-    dyn Fn(
-            String,
-            Option<String>,
-        ) -> Result<PluginLoadResult, Box<dyn std::error::Error + Send + Sync>>
+    dyn Fn(String, Option<String>) -> Result<PluginLoadResult, Box<dyn Error + Send + Sync>>
         + Send
         + Sync,
 >;


### PR DESCRIPTION
Pure refactor. Hoist import of `std::error::Error` to top level. This makes the convoluted `ExternalLinterLoadPluginCb` type easier to read.