### PR TITLE
test(formatter): handle `singleAttributePerLine` option

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 727/758 (95.91%)
+js compatibility: 728/758 (96.04%)
 
 # Failed
 
@@ -33,5 +33,4 @@ js compatibility: 727/758 (95.91%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 570/601 (94.84%)
+ts compatibility: 571/601 (95.01%)
 
 # Failed
 
@@ -7,7 +7,6 @@ ts compatibility: 570/601 (94.84%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/single-attribute-per-line/single-attribute-per-line.js | 💥✨ | 43.37% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -7,9 +7,9 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::VisitMut;
 use oxc_formatter::{
-    ArrowParentheses, BracketSameLine, BracketSpacing, FormatOptions, IndentStyle, IndentWidth,
-    LineEnding, LineWidth, OperatorPosition, QuoteProperties, QuoteStyle, Semicolons,
-    TrailingCommas,
+    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, FormatOptions,
+    IndentStyle, IndentWidth, LineEnding, LineWidth, OperatorPosition, QuoteProperties, QuoteStyle,
+    Semicolons, TrailingCommas,
 };
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
@@ -157,6 +157,12 @@ impl VisitMut<'_> for SpecParser {
                                 };
                             } else if name == "experimentalTernaries" {
                                 options.experimental_ternaries = literal.value;
+                            } else if name == "singleAttributePerLine" {
+                                options.attribute_position = if literal.value {
+                                    AttributePosition::Multiline
+                                } else {
+                                    AttributePosition::Auto
+                                };
                             }
                         }
                         #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]


### PR DESCRIPTION
TIL, `AttributePosition` is the same as `singleAttributePerLine`, so map it