### PR TITLE
fix(linter/plugins): correct bindings package names glob in TSDown config

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -10,7 +10,7 @@ const commonConfig: UserConfig = {
   external: [
     // External native bindings
     './oxlint.*.node',
-    'oxlint-*',
+    '@oxlint/*',
     // Files copied from `oxc-parser`.
     // Not bundled, to avoid needing sourcemaps when debugging.
     /^\.\.?\/.*\/dist\//,


### PR DESCRIPTION
The glob was out of date. Bindings packages now start with `@oxlint/`, not `oxlint-`.