### PR TITLE
chore(editor): Fix "VSCode" to "VS Code" in a few places.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ type: Bug
 ---
 
 <!--
-!!IMPORTANT!! If you are reporting a bug for Oxlint or the Oxc VSCode extension,
+!!IMPORTANT!! If you are reporting a bug for Oxlint or the Oxc VS Code extension,
 please use the "Linter bug report" template instead. You can find it here:
 https://github.com/oxc-project/oxc/issues/new?labels=C-bug,A-linter&projects=&template=linter_bug_report.yaml&title=linter:+
 -->

--- a/editors/vscode/client/StatusBarItemHandler.ts
+++ b/editors/vscode/client/StatusBarItemHandler.ts
@@ -41,7 +41,7 @@ export default class StatusBarItemHandler {
       this.statusBarItem.tooltip.isTrusted = true;
     }
 
-    this.statusBarItem.tooltip.value = `VSCode Extension v${this.extensionVersion}\n\n---\n\n${text}`;
+    this.statusBarItem.tooltip.value = `VS Code Extension v${this.extensionVersion}\n\n---\n\n${text}`;
   }
 
   public dispose(): void {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-vscode",
-  "description": "oxc vscode extension",
+  "description": "oxc vs code extension",
   "license": "MIT",
   "version": "1.29.0",
   "icon": "icon.png",


### PR DESCRIPTION
Just a minor styling nit