### PR TITLE
feat(tasks/lint-rules): track rules with pending fixes in automated issues

### DIFF
--- a/tasks/lint_rules/src/main.mjs
+++ b/tasks/lint_rules/src/main.mjs
@@ -8,6 +8,7 @@ import {
   syncVitestPluginStatusWithJestPluginStatus,
   updateImplementedStatus,
   updateNotSupportedStatus,
+  updatePendingFixStatus,
 } from './oxlint-rules.mjs';
 import { updateGitHubIssue } from './result-reporter.mjs';
 
@@ -58,6 +59,7 @@ void (async () => {
   const ruleEntries = createRuleEntries(linter.getRules());
   await updateImplementedStatus(ruleEntries);
   updateNotSupportedStatus(ruleEntries);
+  await updatePendingFixStatus(ruleEntries);
   await syncTypeScriptPluginStatusWithEslintPluginStatus(ruleEntries);
   await syncVitestPluginStatusWithJestPluginStatus(ruleEntries);
   syncUnicornPluginStatusWithEslintPluginStatus(ruleEntries);


### PR DESCRIPTION
Add functionality to detect and display linter rules that have pending
auto-fixes in the automated GitHub tracking issues.

- Add readAllPendingFixRuleNames() to scan rule files for `pending` keyword
- Update RuleEntry type to include isPendingFix field
- Add updatePendingFixStatus() to mark implemented rules with pending fixes
- Update markdown renderer to show ⏳ emoji for pending fixes
- Add pending fix counts to summary and table headers
- Preserve isPendingFix status across plugin sync operations

Fixes #15977