### PR TITLE
test(all): check parse errors existence

### DIFF
--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -199,14 +199,14 @@ pub mod legal {
             "/* @license */\n//! KEEP\nfoo;bar;",
             "/* @license */\n/*! KEEP */\nfoo;bar;",
             "/* @license *//*! KEEP */\nfoo;bar;",
-            "function () {
+            "function test() {
     /*
     * @license
     * Copyright notice 2
     */
     bar;
 }",
-            "function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }",
+            "function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }",
             "function foo() {
 	(() => {
 		/**

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -55,7 +55,7 @@ bar;
 /*! KEEP */
 
 ########## 5
-function () {
+function test() {
     /*
     * @license
     * Copyright notice 2
@@ -63,7 +63,7 @@ function () {
     bar;
 }
 ----------
-function() {
+function test() {
 	bar;
 }
 
@@ -73,11 +73,11 @@ function() {
 */
 
 ########## 6
-function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
+function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }
 ----------
 function bar() {
 	var foo;
-	function() {}
+	function baz() {}
 }
 
 /*! #__NO_SIDE_EFFECTS__ */

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
@@ -45,7 +45,7 @@ foo;bar;
 /*! KEEP */
 
 ########## 5
-function () {
+function test() {
     /*
     * @license
     * Copyright notice 2
@@ -53,16 +53,16 @@ function () {
     bar;
 }
 ----------
-function(){bar}
+function test(){bar}
 /*
 * @license
 * Copyright notice 2
 */
 
 ########## 6
-function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
+function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }
 ----------
-function bar(){var foo;function(){}}
+function bar(){var foo;function baz(){}}
 /*! #__NO_SIDE_EFFECTS__ */
 
 ########## 7

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_inline_comments.snap
@@ -51,7 +51,7 @@ foo;
 bar;
 
 ########## 5
-function () {
+function test() {
     /*
     * @license
     * Copyright notice 2
@@ -59,7 +59,7 @@ function () {
     bar;
 }
 ----------
-function() {
+function test() {
 	/*
 	* @license
 	* Copyright notice 2
@@ -68,11 +68,11 @@ function() {
 }
 
 ########## 6
-function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
+function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }
 ----------
 function bar() {
 	var foo;
-	/*! #__NO_SIDE_EFFECTS__ */ function() {}
+	/*! #__NO_SIDE_EFFECTS__ */ function baz() {}
 }
 
 ########## 7

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
@@ -46,7 +46,7 @@ bar;
 
 /*! For license information please see test.js */
 ########## 5
-function () {
+function test() {
     /*
     * @license
     * Copyright notice 2
@@ -54,17 +54,17 @@ function () {
     bar;
 }
 ----------
-function() {
+function test() {
 	bar;
 }
 
 /*! For license information please see test.js */
 ########## 6
-function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
+function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }
 ----------
 function bar() {
 	var foo;
-	function() {}
+	function baz() {}
 }
 
 /*! For license information please see test.js */

--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 let x: string = `\x01`;
@@ -96,9 +96,9 @@ class A {constructor(public readonly a: number) {}}
 ----------
 class A{constructor(public readonly a:number){}}
 ########## 22
-abstract class A {private abstract static m() {}}
+abstract class A {private abstract static m()}
 ----------
-abstract class A{private abstract static m(){}}
+abstract class A{private abstract static m();}
 ########## 23
 abstract class A {private abstract static readonly prop: string}
 ----------

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 let x: string = `\x01`;
@@ -142,10 +142,10 @@ class A {
 }
 
 ########## 22
-abstract class A {private abstract static m() {}}
+abstract class A {private abstract static m()}
 ----------
 abstract class A {
-	private abstract static m() {}
+	private abstract static m();
 }
 
 ########## 23

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -17,6 +17,7 @@ fn incorrect_ast() {
     let source_type = SourceType::ts();
     let source_text = "foo\nvar bar = '测试'";
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
 
     let mut program = ret.program;
     program.span = Span::new(0, 0);
@@ -52,6 +53,7 @@ fn no_invalid_tokens_beyond_source() {
         let allocator = Allocator::default();
         let source_type = SourceType::mjs();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
+        assert!(ret.errors.is_empty());
 
         let result = Codegen::new()
             .with_options(CodegenOptions {
@@ -179,6 +181,7 @@ fn('name', () => {
 fn codegen(code: &str) -> (String, String) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, code, SourceType::mjs()).parse();
+    assert!(ret.errors.is_empty());
     let ret = Codegen::new()
         .with_options(CodegenOptions {
             source_map_path: Some(PathBuf::from("input.js")),

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -13,6 +13,7 @@ pub fn test_with_parse_options(source_text: &str, expected: &str, parse_options:
     let allocator = Allocator::default();
     let ret =
         Parser::new(&allocator, source_text, SourceType::tsx()).with_options(parse_options).parse();
+    assert!(ret.errors.is_empty());
     let result = Codegen::new().with_options(default_options()).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text}");
 }
@@ -46,8 +47,17 @@ pub fn test_options_with_source_type(
 ) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
     let result = Codegen::new().with_options(options).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text:?}");
+}
+
+#[track_caller]
+pub fn test_same_ignore_parse_errors(source_text: &str) {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, SourceType::tsx()).parse();
+    let result = Codegen::new().with_options(default_options()).build(&ret.program).code;
+    assert_eq!(result, source_text, "\nfor source: {source_text:?}");
 }
 
 #[track_caller]
@@ -55,6 +65,7 @@ pub fn test_minify(source_text: &str, expected: &str) {
     let source_type = SourceType::jsx();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
     let result = Codegen::new()
         .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
         .build(&ret.program)
@@ -77,6 +88,7 @@ pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenRe
     let allocator = Allocator::default();
     let source_type = SourceType::ts();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
     let mut options = options.clone();
     options.single_quote = true;
     Codegen::new().with_options(options).build(&ret.program)

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -59,7 +59,7 @@ fn ts() {
         "function <const T>(){}",
         "class A {m?(): void}",
         "class A {constructor(public readonly a: number) {}}",
-        "abstract class A {private abstract static m() {}}",
+        "abstract class A {private abstract static m()}",
         "abstract class A {private abstract static readonly prop: string}",
         "interface A { a: string, 'b': number, 'c'(): void }",
         "enum A { a, 'b' }",

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -143,6 +143,7 @@ fn format_source(source_text: &str, source_type: SourceType, options: FormatOpti
     let allocator = Allocator::default();
     let ret =
         Parser::new(&allocator, source_text, source_type).with_options(get_parse_options()).parse();
+    assert!(ret.errors.is_empty());
 
     let formatter = Formatter::new(&allocator, options);
     formatter.build(&ret.program)

--- a/crates/oxc_isolated_declarations/tests/deno/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/deno/mod.rs
@@ -13,6 +13,7 @@ mod tests {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path("test.ts").unwrap();
         let ret = Parser::new(&allocator, source, source_type).parse();
+        assert!(ret.errors.is_empty());
         let ret = IsolatedDeclarations::new(
             &allocator,
             IsolatedDeclarationsOptions { strip_internal: true },

--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -3,7 +3,7 @@ class Cls {
   get a() {
     return 1;
   }
-  set a() {
+  set a(v) {
     return;
   }
 
@@ -13,7 +13,7 @@ class Cls {
   }
 
   private get c() {}
-  private set c() {}
+  private set c(v) {}
 
   accessor d: string;
   private accessor e: string;

--- a/crates/oxc_isolated_declarations/tests/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/mod.rs
@@ -12,6 +12,12 @@ fn transform(path: &Path, source_text: &str) -> String {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(
+        parser_ret.errors.is_empty(),
+        "Parser errors for {}: {:?}",
+        path.display(),
+        parser_ret.errors
+    );
 
     let id_ret =
         IsolatedDeclarations::new(&allocator, IsolatedDeclarationsOptions { strip_internal: true })

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -8,7 +8,7 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
 // Correct
 declare class Cls {
 	get a(): number;
-	set a(value);
+	set a(v: number);
 	get b(): string;
 	set b(v: string);
 	private get c();

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1026,6 +1026,7 @@ mod tests {
     fn process_source<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(allocator, source_text, source_type).parse();
+        assert!(parser_ret.errors.is_empty());
         let semantic_ret = SemanticBuilder::new().build(allocator.alloc(parser_ret.program));
         semantic_ret.semantic
     }

--- a/crates/oxc_linter/src/utils/comment.rs
+++ b/crates/oxc_linter/src/utils/comment.rs
@@ -91,6 +91,7 @@ mod test {
         for (source, source_type, expected_counts) in cases {
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, source, source_type).parse();
+            assert!(ret.errors.is_empty());
             let semantic = SemanticBuilder::new().build(&ret.program).semantic;
             let comments = semantic.comments();
 

--- a/crates/oxc_minifier/examples/dce.rs
+++ b/crates/oxc_minifier/examples/dce.rs
@@ -66,6 +66,7 @@ fn dce(
     max_iterations: Option<u8>,
 ) -> String {
     let ret = Parser::new(allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     let mut program = ret.program;
     Compressor::new(allocator).dead_code_elimination(
         &mut program,

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -62,6 +62,7 @@ fn main() -> std::io::Result<()> {
 fn mangler(source_text: &str, source_type: SourceType, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     let mangler_return = Mangler::new().with_options(options).build(&ret.program);
     Codegen::new()
         .with_scoping(Some(mangler_return.scoping))

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -91,6 +91,7 @@ fn minify(
     max_iterations: Option<u8>,
 ) -> CodegenReturn {
     let ret = Parser::new(allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     let mut program = ret.program;
     let options = MinifierOptions {
         mangle: mangle.then(MangleOptions::default),

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -10,6 +10,7 @@ fn mangle(source_text: &str, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parser errors: {:?}", ret.errors);
     let program = ret.program;
     let mangler_return = Mangler::new().with_options(options).build(&program);
     Codegen::new()
@@ -47,8 +48,8 @@ fn mangler() {
         "function _() { var x; { var y }}",     // y should not shadow x
         "function _() { var x; { let y }}",     // y can shadow x
         "function _() { let x; { let y }}",     // y can shadow x
-        "function _() { var x; { const y }}",   // y can shadow x
-        "function _() { let x; { const y }}",   // y can shadow x
+        "function _() { var x; { const y = 1 }}", // y can shadow x
+        "function _() { let x; { const y = 1 }}", // y can shadow x
         "function _() { var x; { class Y{} }}", // Y can shadow x
         "function _() { let x; { class Y{} }}", // Y can shadow x
         "function _() { var x; try { throw 0 } catch (e) { e } }", // e can shadow x

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -103,19 +103,19 @@ function _() {
 	}
 }
 
-function _() { var x; { const y }}
+function _() { var x; { const y = 1 }}
 function _() {
 	var e;
 	{
-		const e;
+		const e = 1;
 	}
 }
 
-function _() { let x; { const y }}
+function _() { let x; { const y = 1 }}
 function _() {
 	let e;
 	{
-		const e;
+		const e = 1;
 	}
 }
 

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -304,6 +304,7 @@ mod test {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
+        assert!(ret.errors.is_empty());
         ret.program.comments.iter().copied().collect::<Vec<_>>()
     }
 

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -397,6 +397,7 @@ mod module_record_tests {
     fn build<'a>(allocator: &'a Allocator, source_text: &'a str) -> ModuleRecord<'a> {
         let source_type = SourceType::ts();
         let ret = Parser::new(allocator, source_text, source_type).parse();
+        assert!(ret.errors.is_empty());
         ret.module_record
     }
 
@@ -513,9 +514,9 @@ mod module_record_tests {
         // ExportDeclaration : export NamedExports ;
         // ExportSpecifier : ModuleExportName
         let allocator = Allocator::default();
-        let module_record = build(&allocator, "export { x }");
+        let module_record = build(&allocator, "export { x }; var x");
         let export_entry = ExportEntry {
-            statement_span: Span::new(0, 12),
+            statement_span: Span::new(0, 13),
             span: Span::new(9, 10),
             export_name: ExportExportName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
             local_name: ExportLocalName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
@@ -530,9 +531,9 @@ mod module_record_tests {
         // ExportDeclaration : export NamedExports ;
         // ExportSpecifier : ModuleExportName as ModuleExportName
         let allocator = Allocator::default();
-        let module_record = build(&allocator, "export { x as v }");
+        let module_record = build(&allocator, "export { x as v }; var x");
         let export_entry = ExportEntry {
-            statement_span: Span::new(0, 17),
+            statement_span: Span::new(0, 18),
             span: Span::new(9, 15),
             export_name: ExportExportName::Name(NameSpan::new("v".into(), Span::new(14, 15))),
             local_name: ExportLocalName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
@@ -645,16 +646,18 @@ mod module_record_tests {
     #[test]
     fn export_named_default() {
         let allocator = Allocator::default();
-        let module_record = build(&allocator, "export { default }");
+        let module_record = build(&allocator, "export { default } from 'mod'");
         let export_entry = ExportEntry {
-            statement_span: Span::new(0, 18),
+            statement_span: Span::new(0, 29),
+            module_request: Some(NameSpan::new("mod".into(), Span::new(24, 29))),
             span: Span::new(9, 16),
             export_name: ExportExportName::Name(NameSpan::new("default".into(), Span::new(9, 16))),
-            local_name: ExportLocalName::Name(NameSpan::new("default".into(), Span::new(9, 16))),
+            import_name: ExportImportName::Name(NameSpan::new("default".into(), Span::new(9, 16))),
+            local_name: ExportLocalName::Null,
             ..ExportEntry::default()
         };
-        assert_eq!(module_record.local_export_entries.len(), 1);
-        assert_eq!(module_record.local_export_entries[0], export_entry);
+        assert_eq!(module_record.indirect_export_entries.len(), 1);
+        assert_eq!(module_record.indirect_export_entries[0], export_entry);
     }
 
     #[test]

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -11,9 +11,12 @@ use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::{TransformOptions, Transformer};
 
+/// # Panics
+/// Panics if there are parse errors.
 pub fn codegen(source_text: &str, source_type: SourceType) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&ret.program)

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -904,6 +904,7 @@ mod test {
         let source_type = SourceType::default();
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
+        assert!(ret.errors.is_empty());
 
         Codegen::new()
             .with_options(CodegenOptions {

--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -16,6 +16,7 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let source_type = SourceType::default();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let ret = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);

--- a/crates/oxc_transformer_plugins/tests/integrations/main.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/main.rs
@@ -6,9 +6,12 @@ use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
+/// # Panics
+/// Panics if there are parse errors.
 pub fn codegen(source_text: &str, source_type: SourceType) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&ret.program)

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -158,6 +158,7 @@ fn minify_twice(file: &TestFile, options: Options) -> (String, u8) {
 fn minify(source_text: &str, source_type: SourceType, options: Options) -> (String, u8) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty());
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -43,6 +43,7 @@ impl SpecParser {
         }
 
         let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
+        assert!(ret.errors.is_empty());
         self.visit_program(&mut ret.program);
     }
 }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1454,6 +1454,7 @@ fn main() {
             let allocator = Allocator::default();
             let source_type = SourceType::from_path(rule_test_path).unwrap();
             let ret = Parser::new(&allocator, &body, source_type).parse();
+            assert!(ret.errors.is_empty());
 
             let mut state = State::new(&body);
             state.visit_program(&ret.program);
@@ -1540,6 +1541,7 @@ fn main() {
             let allocator = Allocator::default();
             let source_type = SourceType::from_path(rule_src_path).unwrap();
             let ret = Parser::new(&allocator, &body, source_type).parse();
+            assert!(ret.errors.is_empty());
             let debug_mode = false;
             let mut config = RuleConfig::new(&body, debug_mode);
             // TODO: Use the tasks/lint_rules package to get the runtime config object from javascript

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() -> Result<(), io::Error> {
         let mut parsed = Parser::new(&allocator, &file.source_text, file.source_type)
             .with_options(parse_options)
             .parse();
+        assert!(parsed.errors.is_empty());
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let scoping = SemanticBuilder::new().build(&parsed.program).semantic.into_scoping();
@@ -165,6 +166,7 @@ pub fn run() -> Result<(), io::Error> {
         let mut parsed = Parser::new(&allocator, &file.source_text, file.source_type)
             .with_options(parse_options)
             .parse();
+        assert!(parsed.errors.is_empty());
 
         let parser_stats = record_stats(&allocator);
 


### PR DESCRIPTION
Added `assert!(ret.errors.is_empty());` in many places so that invalid inputs are caught properly.