### PR TITLE
perf(linter/plugins): lazy-load tokens parsing code

### DIFF
--- a/apps/oxlint/src-js/plugins/ts_eslint.cjs
+++ b/apps/oxlint/src-js/plugins/ts_eslint.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('@typescript-eslint/typescript-estree');


### PR DESCRIPTION
Tokens APIs (#15861 and further PRs) utilize TS-ESLint for parsing. TS-ESLint uses TypeScript internally. So this pulls in a ton of code (8 MB unminified).

Lazy-load this code only when tokens APIs are used for the first time, so that users don't pay for it if their plugins don't use these APIs (or plugins only use tokens APIs for fixes, and the code being linted has no errors that require fixing).

Do this by compiling `@typescript-eslint/typescript-estree` into a separate bundle. It's bundled as CommonJS, so it can be synchonously `require`-ed without needing `require(esm)` support.

Additionally, minify this bundle, which cuts the increase in package size due to TS-ESLint from 8 MB to 3.7 MB. That's still a lot, but not *completely* unacceptable, given that the `oxlint` binary is around 9.3 MB. As soon as we can, we'll re-implement token-generation in Oxc parser, and then we'll be able to remove TS-ESLint again.