### PR TITLE
fix(linter): gracefully fail when using import plugin, large file counf and JS plugins

### DIFF
--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -17,6 +17,7 @@ pub enum CliRunResult {
     ConfigFileInitFailed,
     ConfigFileInitSucceeded,
     TsGoLintError,
+    TooManyFilesWithImportAndJsPlugins,
 }
 
 impl Termination for CliRunResult {
@@ -37,7 +38,8 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionSeverityWithoutFilter
             | Self::InvalidOptionSeverityWithoutPluginName
             | Self::InvalidOptionSeverityWithoutRuleName
-            | Self::TsGoLintError => ExitCode::FAILURE,
+            | Self::TsGoLintError
+            | Self::TooManyFilesWithImportAndJsPlugins => ExitCode::FAILURE,
         }
     }
 }


### PR DESCRIPTION
Ref https://github.com/oxc-project/oxc/issues/15863



![Screenshot 2025-11-19 at 10.34.28.png](https://app.graphite.com/user-attachments/assets/e19a30f6-45eb-450a-9286-55830160587c.png)



