### PR TITLE
refactor(linter/plugins): remove `noExternal` from TSDown config

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -16,7 +16,6 @@ const commonConfig: UserConfig = {
     /^\.\.?\/.*\/dist\//,
   ],
   fixedExtension: false,
-  noExternal: ['@typescript-eslint/scope-manager'],
   // At present only compress syntax.
   // Don't mangle identifiers or remove whitespace, so `dist` code remains somewhat readable.
   minify: {


### PR DESCRIPTION
`noExternal` is not required. As long as the dependency is not specified in `package.json`'s `dependencies`, it's not externalized.

I've verified that the code for `@typescript-eslint/scope-manager` is still present in `dist/plugins.js` after this change.