### PR TITLE
docs(linter): Use backticks for code elements across more rule diagnostics

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -13,12 +13,12 @@ working directory:
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^
    `----
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
 Found 2 warnings and 0 errors.
 Finished in <variable>ms on 1 file with 89 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -28,12 +28,12 @@ working directory:
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^
    `----
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
 Found 4 warnings and 0 errors.
 Finished in <variable>ms on 3 files with 89 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -20,12 +20,12 @@ working directory:
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^
    `----
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
 Found 3 warnings and 0 errors.
 Finished in <variable>ms on 2 files with 89 rules using 1 threads.

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -7,7 +7,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_self_compare_diagnostic(left_span: Span, right_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Both sides of this comparison are exactly the same")
-        .with_help("If you are testing for NaN, you can use Number.isNaN function.")
+        .with_help("If you are testing for NaN, you can use the `Number.isNaN()` function.")
         .with_labels([left_span, right_span])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 const PRE_DEFINE_VAR: [&str; 5] = ["Infinity", "NaN", "arguments", "eval", "undefined"];
 
 fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Shadowing of global properties such as 'undefined' is not allowed.")
+    OxcDiagnostic::warn("Shadowing of global properties such as `undefined` is not allowed.")
         .with_help(format!("Rename '{shadowed_name}' to avoid shadowing the global property."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -15,8 +15,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_this_before_super_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected to always call super() before this/super property access.")
-        .with_help("Call super() before this/super property access.")
+    OxcDiagnostic::warn("Expected to always call `super()` before `this`/`super` property access.")
+        .with_help("Call `super()` before `this`/`super` property access.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -9,8 +9,10 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_unsafe_finally_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unsafe finally block")
-        .with_help("Control flow inside try or catch blocks will be overwritten by this statement")
+    OxcDiagnostic::warn("Unsafe `finally` block.")
+        .with_help(
+            "Control flow inside `try` or `catch` blocks will be overwritten by this statement.",
+        )
         .with_label(span)
 }
 
@@ -20,7 +22,7 @@ pub struct NoUnsafeFinally;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow control flow statements in finally blocks
+    /// Disallow control flow statements in `finally` blocks.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -11,27 +11,27 @@ use schemars::JsonSchema;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn comparison_with_na_n(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
-        .with_help("Use the isNaN function to compare with NaN.")
+    OxcDiagnostic::warn("Requires calls to `isNaN()` when checking for NaN")
+        .with_help("Use the `isNaN` function to compare with NaN.")
         .with_label(span)
 }
 
 fn switch_na_n(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to `isNaN()` when checking for NaN.")
         .with_help(
-            "'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.",
+            "`switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.",
         )
         .with_label(span)
 }
 
 fn case_na_n(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
-        .with_help("'case NaN' can never match. Use Number.isNaN before the switch.")
+    OxcDiagnostic::warn("Requires calls to `isNaN()` when checking for NaN")
+        .with_help("`case NaN` can never match. Use `Number.isNaN` before the switch.")
         .with_label(span)
 }
 
 fn index_of_na_n(method_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to `isNaN()` when checking for NaN")
         .with_help(format!("Array prototype method '{method_name}' cannot find NaN."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -6,7 +6,7 @@ use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
 fn default_diagnostic(imported_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No default export found in imported module {imported_name:?}"))
-        .with_help(format!("does {imported_name:?} have the default export?"))
+        .with_help(format!("Does {imported_name:?} have the default export?"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -10,7 +10,7 @@ use crate::{
 
 fn named_diagnostic(imported_name: &str, module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("named import {imported_name:?} not found"))
-        .with_help(format!("does {module_name:?} have the export {imported_name:?}?"))
+        .with_help(format!("Does {module_name:?} have the export {imported_name:?}?"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
+++ b/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_empty_named_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected empty named import block.").with_label(span)
+    OxcDiagnostic::warn("Unexpected empty named `import` block.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -5,7 +5,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_self_import_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("module importing itself is not allowed").with_label(span)
+    OxcDiagnostic::warn("A module importing itself is not allowed").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -13,7 +13,7 @@ fn invalid_access_level(span: Span) -> OxcDiagnostic {
 
 fn redundant_access_tags(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
-        "Mixing of @access with @public, @private, @protected, or @package on the same doc block.",
+        "Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.",
     )
     .with_help("There should be only one instance of access tag in a JSDoc comment.")
     .with_label(span)

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 
 fn no_root(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("No root defined for @property path.")
-        .with_help(format!("@property path declaration `{x1}` appears before any real property."))
+    OxcDiagnostic::warn("No root defined for `@property` path.")
+        .with_help(format!("`@property` path declaration `{x1}` appears before any real property."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 fn require_property_description_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing description in @property tag.")
-        .with_help("Add a description to this @property tag.")
+    OxcDiagnostic::warn("Missing description in `@property` tag.")
+        .with_help("Add a description to this `@property` tag.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 fn require_property_name_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing name in @property tag.")
-        .with_help("Add a type name to this @property tag.")
+    OxcDiagnostic::warn("Missing name in `@property` tag.")
+        .with_help("Add a type name to this `@property` tag.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 fn require_property_type_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing type in @property tag.")
-        .with_help("Add a {type} to this @property tag.")
+    OxcDiagnostic::warn("Missing type in `@property` tag.")
+        .with_help("Add a {type} to this `@property` tag.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 pub struct AriaUnsupportedElements;
 
 fn aria_unsupported_elements_diagnostic(span: Span, attr_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This element does not support ARIA roles, states and properties.")
+    OxcDiagnostic::warn("This element does not support ARIA roles, states, or properties.")
         .with_help(format!("Try removing the prop `{attr_name}`."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 
 fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{autocomplete}` is not a valid value for autocomplete."))
-        .with_help(format!("Change `{autocomplete}` to a valid value for autocomplete."))
+    OxcDiagnostic::warn(format!("`{autocomplete}` is not a valid value for `autocomplete`."))
+        .with_help(format!("Change `{autocomplete}` to a valid value for `autocomplete`."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -16,7 +16,7 @@ use crate::{
 
 fn click_events_have_key_events_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce a clickable non-interactive element has at least one keyboard event listener.")
-        .with_help("Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.")
+        .with_help("Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -15,12 +15,12 @@ use crate::{
 
 fn missing_lang_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing lang attribute.")
-        .with_help("Add a lang attribute to the html element whose value represents the primary language of document.")
+        .with_help("Add a `lang` attribute to the `html` element whose value represents the primary language of document.")
         .with_label(span)
 }
 
 fn missing_lang_value(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing value for lang attribute")
+    OxcDiagnostic::warn("Missing value for `lang` attribute")
         .with_help("Must have meaningful value for `lang` prop.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -15,7 +15,7 @@ use crate::{
 
 fn iframe_has_title_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing `title` attribute for the `iframe` element.")
-        .with_help("Provide title property for iframe element.")
+        .with_help("Provide `title` property for `iframe` element.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -21,8 +21,8 @@ use crate::{
 };
 
 fn img_redundant_alt_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Redundant alt attribute.")
-        .with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.").with_label(span)
+    OxcDiagnostic::warn("Redundant `alt` attribute.")
+        .with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 
 fn lang_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Lang attribute must have a valid value.")
-        .with_help("Set a valid value for lang attribute.")
+    OxcDiagnostic::warn("`lang` attribute must have a valid value.")
+        .with_help("Set a valid value for `lang` attribute.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -14,9 +14,11 @@ use serde_json::Value;
 use crate::{AstNode, context::LintContext, rule::Rule, utils::get_element_type};
 
 fn media_has_caption_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing <track> element with captions inside <audio> or <video> element")
-        .with_help("Media elements such as <audio> and <video> must have a <track> for captions.")
-        .with_label(span)
+    OxcDiagnostic::warn(
+        "Missing `<track>` element with captions inside `<audio>` or `<video>` element",
+    )
+    .with_help("Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -13,14 +13,16 @@ use crate::{
 };
 
 fn miss_on_focus(span: Span, attr_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{attr_name} must be accompanied by onFocus for accessibility."))
-        .with_help("Try to add onFocus.")
-        .with_label(span)
+    OxcDiagnostic::warn(format!(
+        "`{attr_name}` must be accompanied by `onFocus` for accessibility."
+    ))
+    .with_help("Try to add `onFocus`.")
+    .with_label(span)
 }
 
 fn miss_on_blur(span: Span, attr_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{attr_name} must be accompanied by onBlur for accessibility."))
-        .with_help("Try to add onBlur.")
+    OxcDiagnostic::warn(format!("`{attr_name}` must be accompanied by `onBlur` for accessibility."))
+        .with_help("Try to add `onBlur`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -10,7 +10,7 @@ use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignor
 
 fn no_access_key_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No access key attribute allowed.")
-        .with_help("Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.")
+        .with_help("Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -7,8 +7,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{LintContext, rule::Rule, utils::get_element_type};
 
 fn no_distracting_elements_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.")
-        .with_help("Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.")
+    OxcDiagnostic::warn("Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.")
+        .with_help("Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("tabIndex should only be declared on interactive elements")
-        .with_help("tabIndex attribute should be removed")
+    OxcDiagnostic::warn("`tabIndex` should only be declared on interactive elements")
+        .with_help("`tabIndex` attribute should be removed")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -15,7 +15,7 @@ use crate::{
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "The element `{element}` has an implicit role of `{role}`. Defining this explicitly is redundant and should be avoided."
+        "The `{element}` element has an implicit role of `{role}`. Defining this explicitly is redundant and should be avoided."
     ))
     .with_help(format!("Remove the redundant role `{role}` from the element `{element}`."))
     .with_label(span)

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -51,14 +51,16 @@ declare_oxc_lint!(
 pub struct RoleSupportsAriaProps;
 
 fn default(span: Span, attr_name: &str, role: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The attribute {attr_name} is not supported by the role {role}."))
-        .with_help(format!("Try to remove invalid attribute {attr_name}."))
-        .with_label(span)
+    OxcDiagnostic::warn(format!(
+        "The attribute `{attr_name}` is not supported by the role `{role}`."
+    ))
+    .with_help(format!("Try to remove invalid attribute `{attr_name}`."))
+    .with_label(span)
 }
 
 fn is_implicit_diagnostic(span: Span, attr_name: &str, role: &str, el_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The attribute {attr_name} is not supported by the role {role}. This role is implicit on the element {el_name}."))
-        .with_help(format!("Try to remove invalid attribute {attr_name}."))
+    OxcDiagnostic::warn(format!("The attribute `{attr_name}` is not supported by the role `{role}`. This role is implicit on the element `{el_name}`."))
+        .with_help(format!("Try to remove invalid attribute `{attr_name}`."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 
 fn scope_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("The scope prop can only be used on <th> elements")
-        .with_help("Must use scope prop only on <th> elements")
+    OxcDiagnostic::warn("The `scope` prop can only be used on `<th>` elements")
+        .with_help("Remove the `scope` prop on elements other than `<th>`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 fn tabindex_no_positive_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid positive integer values for tabIndex.")
-        .with_help("Change the tabIndex prop to a non-negative value")
+    OxcDiagnostic::warn("Avoid positive integer values for `tabIndex`.")
+        .with_help("Change the `tabIndex` prop to a non-negative value")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_self_compare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_self_compare.snap
@@ -6,123 +6,123 @@ source: crates/oxc_linter/src/tester.rs
  1 │ if (x === x) { }
    ·     ─     ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if (x !== x) { }
    ·     ─     ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if (x > x) { }
    ·     ─   ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if ('x' > 'x') { }
    ·     ───   ───
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:14]
  1 │ do {} while (x === x)
    ·              ─     ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x === x
    · ─     ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x !== x
    · ─     ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x == x
    · ─    ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x != x
    · ─    ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x > x
    · ─   ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x < x
    · ─   ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x >= x
    · ─    ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x <= x
    · ─    ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x > (x)
    · ─   ───
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ (x) == x
    · ───    ─
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ (x) >= ((x))
    · ───    ─────
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ foo.bar().baz.qux >= foo.bar ().baz .qux
    · ─────────────────    ───────────────────
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:27]
  1 │ class C { #field; foo() { this.#field === this.#field; } }
    ·                           ───────────     ───────────
    ╰────
-  help: If you are testing for NaN, you can use Number.isNaN function.
+  help: If you are testing for NaN, you can use the `Number.isNaN()` function.

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
@@ -1,518 +1,518 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:5]
  1 │ var undefined = 5;
    ·     ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function NaN(){}
    ·          ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:14]
  1 │ try {} catch(eval){}
    ·              ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·          ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:14]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·              ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:25]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·                         ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:40]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·                                        ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:44]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·                                            ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:64]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }
    ·                                                                ───
    ╰────
   help: Rename 'NaN' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function undefined(undefined) { !function undefined(undefined) { try {} catch(undefined) {} }; }
    ·          ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:20]
  1 │ function undefined(undefined) { !function undefined(undefined) { try {} catch(undefined) {} }; }
    ·                    ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:43]
  1 │ function undefined(undefined) { !function undefined(undefined) { try {} catch(undefined) {} }; }
    ·                                           ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:53]
  1 │ function undefined(undefined) { !function undefined(undefined) { try {} catch(undefined) {} }; }
    ·                                                     ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:79]
  1 │ function undefined(undefined) { !function undefined(undefined) { try {} catch(undefined) {} }; }
    ·                                                                               ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·          ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:19]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·                   ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:35]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·                                   ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:55]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·                                                       ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:64]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·                                                                ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:89]
  1 │ function Infinity(Infinity) { var Infinity; !function Infinity(Infinity) { try {} catch(Infinity) {} }; }
    ·                                                                                         ────────
    ╰────
   help: Rename 'Infinity' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·          ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:20]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·                    ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:37]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·                                     ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:58]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·                                                          ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:68]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·                                                                    ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:94]
  1 │ function arguments(arguments) { var arguments; !function arguments(arguments) { try {} catch(arguments) {} }; }
    ·                                                                                              ─────────
    ╰────
   help: Rename 'arguments' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·          ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:15]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·               ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:27]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                           ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:43]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                           ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:48]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                                ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:69]
  1 │ function eval(eval) { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                                                     ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:5]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·     ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:13]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·             ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:28]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                            ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:44]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                            ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:49]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                                 ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:70]
  1 │ var eval = (eval) => { var eval; !function eval(eval) { try {} catch(eval) {} }; }
    ·                                                                      ────
    ╰────
   help: Rename 'eval' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:6]
  1 │ var [undefined] = [1]
    ·      ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:6]
  1 │ var {undefined} = obj; var {a: undefined} = obj; var {a: {b: {undefined}}} = obj; var {a, ...undefined} = obj;
    ·      ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:32]
  1 │ var {undefined} = obj; var {a: undefined} = obj; var {a: {b: {undefined}}} = obj; var {a, ...undefined} = obj;
    ·                                ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:63]
  1 │ var {undefined} = obj; var {a: undefined} = obj; var {a: {b: {undefined}}} = obj; var {a, ...undefined} = obj;
    ·                                                               ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:94]
  1 │ var {undefined} = obj; var {a: undefined} = obj; var {a: {b: {undefined}}} = obj; var {a, ...undefined} = obj;
    ·                                                                                              ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:5]
  1 │ var undefined; undefined = 5;
    ·     ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:7]
  1 │ class undefined {}
    ·       ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:8]
  1 │ (class undefined {})
    ·        ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:8]
  1 │ import undefined from 'foo';
    ·        ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ import { undefined } from 'foo';
    ·          ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:17]
  1 │ import { baz as undefined } from 'foo';
    ·                 ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:13]
  1 │ import * as undefined from 'foo';
    ·             ─────────
    ╰────
   help: Rename 'undefined' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·          ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:21]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                     ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:39]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                       ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:61]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                             ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:72]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                                        ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:99]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                                                                   ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·          ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:21]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                     ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:39]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                       ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:61]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                             ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:72]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                                        ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:99]
  1 │ function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }
    ·                                                                                                   ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:8]
  1 │ const [globalThis] = [1]
    ·        ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:6]
  1 │ var {globalThis} = obj; var {a: globalThis} = obj; var {a: {b: {globalThis}}} = obj; var {a, ...globalThis} = obj;
    ·      ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:33]
  1 │ var {globalThis} = obj; var {a: globalThis} = obj; var {a: {b: {globalThis}}} = obj; var {a, ...globalThis} = obj;
    ·                                 ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:65]
  1 │ var {globalThis} = obj; var {a: globalThis} = obj; var {a: {b: {globalThis}}} = obj; var {a, ...globalThis} = obj;
    ·                                                                 ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:97]
  1 │ var {globalThis} = obj; var {a: globalThis} = obj; var {a: {b: {globalThis}}} = obj; var {a, ...globalThis} = obj;
    ·                                                                                                 ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:5]
  1 │ let globalThis; globalThis = 5;
    ·     ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:7]
  1 │ class globalThis {}
    ·       ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:8]
  1 │ (class globalThis {})
    ·        ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:8]
  1 │ import globalThis from 'foo';
    ·        ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ import { globalThis } from 'foo';
    ·          ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:17]
  1 │ import { baz as globalThis } from 'foo';
    ·                 ──────────
    ╰────
   help: Rename 'globalThis' to avoid shadowing the global property.
 
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.
+  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:13]
  1 │ import * as globalThis from 'foo';
    ·             ──────────

--- a/crates/oxc_linter/src/snapshots/eslint_no_this_before_super.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_this_before_super.snap
@@ -1,154 +1,154 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { this.c = 0; } }
    ·                     ─────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { this.c(); } }
    ·                     ───────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super.c(); } }
    ·                     ────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { this.c = 0; super(); } }
    ·                     ──────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { this.c(); super(); } }
    ·                     ────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super.c(); super(); } }
    ·                     ─────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(this); } }
    ·                     ──────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(this.c); } }
    ·                     ────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(a(b(this.c))); } }
    ·                     ──────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(this.c()); } }
    ·                     ──────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(super.c); } }
    ·                     ─────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { super(super.c()); } }
    ·                     ───────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { class C extends D { constructor() { super(); this.e(); } } this.f(); super(); } }
    ·                     ───────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:57]
  1 │ class A extends B { constructor() { class C extends D { constructor() { this.e(); super(); } } super(); this.f(); } }
    ·                                                         ────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { if (a) super(); this.a(); } }
    ·                     ───────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { try { super(); } finally { this.a; } } }
    ·                     ──────────────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { try { super(); } catch (err) { } this.a; } }
    ·                     ──────────────────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { foo &&= super().a; this.c(); } }
    ·                     ──────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { foo ||= super().a; this.c(); } }
    ·                     ──────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { foo ??= super().a; this.c(); } }
    ·                     ──────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:1:21]
  1 │ class A extends B { constructor() { if (foo) { if (bar) { } super(); } this.a(); }}
    ·                     ──────────────────────────────────────────────────────────────
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:2:17]
  1 │     class A extends B {
  2 │ ╭─▶                 constructor() {
@@ -160,9 +160,9 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                 }
  9 │                 }
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:2:17]
  1 │     class A extends B {
  2 │ ╭─▶                 constructor() {
@@ -174,9 +174,9 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                 }
  9 │                 }
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:2:17]
  1 │     class A extends B {
  2 │ ╭─▶                 constructor() {
@@ -187,9 +187,9 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                 }
  8 │                 }
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
    ╭─[no_this_before_super.tsx:2:17]
  1 │     class A extends B {
  2 │ ╭─▶                 constructor() {
@@ -200,9 +200,9 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                 }
  8 │                 }
    ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.
 
-  ⚠ eslint(no-this-before-super): Expected to always call super() before this/super property access.
+  ⚠ eslint(no-this-before-super): Expected to always call `super()` before `this`/`super` property access.
     ╭─[no_this_before_super.tsx:2:17]
   1 │     class A extends B {
   2 │ ╭─▶                 constructor() {
@@ -215,4 +215,4 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                 }
  10 │                 }
     ╰────
-  help: Call super() before this/super property access.
+  help: Call `super()` before `this`/`super` property access.

--- a/crates/oxc_linter/src/snapshots/eslint_no_unsafe_finally.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unsafe_finally.snap
@@ -1,118 +1,118 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:7:2]
  6 │  } finally { 
  7 │  return 3; 
    ·  ─────────
  8 │  } 
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:86]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { if(true) { return 3 } else { return 2 } } }
    ·                                                                                      ────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:104]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { if(true) { return 3 } else { return 2 } } }
    ·                                                                                                        ────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:75]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { return 3 } }
    ·                                                                           ────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:75]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { return function(x) { return y } } }
    ·                                                                           ───────────────────────────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:75]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { return { x: function(c) { return c } } } }
    ·                                                                           ──────────────────────────────────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:75]
  1 │ var foo = function() { try { return 1 } catch(err) { return 2 } finally { throw new Error() } }
    ·                                                                           ─────────────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:74]
  1 │ var foo = function() { try { foo(); } finally { try { bar(); } finally { return; } } };
    ·                                                                          ───────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:59]
  1 │ var foo = function() { label: try { return 0; } finally { break label; } return 1; }
    ·                                                           ────────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:7:2]
  6 │  } finally { 
  7 │  break a; 
    ·  ────────
  8 │  } 
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:54]
  1 │ var foo = function() { while (true) try {} finally { break; } }
    ·                                                      ──────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:54]
  1 │ var foo = function() { while (true) try {} finally { continue; } }
    ·                                                      ─────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:68]
  1 │ var foo = function() { switch (true) { case true: try {} finally { break; } } }
    ·                                                                    ──────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:84]
  1 │ var foo = function() { a: while (true) try {} finally { switch (true) { case true: break a; } } }
    ·                                                                                    ────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:84]
  1 │ var foo = function() { a: while (true) try {} finally { switch (true) { case true: continue; } } }
    ·                                                                                    ─────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.
 
-  ⚠ eslint(no-unsafe-finally): Unsafe finally block
+  ⚠ eslint(no-unsafe-finally): Unsafe `finally` block.
    ╭─[no_unsafe_finally.tsx:1:98]
  1 │ var foo = function() { a: switch (true) { case true: try {} finally { switch (true) { case true: break a; } } } }
    ·                                                                                                  ────────
    ╰────
-  help: Control flow inside try or catch blocks will be overwritten by this statement
+  help: Control flow inside `try` or `catch` blocks will be overwritten by this statement.

--- a/crates/oxc_linter/src/snapshots/eslint_use_isnan.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_use_isnan.snap
@@ -1,602 +1,602 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:8]
  1 │ 123 == NaN;
    ·        ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ 123 === NaN;
    ·         ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN === "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN == "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:8]
  1 │ 123 != NaN;
    ·        ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ 123 !== NaN;
    ·         ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN !== "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN != "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN < "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ "abc" < NaN;
    ·         ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN > "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ "abc" > NaN;
    ·         ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN <= "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:10]
  1 │ "abc" <= NaN;
    ·          ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ NaN >= "abc";
    · ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:10]
  1 │ "abc" >= NaN;
    ·          ───
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:8]
  1 │ 123 == Number.NaN;
    ·        ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ 123 === Number.NaN;
    ·         ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN === "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN == "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:8]
  1 │ 123 != Number.NaN;
    ·        ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ 123 !== Number.NaN;
    ·         ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN !== "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN != "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN < "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ "abc" < Number.NaN;
    ·         ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN > "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:9]
  1 │ "abc" > Number.NaN;
    ·         ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN <= "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:10]
  1 │ "abc" <= Number.NaN;
    ·          ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:1]
  1 │ Number.NaN >= "abc";
    · ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:10]
  1 │ "abc" >= Number.NaN;
    ·          ──────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:7]
  1 │ x === Number?.NaN;
    ·       ───────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:7]
  1 │ x === Number['NaN'];
    ·       ─────────────
    ╰────
-  help: Use the isNaN function to compare with NaN.
+  help: Use the `isNaN` function to compare with NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { case foo: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case NaN: break; }
    ·                    ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { case foo: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case NaN: break; }
    ·                    ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) {}
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { case foo: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { default: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { case foo: break; default: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case NaN: }
    ·                    ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case NaN: break; }
    ·                    ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case (NaN): break; }
    ·                    ─────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:37]
  1 │ switch(foo) { case bar: break; case NaN: break; default: break; }
    ·                                     ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:30]
  1 │ switch(foo) { case bar: case NaN: default: break; }
    ·                              ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:37]
  1 │ switch(foo) { case bar: break; case NaN: break; case baz: break; case NaN: break; }
    ·                                     ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:71]
  1 │ switch(foo) { case bar: break; case NaN: break; case baz: break; case NaN: break; }
    ·                                                                       ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(NaN) { case NaN: break; }
    ·        ───
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(NaN) { case NaN: break; }
    ·                    ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { case foo: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case Number.NaN: break; }
    ·                    ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { case foo: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case Number.NaN: break; }
    ·                    ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) {}
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { case foo: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { default: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { case foo: break; default: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case Number.NaN: }
    ·                    ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case Number.NaN: break; }
    ·                    ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ switch(foo) { case (Number.NaN): break; }
    ·                    ────────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:37]
  1 │ switch(foo) { case bar: break; case Number.NaN: break; default: break; }
    ·                                     ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:30]
  1 │ switch(foo) { case bar: case Number.NaN: default: break; }
    ·                              ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:37]
  1 │ switch(foo) { case bar: break; case NaN: break; case baz: break; case Number.NaN: break; }
    ·                                     ───
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:71]
  1 │ switch(foo) { case bar: break; case NaN: break; case baz: break; case Number.NaN: break; }
    ·                                                                       ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN.
    ╭─[use_isnan.tsx:1:8]
  1 │ switch(Number.NaN) { case Number.NaN: break; }
    ·        ──────────
    ╰────
-  help: 'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.
+  help: `switch(NaN)` can never match a case clause. Use `Number.isNaN` instead of the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:27]
  1 │ switch(Number.NaN) { case Number.NaN: break; }
    ·                           ──────────
    ╰────
-  help: 'case NaN' can never match. Use Number.isNaN before the switch.
+  help: `case NaN` can never match. Use `Number.isNaN` before the switch.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:13]
  1 │ foo.indexOf(NaN)
    ·             ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:17]
  1 │ foo.lastIndexOf(NaN)
    ·                 ───
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:16]
  1 │ foo['indexOf'](NaN)
    ·                ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ foo['lastIndexOf'](NaN)
    ·                    ───
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:15]
  1 │ foo().indexOf(NaN)
    ·               ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:21]
  1 │ foo.bar.lastIndexOf(NaN)
    ·                     ───
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:15]
  1 │ foo.indexOf?.(NaN)
    ·               ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:14]
  1 │ foo?.indexOf(NaN)
    ·              ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:16]
  1 │ (foo?.indexOf)(NaN)
    ·                ───
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:13]
  1 │ foo.indexOf(Number.NaN)
    ·             ──────────
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:17]
  1 │ foo.lastIndexOf(Number.NaN)
    ·                 ──────────
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:16]
  1 │ foo['indexOf'](Number.NaN)
    ·                ──────────
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:20]
  1 │ foo['lastIndexOf'](Number.NaN)
    ·                    ──────────
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:15]
  1 │ foo().indexOf(Number.NaN)
    ·               ──────────
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:21]
  1 │ foo.bar.lastIndexOf(Number.NaN)
    ·                     ──────────
    ╰────
   help: Array prototype method 'lastIndexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:15]
  1 │ foo.indexOf?.(Number.NaN)
    ·               ──────────
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:14]
  1 │ foo?.indexOf(Number.NaN)
    ·              ──────────
    ╰────
   help: Array prototype method 'indexOf' cannot find NaN.
 
-  ⚠ eslint(use-isnan): Requires calls to isNaN() when checking for NaN
+  ⚠ eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ╭─[use_isnan.tsx:1:16]
  1 │ (foo?.indexOf)(Number.NaN)
    ·                ──────────

--- a/crates/oxc_linter/src/snapshots/import_default.snap
+++ b/crates/oxc_linter/src/snapshots/import_default.snap
@@ -6,7 +6,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import baz from "./named-exports"
    ·        ───
    ╰────
-  help: does "./named-exports" have the default export?
+  help: Does "./named-exports" have the default export?
 
   × Unexpected token
    ╭─[index.js:1:8]
@@ -31,11 +31,11 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import barDefault from "./re-export"
    ·        ──────────
    ╰────
-  help: does "./re-export" have the default export?
+  help: Does "./re-export" have the default export?
 
   ⚠ eslint-plugin-import(default): No default export found in imported module "./typescript"
    ╭─[index.js:1:8]
  1 │ import foobar from "./typescript"
    ·        ──────
    ╰────
-  help: does "./typescript" have the default export?
+  help: Does "./typescript" have the default export?

--- a/crates/oxc_linter/src/snapshots/import_named.snap
+++ b/crates/oxc_linter/src/snapshots/import_named.snap
@@ -6,70 +6,70 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import { somethingElse } from './test-module'
    ·          ─────────────
    ╰────
-  help: does "./test-module" have the export "somethingElse"?
+  help: Does "./test-module" have the export "somethingElse"?
 
   ⚠ eslint-plugin-import(named): named import "baz" not found
    ╭─[index.js:1:10]
  1 │ import { baz } from './bar'
    ·          ───
    ╰────
-  help: does "./bar" have the export "baz"?
+  help: Does "./bar" have the export "baz"?
 
   ⚠ eslint-plugin-import(named): named import "baz" not found
    ╭─[index.js:1:10]
  1 │ import { baz, bop } from './bar'
    ·          ───
    ╰────
-  help: does "./bar" have the export "baz"?
+  help: Does "./bar" have the export "baz"?
 
   ⚠ eslint-plugin-import(named): named import "bop" not found
    ╭─[index.js:1:15]
  1 │ import { baz, bop } from './bar'
    ·               ───
    ╰────
-  help: does "./bar" have the export "bop"?
+  help: Does "./bar" have the export "bop"?
 
   ⚠ eslint-plugin-import(named): named import "c" not found
    ╭─[index.js:1:15]
  1 │ import {a, b, c} from './named-exports'
    ·               ─
    ╰────
-  help: does "./named-exports" have the export "c"?
+  help: Does "./named-exports" have the export "c"?
 
   ⚠ eslint-plugin-import(named): named import "a" not found
    ╭─[index.js:1:10]
  1 │ import { a } from './default-export'
    ·          ─
    ╰────
-  help: does "./default-export" have the export "a"?
+  help: Does "./default-export" have the export "a"?
 
   ⚠ eslint-plugin-import(named): named import "ActionTypes1" not found
    ╭─[index.js:1:10]
  1 │ import { ActionTypes1 } from './qc'
    ·          ────────────
    ╰────
-  help: does "./qc" have the export "ActionTypes1"?
+  help: Does "./qc" have the export "ActionTypes1"?
 
   ⚠ eslint-plugin-import(named): named import "e" not found
    ╭─[index.js:1:21]
  1 │ import {a, b, c, d, e} from './re-export'
    ·                     ─
    ╰────
-  help: does "./re-export" have the export "e"?
+  help: Does "./re-export" have the export "e"?
 
   ⚠ eslint-plugin-import(named): named import "a" not found
    ╭─[index.js:1:10]
  1 │ import { a } from './re-export-names'
    ·          ─
    ╰────
-  help: does "./re-export-names" have the export "a"?
+  help: Does "./re-export-names" have the export "a"?
 
   ⚠ eslint-plugin-import(named): named import "bar" not found
    ╭─[index.js:1:10]
  1 │ export { bar } from './bar'
    ·          ───
    ╰────
-  help: does "./bar" have the export "bar"?
+  help: Does "./bar" have the export "bar"?
 
   × Unexpected token
    ╭─[index.js:1:8]
@@ -82,39 +82,39 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import { baz } from 'es6-module'
    ·          ───
    ╰────
-  help: does "es6-module" have the export "baz"?
+  help: Does "es6-module" have the export "baz"?
 
   ⚠ eslint-plugin-import(named): named import "bap" not found
    ╭─[index.js:1:20]
  1 │ import { foo, bar, bap } from './re-export-default'
    ·                    ───
    ╰────
-  help: does "./re-export-default" have the export "bap"?
+  help: Does "./re-export-default" have the export "bap"?
 
   ⚠ eslint-plugin-import(named): named import "default" not found
    ╭─[index.js:1:10]
  1 │ import { default as barDefault } from './re-export'
    ·          ───────
    ╰────
-  help: does "./re-export" have the export "default"?
+  help: Does "./re-export" have the export "default"?
 
   ⚠ eslint-plugin-import(named): named import "bar" not found
    ╭─[index.js:1:10]
  1 │ import { bar } from './export-all'
    ·          ───
    ╰────
-  help: does "./export-all" have the export "bar"?
+  help: Does "./export-all" have the export "bar"?
 
   ⚠ eslint-plugin-import(named): named import "NotExported" not found
    ╭─[index.js:1:10]
  1 │ import { NotExported } from './typescript-export-assign-object'
    ·          ───────────
    ╰────
-  help: does "./typescript-export-assign-object" have the export "NotExported"?
+  help: Does "./typescript-export-assign-object" have the export "NotExported"?
 
   ⚠ eslint-plugin-import(named): named import "FooBar" not found
    ╭─[index.js:1:10]
  1 │ import { FooBar } from './typescript-export-assign-object'
    ·          ──────
    ╰────
-  help: does "./typescript-export-assign-object" have the export "FooBar"?
+  help: Does "./typescript-export-assign-object" have the export "FooBar"?

--- a/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
@@ -1,49 +1,49 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import {} from 'mod'
    · ────────────────────
    ╰────
   help: Delete this code.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import Default, {} from 'mod'
    · ─────────────────────────────
    ╰────
   help: Replace `, {} ` with ` `.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import{}from'mod'
    · ─────────────────
    ╰────
   help: Delete this code.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import type {}from'mod'
    · ───────────────────────
    ╰────
   help: Delete this code.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import type {} from 'mod'
    · ─────────────────────────
    ╰────
   help: Delete this code.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import type{}from 'mod'
    · ───────────────────────
    ╰────
   help: Delete this code.
 
-  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named `import` block.
    ╭─[no_empty_named_blocks.tsx:1:1]
  1 │ import{}from ''
    · ───────────────

--- a/crates/oxc_linter/src/snapshots/jsdoc_check_access.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_check_access.snap
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @access public
  4 │                        * @public
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: There should be only one instance of access tag in a JSDoc comment.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @access public
  4 │                        * @access private
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: There should be only one instance of access tag in a JSDoc comment.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @access public
  4 │                        * @access private
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: There should be only one instance of access tag in a JSDoc comment.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @public
  4 │                        * @private
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: There should be only one instance of access tag in a JSDoc comment.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @public
  4 │                        * @private
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: There should be only one instance of access tag in a JSDoc comment.
 
-  ⚠ eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.
+  ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
    ╭─[check_access.tsx:4:17]
  3 │                        * @public
  4 │                        * @public

--- a/crates/oxc_linter/src/snapshots/jsdoc_check_property_names.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_check_property_names.snap
@@ -1,41 +1,41 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:4:27]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property Foo.Bar
    ·                                    ───────
  5 │                        */
    ╰────
-  help: @property path declaration `Foo.Bar` appears before any real property.
+  help: `@property` path declaration `Foo.Bar` appears before any real property.
 
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:5:27]
  4 │                        * @property foo
  5 │                        * @property Foo.Bar
    ·                                    ───────
  6 │                        */
    ╰────
-  help: @property path declaration `Foo.Bar` appears before any real property.
+  help: `@property` path declaration `Foo.Bar` appears before any real property.
 
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:5:36]
  4 │                        * @typedef {SomeType} SomeTypedef
  5 │                        * @property {string} employees[].name - The name of an employee.
    ·                                             ────────────────
  6 │                        * @property {string} employees[].department - The employee's department.
    ╰────
-  help: @property path declaration `employees[].name` appears before any real property.
+  help: `@property` path declaration `employees[].name` appears before any real property.
 
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:6:36]
  5 │                        * @property {string} employees[].name - The name of an employee.
  6 │                        * @property {string} employees[].department - The employee's department.
    ·                                             ──────────────────────
  7 │                        */
    ╰────
-  help: @property path declaration `employees[].department` appears before any real property.
+  help: `@property` path declaration `employees[].department` appears before any real property.
 
   ⚠ eslint-plugin-jsdoc(check-property-names): Duplicate @property found.
    ╭─[check_property_names.tsx:4:27]
@@ -105,23 +105,23 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: @property `cfg.foo` is duplicated on the same block.
 
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:6:27]
  5 │                        * @property foo.bar
  6 │                        * @property foo.bar.baz.qux
    ·                                    ───────────────
  7 │                        * @property bar
    ╰────
-  help: @property path declaration `foo.bar.baz.qux` appears before any real property.
+  help: `@property` path declaration `foo.bar.baz.qux` appears before any real property.
 
-  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for @property path.
+  ⚠ eslint-plugin-jsdoc(check-property-names): No root defined for `@property` path.
    ╭─[check_property_names.tsx:5:36]
  4 │                        * @property {object[]} foo
  5 │                        * @property {number} foo[].bar[].baz
    ·                                             ───────────────
  6 │                        * @property bar
    ╰────
-  help: @property path declaration `foo[].bar[].baz` appears before any real property.
+  help: `@property` path declaration `foo[].bar[].baz` appears before any real property.
 
   ⚠ eslint-plugin-jsdoc(check-property-names): Duplicate @property found.
    ╭─[check_property_names.tsx:4:23]

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_property_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_property_description.snap
@@ -1,38 +1,38 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in `@property` tag.
    ╭─[require_property_description.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property foo
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a description to this @property tag.
+  help: Add a description to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in `@property` tag.
    ╭─[require_property_description.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property {string}
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a description to this @property tag.
+  help: Add a description to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in `@property` tag.
    ╭─[require_property_description.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property {string} foo
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a description to this @property tag.
+  help: Add a description to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-description): Missing description in `@property` tag.
    ╭─[require_property_description.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @prop foo
    ·                          ─────
  5 │                        */
    ╰────
-  help: Add a description to this @property tag.
+  help: Add a description to this `@property` tag.

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_property_name.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_property_name.snap
@@ -1,29 +1,29 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in `@property` tag.
    ╭─[require_property_name.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a type name to this @property tag.
+  help: Add a type name to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in `@property` tag.
    ╭─[require_property_name.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property {string}
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a type name to this @property tag.
+  help: Add a type name to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-name): Missing name in `@property` tag.
    ╭─[require_property_name.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @prop {string}
    ·                          ─────
  5 │                        */
    ╰────
-  help: Add a type name to this @property tag.
+  help: Add a type name to this `@property` tag.

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_property_type.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_property_type.snap
@@ -1,38 +1,38 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in `@property` tag.
    ╭─[require_property_type.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a {type} to this @property tag.
+  help: Add a {type} to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in `@property` tag.
    ╭─[require_property_type.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property foo
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a {type} to this @property tag.
+  help: Add a {type} to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in `@property` tag.
    ╭─[require_property_type.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @property foo bar
    ·                          ─────────
  5 │                        */
    ╰────
-  help: Add a {type} to this @property tag.
+  help: Add a {type} to this `@property` tag.
 
-  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in @property tag.
+  ⚠ eslint-plugin-jsdoc(require-property-type): Missing type in `@property` tag.
    ╭─[require_property_type.tsx:4:17]
  3 │                        * @typedef {SomeType} SomeTypedef
  4 │                        * @prop foo
    ·                          ─────
  5 │                        */
    ╰────
-  help: Add a {type} to this @property tag.
+  help: Add a {type} to this `@property` tag.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_aria_unsupported_elements.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_aria_unsupported_elements.snap
@@ -1,224 +1,224 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <base role {...props} />
    ·       ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:6]
  1 │ <col role {...props} />
    ·      ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:11]
  1 │ <colgroup role {...props} />
    ·           ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <head role {...props} />
    ·       ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <html role {...props} />
    ·       ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <link role {...props} />
    ·       ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <meta role {...props} />
    ·       ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:10]
  1 │ <noembed role {...props} />
    ·          ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:11]
  1 │ <noscript role {...props} />
    ·           ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <param role {...props} />
    ·        ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:10]
  1 │ <picture role {...props} />
    ·          ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:9]
  1 │ <script role {...props} />
    ·         ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:9]
  1 │ <source role {...props} />
    ·         ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <style role {...props} />
    ·        ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <title role {...props} />
    ·        ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <track role {...props} />
    ·        ────
    ╰────
   help: Try removing the prop `role`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <base aria-hidden aria-role="none" {...props} />
    ·       ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:6]
  1 │ <col aria-hidden aria-role="none" {...props} />
    ·      ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:11]
  1 │ <colgroup aria-hidden aria-role="none" {...props} />
    ·           ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <head aria-hidden aria-role="none" {...props} />
    ·       ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <html aria-hidden aria-role="none" {...props} />
    ·       ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <link aria-hidden aria-role="none" {...props} />
    ·       ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:7]
  1 │ <meta aria-hidden aria-role="none" {...props} />
    ·       ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:10]
  1 │ <noembed aria-hidden aria-role="none" {...props} />
    ·          ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:11]
  1 │ <noscript aria-hidden aria-role="none" {...props} />
    ·           ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <param aria-hidden aria-role="none" {...props} />
    ·        ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:10]
  1 │ <picture aria-hidden aria-role="none" {...props} />
    ·          ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:9]
  1 │ <script aria-hidden aria-role="none" {...props} />
    ·         ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:9]
  1 │ <source aria-hidden aria-role="none" {...props} />
    ·         ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <style aria-hidden aria-role="none" {...props} />
    ·        ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <title aria-hidden aria-role="none" {...props} />
    ·        ───────────
    ╰────
   help: Try removing the prop `aria-hidden`.
 
-  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.
+  ⚠ eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states, or properties.
    ╭─[aria_unsupported_elements.tsx:1:8]
  1 │ <track aria-hidden aria-role="none" {...props} />
    ·        ───────────

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_autocomplete_valid.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_autocomplete_valid.snap
@@ -1,44 +1,44 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `foo` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `foo` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:20]
  1 │ <input type='text' autocomplete='foo' />;
    ·                    ──────────────────
    ╰────
-  help: Change `foo` to a valid value for autocomplete.
+  help: Change `foo` to a valid value for `autocomplete`.
 
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `name invalid` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `name invalid` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:20]
  1 │ <input type='text' autocomplete='name invalid' />;
    ·                    ───────────────────────────
    ╰────
-  help: Change `name invalid` to a valid value for autocomplete.
+  help: Change `name invalid` to a valid value for `autocomplete`.
 
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `invalid name` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `invalid name` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:20]
  1 │ <input type='text' autocomplete='invalid name' />;
    ·                    ───────────────────────────
    ╰────
-  help: Change `invalid name` to a valid value for autocomplete.
+  help: Change `invalid name` to a valid value for `autocomplete`.
 
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `home url` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `home url` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:20]
  1 │ <input type='text' autocomplete='home url' />;
    ·                    ───────────────────────
    ╰────
-  help: Change `home url` to a valid value for autocomplete.
+  help: Change `home url` to a valid value for `autocomplete`.
 
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `baz` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `baz` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:6]
  1 │ <Bar autocomplete='baz'></Bar>;
    ·      ──────────────────
    ╰────
-  help: Change `baz` to a valid value for autocomplete.
+  help: Change `baz` to a valid value for `autocomplete`.
 
-  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `baz` is not a valid value for autocomplete.
+  ⚠ eslint-plugin-jsx-a11y(autocomplete-valid): `baz` is not a valid value for `autocomplete`.
    ╭─[autocomplete_valid.tsx:1:20]
  1 │ <Input type='text' autocomplete='baz' />;
    ·                    ──────────────────
    ╰────
-  help: Change `baz` to a valid value for autocomplete.
+  help: Change `baz` to a valid value for `autocomplete`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_click_events_have_key_events.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_click_events_have_key_events.snap
@@ -6,81 +6,81 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div onClick={() => void 0} />;
    · ──────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <div onClick={() => void 0} role={undefined} />;
    · ───────────────────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <div onClick={() => void 0} {...props} />;
    · ─────────────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <section onClick={() => void 0} />;
    · ──────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <main onClick={() => void 0} />;
    · ───────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <article onClick={() => void 0} />;
    · ──────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <header onClick={() => void 0} />;
    · ─────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <footer onClick={() => void 0} />;
    · ─────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <div onClick={() => void 0} aria-hidden={false} />;
    · ──────────────────────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <a onClick={() => void 0} />
    · ────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <a tabIndex="0" onClick={() => void 0} />
    · ─────────────────────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
 
   ⚠ eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
    ╭─[click_events_have_key_events.tsx:1:1]
  1 │ <Footer onClick={doFoo} />
    · ──────────────────────────
    ╰────
-  help: Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_html_has_lang.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_html_has_lang.snap
@@ -6,58 +6,58 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <html />;
    ·  ────
    ╰────
-  help: Add a lang attribute to the html element whose value represents the primary language of document.
+  help: Add a `lang` attribute to the `html` element whose value represents the primary language of document.
 
   ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing lang attribute.
    ╭─[html_has_lang.tsx:1:2]
  1 │ <html {...props} />;
    ·  ────
    ╰────
-  help: Add a lang attribute to the html element whose value represents the primary language of document.
+  help: Add a `lang` attribute to the `html` element whose value represents the primary language of document.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={undefined} />;
    · ─────────────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={null} />;
    · ────────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={false} />;
    · ─────────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={1} />;
    · ─────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={''} />;
    · ──────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang={``} />;
    · ──────────────────
    ╰────
   help: Must have meaningful value for `lang` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute
+  ⚠ eslint-plugin-jsx-a11y(html-has-lang): Missing value for `lang` attribute
    ╭─[html_has_lang.tsx:1:1]
  1 │ <html lang="" />;
    · ────────────────
@@ -69,4 +69,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <HTMLTop />
    ·  ───────
    ╰────
-  help: Add a lang attribute to the html element whose value represents the primary language of document.
+  help: Add a `lang` attribute to the `html` element whose value represents the primary language of document.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_iframe_has_title.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_iframe_has_title.snap
@@ -6,67 +6,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <iframe />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe {...props} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={undefined} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title='' />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={false} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={true} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={''} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={``} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <iframe title={42} />
    ·  ──────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.
 
   ⚠ eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.
    ╭─[iframe_has_title.tsx:1:2]
  1 │ <FooComponent />
    ·  ────────────
    ╰────
-  help: Provide title property for iframe element.
+  help: Provide `title` property for `iframe` element.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_img_redundant_alt.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_img_redundant_alt.snap
@@ -1,170 +1,170 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='Photo of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='Picture of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='Image of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='PhOtO of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={'photo'} />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='piCTUre of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='imAGE of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='photo of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='picture of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='image of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='photo' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='image' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='picture' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`picture doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`photo doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`image doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`picture doing ${picture}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`photo doing ${photo}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt={`image doing ${image}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:8]
  1 │ <Image alt='Photo of a friend' />
    ·        ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='Word1' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:6]
  1 │ <img alt='Word2' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:8]
  1 │ <Image alt='Word1' />;
    ·        ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant `alt` attribute.
    ╭─[img_redundant_alt.tsx:1:8]
  1 │ <Image alt='Word2' />;
    ·        ───
    ╰────
-  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don't need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the `alt` prop.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_lang.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_lang.snap
@@ -1,44 +1,44 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:7]
  1 │ <html lang='foo' />
    ·       ──────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:7]
  1 │ <html lang='n'></html>
    ·       ────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:7]
  1 │ <html lang='zz-LL' />
    ·       ────────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:7]
  1 │ <html lang={undefined} />
    ·       ────────────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:6]
  1 │ <Foo lang={undefined} />
    ·      ────────────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.
+  ⚠ eslint-plugin-jsx-a11y(lang): `lang` attribute must have a valid value.
    ╭─[lang.tsx:1:16]
  1 │ <Box as='html' lang='foo' />
    ·                ──────────
    ╰────
-  help: Set a valid value for lang attribute.
+  help: Set a valid value for `lang` attribute.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_media_has_caption.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_media_has_caption.snap
@@ -1,233 +1,233 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio><track /></audio>
    · ────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio><track kind='subtitles' /></audio>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video><track /></video>
    · ────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video><track kind='subtitles' /></video>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
    · ─────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
    · ─────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video muted={false}></Video>
    · ─────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video muted={false}></Video>
    · ─────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
    · ─────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
    · ─────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video muted={false}></Video>
    · ─────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video muted={false}></Video>
    · ─────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio>Foo</audio>
    · ──────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video>Foo</video>
    · ──────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video />
    · ─────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio><Track /></audio>
    · ────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <video><Track /></video>
    · ────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio><Track kind='subtitles' /></Audio>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video><Track kind='subtitles' /></Video>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio><Track kind='subtitles' /></Audio>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video><Track kind='subtitles' /></Video>
    · ─────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
-  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element
+  ⚠ eslint-plugin-jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Box as='audio'><Track kind='subtitles' /></Box>
    · ────────────────────────────────────────────────
    ╰────
-  help: Media elements such as <audio> and <video> must have a <track> for captions.
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_mouse_events_have_key_events.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_mouse_events_have_key_events.snap
@@ -1,100 +1,100 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOver must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOver` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOver={() => void 0} />;
    ·      ──────────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOut must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOut` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOut={() => void 0} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOver must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOver` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOver={() => void 0} onFocus={undefined} />;
    ·      ──────────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOut must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOut` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOut={() => void 0} onBlur={undefined} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOver must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOver` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOver={() => void 0} {...props} />
    ·      ──────────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOut must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOut` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOut={() => void 0} {...props} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOver must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOver` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOver={() => {}} onMouseOut={() => {}} />
    ·      ──────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOut must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOut` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:29]
  1 │ <div onMouseOver={() => {}} onMouseOut={() => {}} />
    ·                             ─────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onPointerEnter must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onPointerEnter` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onPointerEnter={() => {}} onPointerLeave={() => {}} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onPointerLeave must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onPointerLeave` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:32]
  1 │ <div onPointerEnter={() => {}} onPointerLeave={() => {}} />
    ·                                ─────────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOver must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOver` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOver={() => {}} />
    ·      ──────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onPointerEnter must be accompanied by onFocus for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onPointerEnter` must be accompanied by `onFocus` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onPointerEnter={() => {}} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onFocus.
+  help: Try to add `onFocus`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onMouseOut must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onMouseOut` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onMouseOut={() => {}} />
    ·      ─────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.
 
-  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): onPointerLeave must be accompanied by onBlur for accessibility.
+  ⚠ eslint-plugin-jsx-a11y(mouse-events-have-key-events): `onPointerLeave` must be accompanied by `onBlur` for accessibility.
    ╭─[mouse_events_have_key_events.tsx:1:6]
  1 │ <div onPointerLeave={() => {}} />
    ·      ─────────────────────────
    ╰────
-  help: Try to add onBlur.
+  help: Try to add `onBlur`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_access_key.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_access_key.snap
@@ -6,74 +6,74 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div accesskey="h" />
    ·      ─────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey="h" />
    ·      ─────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey="h" {...props} />
    ·      ─────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div acCesSKeY="y" />
    ·      ─────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={"y"} />
    ·      ───────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={`${y}`} />
    ·      ──────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={`${undefined}y${undefined}`} />
    ·      ───────────────────────────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={`This is ${bad}`} />
    ·      ────────────────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={accessKey} />
    ·      ─────────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={`${undefined}`} />
    ·      ──────────────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.
 
   ⚠ eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.
    ╭─[no_access_key.tsx:1:6]
  1 │ <div accessKey={`${undefined}${undefined}`} />
    ·      ──────────────────────────────────────
    ╰────
-  help: Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.
+  help: Remove the `accessKey` attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create accessibility complications.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_distracting_elements.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_distracting_elements.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <marquee />
    ·  ───────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <marquee {...props} />
    ·  ───────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <marquee lang={undefined} />
    ·  ───────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <blink />
    ·  ─────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <blink {...props} />
    ·  ─────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <blink foo={undefined} />
    ·  ─────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <Blink />
    ·  ─────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.
 
-  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use `<marquee>` or `<blink>` elements as they can create visual accessibility issues and are deprecated.
    ╭─[no_distracting_elements.tsx:1:2]
  1 │ <Marquee />
    ·  ───────
    ╰────
-  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+  help: Replace the `<marquee>` or `<blink>` element with alternative, more accessible ways to achieve your desired visual effects.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
@@ -1,30 +1,30 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): `tabIndex` should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:22]
  1 │ <div role="tabpanel" tabIndex="0" />
    ·                      ────────────
    ╰────
-  help: tabIndex attribute should be removed
+  help: `tabIndex` attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): `tabIndex` should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:44]
  1 │ <div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;
    ·                                            ────────────
    ╰────
-  help: tabIndex attribute should be removed
+  help: `tabIndex` attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): `tabIndex` should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:39]
  1 │ <div role={BUTTON} onClick={() => {}} tabIndex="0" />;
    ·                                       ────────────
    ╰────
-  help: tabIndex attribute should be removed
+  help: `tabIndex` attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): `tabIndex` should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:61]
  1 │ <div role={isButton ? "button" : "link"} onClick={() => {}} tabIndex="0" />;
    ·                                                             ────────────
    ╰────
-  help: tabIndex attribute should be removed
+  help: `tabIndex` attribute should be removed

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -1,21 +1,21 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The element `button` has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
  1 │ <button role='button' />
    ·         ─────────────
    ╰────
   help: Remove the redundant role `button` from the element `button`.
 
-  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The element `body` has an implicit role of `document`. Defining this explicitly is redundant and should be avoided.
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `body` element has an implicit role of `document`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:7]
  1 │ <body role='document' />
    ·       ───────────────
    ╰────
   help: Remove the redundant role `document` from the element `body`.
 
-  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The element `button` has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
  1 │ <Button role='button' />
    ·         ─────────────

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_role_supports_aria_props.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_role_supports_aria_props.snap
@@ -1,254 +1,254 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role link. This role is implicit on the element a.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `link`. This role is implicit on the element `a`.
    ╭─[role_supports_aria_props.tsx:1:13]
  1 │ <a href="/" aria-checked />
    ·             ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role link. This role is implicit on the element area.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `link`. This role is implicit on the element `area`.
    ╭─[role_supports_aria_props.tsx:1:16]
  1 │ <area href="/" aria-checked />
    ·                ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role link. This role is implicit on the element link.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `link`. This role is implicit on the element `link`.
    ╭─[role_supports_aria_props.tsx:1:16]
  1 │ <link href="/" aria-checked />
    ·                ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role img. This role is implicit on the element img.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `img`. This role is implicit on the element `img`.
    ╭─[role_supports_aria_props.tsx:1:19]
  1 │ <img alt="foobar" aria-checked />
    ·                   ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role toolbar. This role is implicit on the element menu.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `toolbar`. This role is implicit on the element `menu`.
    ╭─[role_supports_aria_props.tsx:1:22]
  1 │ <menu type="toolbar" aria-checked />
    ·                      ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role complementary. This role is implicit on the element aside.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `complementary`. This role is implicit on the element `aside`.
    ╭─[role_supports_aria_props.tsx:1:8]
  1 │ <aside aria-checked />
    ·        ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role list. This role is implicit on the element ul.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `list`. This role is implicit on the element `ul`.
    ╭─[role_supports_aria_props.tsx:1:5]
  1 │ <ul aria-expanded />
    ·     ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role group. This role is implicit on the element details.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `group`. This role is implicit on the element `details`.
    ╭─[role_supports_aria_props.tsx:1:10]
  1 │ <details aria-expanded />
    ·          ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role dialog. This role is implicit on the element dialog.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `dialog`. This role is implicit on the element `dialog`.
    ╭─[role_supports_aria_props.tsx:1:9]
  1 │ <dialog aria-expanded />
    ·         ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role complementary. This role is implicit on the element aside.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `complementary`. This role is implicit on the element `aside`.
    ╭─[role_supports_aria_props.tsx:1:8]
  1 │ <aside aria-expanded />
    ·        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role article. This role is implicit on the element article.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `article`. This role is implicit on the element `article`.
    ╭─[role_supports_aria_props.tsx:1:10]
  1 │ <article aria-expanded />
    ·          ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role document. This role is implicit on the element body.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `document`. This role is implicit on the element `body`.
    ╭─[role_supports_aria_props.tsx:1:7]
  1 │ <body aria-expanded />
    ·       ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role listitem. This role is implicit on the element li.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `listitem`. This role is implicit on the element `li`.
    ╭─[role_supports_aria_props.tsx:1:5]
  1 │ <li aria-expanded />
    ·     ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role navigation. This role is implicit on the element nav.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `navigation`. This role is implicit on the element `nav`.
    ╭─[role_supports_aria_props.tsx:1:6]
  1 │ <nav aria-expanded />
    ·      ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role list. This role is implicit on the element ol.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `list`. This role is implicit on the element `ol`.
    ╭─[role_supports_aria_props.tsx:1:5]
  1 │ <ol aria-expanded />
    ·     ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role status. This role is implicit on the element output.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `status`. This role is implicit on the element `output`.
    ╭─[role_supports_aria_props.tsx:1:9]
  1 │ <output aria-expanded />
    ·         ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role region. This role is implicit on the element section.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `region`. This role is implicit on the element `section`.
    ╭─[role_supports_aria_props.tsx:1:10]
  1 │ <section aria-expanded />
    ·          ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role rowgroup. This role is implicit on the element tbody.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `rowgroup`. This role is implicit on the element `tbody`.
    ╭─[role_supports_aria_props.tsx:1:8]
  1 │ <tbody aria-expanded />
    ·        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role rowgroup. This role is implicit on the element tfoot.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `rowgroup`. This role is implicit on the element `tfoot`.
    ╭─[role_supports_aria_props.tsx:1:8]
  1 │ <tfoot aria-expanded />
    ·        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role rowgroup. This role is implicit on the element thead.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `rowgroup`. This role is implicit on the element `thead`.
    ╭─[role_supports_aria_props.tsx:1:8]
  1 │ <thead aria-expanded />
    ·        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `radio`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:21]
  1 │ <input type="radio" aria-invalid />
    ·                     ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-selected is not supported by the role radio. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-selected` is not supported by the role `radio`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:21]
  1 │ <input type="radio" aria-selected />
    ·                     ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-selected.
+  help: Try to remove invalid attribute `aria-selected`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-haspopup is not supported by the role radio. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-haspopup` is not supported by the role `radio`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:21]
  1 │ <input type="radio" aria-haspopup />
    ·                     ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-haspopup.
+  help: Try to remove invalid attribute `aria-haspopup`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-haspopup is not supported by the role checkbox. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-haspopup` is not supported by the role `checkbox`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:24]
  1 │ <input type="checkbox" aria-haspopup />
    ·                        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-haspopup.
+  help: Try to remove invalid attribute `aria-haspopup`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role button. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `button`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:21]
  1 │ <input type="reset" aria-invalid />
    ·                     ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role button. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `button`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:21]
  1 │ <input type="image" aria-invalid />
    ·                     ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role button. This role is implicit on the element input.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `button`. This role is implicit on the element `input`.
    ╭─[role_supports_aria_props.tsx:1:22]
  1 │ <input type="button" aria-invalid />
    ·                      ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role menuitem. This role is implicit on the element menuitem.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `menuitem`. This role is implicit on the element `menuitem`.
    ╭─[role_supports_aria_props.tsx:1:26]
  1 │ <menuitem type="command" aria-invalid />
    ·                          ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-selected is not supported by the role menuitemradio. This role is implicit on the element menuitem.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-selected` is not supported by the role `menuitemradio`. This role is implicit on the element `menuitem`.
    ╭─[role_supports_aria_props.tsx:1:24]
  1 │ <menuitem type="radio" aria-selected />
    ·                        ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-selected.
+  help: Try to remove invalid attribute `aria-selected`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-haspopup is not supported by the role toolbar. This role is implicit on the element menu.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-haspopup` is not supported by the role `toolbar`. This role is implicit on the element `menu`.
    ╭─[role_supports_aria_props.tsx:1:22]
  1 │ <menu type="toolbar" aria-haspopup />
    ·                      ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-haspopup.
+  help: Try to remove invalid attribute `aria-haspopup`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role toolbar. This role is implicit on the element menu.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `toolbar`. This role is implicit on the element `menu`.
    ╭─[role_supports_aria_props.tsx:1:22]
  1 │ <menu type="toolbar" aria-invalid />
    ·                      ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-expanded is not supported by the role toolbar. This role is implicit on the element menu.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-expanded` is not supported by the role `toolbar`. This role is implicit on the element `menu`.
    ╭─[role_supports_aria_props.tsx:1:22]
  1 │ <menu type="toolbar" aria-expanded />
    ·                      ─────────────
    ╰────
-  help: Try to remove invalid attribute aria-expanded.
+  help: Try to remove invalid attribute `aria-expanded`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role link. This role is implicit on the element link.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `link`. This role is implicit on the element `link`.
    ╭─[role_supports_aria_props.tsx:1:16]
  1 │ <link href="/" aria-invalid />
    ·                ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role link. This role is implicit on the element area.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `link`. This role is implicit on the element `area`.
    ╭─[role_supports_aria_props.tsx:1:16]
  1 │ <area href="/" aria-invalid />
    ·                ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-invalid is not supported by the role link. This role is implicit on the element a.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-invalid` is not supported by the role `link`. This role is implicit on the element `a`.
    ╭─[role_supports_aria_props.tsx:1:13]
  1 │ <a href="/" aria-invalid />
    ·             ────────────
    ╰────
-  help: Try to remove invalid attribute aria-invalid.
+  help: Try to remove invalid attribute `aria-invalid`.
 
-  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute aria-checked is not supported by the role link. This role is implicit on the element a.
+  ⚠ eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute `aria-checked` is not supported by the role `link`. This role is implicit on the element `a`.
    ╭─[role_supports_aria_props.tsx:1:16]
  1 │ <Link href="/" aria-checked />
    ·                ────────────
    ╰────
-  help: Try to remove invalid attribute aria-checked.
+  help: Try to remove invalid attribute `aria-checked`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_scope.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_scope.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(scope): The scope prop can only be used on <th> elements
+  ⚠ eslint-plugin-jsx-a11y(scope): The `scope` prop can only be used on `<th>` elements
    ╭─[scope.tsx:1:6]
  1 │ <div scope />
    ·      ─────
    ╰────
-  help: Must use scope prop only on <th> elements
+  help: Remove the `scope` prop on elements other than `<th>`.
 
-  ⚠ eslint-plugin-jsx-a11y(scope): The scope prop can only be used on <th> elements
+  ⚠ eslint-plugin-jsx-a11y(scope): The `scope` prop can only be used on `<th>` elements
    ╭─[scope.tsx:1:6]
  1 │ <Foo scope='bar' />;
    ·      ───────────
    ╰────
-  help: Must use scope prop only on <th> elements
+  help: Remove the `scope` prop on elements other than `<th>`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_tabindex_no_positive.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_tabindex_no_positive.snap
@@ -1,37 +1,37 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.
+  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for `tabIndex`.
    ╭─[tabindex_no_positive.tsx:1:6]
  1 │ <div tabIndex="1" />
    ·      ────────────
    ╰────
-  help: Change the tabIndex prop to a non-negative value
+  help: Change the `tabIndex` prop to a non-negative value
 
-  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.
+  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for `tabIndex`.
    ╭─[tabindex_no_positive.tsx:1:6]
  1 │ <div tabIndex={1} />
    ·      ────────────
    ╰────
-  help: Change the tabIndex prop to a non-negative value
+  help: Change the `tabIndex` prop to a non-negative value
 
-  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.
+  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for `tabIndex`.
    ╭─[tabindex_no_positive.tsx:1:6]
  1 │ <div tabIndex={"1"} />
    ·      ──────────────
    ╰────
-  help: Change the tabIndex prop to a non-negative value
+  help: Change the `tabIndex` prop to a non-negative value
 
-  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.
+  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for `tabIndex`.
    ╭─[tabindex_no_positive.tsx:1:6]
  1 │ <div tabIndex={`1`} />
    ·      ──────────────
    ╰────
-  help: Change the tabIndex prop to a non-negative value
+  help: Change the `tabIndex` prop to a non-negative value
 
-  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.
+  ⚠ eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for `tabIndex`.
    ╭─[tabindex_no_positive.tsx:1:6]
  1 │ <div tabIndex={1.589} />
    ·      ────────────────
    ╰────
-  help: Change the tabIndex prop to a non-negative value
+  help: Change the `tabIndex` prop to a non-negative value


### PR DESCRIPTION
Improves the consistency of diagnostic formatting in 30ish rules, and improves the diagnostic messages in editors that render markdown, plus makes it clearer which parts refer to code for end-users, even with the raw text.

-lso adjust the phrasing of some diagnostics slightly.