### PR TITLE
refactor(oxlint): use vitest `expect` rather than node:assert in test cases

### DIFF
--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -1,5 +1,5 @@
-import assert from 'node:assert';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
 import { getTokens } from '../src-js/plugins/tokens.js';
 import type { Node } from '../src-js/plugins/types.js';
 
@@ -26,81 +26,96 @@ describe('when calling getTokens', () => {
   const BinaryExpression = { range: [26, 35] } as Node;
 
   it('should retrieve all tokens for root node', () => {
-    assert.deepStrictEqual(
-      getTokens(Program).map((token) => token.value),
-      ['var', 'answer', '=', 'a', '*', 'b', 'call', '(', ')', ';'],
-    );
+    expect(getTokens(Program).map((token) => token.value)).toEqual([
+      'var',
+      'answer',
+      '=',
+      'a',
+      '*',
+      'b',
+      'call',
+      '(',
+      ')',
+      ';',
+    ]);
   });
 
   it('should retrieve all tokens for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression).map((token) => token.value),
-      ['a', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression).map((token) => token.value)).toEqual(['a', '*', 'b']);
   });
 
   it('should retrieve all tokens plus one before for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 1).map((token) => token.value),
-      ['=', 'a', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression, 1).map((token) => token.value)).toEqual(['=', 'a', '*', 'b']);
   });
 
   it('should retrieve all tokens plus one after for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 0, 1).map((token) => token.value),
-      ['a', '*', 'b', 'call'],
-    );
+    expect(getTokens(BinaryExpression, 0, 1).map((token) => token.value)).toEqual(['a', '*', 'b', 'call']);
   });
 
   it('should retrieve all tokens plus two before and one after for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 2, 1).map((token) => token.value),
-      ['answer', '=', 'a', '*', 'b', 'call'],
-    );
+    expect(getTokens(BinaryExpression, 2, 1).map((token) => token.value)).toEqual([
+      'answer',
+      '=',
+      'a',
+      '*',
+      'b',
+      'call',
+    ]);
   });
 
   it('should retrieve all matched tokens for root node with filter', () => {
-    assert.deepStrictEqual(
-      getTokens(Program, (t) => t.type === 'Identifier').map((token) => token.value),
-      ['answer', 'a', 'b', 'call'],
-    );
-    assert.deepStrictEqual(
+    expect(getTokens(Program, (t) => t.type === 'Identifier').map((token) => token.value)).toEqual([
+      'answer',
+      'a',
+      'b',
+      'call',
+    ]);
+    expect(
       getTokens(Program, {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['answer', 'a', 'b', 'call'],
-    );
+    ).toEqual(['answer', 'a', 'b', 'call']);
   });
 
   it('should retrieve all tokens and comments in the node for root node with includeComments option', () => {
-    assert.deepStrictEqual(
-      getTokens(Program, { includeComments: true }).map((token) => token.value),
-      ['var', 'answer', 'B', '=', 'C', 'a', 'D', '*', 'b', 'E', 'F', 'call', '(', ')', ';'],
-    );
+    expect(getTokens(Program, { includeComments: true }).map((token) => token.value)).toEqual([
+      'var',
+      'answer',
+      'B',
+      '=',
+      'C',
+      'a',
+      'D',
+      '*',
+      'b',
+      'E',
+      'F',
+      'call',
+      '(',
+      ')',
+      ';',
+    ]);
   });
 
   it('should retrieve matched tokens and comments in the node for root node with includeComments and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokens(Program, {
         includeComments: true,
         filter: (t) => t.type.startsWith('Block'),
       }).map((token) => token.value),
-      ['B', 'C', 'D', 'E'],
-    );
+    ).toEqual(['B', 'C', 'D', 'E']);
   });
 
   it('should retrieve all tokens and comments in the node for binary expression with includeComments option', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, { includeComments: true }).map((token) => token.value),
-      ['a', 'D', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression, { includeComments: true }).map((token) => token.value)).toEqual([
+      'a',
+      'D',
+      '*',
+      'b',
+    ]);
   });
 
   it('should handle out of range nodes gracefully', () => {
-    assert.deepStrictEqual(
-      getTokens({ range: [1000, 1001] } as Node).map((token) => token.value),
-      [],
-    );
+    expect(getTokens({ range: [1000, 1001] } as Node).map((token) => token.value)).toEqual([]);
   });
 });


### PR DESCRIPTION
Using vitest's expect here is more idomatic, considering we're using vitest for our tests, and it should give us better diffs in case of failures.