### PR TITLE
build(linter/plugins): simplify TSDown config

### DIFF
--- a/apps/oxlint/scripts/build.ts
+++ b/apps/oxlint/scripts/build.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { copyFileSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const oxlintDirPath = join(import.meta.dirname, '..'),
@@ -20,6 +20,11 @@ writeFileSync(bindingsPath, bindingsJs);
 // Build with tsdown
 console.log('Building with tsdown...');
 execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
+
+// Delete `cli.d.ts`
+console.log('Deleting cli.d.ts...');
+rmSync(join(distDirPath, 'cli.d.ts'));
+rmSync(join(debugDirPath, 'cli.d.ts'));
 
 // Copy native `.node` files from `src-js`
 console.log('Copying `.node` files...');


### PR DESCRIPTION
#15946 means we can now simplify the TSDown build config.

Previously we had to have 2 separate builds for `index.ts` and `cli.ts`, to avoid `assert*` functions ending up in a shared chunk, and not getting removed by minifier. Now that problem is solved, so we can switch to a single build with 2 entry points.

TSDown does create a small extra chunk for its `__toESM` and `__commonJSMin` functions, but I think that's fine.

Annoyingly it doesn't seem to be possible to tell TSDown to generate `.d.ts` files only for the `index.js` chunk, so have to delete this pointless files in build script.

The point of all this is that `RuleTester` needs to use a ton of code from `plugins.ts`, and we wouldn't want all that code duplicated in both `index` and `plugins` chunks (especially once we're bundling TS-ESlint's parser #15861). Now that code will be shared between the two entry points in a shared chunk, not duplicated.