### PR TITLE
ci(tools): linting check for unused disable directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-test",
     "test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" test",
     "fmt": "oxfmt -c oxfmtrc.jsonc",
-    "lint": "oxlint -c oxlintrc.json --deny-warnings --type-aware"
+    "lint": "oxlint -c oxlintrc.json --deny-warnings --type-aware --report-unused-disable-directives"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "0.18.2",


### PR DESCRIPTION
After #16013, #16014, and #16053, we can now enable checking for unused `oxlint-disable` comments in our linting setup.