### PR TITLE
test(linter/plugins): replace `assert` with vitest's `expect`

### DIFF
--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -293,7 +293,7 @@ describe('when calling getTokenBefore', () => {
     sourceText = '/*comment*/ a + b';
     // TODO: this verbatim range should be replaced with `ast.comments[0]`
     const token = getTokenBefore({ range: [0, 11] } as Node, { includeComments: true });
-    expect(token).toBe(null);
+    expect(token).toBeNull();
   });
 });
 
@@ -380,7 +380,7 @@ describe('when calling getTokenAfter', () => {
     const token = getTokenAfter({ range: [6, 17] } as Node, {
       includeComments: true,
     });
-    expect(token).toBe(null);
+    expect(token).toBeNull();
   });
 });
 
@@ -632,13 +632,13 @@ describe('when calling getFirstToken', () => {
           expect.fail('Unexpected call to filter callback');
         },
       }),
-    ).toBe(null);
+    ).toBeNull();
   });
 
   it('should return null if the source is empty', () => {
     sourceText = '';
     // TODO: this verbatim range should be replaced with `ast`
-    expect(getFirstToken({ range: [0, 0] } as Node)).toBe(null);
+    expect(getFirstToken({ range: [0, 0] } as Node)).toBeNull();
   });
 });
 

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -1,5 +1,4 @@
-import assert from 'node:assert';
-import { beforeEach, describe, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getTokens,
   getTokensBefore,
@@ -57,330 +56,313 @@ const VariableDeclaratorIdentifier = { range: [9, 15] } as Node;
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L62
 describe('when calling getTokens', () => {
   it('should retrieve all tokens for root node', () => {
-    assert.deepStrictEqual(
-      getTokens(Program).map((token) => token.value),
-      ['var', 'answer', '=', 'a', '*', 'b', 'call', '(', ')', ';'],
-    );
+    expect(getTokens(Program).map((token) => token.value)).toEqual([
+      'var',
+      'answer',
+      '=',
+      'a',
+      '*',
+      'b',
+      'call',
+      '(',
+      ')',
+      ';',
+    ]);
   });
 
   it('should retrieve all tokens for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression).map((token) => token.value),
-      ['a', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression).map((token) => token.value)).toEqual(['a', '*', 'b']);
   });
 
   it('should retrieve all tokens plus one before for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 1).map((token) => token.value),
-      ['=', 'a', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression, 1).map((token) => token.value)).toEqual(['=', 'a', '*', 'b']);
   });
 
   it('should retrieve all tokens plus one after for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 0, 1).map((token) => token.value),
-      ['a', '*', 'b', 'call'],
-    );
+    expect(getTokens(BinaryExpression, 0, 1).map((token) => token.value)).toEqual(['a', '*', 'b', 'call']);
   });
 
   it('should retrieve all tokens plus two before and one after for binary expression', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, 2, 1).map((token) => token.value),
-      ['answer', '=', 'a', '*', 'b', 'call'],
-    );
+    expect(getTokens(BinaryExpression, 2, 1).map((token) => token.value)).toEqual([
+      'answer',
+      '=',
+      'a',
+      '*',
+      'b',
+      'call',
+    ]);
   });
 
   it('should retrieve all matched tokens for root node with filter', () => {
-    assert.deepStrictEqual(
-      getTokens(Program, (t) => t.type === 'Identifier').map((token) => token.value),
-      ['answer', 'a', 'b', 'call'],
-    );
-    assert.deepStrictEqual(
+    expect(getTokens(Program, (t) => t.type === 'Identifier').map((token) => token.value)).toEqual([
+      'answer',
+      'a',
+      'b',
+      'call',
+    ]);
+    expect(
       getTokens(Program, {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['answer', 'a', 'b', 'call'],
-    );
+    ).toEqual(['answer', 'a', 'b', 'call']);
   });
 
   it('should retrieve all tokens and comments in the node for root node with includeComments option', () => {
-    assert.deepStrictEqual(
-      getTokens(Program, { includeComments: true }).map((token) => token.value),
-      ['var', 'answer', 'B', '=', 'C', 'a', 'D', '*', 'b', 'E', 'F', 'call', '(', ')', ';'],
-    );
+    expect(getTokens(Program, { includeComments: true }).map((token) => token.value)).toEqual([
+      'var',
+      'answer',
+      'B',
+      '=',
+      'C',
+      'a',
+      'D',
+      '*',
+      'b',
+      'E',
+      'F',
+      'call',
+      '(',
+      ')',
+      ';',
+    ]);
   });
 
   it('should retrieve matched tokens and comments in the node for root node with includeComments and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokens(Program, {
         includeComments: true,
         filter: (t) => t.type.startsWith('Block'),
       }).map((token) => token.value),
-      ['B', 'C', 'D', 'E'],
-    );
+    ).toEqual(['B', 'C', 'D', 'E']);
   });
 
   it('should retrieve all tokens and comments in the node for binary expression with includeComments option', () => {
-    assert.deepStrictEqual(
-      getTokens(BinaryExpression, { includeComments: true }).map((token) => token.value),
-      ['a', 'D', '*', 'b'],
-    );
+    expect(getTokens(BinaryExpression, { includeComments: true }).map((token) => token.value)).toEqual([
+      'a',
+      'D',
+      '*',
+      'b',
+    ]);
   });
 
   it('should handle out of range nodes gracefully', () => {
-    assert.deepStrictEqual(
-      getTokens({ range: [1000, 1001] } as Node).map((token) => token.value),
-      [],
-    );
+    expect(getTokens({ range: [1000, 1001] } as Node).map((token) => token.value)).toEqual([]);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L157
 describe('when calling getTokensBefore', () => {
   it('should retrieve zero tokens before a node', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(BinaryExpression, 0).map((token) => token.value),
-      [],
-    );
+    expect(getTokensBefore(BinaryExpression, 0).map((token) => token.value)).toEqual([]);
   });
 
   it('should retrieve one token before a node', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(BinaryExpression, 1).map((token) => token.value),
-      ['='],
-    );
+    expect(getTokensBefore(BinaryExpression, 1).map((token) => token.value)).toEqual(['=']);
   });
 
   it('should retrieve more than one token before a node', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(BinaryExpression, 2).map((token) => token.value),
-      ['answer', '='],
-    );
+    expect(getTokensBefore(BinaryExpression, 2).map((token) => token.value)).toEqual(['answer', '=']);
   });
 
   it('should retrieve all tokens before a node', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(BinaryExpression, 9e9).map((token) => token.value),
-      ['var', 'answer', '='],
-    );
+    expect(getTokensBefore(BinaryExpression, 9e9).map((token) => token.value)).toEqual(['var', 'answer', '=']);
   });
 
   it('should retrieve more than one token before a node with count option', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(BinaryExpression, { count: 2 }).map((token) => token.value),
-      ['answer', '='],
-    );
+    expect(getTokensBefore(BinaryExpression, { count: 2 }).map((token) => token.value)).toEqual(['answer', '=']);
   });
 
   it('should retrieve matched tokens before a node with count and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensBefore(BinaryExpression, {
         count: 1,
         filter: (t) => t.value !== '=',
       }).map((token) => token.value),
-      ['answer'],
-    );
+    ).toEqual(['answer']);
   });
 
   it('should retrieve all matched tokens before a node with filter option', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensBefore(BinaryExpression, {
         filter: (t) => t.value !== 'answer',
       }).map((token) => token.value),
-      ['var', '='],
-    );
+    ).toEqual(['var', '=']);
   });
 
   it('should retrieve no tokens before the root node', () => {
-    assert.deepStrictEqual(
-      getTokensBefore(Program, { count: 1 }).map((token) => token.value),
-      [],
-    );
+    expect(getTokensBefore(Program, { count: 1 }).map((token) => token.value)).toEqual([]);
   });
 
   it('should retrieve tokens and comments before a node with count and includeComments option', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensBefore(BinaryExpression, {
         count: 3,
         includeComments: true,
       }).map((token) => token.value),
-      ['B', '=', 'C'],
-    );
+    ).toEqual(['B', '=', 'C']);
   });
 
   it('should retrieve all tokens and comments before a node with includeComments option only', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensBefore(BinaryExpression, {
         includeComments: true,
       }).map((token) => token.value),
-      ['A', 'var', 'answer', 'B', '=', 'C'],
-    );
+    ).toEqual(['A', 'var', 'answer', 'B', '=', 'C']);
   });
 
   it('should retrieve all tokens and comments before a node with includeComments and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensBefore(BinaryExpression, {
         includeComments: true,
         filter: (t) => t.type.startsWith('Block'),
       }).map((token) => token.value),
-      ['A', 'B', 'C'],
-    );
+    ).toEqual(['A', 'B', 'C']);
   });
 });
 
 describe('when calling getTokenBefore', () => {
   it('should retrieve one token before a node', () => {
-    assert.strictEqual(getTokenBefore(BinaryExpression)!.value, '=');
+    expect(getTokenBefore(BinaryExpression)!.value).toBe('=');
   });
 
   it('should skip a given number of tokens', () => {
-    assert.strictEqual(getTokenBefore(BinaryExpression, 1)!.value, 'answer');
-    assert.strictEqual(getTokenBefore(BinaryExpression, 2)!.value, 'var');
+    expect(getTokenBefore(BinaryExpression, 1)!.value).toBe('answer');
+    expect(getTokenBefore(BinaryExpression, 2)!.value).toBe('var');
   });
 
   it('should skip a given number of tokens with skip option', () => {
-    assert.strictEqual(getTokenBefore(BinaryExpression, { skip: 1 })!.value, 'answer');
-    assert.strictEqual(getTokenBefore(BinaryExpression, { skip: 2 })!.value, 'var');
+    expect(getTokenBefore(BinaryExpression, { skip: 1 })!.value).toBe('answer');
+    expect(getTokenBefore(BinaryExpression, { skip: 2 })!.value).toBe('var');
   });
 
   it('should retrieve matched token with filter option', () => {
-    assert.strictEqual(getTokenBefore(BinaryExpression, (t) => t.value !== '=')!.value, 'answer');
+    expect(getTokenBefore(BinaryExpression, (t) => t.value !== '=')!.value).toBe('answer');
   });
 
   it('should retrieve matched token with skip and filter options', () => {
-    assert.strictEqual(
+    expect(
       getTokenBefore(BinaryExpression, {
         skip: 1,
         filter: (t) => t.value !== '=',
       })!.value,
-      'var',
-    );
+    ).toBe('var');
   });
 
   it('should retrieve one token or comment before a node with includeComments option', () => {
-    assert.strictEqual(
+    expect(
       getTokenBefore(BinaryExpression, {
         includeComments: true,
       })!.value,
-      'C',
-    );
+    ).toBe('C');
   });
 
   it('should retrieve one token or comment before a node with includeComments and skip options', () => {
-    assert.strictEqual(
+    expect(
       getTokenBefore(BinaryExpression, {
         includeComments: true,
         skip: 1,
       })!.value,
-      '=',
-    );
+    ).toBe('=');
   });
 
   it('should retrieve one token or comment before a node with includeComments and skip and filter options', () => {
-    assert.strictEqual(
+    expect(
       getTokenBefore(BinaryExpression, {
         includeComments: true,
         skip: 1,
         filter: (t) => t.type.startsWith('Block'),
       })!.value,
-      'B',
-    );
+    ).toBe('B');
   });
 
   it('should retrieve the previous node if the comment at the end of source code is specified.', () => {
     sourceText = 'a + b /*comment*/';
     // TODO: this verbatim range should be replaced with `ast.comments[0]`
     const token = getTokenBefore({ range: [6, 17] } as Node);
-    assert.strictEqual(token!.value, 'b');
+    expect(token!.value).toBe('b');
   });
 
   it('should retrieve the previous comment if the first token is specified.', () => {
     sourceText = '/*comment*/ a + b';
     // TODO: this verbatim range should be replaced with `ast.tokens[0]`
     const token = getTokenBefore({ range: [12, 13] } as Node, { includeComments: true });
-    assert.strictEqual(token!.value, 'comment');
+    expect(token!.value).toBe('comment');
   });
 
   it('should retrieve null if the first comment is specified.', () => {
     sourceText = '/*comment*/ a + b';
     // TODO: this verbatim range should be replaced with `ast.comments[0]`
     const token = getTokenBefore({ range: [0, 11] } as Node, { includeComments: true });
-    assert.strictEqual(token, null);
+    expect(token).toBe(null);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L461
 describe('when calling getTokenAfter', () => {
   it('should retrieve one token after a node', () => {
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier)!.value, '=');
+    expect(getTokenAfter(VariableDeclaratorIdentifier)!.value).toBe('=');
   });
 
   it('should skip a given number of tokens', () => {
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier, 1)!.value, 'a');
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier, 2)!.value, '*');
+    expect(getTokenAfter(VariableDeclaratorIdentifier, 1)!.value).toBe('a');
+    expect(getTokenAfter(VariableDeclaratorIdentifier, 2)!.value).toBe('*');
   });
 
   it('should skip a given number of tokens with skip option', () => {
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier, { skip: 1 })!.value, 'a');
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier, { skip: 2 })!.value, '*');
+    expect(getTokenAfter(VariableDeclaratorIdentifier, { skip: 1 })!.value).toBe('a');
+    expect(getTokenAfter(VariableDeclaratorIdentifier, { skip: 2 })!.value).toBe('*');
   });
 
   it('should retrieve matched token with filter option', () => {
-    assert.strictEqual(getTokenAfter(VariableDeclaratorIdentifier, (t) => t.type === 'Identifier')!.value, 'a');
-    assert.strictEqual(
+    expect(getTokenAfter(VariableDeclaratorIdentifier, (t) => t.type === 'Identifier')!.value).toBe('a');
+    expect(
       getTokenAfter(VariableDeclaratorIdentifier, {
         filter: (t) => t.type === 'Identifier',
       })!.value,
-      'a',
-    );
+    ).toBe('a');
   });
 
   it('should retrieve matched token with filter and skip options', () => {
-    assert.strictEqual(
+    expect(
       getTokenAfter(VariableDeclaratorIdentifier, {
         skip: 1,
         filter: (t) => t.type === 'Identifier',
       })!.value,
-      'b',
-    );
+    ).toBe('b');
   });
 
   it('should retrieve one token or comment after a node with includeComments option', () => {
-    assert.strictEqual(
+    expect(
       getTokenAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
       })!.value,
-      'B',
-    );
+    ).toBe('B');
   });
 
   it('should retrieve one token or comment after a node with includeComments and skip options', () => {
-    assert.strictEqual(
+    expect(
       getTokenAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
         skip: 2,
       })!.value,
-      'C',
-    );
+    ).toBe('C');
   });
 
   it('should retrieve one token or comment after a node with includeComments and skip and filter options', () => {
-    assert.strictEqual(
+    expect(
       getTokenAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
         skip: 2,
         filter: (t) => t.type.startsWith('Block'),
       })!.value,
-      'D',
-    );
+    ).toBe('D');
   });
 
   it('should retrieve the next node if the comment at the first of source code is specified.', () => {
     sourceText = '/*comment*/ a + b';
     // TODO: replace this verbatim range with `ast.comments[0]`
     const token = getTokenAfter({ range: [0, 12] } as Node)!;
-    assert.strictEqual(token.value, 'a');
+    expect(token.value).toBe('a');
   });
 
   it('should retrieve the next comment if the last token is specified.', () => {
@@ -389,7 +371,7 @@ describe('when calling getTokenAfter', () => {
     const token = getTokenAfter({ range: [4, 5] } as Node, {
       includeComments: true,
     });
-    assert.strictEqual(token!.value, 'comment');
+    expect(token!.value).toBe('comment');
   });
 
   it('should retrieve null if the last comment is specified.', () => {
@@ -398,247 +380,212 @@ describe('when calling getTokenAfter', () => {
     const token = getTokenAfter({ range: [6, 17] } as Node, {
       includeComments: true,
     });
-    assert.strictEqual(token, null);
+    expect(token).toBe(null);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L363-L459
 describe('when calling getTokensAfter', () => {
   it('should retrieve zero tokens after a node', () => {
-    assert.deepStrictEqual(
-      getTokensAfter(VariableDeclaratorIdentifier, 0).map((token) => token.value),
-      [],
-    );
+    expect(getTokensAfter(VariableDeclaratorIdentifier, 0).map((token) => token.value)).toEqual([]);
   });
 
   it('should retrieve one token after a node', () => {
-    assert.deepStrictEqual(
-      getTokensAfter(VariableDeclaratorIdentifier, 1).map((token) => token.value),
-      ['='],
-    );
+    expect(getTokensAfter(VariableDeclaratorIdentifier, 1).map((token) => token.value)).toEqual(['=']);
   });
 
   it('should retrieve more than one token after a node', () => {
-    assert.deepStrictEqual(
-      getTokensAfter(VariableDeclaratorIdentifier, 2).map((token) => token.value),
-      ['=', 'a'],
-    );
+    expect(getTokensAfter(VariableDeclaratorIdentifier, 2).map((token) => token.value)).toEqual(['=', 'a']);
   });
 
   it('should retrieve all tokens after a node', () => {
-    assert.deepStrictEqual(
-      getTokensAfter(VariableDeclaratorIdentifier, 9e9).map((token) => token.value),
-      ['=', 'a', '*', 'b', 'call', '(', ')', ';'],
-    );
+    expect(getTokensAfter(VariableDeclaratorIdentifier, 9e9).map((token) => token.value)).toEqual([
+      '=',
+      'a',
+      '*',
+      'b',
+      'call',
+      '(',
+      ')',
+      ';',
+    ]);
   });
 
   it('should retrieve more than one token after a node with count option', () => {
-    assert.deepStrictEqual(
-      getTokensAfter(VariableDeclaratorIdentifier, { count: 2 }).map((token) => token.value),
-      ['=', 'a'],
-    );
+    expect(getTokensAfter(VariableDeclaratorIdentifier, { count: 2 }).map((token) => token.value)).toEqual(['=', 'a']);
   });
 
   it('should retrieve all matched tokens after a node with filter option', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['a', 'b', 'call'],
-    );
+    ).toEqual(['a', 'b', 'call']);
   });
 
   it('should retrieve matched tokens after a node with count and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
         count: 2,
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['a', 'b'],
-    );
+    ).toEqual(['a', 'b']);
   });
 
   it('should retrieve all tokens and comments after a node with includeComments option', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
       }).map((token) => token.value),
-      ['B', '=', 'C', 'a', 'D', '*', 'b', 'E', 'F', 'call', '(', ')', ';', 'Z'],
-    );
+    ).toEqual(['B', '=', 'C', 'a', 'D', '*', 'b', 'E', 'F', 'call', '(', ')', ';', 'Z']);
   });
 
   it('should retrieve several tokens and comments after a node with includeComments and count options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
         count: 3,
       }).map((token) => token.value),
-      ['B', '=', 'C'],
-    );
+    ).toEqual(['B', '=', 'C']);
   });
 
   it('should retrieve matched tokens and comments after a node with includeComments and count and filter options', () => {
-    assert.deepStrictEqual(
+    expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
         includeComments: true,
         count: 3,
         filter: (t) => t.type.startsWith('Block'),
       }).map((token) => token.value),
-      ['B', 'C', 'D'],
-    );
+    ).toEqual(['B', 'C', 'D']);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L594-L673
 describe('when calling getFirstTokens', () => {
   it("should retrieve zero tokens from a node's token stream", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, 0).map((token) => token.value),
-      [],
-    );
+    expect(getFirstTokens(BinaryExpression, 0).map((token) => token.value)).toEqual([]);
   });
 
   it("should retrieve one token from a node's token stream", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, 1).map((token) => token.value),
-      ['a'],
-    );
+    expect(getFirstTokens(BinaryExpression, 1).map((token) => token.value)).toEqual(['a']);
   });
 
   it("should retrieve more than one token from a node's token stream", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, 2).map((token) => token.value),
-      ['a', '*'],
-    );
+    expect(getFirstTokens(BinaryExpression, 2).map((token) => token.value)).toEqual(['a', '*']);
   });
 
   it("should retrieve all tokens from a node's token stream", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, 9e9).map((token) => token.value),
-      ['a', '*', 'b'],
-    );
+    expect(getFirstTokens(BinaryExpression, 9e9).map((token) => token.value)).toEqual(['a', '*', 'b']);
   });
 
   it("should retrieve more than one token from a node's token stream with count option", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, { count: 2 }).map((token) => token.value),
-      ['a', '*'],
-    );
+    expect(getFirstTokens(BinaryExpression, { count: 2 }).map((token) => token.value)).toEqual(['a', '*']);
   });
 
   it("should retrieve matched tokens from a node's token stream with filter option", () => {
-    assert.deepStrictEqual(
-      getFirstTokens(BinaryExpression, (t) => t.type === 'Identifier').map((token) => token.value),
-      ['a', 'b'],
-    );
-    assert.deepStrictEqual(
+    expect(getFirstTokens(BinaryExpression, (t) => t.type === 'Identifier').map((token) => token.value)).toEqual([
+      'a',
+      'b',
+    ]);
+    expect(
       getFirstTokens(BinaryExpression, {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['a', 'b'],
-    );
+    ).toEqual(['a', 'b']);
   });
 
   it("should retrieve matched tokens from a node's token stream with filter and count options", () => {
-    assert.deepStrictEqual(
+    expect(
       getFirstTokens(BinaryExpression, {
         count: 1,
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['a'],
-    );
+    ).toEqual(['a']);
   });
 
   it("should retrieve all tokens and comments from a node's token stream with includeComments option", () => {
-    assert.deepStrictEqual(
+    expect(
       getFirstTokens(BinaryExpression, {
         includeComments: true,
       }).map((token) => token.value),
-      ['a', 'D', '*', 'b'],
-    );
+    ).toEqual(['a', 'D', '*', 'b']);
   });
 
   it("should retrieve several tokens and comments from a node's token stream with includeComments and count options", () => {
-    assert.deepStrictEqual(
+    expect(
       getFirstTokens(BinaryExpression, {
         includeComments: true,
         count: 3,
       }).map((token) => token.value),
-      ['a', 'D', '*'],
-    );
+    ).toEqual(['a', 'D', '*']);
   });
 
   it("should retrieve several tokens and comments from a node's token stream with includeComments and count and filter options", () => {
-    assert.deepStrictEqual(
+    expect(
       getFirstTokens(BinaryExpression, {
         includeComments: true,
         count: 3,
         filter: (t) => t.value !== 'a',
       }).map((token) => token.value),
-      ['D', '*', 'b'],
-    );
+    ).toEqual(['D', '*', 'b']);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L675-L849
 describe('when calling getFirstToken', () => {
   it("should retrieve the first token of a node's token stream", () => {
-    assert.strictEqual(getFirstToken(BinaryExpression)!.value, 'a');
+    expect(getFirstToken(BinaryExpression)!.value).toBe('a');
   });
 
   it('should skip a given number of tokens', () => {
-    assert.strictEqual(getFirstToken(BinaryExpression, 1)!.value, '*');
-    assert.strictEqual(getFirstToken(BinaryExpression, 2)!.value, 'b');
+    expect(getFirstToken(BinaryExpression, 1)!.value).toBe('*');
+    expect(getFirstToken(BinaryExpression, 2)!.value).toBe('b');
   });
 
   it('should skip a given number of tokens with skip option', () => {
-    assert.strictEqual(getFirstToken(BinaryExpression, { skip: 1 })!.value, '*');
-    assert.strictEqual(getFirstToken(BinaryExpression, { skip: 2 })!.value, 'b');
+    expect(getFirstToken(BinaryExpression, { skip: 1 })!.value).toBe('*');
+    expect(getFirstToken(BinaryExpression, { skip: 2 })!.value).toBe('b');
   });
 
   it('should retrieve matched token with filter option', () => {
-    assert.strictEqual(getFirstToken(BinaryExpression, (t) => t.type === 'Identifier')!.value, 'a');
-    assert.strictEqual(
+    expect(getFirstToken(BinaryExpression, (t) => t.type === 'Identifier')!.value).toBe('a');
+    expect(
       getFirstToken(BinaryExpression, {
         filter: (t) => t.type === 'Identifier',
       })!.value,
-      'a',
-    );
+    ).toBe('a');
   });
 
   it('should retrieve matched token with filter and skip options', () => {
-    assert.strictEqual(
+    expect(
       getFirstToken(BinaryExpression, {
         skip: 1,
         filter: (t) => t.type === 'Identifier',
       })!.value,
-      'b',
-    );
+    ).toBe('b');
   });
 
   it("should retrieve the first token or comment of a node's token stream with includeComments option", () => {
-    assert.strictEqual(getFirstToken(BinaryExpression, { includeComments: true })!.value, 'a');
+    expect(getFirstToken(BinaryExpression, { includeComments: true })!.value).toBe('a');
   });
 
   it("should retrieve the first matched token or comment of a node's token stream with includeComments and skip options", () => {
-    assert.strictEqual(
+    expect(
       getFirstToken(BinaryExpression, {
         includeComments: true,
         skip: 1,
       })!.value,
-      'D',
-    );
+    ).toBe('D');
   });
 
   it("should retrieve the first matched token or comment of a node's token stream with includeComments and skip and filter options", () => {
-    assert.strictEqual(
+    expect(
       getFirstToken(BinaryExpression, {
         includeComments: true,
         skip: 1,
         filter: (t) => t.value !== 'a',
       })!.value,
-      '*',
-    );
+    ).toBe('*');
   });
 
   it('should retrieve the first comment if the comment is at the last of nodes', () => {
@@ -647,14 +594,13 @@ describe('when calling getFirstToken', () => {
      * A node must not start with a token: it can start with a comment or be empty.
      * This test case is needed for completeness.
      */
-    assert.strictEqual(
+    expect(
       getFirstToken(
         // TODO: this verbatim range should be replaced with `[ast.comments[0].range[0], ast.tokens[5].range[1]]`
         { range: [6, 23] } as Node,
         { includeComments: true },
       )!.value,
-      'comment',
-    );
+    ).toBe('comment');
   });
 
   it('should retrieve the first token (without includeComments option) if the comment is at the last of nodes', () => {
@@ -663,129 +609,107 @@ describe('when calling getFirstToken', () => {
      * A node must not start with a token: it can start with a comment or be empty.
      * This test case is needed for completeness.
      */
-    assert.strictEqual(
+    expect(
       getFirstToken({
         // TODO: this verbatim range should be replaced with `[ast.comments[0].range[0], ast.tokens[5].range[1]]`
         range: [6, 23],
       } as Node)!.value,
-      'c',
-    );
+    ).toBe('c');
   });
 
   it('should retrieve the first token if the root node contains a trailing comment', () => {
     sourceText = 'foo // comment';
     // TODO: this verbatim range should be replaced with `ast`
-    assert.strictEqual(getFirstToken({ range: [0, 14] } as Node)!.value, 'foo');
+    expect(getFirstToken({ range: [0, 14] } as Node)!.value).toBe('foo');
   });
 
   it('should return null if the source contains only comments', () => {
     sourceText = '// comment';
     // TODO: this verbatim range should be replaced with `ast`
-    assert.strictEqual(
+    expect(
       getFirstToken({ range: [0, 11] } as Node, {
         filter() {
-          assert.fail('Unexpected call to filter callback');
+          expect.fail('Unexpected call to filter callback');
         },
       }),
-      null,
-    );
+    ).toBe(null);
   });
 
   it('should return null if the source is empty', () => {
     sourceText = '';
     // TODO: this verbatim range should be replaced with `ast`
-    assert.strictEqual(getFirstToken({ range: [0, 0] } as Node), null);
+    expect(getFirstToken({ range: [0, 0] } as Node)).toBe(null);
   });
 });
 
 // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/token-store.js#L851-L930
 describe('when calling getLastTokens', () => {
   it("should retrieve zero tokens from the end of a node's token stream", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, 0).map((token) => token.value),
-      [],
-    );
+    expect(getLastTokens(BinaryExpression, 0).map((token) => token.value)).toEqual([]);
   });
 
   it("should retrieve one token from the end of a node's token stream", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, 1).map((token) => token.value),
-      ['b'],
-    );
+    expect(getLastTokens(BinaryExpression, 1).map((token) => token.value)).toEqual(['b']);
   });
 
   it("should retrieve more than one token from the end of a node's token stream", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, 2).map((token) => token.value),
-      ['*', 'b'],
-    );
+    expect(getLastTokens(BinaryExpression, 2).map((token) => token.value)).toEqual(['*', 'b']);
   });
 
   it("should retrieve all tokens from the end of a node's token stream", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, 9e9).map((token) => token.value),
-      ['a', '*', 'b'],
-    );
+    expect(getLastTokens(BinaryExpression, 9e9).map((token) => token.value)).toEqual(['a', '*', 'b']);
   });
 
   it("should retrieve more than one token from the end of a node's token stream with count option", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, { count: 2 }).map((token) => token.value),
-      ['*', 'b'],
-    );
+    expect(getLastTokens(BinaryExpression, { count: 2 }).map((token) => token.value)).toEqual(['*', 'b']);
   });
 
   it("should retrieve matched tokens from the end of a node's token stream with filter option", () => {
-    assert.deepStrictEqual(
-      getLastTokens(BinaryExpression, (t) => t.type === 'Identifier').map((token) => token.value),
-      ['a', 'b'],
-    );
-    assert.deepStrictEqual(
+    expect(getLastTokens(BinaryExpression, (t) => t.type === 'Identifier').map((token) => token.value)).toEqual([
+      'a',
+      'b',
+    ]);
+    expect(
       getLastTokens(BinaryExpression, {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['a', 'b'],
-    );
+    ).toEqual(['a', 'b']);
   });
 
   it("should retrieve matched tokens from the end of a node's token stream with filter and count options", () => {
-    assert.deepStrictEqual(
+    expect(
       getLastTokens(BinaryExpression, {
         count: 1,
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
-      ['b'],
-    );
+    ).toEqual(['b']);
   });
 
   it("should retrieve all tokens from the end of a node's token stream with includeComments option", () => {
-    assert.deepStrictEqual(
+    expect(
       getLastTokens(BinaryExpression, {
         includeComments: true,
       }).map((token) => token.value),
-      ['a', 'D', '*', 'b'],
-    );
+    ).toEqual(['a', 'D', '*', 'b']);
   });
 
   it("should retrieve matched tokens from the end of a node's token stream with includeComments and count options", () => {
-    assert.deepStrictEqual(
+    expect(
       getLastTokens(BinaryExpression, {
         includeComments: true,
         count: 3,
       }).map((token) => token.value),
-      ['D', '*', 'b'],
-    );
+    ).toEqual(['D', '*', 'b']);
   });
 
   it("should retrieve matched tokens from the end of a node's token stream with includeComments and count and filter options", () => {
-    assert.deepStrictEqual(
+    expect(
       getLastTokens(BinaryExpression, {
         includeComments: true,
         count: 3,
         filter: (t) => t.type !== 'Punctuator',
       }).map((token) => token.value),
-      ['a', 'D', 'b'],
-    );
+    ).toEqual(['a', 'D', 'b']);
   });
 });
 


### PR DESCRIPTION
- Follow up to review comment in https://github.com/oxc-project/oxc/pull/16002#discussion_r2554317810.
- We were originally using `assert` because it was a direct analogue to `eslint` testing, made migrating their tests slightly easier.