### PR TITLE
refactor(linter/plugins): do not include hashes in filenames in `dist`

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -7,6 +7,7 @@ const commonConfig: UserConfig = {
   outDir: 'dist',
   clean: true,
   unbundle: false,
+  hash: false,
   external: [
     // External native bindings
     './oxlint.*.node',


### PR DESCRIPTION
Follow-on after #15866. Don't include hashes in filenames in `dist`. They're unnecessary and ugly, and Oxlint is not a front-end package, so hashes are not useful for caching.