### PR TITLE
build(linter/plugins): build either release or debug version, not both

### DIFF
--- a/apps/oxlint/.gitignore
+++ b/apps/oxlint/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
 /dist/
-/debug/
 *.node

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -8,8 +8,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build-napi-release && pnpm run build-js",
-    "build-dev": "pnpm run build-napi && pnpm run build-js",
-    "build-test": "pnpm run build-napi-test && pnpm run build-js",
+    "build-dev": "pnpm run build-napi && cross-env DEBUG=true pnpm run build-js",
+    "build-test": "pnpm run build-napi-test && cross-env DEBUG=true pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
     "build-napi-test": "pnpm run build-napi --features force_test_reporter",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
@@ -24,6 +24,7 @@
     "@types/estree": "^1.0.8",
     "@typescript-eslint/scope-manager": "8.46.2",
     "@typescript-eslint/typescript-estree": "^8.47.0",
+    "cross-env": "catalog:",
     "eslint": "^9.36.0",
     "esquery": "^1.6.0",
     "execa": "^9.6.0",
@@ -49,6 +50,6 @@
     ]
   },
   "imports": {
-    "#oxlint": "./debug/index.js"
+    "#oxlint": "./dist/index.js"
   }
 }

--- a/apps/oxlint/scripts/build.ts
+++ b/apps/oxlint/scripts/build.ts
@@ -4,8 +4,7 @@ import { join } from 'node:path';
 
 const oxlintDirPath = join(import.meta.dirname, '..'),
   srcDirPath = join(oxlintDirPath, 'src-js'),
-  distDirPath = join(oxlintDirPath, 'dist'),
-  debugDirPath = join(oxlintDirPath, 'debug');
+  distDirPath = join(oxlintDirPath, 'dist');
 
 // Modify `bindings.js` to use correct package names
 console.log('Modifying bindings.js...');
@@ -24,7 +23,6 @@ execSync('pnpm tsdown', { stdio: 'inherit', cwd: oxlintDirPath });
 // Delete `cli.d.ts`
 console.log('Deleting cli.d.ts...');
 rmSync(join(distDirPath, 'cli.d.ts'));
-rmSync(join(debugDirPath, 'cli.d.ts'));
 
 // Copy native `.node` files from `src-js`
 console.log('Copying `.node` files...');
@@ -32,7 +30,6 @@ for (const filename of readdirSync(srcDirPath)) {
   if (!filename.endsWith('.node')) continue;
   const srcPath = join(srcDirPath, filename);
   copyFileSync(srcPath, join(distDirPath, filename));
-  copyFileSync(srcPath, join(debugDirPath, filename));
 }
 
 console.log('Build complete!');

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -4,7 +4,7 @@ import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from './utils.
 
 import type { Fixture } from './utils.ts';
 
-const CLI_PATH = pathJoin(PACKAGE_ROOT_PATH, 'debug/cli.js');
+const CLI_PATH = pathJoin(PACKAGE_ROOT_PATH, 'dist/cli.js');
 
 // Use current NodeJS executable, rather than `node`, to avoid problems with a Node version manager
 // installed on system resulting in using wrong NodeJS version

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -259,7 +259,7 @@
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.0.0",
-    "cross-env": "^10.0.0",
+    "cross-env": "catalog:",
     "ovsx": "^0.10.0",
     "rolldown": "1.0.0-beta.51",
     "tinyglobby": "^0.2.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@types/node':
       specifier: ^24.0.0
       version: 24.9.1
+    cross-env:
+      specifier: ^10.1.0
+      version: 10.1.0
     publint:
       specifier: 0.3.15
       version: 0.3.15
@@ -104,6 +107,9 @@ importers:
       '@typescript-eslint/typescript-estree':
         specifier: ^8.47.0
         version: 8.47.0(typescript@5.9.3)
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
       eslint:
         specifier: ^9.36.0
         version: 9.38.0(jiti@2.6.1)
@@ -157,7 +163,7 @@ importers:
         specifier: ^3.0.0
         version: 3.6.2
       cross-env:
-        specifier: ^10.0.0
+        specifier: 'catalog:'
         version: 10.1.0
       ovsx:
         specifier: ^0.10.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ catalog:
   '@napi-rs/cli': 3.4.1
   '@napi-rs/wasm-runtime': 1.0.7
   '@types/node': ^24.0.0
+  cross-env: ^10.1.0
   publint: 0.3.15
   rolldown: 1.0.0-beta.51
   tsdown: 0.16.6


### PR DESCRIPTION
#15921 added a debug build for Oxlint, and various PRs since have tweaked it. However, I now realize there's little point in generating *both* a release build and debug build.

Just create one build, and use env var `DEBUG` to control whether it has debug assertions included in it or not.

`pnpm run build` produces release build with no debug assertions, `pnpm run build-test` includes the asserts. I've verified that both do what they're meant to.
