### PR TITLE
test(linter/plugins): remove unnecessary lint disable comment

### DIFF
--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -46,7 +46,6 @@ vi.mock('../src-js/plugins/source_code.ts', async (importOriginal) => {
 // https://github.com/typescript-eslint/typescript-eslint/issues/11026#issuecomment-3421887632
 const Program = { range: [5, 55] } as Node;
 const BinaryExpression = { range: [26, 35] } as Node;
-/* oxlint-disable-next-line no-unused-vars */
 const VariableDeclaratorIdentifier = { range: [9, 15] } as Node;
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L62


### PR DESCRIPTION
Not sure why oxlint didn't flag that this `oxlint-disable-next-line` comment is unnecessary, but it is. Remove it.