### PR TITLE
refactor(allocator)!: make `Address::from_ptr` an unsafe method

### DIFF
--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -66,7 +66,7 @@ export default function generateAncestorsCode(types) {
         impl${lifetimes} GetAddress for ${structName} {
           #[inline]
           fn address(&self) -> Address {
-            Address::from_ptr(self.0)
+            unsafe { Address::from_ptr(self.0) }
           }
         }
       `;

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -2576,7 +2576,7 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
 impl<'a, 't> GetAddress for ProgramWithoutHashbang<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2633,7 +2633,7 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
 impl<'a, 't> GetAddress for ProgramWithoutDirectives<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2691,7 +2691,7 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ProgramWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2715,7 +2715,7 @@ impl<'a, 't> ArrayExpressionWithoutElements<'a, 't> {
 impl<'a, 't> GetAddress for ArrayExpressionWithoutElements<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2740,7 +2740,7 @@ impl<'a, 't> ObjectExpressionWithoutProperties<'a, 't> {
 impl<'a, 't> GetAddress for ObjectExpressionWithoutProperties<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2796,7 +2796,7 @@ impl<'a, 't> ObjectPropertyWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for ObjectPropertyWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2844,7 +2844,7 @@ impl<'a, 't> ObjectPropertyWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for ObjectPropertyWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2878,7 +2878,7 @@ impl<'a, 't> TemplateLiteralWithoutQuasis<'a, 't> {
 impl<'a, 't> GetAddress for TemplateLiteralWithoutQuasis<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2907,7 +2907,7 @@ impl<'a, 't> TemplateLiteralWithoutExpressions<'a, 't> {
 impl<'a, 't> GetAddress for TemplateLiteralWithoutExpressions<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2955,7 +2955,7 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
 impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTag<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -2994,7 +2994,7 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3033,7 +3033,7 @@ impl<'a, 't> TaggedTemplateExpressionWithoutQuasi<'a, 't> {
 impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutQuasi<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3080,7 +3080,7 @@ impl<'a, 't> ComputedMemberExpressionWithoutObject<'a, 't> {
 impl<'a, 't> GetAddress for ComputedMemberExpressionWithoutObject<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3118,7 +3118,7 @@ impl<'a, 't> ComputedMemberExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for ComputedMemberExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3165,7 +3165,7 @@ impl<'a, 't> StaticMemberExpressionWithoutObject<'a, 't> {
 impl<'a, 't> GetAddress for StaticMemberExpressionWithoutObject<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3203,7 +3203,7 @@ impl<'a, 't> StaticMemberExpressionWithoutProperty<'a, 't> {
 impl<'a, 't> GetAddress for StaticMemberExpressionWithoutProperty<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3250,7 +3250,7 @@ impl<'a, 't> PrivateFieldExpressionWithoutObject<'a, 't> {
 impl<'a, 't> GetAddress for PrivateFieldExpressionWithoutObject<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3288,7 +3288,7 @@ impl<'a, 't> PrivateFieldExpressionWithoutField<'a, 't> {
 impl<'a, 't> GetAddress for PrivateFieldExpressionWithoutField<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3343,7 +3343,7 @@ impl<'a, 't> CallExpressionWithoutCallee<'a, 't> {
 impl<'a, 't> GetAddress for CallExpressionWithoutCallee<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3389,7 +3389,7 @@ impl<'a, 't> CallExpressionWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for CallExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3435,7 +3435,7 @@ impl<'a, 't> CallExpressionWithoutArguments<'a, 't> {
 impl<'a, 't> GetAddress for CallExpressionWithoutArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3484,7 +3484,7 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
 impl<'a, 't> GetAddress for NewExpressionWithoutCallee<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3525,7 +3525,7 @@ impl<'a, 't> NewExpressionWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for NewExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3566,7 +3566,7 @@ impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
 impl<'a, 't> GetAddress for NewExpressionWithoutArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3599,7 +3599,7 @@ impl<'a, 't> MetaPropertyWithoutMeta<'a, 't> {
 impl<'a, 't> GetAddress for MetaPropertyWithoutMeta<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3627,7 +3627,7 @@ impl<'a, 't> MetaPropertyWithoutProperty<'a, 't> {
 impl<'a, 't> GetAddress for MetaPropertyWithoutProperty<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3651,7 +3651,7 @@ impl<'a, 't> SpreadElementWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for SpreadElementWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3690,7 +3690,7 @@ impl<'a, 't> UpdateExpressionWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for UpdateExpressionWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3722,7 +3722,7 @@ impl<'a, 't> UnaryExpressionWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for UnaryExpressionWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3763,7 +3763,7 @@ impl<'a, 't> BinaryExpressionWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for BinaryExpressionWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3799,7 +3799,7 @@ impl<'a, 't> BinaryExpressionWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for BinaryExpressionWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3832,7 +3832,7 @@ impl<'a, 't> PrivateInExpressionWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for PrivateInExpressionWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3861,7 +3861,7 @@ impl<'a, 't> PrivateInExpressionWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for PrivateInExpressionWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3903,7 +3903,7 @@ impl<'a, 't> LogicalExpressionWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for LogicalExpressionWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3939,7 +3939,7 @@ impl<'a, 't> LogicalExpressionWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for LogicalExpressionWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -3985,7 +3985,7 @@ impl<'a, 't> ConditionalExpressionWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for ConditionalExpressionWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4022,7 +4022,7 @@ impl<'a, 't> ConditionalExpressionWithoutConsequent<'a, 't> {
 impl<'a, 't> GetAddress for ConditionalExpressionWithoutConsequent<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4059,7 +4059,7 @@ impl<'a, 't> ConditionalExpressionWithoutAlternate<'a, 't> {
 impl<'a, 't> GetAddress for ConditionalExpressionWithoutAlternate<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4103,7 +4103,7 @@ impl<'a, 't> AssignmentExpressionWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentExpressionWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4140,7 +4140,7 @@ impl<'a, 't> AssignmentExpressionWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentExpressionWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4176,7 +4176,7 @@ impl<'a, 't> ArrayAssignmentTargetWithoutElements<'a, 't> {
 impl<'a, 't> GetAddress for ArrayAssignmentTargetWithoutElements<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4205,7 +4205,7 @@ impl<'a, 't> ArrayAssignmentTargetWithoutRest<'a, 't> {
 impl<'a, 't> GetAddress for ArrayAssignmentTargetWithoutRest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4243,7 +4243,7 @@ impl<'a, 't> ObjectAssignmentTargetWithoutProperties<'a, 't> {
 impl<'a, 't> GetAddress for ObjectAssignmentTargetWithoutProperties<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4274,7 +4274,7 @@ impl<'a, 't> ObjectAssignmentTargetWithoutRest<'a, 't> {
 impl<'a, 't> GetAddress for ObjectAssignmentTargetWithoutRest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4299,7 +4299,7 @@ impl<'a, 't> AssignmentTargetRestWithoutTarget<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetRestWithoutTarget<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4337,7 +4337,7 @@ impl<'a, 't> AssignmentTargetWithDefaultWithoutBinding<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetWithDefaultWithoutBinding<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4368,7 +4368,7 @@ impl<'a, 't> AssignmentTargetWithDefaultWithoutInit<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetWithDefaultWithoutInit<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4407,7 +4407,7 @@ impl<'a, 't> AssignmentTargetPropertyIdentifierWithoutBinding<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetPropertyIdentifierWithoutBinding<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4439,7 +4439,7 @@ impl<'a, 't> AssignmentTargetPropertyIdentifierWithoutInit<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetPropertyIdentifierWithoutInit<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4488,7 +4488,7 @@ impl<'a, 't> AssignmentTargetPropertyPropertyWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetPropertyPropertyWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4528,7 +4528,7 @@ impl<'a, 't> AssignmentTargetPropertyPropertyWithoutBinding<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentTargetPropertyPropertyWithoutBinding<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4553,7 +4553,7 @@ impl<'a, 't> SequenceExpressionWithoutExpressions<'a, 't> {
 impl<'a, 't> GetAddress for SequenceExpressionWithoutExpressions<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4577,7 +4577,7 @@ impl<'a, 't> AwaitExpressionWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for AwaitExpressionWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4602,7 +4602,7 @@ impl<'a, 't> ChainExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for ChainExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4630,7 +4630,7 @@ impl<'a, 't> ParenthesizedExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for ParenthesizedExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4660,7 +4660,7 @@ impl<'a, 't> DirectiveWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for DirectiveWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4693,7 +4693,7 @@ impl<'a, 't> BlockStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for BlockStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4734,7 +4734,7 @@ impl<'a, 't> VariableDeclarationWithoutDeclarations<'a, 't> {
 impl<'a, 't> GetAddress for VariableDeclarationWithoutDeclarations<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4783,7 +4783,7 @@ impl<'a, 't> VariableDeclaratorWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for VariableDeclaratorWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4825,7 +4825,7 @@ impl<'a, 't> VariableDeclaratorWithoutInit<'a, 't> {
 impl<'a, 't> GetAddress for VariableDeclaratorWithoutInit<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4850,7 +4850,7 @@ impl<'a, 't> ExpressionStatementWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for ExpressionStatementWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4891,7 +4891,7 @@ impl<'a, 't> IfStatementWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for IfStatementWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4925,7 +4925,7 @@ impl<'a, 't> IfStatementWithoutConsequent<'a, 't> {
 impl<'a, 't> GetAddress for IfStatementWithoutConsequent<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4958,7 +4958,7 @@ impl<'a, 't> IfStatementWithoutAlternate<'a, 't> {
 impl<'a, 't> GetAddress for IfStatementWithoutAlternate<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -4990,7 +4990,7 @@ impl<'a, 't> DoWhileStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for DoWhileStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5018,7 +5018,7 @@ impl<'a, 't> DoWhileStatementWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for DoWhileStatementWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5050,7 +5050,7 @@ impl<'a, 't> WhileStatementWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for WhileStatementWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5078,7 +5078,7 @@ impl<'a, 't> WhileStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for WhileStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5135,7 +5135,7 @@ impl<'a, 't> ForStatementWithoutInit<'a, 't> {
 impl<'a, 't> GetAddress for ForStatementWithoutInit<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5185,7 +5185,7 @@ impl<'a, 't> ForStatementWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for ForStatementWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5235,7 +5235,7 @@ impl<'a, 't> ForStatementWithoutUpdate<'a, 't> {
 impl<'a, 't> GetAddress for ForStatementWithoutUpdate<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5288,7 +5288,7 @@ impl<'a, 't> ForStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ForStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5337,7 +5337,7 @@ impl<'a, 't> ForInStatementWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for ForInStatementWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5381,7 +5381,7 @@ impl<'a, 't> ForInStatementWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for ForInStatementWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5425,7 +5425,7 @@ impl<'a, 't> ForInStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ForInStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5480,7 +5480,7 @@ impl<'a, 't> ForOfStatementWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for ForOfStatementWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5529,7 +5529,7 @@ impl<'a, 't> ForOfStatementWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for ForOfStatementWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5578,7 +5578,7 @@ impl<'a, 't> ForOfStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ForOfStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5602,7 +5602,7 @@ impl<'a, 't> ContinueStatementWithoutLabel<'a, 't> {
 impl<'a, 't> GetAddress for ContinueStatementWithoutLabel<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5626,7 +5626,7 @@ impl<'a, 't> BreakStatementWithoutLabel<'a, 't> {
 impl<'a, 't> GetAddress for BreakStatementWithoutLabel<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5650,7 +5650,7 @@ impl<'a, 't> ReturnStatementWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for ReturnStatementWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5689,7 +5689,7 @@ impl<'a, 't> WithStatementWithoutObject<'a, 't> {
 impl<'a, 't> GetAddress for WithStatementWithoutObject<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5725,7 +5725,7 @@ impl<'a, 't> WithStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for WithStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5768,7 +5768,7 @@ impl<'a, 't> SwitchStatementWithoutDiscriminant<'a, 't> {
 impl<'a, 't> GetAddress for SwitchStatementWithoutDiscriminant<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5805,7 +5805,7 @@ impl<'a, 't> SwitchStatementWithoutCases<'a, 't> {
 impl<'a, 't> GetAddress for SwitchStatementWithoutCases<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5838,7 +5838,7 @@ impl<'a, 't> SwitchCaseWithoutTest<'a, 't> {
 impl<'a, 't> GetAddress for SwitchCaseWithoutTest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5866,7 +5866,7 @@ impl<'a, 't> SwitchCaseWithoutConsequent<'a, 't> {
 impl<'a, 't> GetAddress for SwitchCaseWithoutConsequent<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5898,7 +5898,7 @@ impl<'a, 't> LabeledStatementWithoutLabel<'a, 't> {
 impl<'a, 't> GetAddress for LabeledStatementWithoutLabel<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5927,7 +5927,7 @@ impl<'a, 't> LabeledStatementWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for LabeledStatementWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5951,7 +5951,7 @@ impl<'a, 't> ThrowStatementWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for ThrowStatementWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -5993,7 +5993,7 @@ impl<'a, 't> TryStatementWithoutBlock<'a, 't> {
 impl<'a, 't> GetAddress for TryStatementWithoutBlock<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6030,7 +6030,7 @@ impl<'a, 't> TryStatementWithoutHandler<'a, 't> {
 impl<'a, 't> GetAddress for TryStatementWithoutHandler<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6067,7 +6067,7 @@ impl<'a, 't> TryStatementWithoutFinalizer<'a, 't> {
 impl<'a, 't> GetAddress for TryStatementWithoutFinalizer<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6109,7 +6109,7 @@ impl<'a, 't> CatchClauseWithoutParam<'a, 't> {
 impl<'a, 't> GetAddress for CatchClauseWithoutParam<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6146,7 +6146,7 @@ impl<'a, 't> CatchClauseWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for CatchClauseWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6170,7 +6170,7 @@ impl<'a, 't> CatchParameterWithoutPattern<'a, 't> {
 impl<'a, 't> GetAddress for CatchParameterWithoutPattern<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6204,7 +6204,7 @@ impl<'a, 't> BindingPatternWithoutKind<'a, 't> {
 impl<'a, 't> GetAddress for BindingPatternWithoutKind<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6233,7 +6233,7 @@ impl<'a, 't> BindingPatternWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for BindingPatternWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6265,7 +6265,7 @@ impl<'a, 't> AssignmentPatternWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentPatternWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6294,7 +6294,7 @@ impl<'a, 't> AssignmentPatternWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for AssignmentPatternWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6327,7 +6327,7 @@ impl<'a, 't> ObjectPatternWithoutProperties<'a, 't> {
 impl<'a, 't> GetAddress for ObjectPatternWithoutProperties<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6356,7 +6356,7 @@ impl<'a, 't> ObjectPatternWithoutRest<'a, 't> {
 impl<'a, 't> GetAddress for ObjectPatternWithoutRest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6401,7 +6401,7 @@ impl<'a, 't> BindingPropertyWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for BindingPropertyWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6439,7 +6439,7 @@ impl<'a, 't> BindingPropertyWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for BindingPropertyWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6472,7 +6472,7 @@ impl<'a, 't> ArrayPatternWithoutElements<'a, 't> {
 impl<'a, 't> GetAddress for ArrayPatternWithoutElements<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6501,7 +6501,7 @@ impl<'a, 't> ArrayPatternWithoutRest<'a, 't> {
 impl<'a, 't> GetAddress for ArrayPatternWithoutRest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6526,7 +6526,7 @@ impl<'a, 't> BindingRestElementWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for BindingRestElementWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6639,7 +6639,7 @@ impl<'a, 't> FunctionWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6737,7 +6737,7 @@ impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6835,7 +6835,7 @@ impl<'a, 't> FunctionWithoutThisParam<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutThisParam<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -6933,7 +6933,7 @@ impl<'a, 't> FunctionWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7031,7 +7031,7 @@ impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7129,7 +7129,7 @@ impl<'a, 't> FunctionWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for FunctionWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7171,7 +7171,7 @@ impl<'a, 't> FormalParametersWithoutItems<'a, 't> {
 impl<'a, 't> GetAddress for FormalParametersWithoutItems<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7208,7 +7208,7 @@ impl<'a, 't> FormalParametersWithoutRest<'a, 't> {
 impl<'a, 't> GetAddress for FormalParametersWithoutRest<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7264,7 +7264,7 @@ impl<'a, 't> FormalParameterWithoutDecorators<'a, 't> {
 impl<'a, 't> GetAddress for FormalParameterWithoutDecorators<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7311,7 +7311,7 @@ impl<'a, 't> FormalParameterWithoutPattern<'a, 't> {
 impl<'a, 't> GetAddress for FormalParameterWithoutPattern<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7344,7 +7344,7 @@ impl<'a, 't> FunctionBodyWithoutDirectives<'a, 't> {
 impl<'a, 't> GetAddress for FunctionBodyWithoutDirectives<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7373,7 +7373,7 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
 impl<'a, 't> GetAddress for FunctionBodyWithoutStatements<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7478,7 +7478,7 @@ impl<'a, 't> ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7562,7 +7562,7 @@ impl<'a, 't> ArrowFunctionExpressionWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7646,7 +7646,7 @@ impl<'a, 't> ArrowFunctionExpressionWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7730,7 +7730,7 @@ impl<'a, 't> ArrowFunctionExpressionWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7760,7 +7760,7 @@ impl<'a, 't> YieldExpressionWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for YieldExpressionWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7859,7 +7859,7 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutDecorators<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -7942,7 +7942,7 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8027,7 +8027,7 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8113,7 +8113,7 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutSuperClass<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8198,7 +8198,7 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutSuperTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8283,7 +8283,7 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutImplements<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8368,7 +8368,7 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ClassWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8392,7 +8392,7 @@ impl<'a, 't> ClassBodyWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for ClassBodyWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8487,7 +8487,7 @@ impl<'a, 't> MethodDefinitionWithoutDecorators<'a, 't> {
 impl<'a, 't> GetAddress for MethodDefinitionWithoutDecorators<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8568,7 +8568,7 @@ impl<'a, 't> MethodDefinitionWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for MethodDefinitionWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8648,7 +8648,7 @@ impl<'a, 't> MethodDefinitionWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for MethodDefinitionWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8768,7 +8768,7 @@ impl<'a, 't> PropertyDefinitionWithoutDecorators<'a, 't> {
 impl<'a, 't> GetAddress for PropertyDefinitionWithoutDecorators<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8864,7 +8864,7 @@ impl<'a, 't> PropertyDefinitionWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for PropertyDefinitionWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -8959,7 +8959,7 @@ impl<'a, 't> PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9054,7 +9054,7 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for PropertyDefinitionWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9087,7 +9087,7 @@ impl<'a, 't> StaticBlockWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for StaticBlockWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9183,7 +9183,7 @@ impl<'a, 't> AccessorPropertyWithoutDecorators<'a, 't> {
 impl<'a, 't> GetAddress for AccessorPropertyWithoutDecorators<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9264,7 +9264,7 @@ impl<'a, 't> AccessorPropertyWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for AccessorPropertyWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9344,7 +9344,7 @@ impl<'a, 't> AccessorPropertyWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for AccessorPropertyWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9424,7 +9424,7 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for AccessorPropertyWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9466,7 +9466,7 @@ impl<'a, 't> ImportExpressionWithoutSource<'a, 't> {
 impl<'a, 't> GetAddress for ImportExpressionWithoutSource<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9502,7 +9502,7 @@ impl<'a, 't> ImportExpressionWithoutOptions<'a, 't> {
 impl<'a, 't> GetAddress for ImportExpressionWithoutOptions<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9565,7 +9565,7 @@ impl<'a, 't> ImportDeclarationWithoutSpecifiers<'a, 't> {
 impl<'a, 't> GetAddress for ImportDeclarationWithoutSpecifiers<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9618,7 +9618,7 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
 impl<'a, 't> GetAddress for ImportDeclarationWithoutSource<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9671,7 +9671,7 @@ impl<'a, 't> ImportDeclarationWithoutWithClause<'a, 't> {
 impl<'a, 't> GetAddress for ImportDeclarationWithoutWithClause<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9714,7 +9714,7 @@ impl<'a, 't> ImportSpecifierWithoutImported<'a, 't> {
 impl<'a, 't> GetAddress for ImportSpecifierWithoutImported<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9751,7 +9751,7 @@ impl<'a, 't> ImportSpecifierWithoutLocal<'a, 't> {
 impl<'a, 't> GetAddress for ImportSpecifierWithoutLocal<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9779,7 +9779,7 @@ impl<'a, 't> ImportDefaultSpecifierWithoutLocal<'a, 't> {
 impl<'a, 't> GetAddress for ImportDefaultSpecifierWithoutLocal<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9807,7 +9807,7 @@ impl<'a, 't> ImportNamespaceSpecifierWithoutLocal<'a, 't> {
 impl<'a, 't> GetAddress for ImportNamespaceSpecifierWithoutLocal<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9839,7 +9839,7 @@ impl<'a, 't> WithClauseWithoutWithEntries<'a, 't> {
 impl<'a, 't> GetAddress for WithClauseWithoutWithEntries<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9871,7 +9871,7 @@ impl<'a, 't> ImportAttributeWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for ImportAttributeWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9900,7 +9900,7 @@ impl<'a, 't> ImportAttributeWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for ImportAttributeWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -9968,7 +9968,7 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
 impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10023,7 +10023,7 @@ impl<'a, 't> ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
 impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10078,7 +10078,7 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
 impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutSource<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10133,7 +10133,7 @@ impl<'a, 't> ExportNamedDeclarationWithoutWithClause<'a, 't> {
 impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutWithClause<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10161,7 +10161,7 @@ impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
 impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10216,7 +10216,7 @@ impl<'a, 't> ExportAllDeclarationWithoutExported<'a, 't> {
 impl<'a, 't> GetAddress for ExportAllDeclarationWithoutExported<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10261,7 +10261,7 @@ impl<'a, 't> ExportAllDeclarationWithoutSource<'a, 't> {
 impl<'a, 't> GetAddress for ExportAllDeclarationWithoutSource<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10306,7 +10306,7 @@ impl<'a, 't> ExportAllDeclarationWithoutWithClause<'a, 't> {
 impl<'a, 't> GetAddress for ExportAllDeclarationWithoutWithClause<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10349,7 +10349,7 @@ impl<'a, 't> ExportSpecifierWithoutLocal<'a, 't> {
 impl<'a, 't> GetAddress for ExportSpecifierWithoutLocal<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10386,7 +10386,7 @@ impl<'a, 't> ExportSpecifierWithoutExported<'a, 't> {
 impl<'a, 't> GetAddress for ExportSpecifierWithoutExported<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10422,7 +10422,7 @@ impl<'a, 't> V8IntrinsicExpressionWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for V8IntrinsicExpressionWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10451,7 +10451,7 @@ impl<'a, 't> V8IntrinsicExpressionWithoutArguments<'a, 't> {
 impl<'a, 't> GetAddress for V8IntrinsicExpressionWithoutArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10495,7 +10495,7 @@ impl<'a, 't> JSXElementWithoutOpeningElement<'a, 't> {
 impl<'a, 't> GetAddress for JSXElementWithoutOpeningElement<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10532,7 +10532,7 @@ impl<'a, 't> JSXElementWithoutChildren<'a, 't> {
 impl<'a, 't> GetAddress for JSXElementWithoutChildren<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10569,7 +10569,7 @@ impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
 impl<'a, 't> GetAddress for JSXElementWithoutClosingElement<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10613,7 +10613,7 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for JSXOpeningElementWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10650,7 +10650,7 @@ impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for JSXOpeningElementWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10687,7 +10687,7 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
 impl<'a, 't> GetAddress for JSXOpeningElementWithoutAttributes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10711,7 +10711,7 @@ impl<'a, 't> JSXClosingElementWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for JSXClosingElementWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10755,7 +10755,7 @@ impl<'a, 't> JSXFragmentWithoutOpeningFragment<'a, 't> {
 impl<'a, 't> GetAddress for JSXFragmentWithoutOpeningFragment<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10792,7 +10792,7 @@ impl<'a, 't> JSXFragmentWithoutChildren<'a, 't> {
 impl<'a, 't> GetAddress for JSXFragmentWithoutChildren<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10829,7 +10829,7 @@ impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
 impl<'a, 't> GetAddress for JSXFragmentWithoutClosingFragment<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10863,7 +10863,7 @@ impl<'a, 't> JSXNamespacedNameWithoutNamespace<'a, 't> {
 impl<'a, 't> GetAddress for JSXNamespacedNameWithoutNamespace<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10892,7 +10892,7 @@ impl<'a, 't> JSXNamespacedNameWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for JSXNamespacedNameWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10927,7 +10927,7 @@ impl<'a, 't> JSXMemberExpressionWithoutObject<'a, 't> {
 impl<'a, 't> GetAddress for JSXMemberExpressionWithoutObject<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10956,7 +10956,7 @@ impl<'a, 't> JSXMemberExpressionWithoutProperty<'a, 't> {
 impl<'a, 't> GetAddress for JSXMemberExpressionWithoutProperty<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -10984,7 +10984,7 @@ impl<'a, 't> JSXExpressionContainerWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for JSXExpressionContainerWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11017,7 +11017,7 @@ impl<'a, 't> JSXAttributeWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for JSXAttributeWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11045,7 +11045,7 @@ impl<'a, 't> JSXAttributeWithoutValue<'a, 't> {
 impl<'a, 't> GetAddress for JSXAttributeWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11070,7 +11070,7 @@ impl<'a, 't> JSXSpreadAttributeWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for JSXSpreadAttributeWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11094,7 +11094,7 @@ impl<'a, 't> JSXSpreadChildWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for JSXSpreadChildWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11125,7 +11125,7 @@ impl<'a, 't> TSThisParameterWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSThisParameterWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11179,7 +11179,7 @@ impl<'a, 't> TSEnumDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSEnumDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11226,7 +11226,7 @@ impl<'a, 't> TSEnumDeclarationWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSEnumDeclarationWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11250,7 +11250,7 @@ impl<'a, 't> TSEnumBodyWithoutMembers<'a, 't> {
 impl<'a, 't> GetAddress for TSEnumBodyWithoutMembers<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11283,7 +11283,7 @@ impl<'a, 't> TSEnumMemberWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSEnumMemberWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11311,7 +11311,7 @@ impl<'a, 't> TSEnumMemberWithoutInitializer<'a, 't> {
 impl<'a, 't> GetAddress for TSEnumMemberWithoutInitializer<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11336,7 +11336,7 @@ impl<'a, 't> TSTypeAnnotationWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAnnotationWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11360,7 +11360,7 @@ impl<'a, 't> TSLiteralTypeWithoutLiteral<'a, 't> {
 impl<'a, 't> GetAddress for TSLiteralTypeWithoutLiteral<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11424,7 +11424,7 @@ impl<'a, 't> TSConditionalTypeWithoutCheckType<'a, 't> {
 impl<'a, 't> GetAddress for TSConditionalTypeWithoutCheckType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11476,7 +11476,7 @@ impl<'a, 't> TSConditionalTypeWithoutExtendsType<'a, 't> {
 impl<'a, 't> GetAddress for TSConditionalTypeWithoutExtendsType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11529,7 +11529,7 @@ impl<'a, 't> TSConditionalTypeWithoutTrueType<'a, 't> {
 impl<'a, 't> GetAddress for TSConditionalTypeWithoutTrueType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11581,7 +11581,7 @@ impl<'a, 't> TSConditionalTypeWithoutFalseType<'a, 't> {
 impl<'a, 't> GetAddress for TSConditionalTypeWithoutFalseType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11605,7 +11605,7 @@ impl<'a, 't> TSUnionTypeWithoutTypes<'a, 't> {
 impl<'a, 't> GetAddress for TSUnionTypeWithoutTypes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11629,7 +11629,7 @@ impl<'a, 't> TSIntersectionTypeWithoutTypes<'a, 't> {
 impl<'a, 't> GetAddress for TSIntersectionTypeWithoutTypes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11654,7 +11654,7 @@ impl<'a, 't> TSParenthesizedTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSParenthesizedTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11688,7 +11688,7 @@ impl<'a, 't> TSTypeOperatorWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeOperatorWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11712,7 +11712,7 @@ impl<'a, 't> TSArrayTypeWithoutElementType<'a, 't> {
 impl<'a, 't> GetAddress for TSArrayTypeWithoutElementType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11747,7 +11747,7 @@ impl<'a, 't> TSIndexedAccessTypeWithoutObjectType<'a, 't> {
 impl<'a, 't> GetAddress for TSIndexedAccessTypeWithoutObjectType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11776,7 +11776,7 @@ impl<'a, 't> TSIndexedAccessTypeWithoutIndexType<'a, 't> {
 impl<'a, 't> GetAddress for TSIndexedAccessTypeWithoutIndexType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11800,7 +11800,7 @@ impl<'a, 't> TSTupleTypeWithoutElementTypes<'a, 't> {
 impl<'a, 't> GetAddress for TSTupleTypeWithoutElementTypes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11843,7 +11843,7 @@ impl<'a, 't> TSNamedTupleMemberWithoutLabel<'a, 't> {
 impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutLabel<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11879,7 +11879,7 @@ impl<'a, 't> TSNamedTupleMemberWithoutElementType<'a, 't> {
 impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutElementType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11904,7 +11904,7 @@ impl<'a, 't> TSOptionalTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSOptionalTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11929,7 +11929,7 @@ impl<'a, 't> TSRestTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSRestTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11963,7 +11963,7 @@ impl<'a, 't> TSTypeReferenceWithoutTypeName<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -11992,7 +11992,7 @@ impl<'a, 't> TSTypeReferenceWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12025,7 +12025,7 @@ impl<'a, 't> TSQualifiedNameWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for TSQualifiedNameWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12053,7 +12053,7 @@ impl<'a, 't> TSQualifiedNameWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for TSQualifiedNameWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12082,7 +12082,7 @@ impl<'a, 't> TSTypeParameterInstantiationWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeParameterInstantiationWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12143,7 +12143,7 @@ impl<'a, 't> TSTypeParameterWithoutName<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeParameterWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12195,7 +12195,7 @@ impl<'a, 't> TSTypeParameterWithoutConstraint<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeParameterWithoutConstraint<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12247,7 +12247,7 @@ impl<'a, 't> TSTypeParameterWithoutDefault<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeParameterWithoutDefault<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12275,7 +12275,7 @@ impl<'a, 't> TSTypeParameterDeclarationWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeParameterDeclarationWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12342,7 +12342,7 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12396,7 +12396,7 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12450,7 +12450,7 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12485,7 +12485,7 @@ impl<'a, 't> TSClassImplementsWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSClassImplementsWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12514,7 +12514,7 @@ impl<'a, 't> TSClassImplementsWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSClassImplementsWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12590,7 +12590,7 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12652,7 +12652,7 @@ impl<'a, 't> TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12714,7 +12714,7 @@ impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutExtends<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12776,7 +12776,7 @@ impl<'a, 't> TSInterfaceDeclarationWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12800,7 +12800,7 @@ impl<'a, 't> TSInterfaceBodyWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceBodyWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12861,7 +12861,7 @@ impl<'a, 't> TSPropertySignatureWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for TSPropertySignatureWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12911,7 +12911,7 @@ impl<'a, 't> TSPropertySignatureWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSPropertySignatureWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12958,7 +12958,7 @@ impl<'a, 't> TSIndexSignatureWithoutParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSIndexSignatureWithoutParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -12997,7 +12997,7 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13065,7 +13065,7 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13120,7 +13120,7 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
 impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13175,7 +13175,7 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13230,7 +13230,7 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13326,7 +13326,7 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
 impl<'a, 't> GetAddress for TSMethodSignatureWithoutKey<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13404,7 +13404,7 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSMethodSignatureWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13482,7 +13482,7 @@ impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
 impl<'a, 't> GetAddress for TSMethodSignatureWithoutThisParam<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13560,7 +13560,7 @@ impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSMethodSignatureWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13638,7 +13638,7 @@ impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for TSMethodSignatureWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13697,7 +13697,7 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13745,7 +13745,7 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13793,7 +13793,7 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13828,7 +13828,7 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13863,7 +13863,7 @@ impl<'a, 't> TSInterfaceHeritageWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13892,7 +13892,7 @@ impl<'a, 't> TSInterfaceHeritageWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13933,7 +13933,7 @@ impl<'a, 't> TSTypePredicateWithoutParameterName<'a, 't> {
 impl<'a, 't> GetAddress for TSTypePredicateWithoutParameterName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -13967,7 +13967,7 @@ impl<'a, 't> TSTypePredicateWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSTypePredicateWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14028,7 +14028,7 @@ impl<'a, 't> TSModuleDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSModuleDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14080,7 +14080,7 @@ impl<'a, 't> TSModuleDeclarationWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSModuleDeclarationWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14132,7 +14132,7 @@ impl<'a, 't> TSGlobalDeclarationWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSGlobalDeclarationWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14165,7 +14165,7 @@ impl<'a, 't> TSModuleBlockWithoutDirectives<'a, 't> {
 impl<'a, 't> GetAddress for TSModuleBlockWithoutDirectives<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14194,7 +14194,7 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
 impl<'a, 't> GetAddress for TSModuleBlockWithoutBody<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14218,7 +14218,7 @@ impl<'a, 't> TSTypeLiteralWithoutMembers<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeLiteralWithoutMembers<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14243,7 +14243,7 @@ impl<'a, 't> TSInferTypeWithoutTypeParameter<'a, 't> {
 impl<'a, 't> GetAddress for TSInferTypeWithoutTypeParameter<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14277,7 +14277,7 @@ impl<'a, 't> TSTypeQueryWithoutExprName<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeQueryWithoutExprName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14306,7 +14306,7 @@ impl<'a, 't> TSTypeQueryWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14358,7 +14358,7 @@ impl<'a, 't> TSImportTypeWithoutArgument<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14402,7 +14402,7 @@ impl<'a, 't> TSImportTypeWithoutOptions<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeWithoutOptions<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14446,7 +14446,7 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeWithoutQualifier<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14490,7 +14490,7 @@ impl<'a, 't> TSImportTypeWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14528,7 +14528,7 @@ impl<'a, 't> TSImportTypeQualifiedNameWithoutLeft<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeQualifiedNameWithoutLeft<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14559,7 +14559,7 @@ impl<'a, 't> TSImportTypeQualifiedNameWithoutRight<'a, 't> {
 impl<'a, 't> GetAddress for TSImportTypeQualifiedNameWithoutRight<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14621,7 +14621,7 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSFunctionTypeWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14674,7 +14674,7 @@ impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
 impl<'a, 't> GetAddress for TSFunctionTypeWithoutThisParam<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14727,7 +14727,7 @@ impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSFunctionTypeWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14780,7 +14780,7 @@ impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for TSFunctionTypeWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14841,7 +14841,7 @@ impl<'a, 't> TSConstructorTypeWithoutTypeParameters<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructorTypeWithoutTypeParameters<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14891,7 +14891,7 @@ impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructorTypeWithoutParams<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -14941,7 +14941,7 @@ impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
 impl<'a, 't> GetAddress for TSConstructorTypeWithoutReturnType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15012,7 +15012,7 @@ impl<'a, 't> TSMappedTypeWithoutTypeParameter<'a, 't> {
 impl<'a, 't> GetAddress for TSMappedTypeWithoutTypeParameter<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15073,7 +15073,7 @@ impl<'a, 't> TSMappedTypeWithoutNameType<'a, 't> {
 impl<'a, 't> GetAddress for TSMappedTypeWithoutNameType<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15134,7 +15134,7 @@ impl<'a, 't> TSMappedTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSMappedTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15172,7 +15172,7 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
 impl<'a, 't> GetAddress for TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15203,7 +15203,7 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutTypes<'a, 't> {
 impl<'a, 't> GetAddress for TSTemplateLiteralTypeWithoutTypes<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15237,7 +15237,7 @@ impl<'a, 't> TSAsExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSAsExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15266,7 +15266,7 @@ impl<'a, 't> TSAsExpressionWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSAsExpressionWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15302,7 +15302,7 @@ impl<'a, 't> TSSatisfiesExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSSatisfiesExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15331,7 +15331,7 @@ impl<'a, 't> TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15366,7 +15366,7 @@ impl<'a, 't> TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15395,7 +15395,7 @@ impl<'a, 't> TSTypeAssertionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSTypeAssertionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15443,7 +15443,7 @@ impl<'a, 't> TSImportEqualsDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSImportEqualsDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15482,7 +15482,7 @@ impl<'a, 't> TSImportEqualsDeclarationWithoutModuleReference<'a, 't> {
 impl<'a, 't> GetAddress for TSImportEqualsDeclarationWithoutModuleReference<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15510,7 +15510,7 @@ impl<'a, 't> TSExternalModuleReferenceWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSExternalModuleReferenceWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15535,7 +15535,7 @@ impl<'a, 't> TSNonNullExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSNonNullExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15559,7 +15559,7 @@ impl<'a, 't> DecoratorWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for DecoratorWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15584,7 +15584,7 @@ impl<'a, 't> TSExportAssignmentWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSExportAssignmentWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15613,7 +15613,7 @@ impl<'a, 't> TSNamespaceExportDeclarationWithoutId<'a, 't> {
 impl<'a, 't> GetAddress for TSNamespaceExportDeclarationWithoutId<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15651,7 +15651,7 @@ impl<'a, 't> TSInstantiationExpressionWithoutExpression<'a, 't> {
 impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutExpression<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15682,7 +15682,7 @@ impl<'a, 't> TSInstantiationExpressionWithoutTypeArguments<'a, 't> {
 impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15714,7 +15714,7 @@ impl<'a, 't> JSDocNullableTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for JSDocNullableTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }
 
@@ -15751,6 +15751,6 @@ impl<'a, 't> JSDocNonNullableTypeWithoutTypeAnnotation<'a, 't> {
 impl<'a, 't> GetAddress for JSDocNonNullableTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(self.0)
+        unsafe { Address::from_ptr(self.0) }
     }
 }


### PR DESCRIPTION
A further step in refactoring `Address` to make it more robust and performant.

Make `Address::from_ptr` an unsafe method, with the safety invariant that the pointer must be non-null. This:

1. Further discourages use of `Address::from_ptr` - `GetAddress::address` or `UnstableAddress::unstable_address` should be used instead.
2. Opens the door to changing `Address`'s inner type from `usize` to `NonZeroUsize`, which will reduce `Option<Address>` from 16 bytes to 8.
