### PR TITLE
chore(linter): Improve the promise/valid-params rule diagnostics.

### DIFF
--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -11,7 +11,7 @@ fn zero_or_one_argument_required_diagnostic(
     args_len: usize,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Promise.{prop_name}() requires 0 or 1 arguments, but received {args_len}"
+        "`Promise.{prop_name}()` requires 0 or 1 arguments, but received {args_len}."
     ))
     .with_label(span)
 }
@@ -22,20 +22,16 @@ fn one_or_two_argument_required_diagnostic(
     args_len: usize,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Promise.{prop_name}() requires 1 or 2 arguments, but received {args_len}"
+        "`Promise.{prop_name}()` requires 1 or 2 arguments, but received {args_len}."
     ))
     .with_label(span)
 }
 
 fn one_argument_required_diagnostic(span: Span, prop_name: &str, args_len: usize) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Promise.{prop_name}() requires 1 argument, but received {args_len}"
+        "`Promise.{prop_name}()` requires 1 argument, but received {args_len}."
     ))
     .with_label(span)
-}
-
-fn valid_params_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(x0.to_string()).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -45,6 +41,8 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// Enforces the proper number of arguments are passed to Promise functions.
+    ///
+    /// This rule is generally unnecessary if using TypeScript.
     ///
     /// ### Why is this bad?
     ///
@@ -96,7 +94,6 @@ impl Rule for ValidParams {
                         &prop_name,
                         args_len,
                     ));
-                    ctx.diagnostic(valid_params_diagnostic(call_expr.span, &format!("Promise.{prop_name}() requires 1 or 2 arguments, but received {args_len}")));
                 }
             }
             "race" | "all" | "allSettled" | "any" | "catch" | "finally" => {

--- a/crates/oxc_linter/src/snapshots/promise_valid_params.snap
+++ b/crates/oxc_linter/src/snapshots/promise_valid_params.snap
@@ -1,169 +1,145 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-promise(valid-params): Promise.resolve() requires 0 or 1 arguments, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.resolve()` requires 0 or 1 arguments, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.resolve(1, 2)
    · ─────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.resolve() requires 0 or 1 arguments, but received 5
+  ⚠ eslint-plugin-promise(valid-params): `Promise.resolve()` requires 0 or 1 arguments, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.resolve({}, function() {}, 1, 2, 3)
    · ───────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.reject() requires 0 or 1 arguments, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject(1, 2, 3)
    · ───────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.reject() requires 0 or 1 arguments, but received 4
+  ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject({}, function() {}, 1, 2)
    · ───────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.race() requires 1 argument, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race(1, 2)
    · ──────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.race() requires 1 argument, but received 5
+  ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race({}, function() {}, 1, 2, 3)
    · ────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.all() requires 1 argument, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all(1, 2, 3)
    · ────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.all() requires 1 argument, but received 4
+  ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.allSettled() requires 1 argument, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled(1, 2, 3)
    · ───────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.allSettled() requires 1 argument, but received 4
+  ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled({}, function() {}, 1, 2)
    · ───────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.any() requires 1 argument, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any(1, 2, 3)
    · ────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.any() requires 1 argument, but received 4
+  ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then()
    · ────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 0
-   ╭─[valid_params.tsx:1:1]
- 1 │ somePromise().then()
-   · ────────────────────
-   ╰────
-
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then(() => {}, () => {}, () => {})
    · ────────────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 3
-   ╭─[valid_params.tsx:1:1]
- 1 │ somePromise().then(() => {}, () => {}, () => {})
-   · ────────────────────────────────────────────────
-   ╰────
-
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then()
    · ───────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 0
-   ╭─[valid_params.tsx:1:1]
- 1 │ promiseReference.then()
-   · ───────────────────────
-   ╰────
-
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 3
+  ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then(() => {}, () => {}, () => {})
    · ───────────────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.then() requires 1 or 2 arguments, but received 3
-   ╭─[valid_params.tsx:1:1]
- 1 │ promiseReference.then(() => {}, () => {}, () => {})
-   · ───────────────────────────────────────────────────
-   ╰────
-
-  ⚠ eslint-plugin-promise(valid-params): Promise.catch() requires 1 argument, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch()
    · ─────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.catch() requires 1 argument, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch(() => {}, () => {})
    · ───────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.catch() requires 1 argument, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch()
    · ────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.catch() requires 1 argument, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch(() => {}, () => {})
    · ──────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.finally() requires 1 argument, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally()
    · ───────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.finally() requires 1 argument, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally(() => {}, () => {})
    · ─────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.finally() requires 1 argument, but received 0
+  ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally()
    · ──────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(valid-params): Promise.finally() requires 1 argument, but received 2
+  ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally(() => {}, () => {})
    · ────────────────────────────────────────────


### PR DESCRIPTION
Remove an unnecessary helper function that caused multiple diagnostics for no reason, and note in the docs that this generally isn't a necessary rule anymore for TypeScript code.

In the future maybe we should just exclude this rule for ts files? *shrug*