### PR TITLE
chore(linter): Use meaningful param names in various diagnostic functions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -7,12 +7,12 @@ use serde_json::Value;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(x0.to_string())
+fn max_params_diagnostic(message: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(message.to_string())
         .with_help(
             "This rule enforces a maximum number of parameters allowed in function definitions.",
         )
-        .with_label(span1)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -10,8 +10,14 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_jasmine_globals_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0:?}")).with_help(format!("{x1:?}")).with_label(span2)
+fn no_jasmine_globals_diagnostic(
+    error_message: &str,
+    help_text: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{error_message:?}"))
+        .with_help(format!("{help_text:?}"))
+        .with_label(span)
 }
 
 /// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-jasmine-globals.md>

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -12,12 +12,12 @@ use crate::{
     utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call},
 };
 
-fn restricted_jest_method(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use of `{x0}` is not allowed")).with_label(span1)
+fn restricted_jest_method(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed")).with_label(span)
 }
 
-fn restricted_jest_method_with_message(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(x0.to_string()).with_label(span1)
+fn restricted_jest_method_with_message(message: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(message.to_string()).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -12,7 +12,9 @@ fn add_type_parameter_to_module_mock_diagnostic(module_name: &str, span: Span) -
     OxcDiagnostic::warn(
         "`jest.mock()` factories should not be used without an explicit type parameter.",
     )
-    .with_help(format!("Add a type parameter to the mock factory such as `typeof import({module_name:?})`"))
+    .with_help(format!(
+        "Add a type parameter to the mock factory such as `typeof import({module_name:?})`"
+    ))
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -8,12 +8,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::PossibleJestNode};
 
-fn add_type_parameter_to_module_mock_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn add_type_parameter_to_module_mock_diagnostic(module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "`jest.mock()` factories should not be used without an explicit type parameter.",
     )
-    .with_help(format!("Add a type parameter to the mock factory such as `typeof import({x0:?})`"))
-    .with_label(span1)
+    .with_help(format!("Add a type parameter to the mock factory such as `typeof import({module_name:?})`"))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -17,10 +17,10 @@ use crate::{
     },
 };
 
-fn use_to_be_comparison(x0: &str, span1: Span) -> OxcDiagnostic {
+fn use_to_be_comparison(preferred_method: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using the built-in comparison matchers")
-        .with_help(format!("Prefer using `{x0:?}` instead"))
-        .with_label(span1)
+        .with_help(format!("Prefer using `{preferred_method:?}` instead"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -8,10 +8,10 @@ use oxc_span::{Atom, Span};
 
 use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, utils::get_node_name};
 
-fn use_mock_shorthand(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer mock resolved/rejected shorthands for promises")
-        .with_help(format!("Prefer {x0:?}"))
-        .with_label(span1)
+fn use_mock_shorthand(preferred_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer mock resolved/rejected shorthands for promises.")
+        .with_help(format!("Prefer {preferred_name:?}"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -17,8 +17,8 @@ use crate::{
     utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, parse_general_jest_fn_call},
 };
 
-fn valid_title_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0:?}")).with_help(format!("{x1:?}")).with_label(span2)
+fn valid_title_diagnostic(error_message: &str, help_text: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{error_message:?}")).with_help(format!("{help_text:?}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -26,12 +26,19 @@ pub struct ValidTitle(Box<ValidTitleConfig>);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidTitleConfig {
+    /// Whether to ignore the type of the name passed to `test`.
     ignore_type_of_test_name: bool,
+    /// Whether to ignore the type of the name passed to `describe`.
     ignore_type_of_describe_name: bool,
+    /// Whether to allow arguments as titles.
     allow_arguments: bool,
+    /// A list of disallowed words, which will not be allowed in titles.
     disallowed_words: Vec<CompactStr>,
+    /// Whether to ignore leading and trailing spaces in titles.
     ignore_space: bool,
+    /// Patterns for titles that must not match.
     must_not_match_patterns: FxHashMap<MatchKind, CompiledMatcherAndMessage>,
+    /// Patterns for titles that must be matched for the title to be valid.
     must_match_patterns: FxHashMap<MatchKind, CompiledMatcherAndMessage>,
 }
 
@@ -91,7 +98,6 @@ declare_oxc_lint!(
     ///     mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
     /// }
     /// ```
-    ///
     ValidTitle,
     jest,
     correctness,

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -18,7 +18,9 @@ use crate::{
 };
 
 fn valid_title_diagnostic(error_message: &str, help_text: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{error_message:?}")).with_help(format!("{help_text:?}")).with_label(span)
+    OxcDiagnostic::warn(format!("{error_message:?}"))
+        .with_help(format!("{help_text:?}"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/jest_prefer_mock_promise_shorthand.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_mock_promise_shorthand.snap
@@ -1,105 +1,105 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42, 25))
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ jest.fn().mockImplementation(() => Promise.reject(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.resolve(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => { return Promise.resolve(42); })
    ·           ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42),)
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementationOnce(() => Promise.resolve(42))
    ·           ──────────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementationOnce(() => Promise.reject(42))
    ·           ──────────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ jest.fn().mockReturnValue(Promise.resolve(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ jest.fn().mockReturnValue(Promise.reject(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValue(Promise.resolve(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValue(Promise.reject(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve(42))
    ·           ───────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(42))
    ·           ───────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:2:27]
  1 │ 
  2 │                 aVariable.mockReturnValue(Promise.resolve({
@@ -108,7 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:5:22]
  4 │                     .mockImplementation(() => Promise.resolve(42))
  5 │                     .mockReturnValue(Promise.reject(42))
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:4:22]
  3 │                     .mockImplementation(() => Promise.reject(42))
  4 │                     .mockImplementation(() => Promise.resolve(42))
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:3:22]
  2 │                 aVariable
  3 │                     .mockImplementation(() => Promise.reject(42))
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:5:22]
  4 │                     .mockImplementation(() => Promise.resolve(42))
  5 │                     .mockReturnValueOnce(Promise.reject(42))
@@ -144,7 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:4:22]
  3 │                     .mockReturnValueOnce(Promise.reject(42))
  4 │                     .mockImplementation(() => Promise.resolve(42))
@@ -153,7 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:3:22]
  2 │                 aVariable
  3 │                     .mockReturnValueOnce(Promise.reject(42))
@@ -162,7 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:2:27]
  1 │ 
  2 │                 aVariable.mockReturnValueOnce(
@@ -171,217 +171,217 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ jest.fn().mockReturnValue(Promise.resolve(42), xyz)
    ·           ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ jest.fn().mockImplementation(() => Promise.reject(42), xyz)
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve(42, xyz))
    ·           ───────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve())
    ·           ───────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:28]
  1 │ jest.spyOn(fs, "readFile").mockReturnValue(Promise.reject(new Error("oh noes!")))
    ·                            ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockImplementation(() => Promise.resolve(42))
    ·         ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockImplementation(() => Promise.reject(42))
    ·         ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.resolve(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => { return Promise.resolve(42) })
    ·           ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42),)
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementationOnce(() => Promise.resolve(42))
    ·           ──────────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementationOnce(() => Promise.reject(42))
    ·           ──────────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockReturnValue(Promise.resolve(42))
    ·         ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockReturnValue(Promise.reject(42))
    ·         ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValue(Promise.resolve(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValue(Promise.reject(42))
    ·           ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve(42))
    ·           ───────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(42))
    ·           ───────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValue(Promise.resolve({ target: 'world', message: 'hello' }))
    ·           ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:102]
  1 │ aVariable.mockImplementation(() => Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValue(Promise.reject(42))
    ·                                                                                                      ───────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:56]
  1 │ aVariable.mockImplementation(() => Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValue(Promise.reject(42))
    ·                                                        ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockImplementation(() => Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValue(Promise.reject(42))
    ·           ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:97]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValueOnce(Promise.reject(42))
    ·                                                                                                 ───────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:51]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValueOnce(Promise.reject(42))
    ·                                                   ──────────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(42)).mockImplementation(() => Promise.resolve(42)).mockReturnValueOnce(Promise.reject(42))
    ·           ───────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.reject(new Error('oh noes!')))
    ·           ───────────────────
    ╰────
   help: Prefer "mockRejectedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockReturnValue(Promise.resolve(42), xyz)
    ·         ───────────────
    ╰────
   help: Prefer "mockResolvedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:9]
  1 │ vi.fn().mockImplementation(() => Promise.reject(42), xyz)
    ·         ──────────────────
    ╰────
   help: Prefer "mockRejectedValue"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve(42, xyz))
    ·           ───────────────────
    ╰────
   help: Prefer "mockResolvedValueOnce"
 
-  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises
+  ⚠ eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises.
    ╭─[prefer_mock_promise_shorthand.tsx:1:11]
  1 │ aVariable.mockReturnValueOnce(Promise.resolve())
    ·           ───────────────────


### PR DESCRIPTION
This updates various rules' diagnostic functions to replace parameter names like `x0` with actual names. Also adds some comments to jest/valid-title for later when we can eventually generate docs from them. 

There are now no more usages of `x0` in the oxc_linter directory.