### PR TITLE
refactor(linter/plugins): bundle deserializer

### DIFF
--- a/apps/oxlint/scripts/build.ts
+++ b/apps/oxlint/scripts/build.ts
@@ -19,35 +19,6 @@ writeFileSync(bindingsPath, bindingsJs);
 console.log('Building with tsdown...');
 execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
 
-// Lazy implementation
-/*
-// Copy files from `napi/parser` to `apps/oxlint/dist`
-console.log('Copying files from parser...');
-
-const parserDirPath = join(oxlintDirPath, '../../napi/parser');
-
-const parserFilePaths = [
-  'src-js/raw-transfer/lazy-common.js',
-  'src-js/raw-transfer/node-array.js',
-  'generated/lazy/constructors.js',
-  'generated/lazy/type_ids.js',
-  'generated/lazy/walk.js',
-  'generated/deserialize/ts_range_loc_parent_no_parens.js',
-];
-
-for (const parserFilePath of parserFilePaths) {
-  copyFile(join(parserDirPath, parserFilePath), join(distDirPath, parserFilePath));
-}
-*/
-
-// Copy files from `src-js/generated` to `dist/generated`
-console.log('Copying generated files...');
-
-const generatedFilePaths = ['deserialize.js'];
-for (const filePath of generatedFilePaths) {
-  copyFile(join(oxlintDirPath, 'src-js/generated', filePath), join(distDirPath, 'generated', filePath));
-}
-
 // Copy native `.node` files from `src-js`
 console.log('Copying `.node` files...');
 

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -3,7 +3,7 @@ import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from '../generated/constants.j
 // We use the deserializer which removes `ParenthesizedExpression`s from AST,
 // and with `range`, `loc`, and `parent` properties on AST nodes, to match ESLint
 // @ts-expect-error we need to generate `.d.ts` file for this module
-import { deserializeProgramOnly, resetBuffer } from '../../dist/generated/deserialize.js';
+import { deserializeProgramOnly, resetBuffer } from '../generated/deserialize.js';
 
 import visitorKeys from '../generated/keys.js';
 import * as commentMethods from './comments.js';

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -11,9 +11,6 @@ const commonConfig: UserConfig = {
     // External native bindings
     './oxlint.*.node',
     '@oxlint/*',
-    // Files copied from `oxc-parser`.
-    // Not bundled, to avoid needing sourcemaps when debugging.
-    /^\.\.?\/.*\/dist\//,
   ],
   fixedExtension: false,
   // At present only compress syntax.


### PR DESCRIPTION
Bundle the deserializer. Originally it wasn't bundled at my request, so that source maps wouldn't be required for debugging. But it's turning out that we have no problems in the deserializer - our problems are elsewhere!