### PR TITLE
docs(linter): Add config docs generation for rules with Regex arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "dyn-clone",
  "indexmap",
  "oxc_schemars_derive",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -63,7 +63,7 @@ phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }
 rust-lapper = { workspace = true }
 rustc-hash = { workspace = true }
-schemars = { workspace = true, features = ["indexmap2"] }
+schemars = { workspace = true, features = ["indexmap2", "regex"] }
 self_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] } # preserve_order: print config with ordered keys.

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -6,6 +6,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,9 +20,14 @@ fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct ParamNames(Box<ParamNamesConfig>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct ParamNamesConfig {
+    /// Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
+    /// is used instead of the default `^_?resolve$` check.
     resolve_pattern: Option<Regex>,
+    /// Regex pattern used to validate the `reject` parameter name. If provided, this pattern
+    /// is used instead of the default `^_?reject$` check.
     reject_pattern: Option<Regex>,
 }
 
@@ -65,6 +71,7 @@ declare_oxc_lint!(
     ParamNames,
     promise,
     style,
+    config = ParamNamesConfig,
 );
 
 impl Rule for ParamNames {

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -7,6 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use oxc_syntax::identifier::is_identifier_name;
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -24,9 +25,14 @@ fn catch_error_name_diagnostic(
 #[derive(Debug, Default, Clone)]
 pub struct CatchErrorName(Box<CatchErrorNameConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct CatchErrorNameConfig {
+    /// A list of patterns to ignore when checking `catch` variable names. The pattern
+    /// can be a string or regular expression.
     ignore: Vec<Regex>,
+    /// The name to use for error variables in `catch` blocks. You can customize it
+    /// to something other than `'error'` (e.g., `'exception'`).
     name: CompactStr,
 }
 
@@ -82,46 +88,11 @@ declare_oxc_lint!(
     ///
     /// promise.then(undefined, error => {});
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### name
-    ///
-    /// `{ type: string, default: "error" }`
-    ///
-    /// The name to use for error variables in `catch` blocks. You can customize it
-    /// to something other than `'error'` (e.g., `'exception'`).
-    ///
-    /// Example:
-    /// ```json
-    /// "unicorn/catch-error-name": [
-    ///   "error",
-    ///   { "name": "exception" }
-    /// ]
-    /// ```
-    ///
-    /// #### ignore
-    ///
-    /// `{ type: Array<string | RegExp>, default: [] }`
-    ///
-    /// A list of patterns to ignore when checking `catch` variable names. The pattern
-    /// can be a string or regular expression.
-    ///
-    /// Example:
-    /// ```json
-    /// "unicorn/catch-error-name": [
-    ///   "error",
-    ///   {
-    ///     "ignore": [
-    ///       "^error\\d*$"
-    ///     ]
-    ///   }
-    /// ]
-    /// ```
     CatchErrorName,
     unicorn,
     style,
-    fix
+    fix,
+    config = CatchErrorNameConfig,
 );
 
 impl Rule for CatchErrorName {

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -44,8 +44,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         // jest
         "jest/consistent-test-it",
         "jest/valid-title",
-        // promise
-        "promise/param-names",
         // react
         "react/forbid-dom-props",
         "react/forbid-elements",
@@ -55,7 +53,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "typescript/ban-ts-comment",
         "typescript/consistent-type-imports",
         // unicorn
-        "unicorn/catch-error-name",
         "unicorn/filename-case",
     ];
 


### PR DESCRIPTION
~~Draft until we merge https://github.com/oxc-project/schemars/pull/9 and upgrade the oxc-schemars crate in this repo afterwards. Once we have the schemars crate bumped up to 0.8.27 we can safely rebase this branch and this'll be ready to merge.~~

But I can confirm that this now works with my patch to schemars :D 

Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### ignore

type: `string[]`


A list of patterns to ignore when checking `catch` variable names. The pattern
can be a string or regular expression.


### name

type: `string`

default: `"error"`

The name to use for error variables in `catch` blocks. You can customize it
to something other than `'error'` (e.g., `'exception'`).
```

Unfortunately it doesn't recognize the default value in this case, although I'm not 100% sure why. But at the very least, this works and allows us to finish the docs for most of the remaining lint rules.

```md
## Configuration

This rule accepts a configuration object with the following properties:

### rejectPattern

type: `[
  string,
  null
]`


Regex pattern used to validate the `reject` parameter name. If provided, this pattern
is used instead of the default `^_?reject$` check.


### resolvePattern

type: `[
  string,
  null
]`


Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
is used instead of the default `^_?resolve$` check.
```