### PR TITLE
fix(language_server): always write to memory file system

### DIFF
--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -9,7 +9,6 @@ pub struct Capabilities {
     pub workspace_apply_edit: bool,
     pub workspace_configuration: bool,
     pub dynamic_watchers: bool,
-    pub dynamic_formatting: bool,
 }
 
 impl From<ClientCapabilities> for Capabilities {
@@ -25,13 +24,8 @@ impl From<ClientCapabilities> for Capabilities {
                 watched_files.dynamic_registration.is_some_and(|dynamic| dynamic)
             })
         });
-        let dynamic_formatting = value.text_document.as_ref().is_some_and(|text_document| {
-            text_document.formatting.is_some_and(|formatting| {
-                formatting.dynamic_registration.is_some_and(|dynamic| dynamic)
-            })
-        });
 
-        Self { workspace_apply_edit, workspace_configuration, dynamic_watchers, dynamic_formatting }
+        Self { workspace_apply_edit, workspace_configuration, dynamic_watchers }
     }
 }
 


### PR DESCRIPTION
In https://github.com/oxc-project/oxc/pull/15882 we removed the dynamic formatting registration and registered them statically.
LSP Clients could only support static formatting registration and the checks would fail. When someone formats, while not saving, the unsaved changes would disappear.

Removed the checks, so it always saves the content in the file system. Later the Linter will use the file system too when supporting [textDocument/diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic)