### PR TITLE
test(linter/plugins): avoid using scope constructor names in test snapshot

### DIFF
--- a/apps/oxlint/test/fixtures/scope_manager/output.snap.md
+++ b/apps/oxlint/test/fixtures/scope_manager/output.snap.md
@@ -3,8 +3,19 @@
 
 # stdout
 ```
-  x scope-manager-plugin(scope): File has 12 scopes: <GlobalScope>, <ModuleScope>, topLevelFunction, <BlockScope>, TopLevelModule, GenericInterface, TestClass, <ClassStaticBlockScope>,
-  | <FunctionScope>, <FunctionScope>, <BlockScope>, <BlockScope>
+  x scope-manager-plugin(scope): File has 12 scopes:
+  | - global
+  | - module
+  | - function(topLevelFunction)
+  | - block
+  | - tsModule(TopLevelModule)
+  | - type(GenericInterface)
+  | - class(TestClass)
+  | - class-static-block
+  | - function
+  | - function
+  | - block
+  | - block
    ,-[files/index.ts:1:1]
  1 | const { a, b, c } = {};
    : ^

--- a/apps/oxlint/test/fixtures/scope_manager/plugin.ts
+++ b/apps/oxlint/test/fixtures/scope_manager/plugin.ts
@@ -24,9 +24,14 @@ const rule: Rule = {
         assert.equal(moduleScope.upper, scopeManager.globalScope);
 
         context.report({
-          message: `File has ${scopeManager.scopes.length} scopes: ${scopeManager.scopes
-            .map((s: any) => s.block?.id?.name ?? '<' + s.constructor.name + '>')
-            .join(', ')}`,
+          message:
+            `File has ${scopeManager.scopes.length} scopes:\n- ` +
+            scopeManager.scopes
+              .map((s: any) => {
+                const name = s.block?.id?.name;
+                return name ? `${s.type}(${name})` : `${s.type}`;
+              })
+              .join('\n- '),
           node: SPAN,
         });
 


### PR DESCRIPTION
Contents of this test snapshot depends on the constructor names of scope class instances. This is a little fragile, as they can change depending on how the code is bundled (see https://github.com/oxc-project/oxc/pull/15861#discussion_r2542816947).

At some point, we'll full minify the bundle, at which point class names will be come random gibberish like `e`, `t`, `aZ`, etc.

Avoid this problem by outputting `type` field of scope objects instead.