### PR TITLE
feat(vscode): add quick actions to status bar tooltip

### DIFF
--- a/editors/vscode/client/StatusBarItemHandler.ts
+++ b/editors/vscode/client/StatusBarItemHandler.ts
@@ -1,0 +1,50 @@
+import { MarkdownString, StatusBarAlignment, StatusBarItem, ThemeColor, window } from 'vscode';
+
+type StatusBarTool = 'linter' | 'formatter';
+
+export default class StatusBarItemHandler {
+  private tooltipSections: Map<StatusBarTool, string> = new Map();
+
+  private statusBarItem: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+
+  private extensionVersion: string = '<unknown>';
+
+  constructor(extensionVersion?: string) {
+    if (extensionVersion) {
+      this.extensionVersion = extensionVersion;
+    }
+  }
+
+  public show(): void {
+    this.statusBarItem.show();
+  }
+
+  public setColorAndIcon(bgColor: string, icon: string): void {
+    this.statusBarItem.backgroundColor = new ThemeColor(bgColor);
+    this.statusBarItem.text = `$(${icon}) oxc`;
+  }
+
+  /**
+   * Updates the tooltip text for a specific tool section.
+   * The tooltip can use markdown syntax and VSCode icons.
+   */
+  public updateToolTooltip(toolId: StatusBarTool, text: string): void {
+    this.tooltipSections.set(toolId, text);
+    this.updateFullTooltip();
+  }
+
+  private updateFullTooltip(): void {
+    const text = Array.from(this.tooltipSections.values()).join('\n\n');
+
+    if (!(this.statusBarItem.tooltip instanceof MarkdownString)) {
+      this.statusBarItem.tooltip = new MarkdownString('', true);
+      this.statusBarItem.tooltip.isTrusted = true;
+    }
+
+    this.statusBarItem.tooltip.value = `VSCode Extension v${this.extensionVersion}\n\n---\n\n${text}`;
+  }
+
+  public dispose(): void {
+    this.statusBarItem.dispose();
+  }
+}

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -9,6 +9,7 @@ import {
   restartClient,
   toggleClient,
 } from './linter';
+import StatusBarItemHandler from './StatusBarItemHandler';
 
 const outputChannelName = 'Oxc';
 
@@ -42,6 +43,8 @@ export async function activate(context: ExtensionContext) {
     }
   });
 
+  const statusBarItemHandler = new StatusBarItemHandler(context.extension.packageJSON?.version);
+
   context.subscriptions.push(
     restartCommand,
     showOutputCommand,
@@ -49,13 +52,16 @@ export async function activate(context: ExtensionContext) {
     configService,
     outputChannel,
     onDidChangeWorkspaceFoldersDispose,
+    statusBarItemHandler,
   );
 
   configService.onConfigChange = async function onConfigChange(event) {
-    await onConfigChangeLinter(context, event, configService);
+    await onConfigChangeLinter(event, configService, statusBarItemHandler);
   };
 
-  await activateLinter(context, outputChannel, configService);
+  await activateLinter(context, outputChannel, configService, statusBarItemHandler);
+  // Show status bar item after activation
+  statusBarItemHandler.show();
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
> This PR enhances the VSCode extension's status bar functionality by adding quick action commands to the status bar tooltip. 

<img width="202" height="184" alt="grafik" src="https://github.com/user-attachments/assets/9816f28a-0a76-413f-9f43-4aca74182ac0" />
<img width="175" height="189" alt="grafik" src="https://github.com/user-attachments/assets/ffd76f3b-8b86-4508-a2f1-9a877c739d6f" />
