### PR TITLE
style(oxlint/plugins): update `oxfmt` config to only format plugins in `oxlint` fixtures

### DIFF
--- a/oxfmtrc.jsonc
+++ b/oxfmtrc.jsonc
@@ -8,7 +8,7 @@
     "**/generated/**",
     // Ignore `fixtures` directories except for `apps/oxlint/test/fixtures`
     "**/fixtures/**",
-    "!apps/oxlint/test/fixtures/**",
+    "!apps/oxlint/test/fixtures/**/plugin.ts",
     "tasks/coverage/node-compat-table",
     "tasks/coverage/misc",
     "tasks/coverage/src/runtime/babelHelpers.js",

--- a/oxfmtrc.jsonc
+++ b/oxfmtrc.jsonc
@@ -6,9 +6,11 @@
     "**/dist/**",
     "**/tests/**",
     "**/generated/**",
-    // Ignore `fixtures` directories except for `apps/oxlint/test/fixtures`
     "**/fixtures/**",
-    "!apps/oxlint/test/fixtures/**/plugin.ts",
+    // Ignore only the linted files in `oxlint`'s fixtures.
+    // Test plugins should be formatted.
+    "!apps/oxlint/test/fixtures/**",
+    "apps/oxlint/test/fixtures/**/files",
     "tasks/coverage/node-compat-table",
     "tasks/coverage/misc",
     "tasks/coverage/src/runtime/babelHelpers.js",


### PR DESCRIPTION
- Follow up to #15600 and #15601.
- Makes the inclusion of the fixtures more specific to only target the plugin files.
- The intention is to prevent autofix CI formatting lintable files and autobreaking assertions in the process.