### PR TITLE
test(linter/plugins): use subpath imports

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -45,5 +45,8 @@
       "darwin-x64",
       "darwin-arm64"
     ]
+  },
+  "imports": {
+    "#oxlint": "./dist/index.js"
   }
 }

--- a/apps/oxlint/test/fixtures/basic_custom_plugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_many_files/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_multiple_rules/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_custom_plugin_warn_severity/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { Comment, Plugin, Rule } from '../../../dist/index.js';
+import type { Comment, Plugin, Rule } from '#oxlint';
 
 function formatComments(comments: Comment[]): string {
   let text = `${comments.length} comment${comments.length === 1 ? '' : 's'}`;

--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { Node, Plugin, Rule } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule, Context, Diagnostic, Node } from '../../../dist/index.js';
+import type { Plugin, Rule, Context, Diagnostic, Node } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { Node, Plugin, Rule } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/custom_plugin_disable_directives/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_disable_directives/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_after_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_before_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_createOnce_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_create_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_fix_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_lint_visit_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_nested_config_duplicate/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_via_overrides_missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -1,6 +1,6 @@
-import { definePlugin } from '../../../dist/index.js';
+import { definePlugin } from '#oxlint';
 
-import type { Node, Rule } from '../../../dist/index.js';
+import type { Node, Rule } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -1,6 +1,6 @@
-import { definePlugin, defineRule } from '../../../dist/index.js';
+import { definePlugin, defineRule } from '#oxlint';
 
-import type { Node } from '../../../dist/index.js';
+import type { Node } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -1,6 +1,6 @@
-import { defineRule } from '../../../dist/index.js';
+import { defineRule } from '#oxlint';
 
-import type { Node } from '../../../dist/index.js';
+import type { Node } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -2,7 +2,7 @@
 
 import assert from 'node:assert';
 
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/fixes/plugin.ts
+++ b/apps/oxlint/test/fixtures/fixes/plugin.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, Node, Plugin } from '../../../dist/index.js';
+import type { Diagnostic, Node, Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { Plugin, Rule, Node } from '../../../dist/index.js';
+import type { Plugin, Rule, Node } from '#oxlint';
 
 const testRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/languageOptions/plugin.ts
+++ b/apps/oxlint/test/fixtures/languageOptions/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { Plugin, Node } from '../../../dist/index.js';
+import type { Plugin, Node } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { Plugin } from '../../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const MESSAGE_ID_ERROR = 'no-var/error';
 const messages = {

--- a/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parent/plugin.ts
+++ b/apps/oxlint/test/fixtures/parent/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Node } from '../../../dist/index.js';
+import type { Plugin, Node } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/reserved_name/plugin.ts
+++ b/apps/oxlint/test/fixtures/reserved_name/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/scope_manager/plugin.ts
+++ b/apps/oxlint/test/fixtures/scope_manager/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { Node, Plugin, Rule, Scope } from '../../../dist/index.js';
+import type { Node, Plugin, Rule, Scope } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -1,4 +1,4 @@
-import type { ESTree, Plugin, Visitor } from '../../../dist/index.js';
+import type { ESTree, Plugin, Visitor } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/settings/plugin.ts
+++ b/apps/oxlint/test/fixtures/settings/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { Node, Plugin, Rule } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { ESTree, Node, Plugin, Rule } from '../../../dist/index.js';
+import type { ESTree, Node, Plugin, Rule } from '#oxlint';
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import type { ESTree, Node, Plugin, Rule } from '../../../dist/index.js';
+import type { ESTree, Node, Plugin, Rule } from '#oxlint';
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_late_access_after_only/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access_after_only/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from '../../../dist/index.js';
+import type { Node, Plugin, Rule } from '#oxlint';
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from '../../../dist/index.js';
+import type { Plugin, Rule } from '#oxlint';
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import type { Plugin, Rule } from '../../../dist/index.js';
+import type { Plugin, Rule } from '#oxlint';
 
 const unicodeCommentsRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
+++ b/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
@@ -1,6 +1,6 @@
 // oxlint-disable typescript/restrict-template-expressions
 
-import type { Plugin } from '../../../dist/index.js';
+import type { Plugin } from '#oxlint';
 
 const plugin: Plugin = {
   meta: {


### PR DESCRIPTION
Shorten imports in test fixtures using [subpath imports](https://nodejs.org/docs/latest-v24.x/api/packages.html#subpath-imports).

Before:

```ts
import type { Plugin } from '../../../dist/index.js';
```

After:

```ts
import type { Plugin } from '#oxlint';
```