### PR TITLE
perf(linter/plugins): downgrade some checks to debug-only

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -98,11 +98,13 @@ function lintFileImpl(
   }
   assertIs<BufferWithArrays>(buffer);
 
-  if (typeof filePath !== 'string' || filePath.length === 0) {
-    throw new Error('expected filePath to be a non-zero length string');
-  }
-  if (!Array.isArray(ruleIds) || ruleIds.length === 0) {
-    throw new Error('Expected `ruleIds` to be a non-zero len array');
+  if (DEBUG) {
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+      throw new Error('Expected filePath to be a non-zero length string');
+    }
+    if (!Array.isArray(ruleIds) || ruleIds.length === 0) {
+      throw new Error('Expected `ruleIds` to be a non-zero length array');
+    }
   }
 
   // Pass file path to context module, so `Context`s know what file is being linted

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -135,13 +135,12 @@ export async function loadPlugin(path: string, packageName: string | null): Prom
  * @throws {*} If plugin throws an error during import
  */
 async function loadPluginImpl(path: string, packageName: string | null): Promise<PluginDetails> {
-  if (registeredPluginPaths.has(path)) {
-    throw new Error('This plugin has already been registered. This is a bug in Oxlint. Please report it.');
+  if (DEBUG) {
+    if (registeredPluginPaths.has(path)) throw new Error('This plugin has already been registered');
+    registeredPluginPaths.add(path);
   }
 
   const { default: plugin } = (await import(pathToFileURL(path).href)) as { default: Plugin };
-
-  registeredPluginPaths.add(path);
 
   // TODO: Use a validation library to assert the shape of the plugin, and of rules
 


### PR DESCRIPTION
These checks are "sanity checks" only. The inputs to these functions comes from Rust code which we control, and would be `debug_assert!` if this was Rust. So only run these assertions in debug build.