### PR TITLE
refactor(linter/plugins): enable TS `strictNullChecks`

### DIFF
--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -24,7 +24,7 @@ function loadPluginWrapper(path: string, packageName: string | null): Promise<st
       return loadPlugin(path, packageName);
     });
   }
-  return loadPlugin(path, packageName);
+  return loadPlugin!(path, packageName);
 }
 
 /**

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,8 +1,11 @@
+import { assertIsNonNull } from './plugins/utils.js';
+
 import type { Context, FileContext, LanguageOptions } from './plugins/context.ts';
 import type { CreateOnceRule, Plugin, Rule } from './plugins/load.ts';
 import type { Settings } from './plugins/settings.ts';
 import type { SourceCode } from './plugins/source_code.ts';
 import type { BeforeHook, Visitor, VisitorWithHooks } from './plugins/types.ts';
+import type { SetNullable } from './plugins/utils.ts';
 
 export type * as ESTree from './generated/types.d.ts';
 export type { Context, LanguageOptions } from './plugins/context.ts';
@@ -114,6 +117,7 @@ export function defineRule(rule: Rule): Rule {
     if (context === null) {
       ({ context, visitor, beforeHook } = createContextAndVisitor(rule));
     }
+    assertIsNonNull(visitor);
 
     // Copy properties from ESLint's context object to `context`.
     // ESLint's context object is an object of form `{ id, options, report }`, with all other properties
@@ -131,7 +135,7 @@ export function defineRule(rule: Rule): Rule {
     }
 
     // Return same visitor each time
-    return visitor!;
+    return visitor;
   };
 
   return rule;
@@ -231,9 +235,13 @@ function createContextAndVisitor(rule: CreateOnceRule): {
     report: { value: null, enumerable: true, configurable: true },
   });
 
-  let { before: beforeHook, after: afterHook, ...visitor } = createOnce.call(rule, context) as VisitorWithHooks;
+  let {
+    before: beforeHook,
+    after: afterHook,
+    ...visitor
+  } = createOnce.call(rule, context) as SetNullable<VisitorWithHooks, 'before' | 'after'>;
 
-  if (beforeHook === void 0) {
+  if (beforeHook === undefined) {
     beforeHook = null;
   } else if (beforeHook !== null && typeof beforeHook !== 'function') {
     throw new Error('`before` property of visitor must be a function if defined');

--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -3,6 +3,7 @@
  */
 
 import { ast, initAst, sourceText } from './source_code.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { Comment, Node, NodeOrToken } from './types.ts';
 
@@ -15,6 +16,8 @@ const WHITESPACE_ONLY_REGEXP = /^\s*$/;
  */
 export function getAllComments(): Comment[] {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
+
   // `comments` property is a getter. Comments are deserialized lazily.
   return ast.comments;
 }
@@ -38,6 +41,8 @@ export function getAllComments(): Comment[] {
  */
 export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
+  assertIsNonNull(sourceText);
 
   const { comments } = ast,
     commentsLength = comments.length;
@@ -93,6 +98,8 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
  */
 export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
+  assertIsNonNull(sourceText);
 
   const { comments } = ast,
     commentsLength = comments.length;
@@ -135,6 +142,7 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
  */
 export function getCommentsInside(node: Node): Comment[] {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
 
   const { comments } = ast,
     commentsLength = comments.length;
@@ -178,6 +186,7 @@ export function getCommentsInside(node: Node): Comment[] {
  */
 export function commentsExistBetween(nodeOrToken1: NodeOrToken, nodeOrToken2: NodeOrToken): boolean {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
 
   // Find the first comment after `nodeOrToken1` ends.
   const { comments } = ast,

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -29,6 +29,7 @@
 import { ast, initAst, SOURCE_CODE } from './source_code.js';
 import { report } from './report.js';
 import { settings, initSettings } from './settings.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { Options, RuleDetails } from './load.ts';
 import type { Diagnostic } from './report.ts';
@@ -78,6 +79,8 @@ const PARSER_OPTIONS = freeze({
     // in case it's used in `create` to return an empty visitor if wrong type.
     // TODO: ESLint also has `commonjs` option.
     if (ast === null) initAst();
+    assertIsNonNull(ast);
+
     return ast.sourceType;
   },
 });
@@ -92,6 +95,8 @@ const LANGUAGE_OPTIONS = freeze({
     // in case it's used in `create` to return an empty visitor if wrong type.
     // TODO: ESLint also has `commonjs` option.
     if (ast === null) initAst();
+    assertIsNonNull(ast);
+
     return ast.sourceType;
   },
 
@@ -250,7 +255,10 @@ const FILE_CONTEXT = freeze({
    */
   get settings(): Readonly<Settings> {
     if (filePath === null) throw new Error('Cannot access `context.settings` in `createOnce`');
+
     if (settings === null) initSettings();
+    assertIsNonNull(settings);
+
     return settings;
   },
 

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -3,7 +3,7 @@ import { registeredRules } from './load.js';
 import { diagnostics } from './report.js';
 import { setSettingsForFile, resetSettings } from './settings.js';
 import { ast, initAst, resetSourceAndAst, setupSourceForFile } from './source_code.js';
-import { assertIs, getErrorMessage } from './utils.js';
+import { assertIs, assertIsNonNull, getErrorMessage } from './utils.js';
 import { addVisitorToCompiled, compiledVisitor, finalizeCompiledVisitor, initCompiledVisitor } from './visitor.js';
 
 // Lazy implementation
@@ -136,6 +136,7 @@ function lintFileImpl(
     let { visitor } = ruleDetails;
     if (visitor === null) {
       // Rule defined with `create` method
+      assertIsNonNull(ruleDetails.rule.create);
       visitor = ruleDetails.rule.create(ruleDetails.context);
     } else {
       // Rule defined with `createOnce` method

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -8,6 +8,7 @@ import type { Context } from './context.ts';
 import type { JsonValue } from './json.ts';
 import type { RuleMeta } from './rule_meta.ts';
 import type { AfterHook, BeforeHook, Visitor, VisitorWithHooks } from './types.ts';
+import type { SetNullable } from './utils.ts';
 
 const ObjectKeys = Object.keys;
 
@@ -181,7 +182,7 @@ async function loadPluginImpl(path: string, packageName: string | null): Promise
     // Create `RuleDetails` object for rule.
     const ruleDetails: RuleDetails = {
       rule: rule as CreateRule, // Could also be `CreateOnceRule`, but just to satisfy type checker
-      context: null as Readonly<Context>, // Filled in below
+      context: null!, // Filled in below
       isFixable,
       messages,
       ruleIndex: 0,
@@ -197,7 +198,7 @@ async function loadPluginImpl(path: string, packageName: string | null): Promise
 
     if ('createOnce' in rule) {
       // TODO: Compile visitor object to array here, instead of repeating compilation on each file
-      let visitorWithHooks = rule.createOnce(context);
+      let visitorWithHooks = rule.createOnce(context) as SetNullable<VisitorWithHooks, 'before' | 'after'>;
       if (typeof visitorWithHooks !== 'object' || visitorWithHooks === null) {
         throw new TypeError('`createOnce` must return an object');
       }
@@ -219,9 +220,9 @@ async function loadPluginImpl(path: string, packageName: string | null): Promise
         afterHook = null;
       }
 
-      (ruleDetails as Writable<CreateOnceRuleDetails>).visitor = visitor;
-      (ruleDetails as Writable<CreateOnceRuleDetails>).beforeHook = beforeHook;
-      (ruleDetails as Writable<CreateOnceRuleDetails>).afterHook = afterHook;
+      (ruleDetails as unknown as Writable<CreateOnceRuleDetails>).visitor = visitor;
+      (ruleDetails as unknown as Writable<CreateOnceRuleDetails>).beforeHook = beforeHook;
+      (ruleDetails as unknown as Writable<CreateOnceRuleDetails>).afterHook = afterHook;
     }
 
     registeredRules.push(ruleDetails);

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -4,6 +4,7 @@
  */
 
 import { initSourceText, sourceText } from './source_code.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { Node } from './types.ts';
 
@@ -60,6 +61,7 @@ const lineStartOffsets: number[] = [0];
  */
 export function initLines(): void {
   if (sourceText === null) initSourceText();
+  assertIsNonNull(sourceText);
 
   // This implementation is based on the one in ESLint.
   // TODO: Investigate if using `String.prototype.matchAll` is faster.
@@ -109,6 +111,7 @@ export function getLineColumnFromOffset(offset: number): LineColumn {
   // Build `lines` and `lineStartOffsets` tables if they haven't been already.
   // This also decodes `sourceText` if it wasn't already.
   if (lines.length === 0) initLines();
+  assertIsNonNull(sourceText);
 
   if (offset > sourceText.length) {
     throw new RangeError(
@@ -158,6 +161,7 @@ export function getOffsetFromLineColumn(loc: LineColumn): number {
       // Build `lines` and `lineStartOffsets` tables if they haven't been already.
       // This also decodes `sourceText` if it wasn't already.
       if (lines.length === 0) initLines();
+      assertIsNonNull(sourceText);
 
       const linesCount = lineStartOffsets.length;
       if (line <= 0 || line > linesCount) {

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -84,7 +84,7 @@ export function report(diagnostic: Diagnostic, ruleDetails: RuleDetails): void {
   }
 
   // TODO: Validate `diagnostic`
-  let start: number, end: number, loc: Location;
+  let start: number, end: number, loc: Location | undefined;
 
   if (hasOwn(diagnostic, 'loc') && (loc = diagnostic.loc) != null) {
     // `loc`

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -8,7 +8,7 @@ import {
   type ScopeManager as TSESLintScopeManager,
 } from '@typescript-eslint/scope-manager';
 import { ast, initAst } from './source_code.js';
-import { assertIs } from './utils.js';
+import { assertIs, assertIsNonNull } from './utils.js';
 
 import type * as ESTree from '../generated/types.d.ts';
 import type { SetNullable } from './utils.ts';
@@ -109,6 +109,7 @@ const analyzeOptions: SetNullable<AnalyzeOptions, 'sourceType'> = {
  */
 function initTsScopeManager() {
   if (ast === null) initAst();
+  assertIsNonNull(ast);
 
   analyzeOptions.sourceType = ast.sourceType;
   assertIs<AnalyzeOptions>(analyzeOptions);
@@ -199,6 +200,7 @@ export function isGlobalReference(node: ESTree.Node): boolean {
   if (node.type !== 'Identifier') return false;
 
   if (tsScopeManager === null) initTsScopeManager();
+  assertIsNonNull(tsScopeManager);
 
   const { scopes } = tsScopeManager;
   if (scopes.length === 0) return false;
@@ -229,6 +231,8 @@ export function isGlobalReference(node: ESTree.Node): boolean {
 export function getDeclaredVariables(node: ESTree.Node): Variable[] {
   // ref: https://github.com/eslint/eslint/blob/e7cda3bdf1bdd664e6033503a3315ad81736b200/lib/languages/js/source-code/source-code.js#L904
   if (tsScopeManager === null) initTsScopeManager();
+  assertIsNonNull(tsScopeManager);
+
   // @ts-expect-error // TODO: Our types don't quite align yet
   return tsScopeManager.getDeclaredVariables(node);
 }
@@ -243,6 +247,7 @@ export function getScope(node: ESTree.Node): Scope {
   if (!node) throw new TypeError('Missing required argument: `node`');
 
   if (tsScopeManager === null) initTsScopeManager();
+  assertIsNonNull(tsScopeManager);
 
   const inner = node.type !== 'Program';
 
@@ -254,6 +259,7 @@ export function getScope(node: ESTree.Node): Scope {
       return scope.type === 'function-expression-name' ? scope.childScopes[0] : scope;
     }
 
+    // @ts-expect-error - Don't want to create a new variable just to make it nullable
     node = node.parent;
   } while (node !== null);
 

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -54,7 +54,7 @@ const EMPTY_TYPE_IDS_ARRAY: NodeTypeId[] = [];
 export function parseSelector(key: string): Selector {
   // Used cached object if we've parsed this key before
   let selector = cache.get(key);
-  if (selector !== void 0) return selector;
+  if (selector !== undefined) return selector;
 
   // Parse with `esquery` and analyse
   const esquerySelector = esqueryParse(key);
@@ -97,7 +97,7 @@ function analyzeSelector(esquerySelector: EsquerySelector, selector: Selector): 
       // If the type is invalid, just treat this selector as not matching any types.
       // But still increment `identifierCount`.
       // This matches ESLint's behavior.
-      return typeId === void 0 ? EMPTY_TYPE_IDS_ARRAY : [typeId];
+      return typeId === undefined ? EMPTY_TYPE_IDS_ARRAY : [typeId];
     }
 
     case 'not':
@@ -144,7 +144,7 @@ function analyzeSelector(esquerySelector: EsquerySelector, selector: Selector): 
         } else {
           // Selector only matches intersection of all child selectors.
           // TODO: Could make this faster if `analyzeSelector` always returned an ordered array.
-          nodeTypes = childNodeTypes.filter((nodeType) => nodeTypes.includes(nodeType));
+          nodeTypes = childNodeTypes.filter((nodeType) => nodeTypes!.includes(nodeType));
         }
       }
       return nodeTypes;

--- a/apps/oxlint/src-js/plugins/settings.ts
+++ b/apps/oxlint/src-js/plugins/settings.ts
@@ -3,6 +3,7 @@
  */
 
 import { deepFreezeJsonValue } from './json.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { JsonObject } from './json.ts';
 
@@ -35,6 +36,7 @@ export function setSettingsForFile(settingsJSONInput: string): undefined {
  * Deserialize settings from JSON.
  */
 export function initSettings(): undefined {
+  assertIsNonNull(settingsJSON);
   settings = JSON.parse(settingsJSON);
   // Deep freeze the settings object, to prevent any mutation of the settings from plugins
   deepFreezeJsonValue(settings);

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -18,6 +18,7 @@ import {
 import { resetScopeManager, SCOPE_MANAGER } from './scope.js';
 import * as scopeMethods from './scope.js';
 import * as tokenMethods from './tokens.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { Program } from '../generated/types.d.ts';
 import type { Ranged } from './location.ts';
@@ -64,6 +65,7 @@ export function setupSourceForFile(
  * Decode source text from buffer.
  */
 export function initSourceText(): void {
+  assertIsNonNull(buffer);
   const { uint32 } = buffer,
     programPos = uint32[DATA_POINTER_POS_32];
   sourceByteLen = uint32[(programPos + SOURCE_LEN_OFFSET) >> 2];
@@ -112,6 +114,7 @@ export const SOURCE_CODE = Object.freeze({
   // Get source text.
   get text(): string {
     if (sourceText === null) initSourceText();
+    assertIsNonNull(sourceText);
     return sourceText;
   },
 
@@ -123,6 +126,7 @@ export const SOURCE_CODE = Object.freeze({
   // Get AST of the file.
   get ast(): Program {
     if (ast === null) initAst();
+    assertIsNonNull(ast);
     return ast;
   },
 
@@ -138,6 +142,7 @@ export const SOURCE_CODE = Object.freeze({
 
   // Get parser services for the file.
   get parserServices(): Record<string, unknown> {
+    assertIsNonNull(parserServices);
     return parserServices;
   },
 
@@ -156,6 +161,7 @@ export const SOURCE_CODE = Object.freeze({
    */
   getText(node?: Ranged | null, beforeCount?: number | null, afterCount?: number | null): string {
     if (sourceText === null) initSourceText();
+    assertIsNonNull(sourceText);
 
     // ESLint treats all falsy values for `node` as undefined
     if (!node) return sourceText;

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -3,6 +3,7 @@
  */
 
 import { sourceText, initSourceText } from './source_code.js';
+import { assertIsNonNull } from './utils.js';
 
 import type { Comment, Node, NodeOrToken, Token } from './types.ts';
 
@@ -370,6 +371,7 @@ export function isSpaceBetween(nodeOrToken1: NodeOrToken, nodeOrToken2: NodeOrTo
 
   // Check if there's any whitespace in the gap
   if (sourceText === null) initSourceText();
+  assertIsNonNull(sourceText);
 
   return WHITESPACE_REGEXP.test(sourceText.slice(gapStart, gapEnd));
 }

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -19,10 +19,10 @@ export type BeforeHook = () => boolean | void;
 export type AfterHook = () => void;
 
 // Visitor object returned by a `Rule`'s `createOnce` function.
-export interface VisitorWithHooks extends Visitor {
+export type VisitorWithHooks = Visitor & {
   before?: BeforeHook;
   after?: AfterHook;
-}
+};
 
 // Visit function for a specific AST node type.
 export type VisitFn = (node: Node) => void;

--- a/apps/oxlint/src-js/plugins/utils.ts
+++ b/apps/oxlint/src-js/plugins/utils.ts
@@ -43,6 +43,17 @@ export function getErrorMessage(err: unknown): string {
 export function assertIs<T>(value: unknown): asserts value is T {}
 
 /**
+ * Assert a value is not `null` or `undefined`.
+ *
+ * Has no runtime effect - only for guiding the type-checker.
+ * Minification removes this function and all calls to it, so it has zero runtime cost.
+ *
+ * @param value - Value
+ */
+// oxlint-disable-next-line no-unused-vars
+export function assertIsNonNull<T>(value: T | null | undefined): asserts value is T {}
+
+/**
  * Utility type to make specified properties of a type nullable.
  *
  * @example

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -76,6 +76,7 @@ import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP, NODE_TYPES_COUNT } from '../g
 import { parseSelector, wrapVisitFnWithSelectorMatch } from './selector.js';
 
 import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from './types.ts';
+import { assertIs, assertIsNonNull } from './utils.js';
 
 const ObjectKeys = Object.keys,
   { isArray } = Array;
@@ -224,7 +225,7 @@ export function addVisitorToCompiled(visitor: Visitor): void {
     // TODO: Combine the two hashmaps `NODE_TYPE_IDS_MAP` and selectors cache into one `Map`
     // to avoid 2 hashmap lookups for selectors?
     let typeId = NODE_TYPE_IDS_MAP.get(name);
-    if (typeId !== void 0) {
+    if (typeId !== undefined) {
       // Single type visit function e.g. `Program`
       addVisitFn(typeId, isExit, visitFn);
       continue;
@@ -371,13 +372,17 @@ export function finalizeCompiledVisitor() {
   for (let i = mergedEnterVisitorTypeIds.length - 1; i >= 0; i--) {
     const typeId = mergedEnterVisitorTypeIds[i];
     const enterExit = compiledVisitor[typeId] as CompilingNonLeafVisitorEntry;
-    enterExit.enter = mergeVisitFns(enterExit.enter as VisitFn[]);
+    assertIsNonNull(enterExit);
+    assertIs<VisitFn[]>(enterExit.enter);
+    enterExit.enter = mergeVisitFns(enterExit.enter);
   }
 
   for (let i = mergedExitVisitorTypeIds.length - 1; i >= 0; i--) {
     const typeId = mergedExitVisitorTypeIds[i];
     const enterExit = compiledVisitor[typeId] as CompilingNonLeafVisitorEntry;
-    enterExit.exit = mergeVisitFns(enterExit.exit as VisitFn[]);
+    assertIsNonNull(enterExit);
+    assertIs<VisitFn[]>(enterExit.exit);
+    enterExit.exit = mergeVisitFns(enterExit.exit);
   }
 
   // Reset state, ready for next time
@@ -412,7 +417,7 @@ function mergeVisitFns(visitFns: VisitFn[]): VisitFn {
   const numVisitFns = visitFns.length;
 
   // Get or create merger for merging `numVisitFns` functions
-  let merger: Merger;
+  let merger: Merger | null;
   if (mergers.length <= numVisitFns) {
     while (mergers.length < numVisitFns) {
       mergers.push(null);

--- a/apps/oxlint/test/compile-visitor.test.ts
+++ b/apps/oxlint/test/compile-visitor.test.ts
@@ -9,13 +9,13 @@ import {
 
 import type { EnterExit, Node, VisitFn } from '../src-js/plugins/types.ts';
 
-const PROGRAM_TYPE_ID = NODE_TYPE_IDS_MAP.get('Program'),
-  EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get('EmptyStatement'),
-  IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('Identifier'),
-  JSX_IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('JSXIdentifier'),
-  FUNC_DECL_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionDeclaration'),
-  FUNC_EXPR_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionExpression'),
-  ARROW_FUNC_TYPE_ID = NODE_TYPE_IDS_MAP.get('ArrowFunctionExpression');
+const PROGRAM_TYPE_ID = NODE_TYPE_IDS_MAP.get('Program')!,
+  EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get('EmptyStatement')!,
+  IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('Identifier')!,
+  JSX_IDENTIFIER_TYPE_ID = NODE_TYPE_IDS_MAP.get('JSXIdentifier')!,
+  FUNC_DECL_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionDeclaration')!,
+  FUNC_EXPR_TYPE_ID = NODE_TYPE_IDS_MAP.get('FunctionExpression')!,
+  ARROW_FUNC_TYPE_ID = NODE_TYPE_IDS_MAP.get('ArrowFunctionExpression')!;
 
 const SPAN: Node = {
   start: 0,
@@ -34,22 +34,18 @@ describe('compile visitor', () => {
   it('throws if visitor is not an object', () => {
     const expectedErr = new TypeError('Visitor returned from `create` method must be an object');
     expect(() => (addVisitorToCompiled as any)()).toThrow(expectedErr);
-    // oxlint-disable typescript-eslint/no-confusing-void-expression
-    expect(() => addVisitorToCompiled(null)).toThrow(expectedErr);
-    expect(() => addVisitorToCompiled(undefined)).toThrow(expectedErr);
+    expect(() => addVisitorToCompiled(null as any)).toThrow(expectedErr);
+    expect(() => addVisitorToCompiled(undefined as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled(true as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled('xyz' as any)).toThrow(expectedErr);
-    // oxlint-enable typescript-eslint/no-confusing-void-expression
   });
 
   it('throws if visitor property is not a function', () => {
     const expectedErr = new TypeError("'Program' property of visitor object is not a function");
-    // oxlint-disable typescript-eslint/no-confusing-void-expression
-    expect(() => addVisitorToCompiled({ Program: null })).toThrow(expectedErr);
-    expect(() => addVisitorToCompiled({ Program: undefined })).toThrow(expectedErr);
+    expect(() => addVisitorToCompiled({ Program: null as any })).toThrow(expectedErr);
+    expect(() => addVisitorToCompiled({ Program: undefined as any })).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: true } as any)).toThrow(expectedErr);
     expect(() => addVisitorToCompiled({ Program: {} } as any)).toThrow(expectedErr);
-    // oxlint-enable typescript-eslint/no-confusing-void-expression
   });
 
   it('accepts unknown visitor key', () => {
@@ -257,12 +253,12 @@ describe('compile visitor', () => {
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
         const enterNode = { type: 'Program', ...SPAN };
-        enterExit.enter(enterNode);
+        enterExit.enter!(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
         const exitNode = { type: 'Program', ...SPAN };
-        enterExit.exit(exitNode);
+        enterExit.exit!(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
       });
@@ -281,12 +277,12 @@ describe('compile visitor', () => {
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
         const enterNode = { type: 'Program', ...SPAN };
-        enterExit.enter(enterNode);
+        enterExit.enter!(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
         const exitNode = { type: 'Program', ...SPAN };
-        enterExit.exit(exitNode);
+        enterExit.exit!(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
       });
@@ -305,12 +301,12 @@ describe('compile visitor', () => {
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
         const enterNode = { type: 'Program', ...SPAN };
-        enterExit.enter(enterNode);
+        enterExit.enter!(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
         const exitNode = { type: 'Program', ...SPAN };
-        enterExit.exit(exitNode);
+        enterExit.exit!(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
       });
@@ -329,12 +325,12 @@ describe('compile visitor', () => {
         const enterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
 
         const enterNode = { type: 'Program', ...SPAN };
-        enterExit.enter(enterNode);
+        enterExit.enter!(enterNode);
         expect(enter1).toHaveBeenCalledWith(enterNode);
         expect(enter2).toHaveBeenCalledWith(enterNode);
 
         const exitNode = { type: 'Program', ...SPAN };
-        enterExit.exit(exitNode);
+        enterExit.exit!(exitNode);
         expect(exit1).toHaveBeenCalledWith(exitNode);
         expect(exit2).toHaveBeenCalledWith(exitNode);
       });
@@ -459,11 +455,11 @@ describe('compile visitor', () => {
       expect(enterExit.exit).not.toBe(exit);
 
       const enterNode = { type: 'Program', ...SPAN };
-      enterExit.enter(enterNode);
+      enterExit.enter!(enterNode);
       expect(enter).toHaveBeenCalledWith(enterNode);
 
       const exitNode = { type: 'Program', ...SPAN };
-      enterExit.exit(exitNode);
+      enterExit.exit!(exitNode);
       expect(exit).toHaveBeenCalledWith(exitNode);
 
       const node = { type: 'EmptyStatement', ...SPAN };
@@ -501,8 +497,8 @@ describe('compile visitor', () => {
 
       const program = { type: 'Program', ...SPAN };
       const programEnterExit = compiledVisitor[PROGRAM_TYPE_ID] as EnterExit;
-      programEnterExit.enter(program);
-      programEnterExit.exit(program);
+      programEnterExit.enter!(program);
+      programEnterExit.exit!(program);
       expect(enter).not.toHaveBeenCalled();
       expect(exit).not.toHaveBeenCalled();
 
@@ -510,8 +506,8 @@ describe('compile visitor', () => {
       const jsxIdentVisit = compiledVisitor[JSX_IDENTIFIER_TYPE_ID] as VisitFn;
 
       let ident = { type: 'Identifier', name: 'bar', ...SPAN };
-      identEnterExit.enter(ident);
-      identEnterExit.exit(ident);
+      identEnterExit.enter!(ident);
+      identEnterExit.exit!(ident);
       expect(enter).not.toHaveBeenCalled();
       expect(exit).not.toHaveBeenCalled();
 
@@ -521,10 +517,10 @@ describe('compile visitor', () => {
       expect(exit).not.toHaveBeenCalled();
 
       ident = { type: 'Identifier', name: 'foo', ...SPAN };
-      identEnterExit.enter(ident);
+      identEnterExit.enter!(ident);
       expect(enter).toHaveBeenCalledWith(ident);
       ident = { type: 'Identifier', name: 'foo', ...SPAN };
-      identEnterExit.exit(ident);
+      identEnterExit.exit!(ident);
       expect(exit).toHaveBeenCalledWith(ident);
 
       ident = { type: 'JSXIdentifier', name: 'foo', ...SPAN };
@@ -555,16 +551,16 @@ describe('compile visitor', () => {
       }
 
       let ident = { type: 'Identifier', name: 'bar', ...SPAN };
-      identEnterExit.enter(ident);
-      identEnterExit.exit(ident);
+      identEnterExit.enter!(ident);
+      identEnterExit.exit!(ident);
       expect(enter).not.toHaveBeenCalled();
       expect(exit).not.toHaveBeenCalled();
 
       ident = { type: 'Identifier', name: 'foo', ...SPAN };
-      identEnterExit.enter(ident);
+      identEnterExit.enter!(ident);
       expect(enter).toHaveBeenCalledWith(ident);
       ident = { type: 'Identifier', name: 'foo', ...SPAN };
-      identEnterExit.exit(ident);
+      identEnterExit.exit!(ident);
       expect(exit).toHaveBeenCalledWith(ident);
     });
 
@@ -606,38 +602,38 @@ describe('compile visitor', () => {
       }
 
       let arrowExpr = { type: 'ArrowFunctionExpression', ...SPAN };
-      arrowFuncEnterExit.enter(arrowExpr);
+      arrowFuncEnterExit.enter!(arrowExpr);
       expect(enter2).toHaveBeenCalledWith(arrowExpr);
       arrowExpr = { type: 'ArrowFunctionExpression', ...SPAN };
-      arrowFuncEnterExit.exit(arrowExpr);
+      arrowFuncEnterExit.exit!(arrowExpr);
       expect(exit2).toHaveBeenCalledWith(arrowExpr);
       expect(enter1).not.toHaveBeenCalled();
       expect(exit1).not.toHaveBeenCalled();
 
       let funcExpr = { type: 'FunctionExpression', name: 'foo', ...SPAN };
-      funcExprEnterExit.enter(funcExpr);
+      funcExprEnterExit.enter!(funcExpr);
       expect(enter2).toHaveBeenCalledWith(funcExpr);
       funcExpr = { type: 'FunctionExpression', name: 'foo', ...SPAN };
-      funcExprEnterExit.exit(funcExpr);
+      funcExprEnterExit.exit!(funcExpr);
       expect(exit2).toHaveBeenCalledWith(funcExpr);
       expect(enter1).not.toHaveBeenCalled();
       expect(exit1).not.toHaveBeenCalled();
 
       let funcDecl = { type: 'FunctionDeclaration', name: 'bar', ...SPAN };
-      funcDeclEnterExit.enter(funcDecl);
+      funcDeclEnterExit.enter!(funcDecl);
       expect(enter2).toHaveBeenCalledWith(funcDecl);
       funcDecl = { type: 'FunctionDeclaration', name: 'bar', ...SPAN };
-      funcDeclEnterExit.exit(funcDecl);
+      funcDeclEnterExit.exit!(funcDecl);
       expect(exit2).toHaveBeenCalledWith(funcDecl);
       expect(enter1).not.toHaveBeenCalled();
       expect(exit1).not.toHaveBeenCalled();
 
       funcDecl = { type: 'FunctionDeclaration', name: 'foo', ...SPAN };
-      funcDeclEnterExit.enter(funcDecl);
+      funcDeclEnterExit.enter!(funcDecl);
       expect(enter1).toHaveBeenCalledWith(funcDecl);
       expect(enter2).toHaveBeenCalledWith(funcDecl);
       funcDecl = { type: 'FunctionDeclaration', name: 'foo', ...SPAN };
-      funcDeclEnterExit.exit(funcDecl);
+      funcDeclEnterExit.exit!(funcDecl);
       expect(exit1).toHaveBeenCalledWith(funcDecl);
       expect(exit2).toHaveBeenCalledWith(funcDecl);
     });

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -26,7 +26,7 @@ const testCommentsRule: Rule = {
     const [, topLevelVariable2, topLevelFunctionExport] = ast.body;
     assert(topLevelFunctionExport.type === 'ExportNamedDeclaration');
     const topLevelFunction = topLevelFunctionExport.declaration;
-    assert(topLevelFunction.type === 'FunctionDeclaration');
+    assert(topLevelFunction?.type === 'FunctionDeclaration');
 
     context.report({
       message:
@@ -64,7 +64,7 @@ const testCommentsRule: Rule = {
       FunctionDeclaration(node) {
         context.report({
           message:
-            `FunctionDeclaration(${node.id.name}):\n` +
+            `FunctionDeclaration(${node.id?.name}):\n` +
             `getCommentsBefore: ${formatComments(sourceCode.getCommentsBefore(node))}\n` +
             `getCommentsInside: ${formatComments(sourceCode.getCommentsInside(node))}\n` +
             `getCommentsAfter: ${formatComments(sourceCode.getCommentsAfter(node))}`,

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -33,7 +33,7 @@ const plugin: Plugin = {
           },
           VariableDeclarator(decl) {
             // `init` should not be `ParenthesizedExpression`
-            visits.push(`${decl.type}: (init: ${decl.init.type})`);
+            visits.push(`${decl.type}: (init: ${decl.init?.type})`);
           },
           Identifier(ident) {
             // Check `loc` property returns same object each time it's accessed

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -81,7 +81,8 @@ const testRule: Rule = {
 
       JSXElement(node) {
         const { isSpaceBetween, isSpaceBetweenTokens } = context.sourceCode,
-          { openingElement, closingElement } = node;
+          openingElement = node.openingElement,
+          closingElement = node.closingElement!;
 
         // We get this wrong.
         // `isSpaceBetween` should return `false` for last 2 `JSXElement`s, but we get `true`.

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -66,7 +66,7 @@ const plugin: Plugin = {
               if (type === 'Identifier') {
                 nodeDescription += `(${node.name})`;
               } else if (type === 'FunctionDeclaration') {
-                nodeDescription += `(${node.id.name})`;
+                nodeDescription += `(${node.id?.name})`;
               }
               return `${key}: ${nodeDescription}`;
             })

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -22,7 +22,7 @@ const rule: Rule = {
         const scope = sourceCode.getScope(node);
         context.report({
           message:
-            `getScope(${node.id.name}):\n` +
+            `getScope(${node.id?.name}):\n` +
             `type: ${scope.type}\n` +
             `isStrict: ${scope.isStrict}\n` +
             `variables: [${scope.variables.map((v) => v.name).join(', ')}]\n` +

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "target": "ESNext",
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "skipLibCheck": true
   },
   "exclude": [


### PR DESCRIPTION
Adapted from #15868. Enable `strictNullChecks` in TSConfig for `apps/oxlint`.

Rather than using `!` all over the place, I've added a function `assertIsNonNull`, which performs the same function. Idea is that we can later on produce a debug build where `assertIsNonNull` does an actual runtime assertion (rather than just a TS `asserts`) that the value is not `null` or `undefined`. We can use the debug build in tests, and catch any logic errors.

Unfortunately, TypeScript doesn't seem able to track side effects, so there seems to be no way to tell it "after calling `initAst()`, `ast` is always non-null". Don't want to switch to a having a `getAst` function which returns a non-null value, as that'd introduce unnecessary temp vars, and function calls, on hot paths. So this seems to be the best we can do without incurring runtime cost.