### PR TITLE
fix(formatter): comments in export class decorators are printing incorrectly

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -4,6 +4,8 @@
 //! - `impl_ast_node_vec!` - For non-Option types (uses `.map()`)
 //! - `impl_ast_node_vec_for_option!` - For Option types (uses `.and_then()`)
 
+use std::cmp::min;
+
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
@@ -158,7 +160,6 @@ impl_ast_node_vec!(ObjectPropertyKind<'a>);
 impl_ast_node_vec!(TemplateElement<'a>);
 impl_ast_node_vec!(Argument<'a>);
 impl_ast_node_vec!(AssignmentTargetProperty<'a>);
-impl_ast_node_vec!(Statement<'a>);
 impl_ast_node_vec!(Directive<'a>);
 impl_ast_node_vec!(VariableDeclarator<'a>);
 impl_ast_node_vec!(SwitchCase<'a>);
@@ -181,3 +182,97 @@ impl_ast_node_vec!(TSInterfaceHeritage<'a>);
 impl_ast_node_vec!(Decorator<'a>);
 impl_ast_node_vec_for_option!(Option<AssignmentTargetMaybeDefault<'a>>);
 impl_ast_node_vec_for_option!(Option<BindingPattern<'a>>);
+
+// Manual implementation for Vec<Statement> because we have to handle span
+// for ExportDefaultDeclaration and ExportNamedDeclaration that may include
+// decorators.
+// <https://github.com/oxc-project/oxc/issues/10409>
+impl<'a> AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn iter(&self) -> AstNodeIterator<'a, Statement<'a>> {
+        AstNodeIterator {
+            inner: self.inner.iter().peekable(),
+            parent: self.parent,
+            allocator: self.allocator,
+        }
+    }
+    pub fn first(&self) -> Option<&'a AstNode<'a, Statement<'a>>> {
+        let mut inner_iter = self.inner.iter();
+        self.allocator
+            .alloc(inner_iter.next().map(|inner| AstNode {
+                inner,
+                parent: self.parent,
+                allocator: self.allocator,
+                following_span: inner_iter.next().map(GetSpan::span),
+            }))
+            .as_ref()
+    }
+    pub fn last(&self) -> Option<&'a AstNode<'a, Statement<'a>>> {
+        self.allocator
+            .alloc(self.inner.last().map(|inner| AstNode {
+                inner,
+                parent: self.parent,
+                allocator: self.allocator,
+                following_span: None,
+            }))
+            .as_ref()
+    }
+}
+impl<'a> Iterator for AstNodeIterator<'a, Statement<'a>> {
+    type Item = &'a AstNode<'a, Statement<'a>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let allocator = self.allocator;
+        allocator
+            .alloc(self.inner.next().map(|inner| AstNode {
+                parent: self.parent,
+                inner,
+                allocator,
+                following_span: {
+                    match self.inner.peek() {
+                        // `@decorator export default class A {}`
+                        // Get the span of the decorator.
+                        Some(Statement::ExportDefaultDeclaration(export)) => {
+                            if let ExportDefaultDeclarationKind::ClassDeclaration(class) =
+                                &export.declaration
+                                && let Some(decorator) = class.decorators.first()
+                            {
+                                Some(Span::new(
+                                    min(decorator.span.start, export.span.start),
+                                    export.span.end,
+                                ))
+                            } else {
+                                Some(export.span)
+                            }
+                        }
+                        // `@decorator export class A {}`
+                        // Get the span of the decorator.
+                        Some(Statement::ExportNamedDeclaration(export)) => {
+                            if let Some(Declaration::ClassDeclaration(class)) = &export.declaration
+                                && let Some(decorator) = class.decorators.first()
+                            {
+                                Some(Span::new(
+                                    min(decorator.span.start, export.span.start),
+                                    export.span.end,
+                                ))
+                            } else {
+                                Some(export.span)
+                            }
+                        }
+                        Some(next) => Some(next.span()),
+                        None => None,
+                    }
+                },
+            }))
+            .as_ref()
+    }
+}
+impl<'a> IntoIterator for &AstNode<'a, Vec<'a, Statement<'a>>> {
+    type Item = &'a AstNode<'a, Statement<'a>>;
+    type IntoIter = AstNodeIterator<'a, Statement<'a>>;
+    fn into_iter(self) -> Self::IntoIter {
+        AstNodeIterator::<Statement<'a>> {
+            inner: self.inner.iter().peekable(),
+            parent: self.parent,
+            allocator: self.allocator,
+        }
+    }
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/decorators.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/decorators.ts
@@ -1,0 +1,12 @@
+// test.ts
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "my-component", // test
+})
+export class AppMyComponent {}
+
+@Component({
+  selector: "my-component", // test
+})
+export default class AppMyComponent {}

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/decorators.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/decorators.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// test.ts
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "my-component", // test
+})
+export class AppMyComponent {}
+
+@Component({
+  selector: "my-component", // test
+})
+export default class AppMyComponent {}
+==================== Output ====================
+// test.ts
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "my-component", // test
+})
+export class AppMyComponent {}
+
+@Component({
+  selector: "my-component", // test
+})
+export default class AppMyComponent {}
+
+===================== End =====================


### PR DESCRIPTION
* Fixes #15860

Due to https://github.com/oxc-project/oxc/issues/10409