### PR TITLE
refactor(linter/plugins): remove `require(esm)`

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -29,10 +29,7 @@ const commonConfig: UserConfig = {
 // Only generate `.d.ts` file for main export, not for CLI
 export default defineConfig([
   {
-    entry: {
-      cli: 'src-js/cli.ts',
-      plugins: 'src-js/plugins/index.ts',
-    },
+    entry: 'src-js/cli.ts',
     ...commonConfig,
     dts: false,
   },


### PR DESCRIPTION
`loadPlugin` is already async, so we don't need to use `require(esm)` for lazy-loading the JS plugins-related code. Use `import` instead.

This has 3 advantages:

1. Removes the hacky workaround of a separate entry point for TSDown, and hard-coded path in `require('./plugins.js')`, which is only correct if TSDown config remains unchanged.
2. TypeScript can "see into" the `import` -> better type safety.
3. Support versions of NodeJS which don't support `require(esm)`.

On the last one, it's not strictly necessary, as `oxlint` requires a version of NodeJS with `require(esm)` support:

https://github.com/oxc-project/oxc/blob/b622ef87adf1bbed1e76ba0f610b653acb93e72b/apps/oxlint/package.json#L19-L21

But if user *is* on an older version of NodeJS, JS plugins should now work.
