### PR TITLE
feat(linter): add ignores option to overrides

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -419,6 +419,10 @@ export interface OxlintOverride {
    */
   globals?: OxlintGlobals;
   /**
+   * If a file matches any of these glob patterns, the overrides configuration won't apply.
+   */
+  ignores?: GlobSet;
+  /**
    * JS plugins for this override, allows usage of ESLint plugins with Oxlint.
    *
    * Read more about JS plugins in

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -536,6 +536,7 @@ impl ConfigStoreBuilder {
 
                 Ok::<_, Vec<OverrideRulesError>>(ResolvedOxlintOverride {
                     files: override_config.files,
+                    ignores: override_config.ignores,
                     env: override_config.env,
                     globals: override_config.globals,
                     plugins: override_config.plugins,

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -46,10 +46,18 @@ impl ResolvedOxlintOverrides {
 #[derive(Debug, Clone)]
 pub struct ResolvedOxlintOverride {
     pub files: GlobSet,
+    pub ignores: Option<GlobSet>,
     pub env: Option<OxlintEnv>,
     pub globals: Option<OxlintGlobals>,
     pub plugins: Option<LintPlugins>,
     pub rules: ResolvedOxlintOverrideRules,
+}
+
+impl ResolvedOxlintOverride {
+    pub fn is_match(&self, path: &str) -> bool {
+        self.files.is_match(path)
+            && !self.ignores.as_ref().is_some_and(|ignores| ignores.is_match(path))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -136,7 +144,7 @@ impl Config {
 
         let path = relative_path.to_string_lossy();
         let overrides_to_apply =
-            self.overrides.iter().filter(|config| config.files.is_match(path.as_ref()));
+            self.overrides.iter().filter(|config| config.is_match(path.as_ref()));
 
         let mut overrides_to_apply = overrides_to_apply.peekable();
 
@@ -429,6 +437,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
+            ignores: None,
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -460,6 +469,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
+            ignores: None,
             plugins: Some(
                 LintPlugins::REACT
                     | LintPlugins::TYPESCRIPT
@@ -496,6 +506,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.test.{ts,tsx}"]),
+            ignores: None,
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -533,6 +544,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]),
+            ignores: Some(GlobSet::new(vec!["src/foobar/**/*"])),
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -562,6 +574,11 @@ mod test {
         assert_eq!(store.resolve("src/App.ts".as_ref()).rules.len(), 2);
         assert_eq!(store.resolve("src/foo/bar/baz/App.tsx".as_ref()).rules.len(), 2);
         assert_eq!(store.resolve("src/foo/bar/baz/App.spec.tsx".as_ref()).rules.len(), 2);
+        // ignored files
+        assert_eq!(store.resolve("src/foobar/App.tsx".as_ref()).rules.len(), 1);
+        assert_eq!(store.resolve("src/foobar/App.spec.tsx".as_ref()).rules.len(), 1);
+        assert_eq!(store.resolve("src/foobar/baz/App.tsx".as_ref()).rules.len(), 1);
+        assert_eq!(store.resolve("src/foobar/baz/App.spec.tsx".as_ref()).rules.len(), 1);
     }
 
     #[test]
@@ -570,6 +587,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["src/**/*.{ts,tsx}"]),
+            ignores: None,
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -610,6 +628,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.jsx", "*.tsx"]),
+                ignores: None,
                 plugins: Some(LintPlugins::REACT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -620,6 +639,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.ts", "*.tsx"]),
+                ignores: None,
                 plugins: Some(LintPlugins::TYPESCRIPT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -656,6 +676,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: Some(OxlintEnv::from_iter(["es2024".to_string()])),
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -678,6 +699,7 @@ mod test {
             LintConfig { env: OxlintEnv::from_iter(["es2024".into()]), ..Default::default() };
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             env: Some(from_json!({ "es2024": false })),
             plugins: None,
             globals: None,
@@ -701,6 +723,7 @@ mod test {
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             env: None,
             plugins: None,
             globals: Some(from_json!({ "React": "readonly", "Secret": "writable" })),
@@ -739,6 +762,7 @@ mod test {
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             files: GlobSet::new(vec!["*.ts"]),
+            ignores: None,
             env: None,
             plugins: None,
             globals: None,
@@ -776,6 +800,7 @@ mod test {
 
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             env: None,
             plugins: None,
             globals: Some(from_json!({ "React": "off", "Secret": "off" })),
@@ -821,6 +846,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
+                ignores: None,
                 plugins: Some(LintPlugins::TYPESCRIPT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -832,6 +858,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx}"]),
+                ignores: None,
                 plugins: Some(LintPlugins::REACT),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -846,6 +873,7 @@ mod test {
             ResolvedOxlintOverride {
                 env: None,
                 files: GlobSet::new(vec!["*.{ts,tsx,mts}"]),
+                ignores: None,
                 plugins: Some(LintPlugins::UNICORN),
                 globals: None,
                 rules: ResolvedOxlintOverrideRules {
@@ -907,6 +935,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             plugins: Some(LintPlugins::REACT),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -940,6 +969,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             plugins: None,
             globals: None,
             rules: ResolvedOxlintOverrideRules {
@@ -1019,6 +1049,7 @@ mod test {
         let overrides = ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
             env: None,
             files: GlobSet::new(vec!["*.tsx"]),
+            ignores: None,
             plugins: Some(LintPlugins::TYPESCRIPT),
             globals: None,
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
@@ -1137,6 +1168,7 @@ mod test {
             LintConfig::default(),
             ResolvedOxlintOverrides::new(vec![ResolvedOxlintOverride {
                 files: GlobSet::new(vec!["*.js"]),
+                ignores: None,
                 env: None,
                 globals: None,
                 plugins: None,

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -85,6 +85,9 @@ pub struct OxlintOverride {
     /// `[ "*.test.ts", "*.spec.ts" ]`
     pub files: GlobSet,
 
+    /// If a file matches any of these glob patterns, the overrides configuration won't apply.
+    pub ignores: Option<GlobSet>,
+
     /// Environments enable and disable collections of global variables.
     pub env: Option<OxlintEnv>,
 
@@ -219,6 +222,15 @@ mod test {
         .unwrap();
         assert!(config.files.is_match("../foo.js"));
         assert!(!config.files.is_match("foo.js"));
+
+        // Test ignores pattern
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx",],
+            "ignores": ["*.test.tsx"]
+        }))
+        .unwrap();
+        assert!(config.files.is_match("/some/path/foo.tsx"));
+        assert!(config.ignores.is_some_and(|ignores| ignores.is_match("/some/path/foo.test.tsx")));
     }
 
     #[test]

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -522,6 +522,18 @@ expression: json
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
         },
+        "ignores": {
+          "description": "If a file matches any of these glob patterns, the overrides configuration won't apply.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "If a file matches any of these glob patterns, the overrides configuration won't apply."
+        },
         "jsPlugins": {
           "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.",
           "anyOf": [

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -553,6 +553,15 @@
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
         },
+        "ignores": {
+          "description": "If a file matches any of these glob patterns, the overrides configuration won't apply.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
+          "markdownDescription": "If a file matches any of these glob patterns, the overrides configuration won't apply."
+        },
         "jsPlugins": {
           "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.",
           "anyOf": [

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -557,6 +557,15 @@ expression: json
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
         },
+        "ignores": {
+          "description": "If a file matches any of these glob patterns, the overrides configuration won't apply.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
+          "markdownDescription": "If a file matches any of these glob patterns, the overrides configuration won't apply."
+        },
         "jsPlugins": {
           "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.",
           "anyOf": [

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -428,6 +428,22 @@ type: `object`
 Enabled or disabled specific global variables.
 
 
+#### overrides[n].ignores
+
+type: `array`
+
+
+If a file matches any of these glob patterns, the overrides configuration won't apply.
+
+
+##### overrides[n].ignores[n]
+
+type: `string`
+
+
+
+
+
 #### overrides[n].jsPlugins
 
 type: `array`


### PR DESCRIPTION
This will add a new `ignores` option to oxlint override config, allowing excluding some files matched by `files` from applying the override.

Resolves #15932