### PR TITLE
docs(linter): Add config option docs for various rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -24,11 +25,14 @@ pub struct NoCondAssign {
     config: NoCondAssignConfig,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum NoCondAssignConfig {
+    /// Allow assignments in conditional expressions only if they are
+    /// enclosed in parentheses.
     #[default]
     ExceptParens,
+    /// Disallow all assignments in conditional expressions.
     Always,
 }
 
@@ -65,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     NoCondAssign,
     eslint,
-    correctness
+    correctness,
+    config = NoCondAssignConfig,
 );
 
 impl Rule for NoCondAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -3,11 +3,47 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeId;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-#[derive(Debug, Clone)]
+fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary `else` after `return`.")
+        .with_labels([
+            last_return.label("This consequent block always returns,"),
+            else_keyword.label("Making this `else` block unnecessary."),
+        ])
+        .with_help("Remove the `else` block, moving its contents outside of the `if` statement.")
+}
+
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoElseReturn {
+    /// Whether to allow `else if` blocks after a return statement.
+    ///
+    /// Examples of **incorrect** code for this rule with `allowElseIf: false`:
+    /// ```javascript
+    /// function foo() {
+    ///     if (error) {
+    ///         return 'It failed';
+    ///     } else if (loading) {
+    ///         return "It's still loading";
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `allowElseIf: false`:
+    /// ```javascript
+    /// function foo() {
+    ///     if (error) {
+    ///         return 'It failed';
+    ///     }
+    ///
+    ///     if (loading) {
+    ///         return "It's still loading";
+    ///     }
+    /// }
+    /// ```
     allow_else_if: bool,
 }
 
@@ -41,12 +77,6 @@ declare_oxc_lint!(
     /// following an `if` containing a return statement. As such, it will warn
     /// when it encounters an `else` following a chain of `if`s, all of them
     /// containing a `return` statement.
-    ///
-    /// Options
-    /// This rule has an object option:
-    ///
-    /// - `allowElseIf`: `true` _(default)_ allows `else if` blocks after a return
-    /// - `allowElseIf`: `false` disallows `else if` blocks after a return
     ///
     /// ### Examples
     ///
@@ -143,46 +173,12 @@ declare_oxc_lint!(
     ///     }
     /// }
     /// ```
-    ///
-    /// #### `allowElseIf: false`
-    ///
-    /// Examples of **incorrect** code for this rule:
-    /// ```javascript
-    /// function foo() {
-    ///     if (error) {
-    ///         return 'It failed';
-    ///     } else if (loading) {
-    ///         return "It's still loading";
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```javascript
-    /// function foo() {
-    ///     if (error) {
-    ///         return 'It failed';
-    ///     }
-    ///
-    ///     if (loading) {
-    ///         return "It's still loading";
-    ///     }
-    /// }
-    /// ```
     NoElseReturn,
     eslint,
     pedantic,
-    conditional_fix
+    conditional_fix,
+    config = NoElseReturn,
 );
-
-fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unnecessary 'else' after 'return'.")
-        .with_labels([
-            last_return.label("This consequent block always returns,"),
-            else_keyword.label("Making this `else` block unnecessary."),
-        ])
-        .with_help("Remove the `else` block, moving its contents outside of the `if` statement.")
-}
 
 fn is_safe_from_name_collisions(
     ctx: &LintContext,

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -11,6 +11,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use schemars::JsonSchema;
 use serde_json::Value;
 
 fn bad_handler_name_diagnostic(
@@ -50,7 +51,8 @@ fn bad_handler_prop_name_diagnostic(
 #[derive(Debug, Default, Clone)]
 pub struct JsxHandlerNames(Box<JsxHandlerNamesConfig>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxHandlerNamesConfig {
     /// Whether to check for inline functions in JSX attributes.
     check_inline_functions: bool,
@@ -98,35 +100,10 @@ declare_oxc_lint!(
     /// <MyComponent onChange={this.handleChange} />
     /// <MyComponent onChange={this.props.onFoo} />
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// ```json
-    /// {
-    ///   "react/jsx-handler-names": [<enabled>, {
-    ///     "eventHandlerPrefix": <eventHandlerPrefix>,
-    ///     "eventHandlerPropPrefix": <eventHandlerPropPrefix>,
-    ///     "checkLocalVariables": <boolean>,
-    ///     "checkInlineFunction": <boolean>,
-    ///     "ignoreComponentNames": Array<string>
-    ///   }]
-    /// }
-    /// ```
-    ///
-    /// - `eventHandlerPrefix`: Prefix for component methods used as event handlers.
-    ///   Defaults to `handle`
-    /// - `eventHandlerPropPrefix`: Prefix for props that are used as event handlers
-    ///   Defaults to `on`
-    /// - `checkLocalVariables`: Determines whether event handlers stored as local variables
-    ///   are checked. Defaults to `false`
-    /// - `checkInlineFunction`: Determines whether event handlers set as inline functions are
-    ///   checked. Defaults to `false`
-    /// - `ignoreComponentNames`: Array of glob strings, when matched with component name,
-    ///   ignores the rule on that component. Defaults to `[]`
-    ///
     JsxHandlerNames,
     react,
     style,
+    config = JsxHandlerNamesConfig,
 );
 
 fn build_event_handler_regex(handler_prefix: &str, handler_prop_prefix: &str) -> Option<Regex> {

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
@@ -21,10 +22,13 @@ fn state_in_constructor_diagnostic(span: Span, is_state_init_constructor: bool) 
     OxcDiagnostic::warn(message).with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 pub enum StateInConstructorConfig {
+    /// Enforce state initialization in the constructor.
     #[default]
     Always,
+    /// Enforce state initialization with a class property.
     Never,
 }
 
@@ -119,6 +123,7 @@ declare_oxc_lint!(
     StateInConstructor,
     react,
     style,
+    config = StateInConstructorConfig,
 );
 
 impl Rule for StateInConstructor {

--- a/crates/oxc_linter/src/snapshots/eslint_default_case.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_default_case.snap
@@ -1,39 +1,39 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ switch (a) { case 1: break; }
    · ─────────────────────────────
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.
 
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ ╭─▶ switch (a) {
  2 │ │                // no default
  3 │ ╰─▶              case 1: break;  }
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.
 
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ ╭─▶ switch (a) { case 1: break;
  2 │ │                // no default
  3 │ │                // nope
  4 │ ╰─▶               }
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.
 
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ ╭─▶ switch (a) { case 1: break;
  2 │ │                // no default
  3 │ ╰─▶              }
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.
 
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ ╭─▶ switch (a) {
  2 │ │               case 1: break;
@@ -41,12 +41,12 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │               // TODO: add default case
  5 │ ╰─▶             }
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.
 
-  ⚠ eslint(default-case): Require default cases in switch statements.
+  ⚠ eslint(default-case): Require `default` cases in `switch` statements.
    ╭─[default_case.tsx:1:1]
  1 │ ╭─▶ switch (a) {
  2 │ │               case 1: break;
  3 │ ╰─▶             }
    ╰────
-  help: Add a default case.
+  help: Add a `default` case.

--- a/crates/oxc_linter/src/snapshots/eslint_no_else_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_else_return.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:6]
  1 │ if(0)return;else r
    ·      ───┬─────┬──
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:31]
  1 │ function foo1() { if (true) { return x; } else { return y; } }
    ·                               ────┬────  ───┬──
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:44]
  1 │ function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }
    ·                                            ────┬────  ───┬──
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo3() { if (true) return x; else return y; }
    ·                             ────┬───────┬──
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:42]
  1 │ function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }
    ·                                          ────┬────                 ───┬──
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:42]
  1 │ function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }
    ·                                          ────┬───────┬──
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:54]
  1 │ function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }
    ·                                                      ────┬───────┬──
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:54]
  1 │ function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }
    ·                                                      ────┬───────┬──
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:81]
  1 │ function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }
    ·                                                                                 ────┬────  ───┬──
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:54]
  1 │ function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }
    ·                                                      ────┬───────┬──
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:54]
  1 │ function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }
    ·                                                      ────┬────                 ───┬──
@@ -100,7 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:54]
  1 │ function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }
    ·                                                      ────┬───────┬──
@@ -109,7 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:56]
  1 │ function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }
    ·                                                        ──────┬─────  ───┬──
@@ -118,7 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:28]
  1 │ function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }
    ·                            ──────┬─────  ───┬──
@@ -127,7 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:52]
  1 │ function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }
    ·                                                    ──────┬─────  ───┬──
@@ -136,7 +136,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo10() { if (foo) return bar; else (foo).bar(); }
    ·                             ─────┬────────┬──
@@ -145,7 +145,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo11() { if (foo) return bar
    · │                               ─────┬────
@@ -155,7 +155,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo12() { if (foo) return bar
    · │                               ─────┬────
@@ -166,7 +166,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo13() { if (foo) return bar;
    · │                               ─────┬─────
@@ -176,7 +176,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo14() { if (foo) return bar
    · │                               ─────┬────
@@ -187,7 +187,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo15() { if (foo) return bar; else { baz() } qaz() }
    ·                             ─────┬────────┬──
@@ -196,7 +196,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo16() { if (foo) return bar
    · │                               ─────┬────
@@ -206,7 +206,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo17() { if (foo) return bar
    · │                               ─────┬────
@@ -217,7 +217,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ ╭─▶ function foo18() { if (foo) return function() {}
    · │                               ──────────┬─────────
@@ -227,7 +227,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:32]
  1 │ function foo19() { if (true) { return x; } else if (false) { return y; } }
    ·                                ────┬────  ───┬──
@@ -236,7 +236,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:28]
  1 │ function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }
    ·                            ──────┬─────  ───┬──
@@ -245,7 +245,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:43]
  1 │ function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }
    ·                                           ────┬────  ───┬──
@@ -254,7 +254,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { var a; if (bar) { return true; } else { var a; } }
    ·                                    ──────┬─────  ───┬──
@@ -263,7 +263,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:47]
  1 │ function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }
    ·                                               ──────┬─────  ───┬──
@@ -272,7 +272,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { var a; if (bar) { return true; } else { var a; } }
    ·                                    ──────┬─────  ───┬──
@@ -281,7 +281,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:47]
  1 │ function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }
    ·                                               ──────┬─────  ───┬──
@@ -290,7 +290,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { let a; if (bar) { return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
@@ -299,7 +299,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:39]
  1 │ class foo { bar() { let a; if (baz) { return true; } else { let a; } } }
    ·                                       ──────┬─────  ───┬──
@@ -308,7 +308,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:47]
  1 │ function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }
    ·                                               ──────┬─────  ───┬──
@@ -317,7 +317,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:46]
  1 │ function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }
    ·                                              ──────┬─────  ───┬──
@@ -326,7 +326,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:42]
  1 │ function foo() { const a = 1; if (bar) { return true; } else { let a; } }
    ·                                          ──────┬─────  ───┬──
@@ -335,7 +335,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:53]
  1 │ function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }
    ·                                                     ──────┬─────  ───┬──
@@ -344,7 +344,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { let a; if (bar) { return true; } else { const a = 1 } }
    ·                                    ──────┬─────  ───┬──
@@ -353,7 +353,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:47]
  1 │ function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }
    ·                                               ──────┬─────  ───┬──
@@ -362,7 +362,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:41]
  1 │ function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }
    ·                                         ──────┬─────  ───┬──
@@ -371,7 +371,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:52]
  1 │ function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }
    ·                                                    ──────┬─────  ───┬──
@@ -380,7 +380,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:42]
  1 │ function foo() { const a = 1; if (bar) { return true; } else { class a {} } }
    ·                                          ──────┬─────  ───┬──
@@ -389,7 +389,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:53]
  1 │ function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }
    ·                                                     ──────┬─────  ───┬──
@@ -398,7 +398,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { var a; if (bar) { return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
@@ -407,7 +407,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { if (bar) { var a; return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
@@ -416,7 +416,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }
    ·                             ──────┬─────  ───┬──
@@ -425,7 +425,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:30]
  1 │ function foo(a) { if (bar) { return true; } else { let a; } }
    ·                              ──────┬─────  ───┬──
@@ -434,7 +434,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:34]
  1 │ function foo(a = 1) { if (bar) { return true; } else { let a; } }
    ·                                  ──────┬─────  ───┬──
@@ -443,7 +443,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:37]
  1 │ function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}
    ·                                     ──────┬─────  ───┬──
@@ -452,7 +452,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:80]
  1 │ function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}
    ·                                                                                ──────┬─────  ───┬──
@@ -461,7 +461,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo(...args) { if (bar) { return true; } else { let args; } }
    ·                                    ──────┬─────  ───┬──
@@ -470,7 +470,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:48]
  1 │ function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }
    ·                                                ──────┬─────  ───┬──
@@ -479,7 +479,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:59]
  1 │ function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }
    ·                                                           ──────┬─────  ───┬──
@@ -488,7 +488,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:59]
  1 │ function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }
    ·                                                           ──────┬─────  ───┬──
@@ -497,7 +497,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } }
    ·                             ──────┬─────  ───┬──
@@ -506,7 +506,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }
    ·                             ──────┬─────  ───┬──
@@ -515,7 +515,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }
    ·                             ──────┬─────  ───┬──
@@ -524,7 +524,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }
    ·                                        ──────┬─────  ───┬──
@@ -533,7 +533,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; } a; }
    ·                             ──────┬─────  ───┬──
@@ -542,7 +542,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }
    ·                             ──────┬─────  ───┬──
@@ -551,7 +551,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }
    ·                                        ──────┬─────  ───┬──
@@ -560,7 +560,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }
    ·                                        ──────┬─────  ───┬──
@@ -569,7 +569,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }
    ·                                        ──────┬─────  ───┬──
@@ -578,7 +578,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:27]
  1 │ function a() { if (foo) { return true; } else { let a; } a(); }
    ·                           ──────┬─────  ───┬──
@@ -587,7 +587,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:25]
  1 │ function a() { if (a) { return true; } else { let a; } }
    ·                         ──────┬─────  ───┬──
@@ -596,7 +596,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:27]
  1 │ function a() { if (foo) { return a; } else { let a; } }
    ·                           ────┬────  ───┬──
@@ -605,7 +605,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }
    ·                             ──────┬─────  ───┬──
@@ -614,7 +614,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }
    ·                                        ──────┬─────  ───┬──
@@ -623,7 +623,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; } var a; }
    ·                             ──────┬─────  ───┬──
@@ -632,7 +632,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }
    ·                                        ──────┬─────  ───┬──
@@ -641,7 +641,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }
    ·                                        ──────┬─────  ───┬──
@@ -650,7 +650,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }
    ·                                        ──────┬─────  ───┬──
@@ -659,7 +659,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }
    ·                                        ──────┬─────  ───┬──
@@ -668,7 +668,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:61]
  1 │ function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }
    ·                                                             ──────┬─────  ───┬──
@@ -677,7 +677,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else { let a; } function a(){} }
    ·                             ──────┬─────  ───┬──
@@ -686,7 +686,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }
    ·                                        ──────┬─────  ───┬──
@@ -695,7 +695,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }
    ·                                        ──────┬─────  ───┬──
@@ -704,7 +704,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:40]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }
    ·                                        ──────┬─────  ───┬──
@@ -713,7 +713,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { let a; if (bar) { return true; } else { function a(){} } }
    ·                                    ──────┬─────  ───┬──
@@ -722,7 +722,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:36]
  1 │ function foo() { var a; if (bar) { return true; } else { function a(){} } }
    ·                                    ──────┬─────  ───┬──
@@ -731,7 +731,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:29]
  1 │ function foo() { if (bar) { return true; } else function baz() {} };
    ·                             ──────┬─────  ───┬──
@@ -740,7 +740,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:12]
  1 │ if (foo) { return true; } else { let a; }
    ·            ──────┬─────  ───┬──
@@ -749,7 +749,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
-  ⚠ eslint(no-else-return): Unnecessary 'else' after 'return'.
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
    ╭─[no_else_return.tsx:1:19]
  1 │ let a; if (foo) { return true; } else { let a; }
    ·                   ──────┬─────  ───┬──

--- a/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
@@ -1,168 +1,168 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:2:1]
  1 │ switch(foo) { case 0: a();
  2 │ case 1: b() }
    · ───────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:2:1]
  1 │ switch(foo) { case 0: a();
  2 │ default: b() }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:28]
  1 │ switch(foo) { case 0: a(); default: b() }
    ·                            ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:41]
  1 │ switch(foo) { case 0: if (a) { break; } default: b() }
    ·                                         ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:55]
  1 │ switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
    ·                                                       ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:44]
  1 │ switch(foo) { case 0: while (a) { break; } default: b() }
    ·                                            ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:48]
  1 │ switch(foo) { case 0: do { break; } while (a); default: b() }
    ·                                                ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:3:2]
  2 │ 
  3 │  default: b() }
    ·  ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:26]
  1 │ switch(foo) { case 0: {} default: b() }
    ·                          ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:52]
  1 │ switch(foo) { case 0: a(); { /* falls through */ } default: b() }
    ·                                                    ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:52]
  1 │ switch(foo) { case 0: { /* falls through */ } a(); default: b() }
    ·                                                    ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:54]
  1 │ switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
    ·                                                      ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:51]
  1 │ switch(foo) { case 0: { { /* falls through */ } } default: b() }
    ·                                                   ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:41]
  1 │ switch(foo) { case 0: { /* comment */ } default: b() }
    ·                                         ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:3:2]
  2 │  // comment
  3 │  default: b() }
    ·  ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:50]
  1 │ switch(foo) { case 0: a(); /* falling through */ default: b() }
    ·                                                  ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
  2 │ /* no break */
  3 │ case 1: b(); }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:4:1]
  3 │ /* todo: fix readability */
  4 │ default: b() }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'default'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:4:1]
  3 │ /* todo: fix readability */ }
  4 │ default: b() }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
  2 │  /* with comments */  
  3 │ case 1: b(); }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
  2 │ 
  3 │ case 1: b(); }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
  2 │ 
  3 │ case 1: b(); }
    · ────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:2:4]
  1 │ switch (a) { case 1: 
  2 │  ; case 2:  }
    ·    ───────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:24]
  1 │ switch (a) { case 1: ; case 2: ; case 3: }
    ·                        ─────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:34]
  1 │ switch (a) { case 1: ; case 2: ; case 3: }
    ·                                  ───────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:2]
  2 │ // eslint-enable no-fallthrough
  3 │  case 1: }
@@ -175,13 +175,13 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ─────────────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:46]
  1 │ switch(true) { case x === 1 || x === 2: a(); case x === 3: b(); }
    ·                                              ──────────────────
    ╰────
 
-  ⚠ eslint(no-fallthrough): Expected a 'break' statement before 'case'.
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:40]
  1 │ switch(true) { case x === 1 && y: a(); case x === 3: b(); }
    ·                                        ──────────────────

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -31,13 +31,8 @@ fn test_rules_with_custom_configuration_have_schema() {
     let exceptions: &[&str] = &[
         // eslint
         "eslint/arrow-body-style",
-        "eslint/default-case",
         "eslint/func-names",
-        "eslint/new-cap",
-        "eslint/no-cond-assign",
-        "eslint/no-else-return",
         "eslint/no-empty-function",
-        "eslint/no-fallthrough",
         "eslint/no-restricted-imports",
         "eslint/no-warning-comments",
         "eslint/yoda",
@@ -47,11 +42,8 @@ fn test_rules_with_custom_configuration_have_schema() {
         // react
         "react/forbid-dom-props",
         "react/forbid-elements",
-        "react/jsx-handler-names",
-        "react/state-in-constructor",
         // typescript
         "typescript/ban-ts-comment",
-        "typescript/consistent-type-imports",
         // unicorn
         "unicorn/filename-case",
     ];


### PR DESCRIPTION
Part of #14743.

- `typescript/consistent-type-imports`
- `eslint/no-else-return`
- `react/state-in-constructor`
- `eslint/no-cond-assign`
- `eslint/default-case`
- `react/jsx-handler-names`
- `eslint/new-cap`

Generated docs:

typescript/consistent-type-imports:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### disallowTypeAnnotations

type: `boolean`

Disallow using `import()` in type annotations, like `type T = import('foo')`


### fixStyle

type: `"separate-type-imports" | "inline-type-imports"`

Control how type imports are added when auto-fixing.


#### `"separate-type-imports"`

Will add the type keyword after the import keyword `import type { A } from '...'`


#### `"inline-type-imports"`

Will inline the type keyword `import { type A } from '...'` (only available in TypeScript 4.5+)


### prefer

type: `"type-imports" | "no-type-imports"`


Control whether to enforce type imports or value imports.


#### `"type-imports"`

Will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators.


#### `"no-type-imports"`

Will enforce that you always use `import Foo from '...'`
```

eslint/no-else-return:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowElseIf

type: `boolean`

default: `true`

Whether to allow `else if` blocks after a return statement.

Examples of **incorrect** code for this rule with `allowElseIf: false`:
\```javascript
function foo() {
if (error) {
return 'It failed';
} else if (loading) {
return "It's still loading";
}
}
\```

Examples of **correct** code for this rule with `allowElseIf: false`:
\```javascript
function foo() {
if (error) {
return 'It failed';
}

if (loading) {
return "It's still loading";
}
}
\```
```

react/state-in-constructor:

```md
## Configuration

This rule accepts one of the following string values:

### `"always"`

Enforce state initialization in the constructor.

### `"never"`

Enforce state initialization with a class property.
```

eslint/no-cond-assign:

```md
## Configuration

This rule accepts one of the following string values:

### `"except-parens"`

Allow assignments in conditional expressions only if they are
enclosed in parentheses.


### `"always"`

Disallow all assignments in conditional expressions.
```

eslint/default-case:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### commentPattern

type: `[
  string,
  null
]`

A regex pattern used to detect comments that mark the absence
of a `default` case as intentional.

Default value: `no default`.

Examples of **incorrect** code for this rule with the `{ "commentPattern": "^skip\\sdefault" }` option:
\```js
/* default-case: ["error", { "commentPattern": "^skip\sdefault" }] */

switch (a) {
case 1:
break;
// no default
}
\```

Examples of **correct** code for this rule with the `{ "commentPattern": "^skip\\sdefault" }` option:
\```js
/* default-case: ["error", { "commentPattern": "^skip\\sdefault" }] */

switch (a) {
case 1:
break;
// skip default
}
\```
```

eslint/no-fallthrough:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowEmptyCase

type: `boolean`

default: `false`

Whether to allow empty case clauses to fall through.


### commentPattern

type: `[
  string,
  null
]`


Custom regex pattern to match fallthrough comments.


### reportUnusedFallthroughComment

type: `boolean`

default: `false`

Whether to report unused fallthrough comments.
```

react/jsx-handler-names:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### checkInlineFunctions

type: `boolean`

default: `false`

Whether to check for inline functions in JSX attributes.

### checkLocalVariables

type: `boolean`

default: `false`

Whether to check for local variables in JSX attributes.

### eventHandlerPrefixes

type: `string`

default: `"handle"`

Event handler prefixes to check against.

### eventHandlerPropPrefixes

type: `string`

default: `"on"`

Event handler prop prefixes to check against.

### eventHandlerPropRegex

type: `[
  string,
  null
]`

Compiled regex for event handler prop prefixes.


### eventHandlerRegex

type: `[
  string,
  null
]`

Compiled regex for event handler prefixes.

### ignoreComponentNames

type: `string[]`

default: `[]`

Component names to ignore when checking for event handler prefixes.
```

eslint/new-cap:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### capIsNew

type: `boolean`

default: `true`

Whether to enforce that functions with names starting with an uppercase letter are only used as constructors.


### capIsNewExceptionPattern

type: `[
  string,
  null
]`


A regex pattern to match exceptions for functions with names starting with an uppercase letter.


### capIsNewExceptions

type: `string[]`

default: `[]`

Exceptions to ignore for functions with names starting with an uppercase letter.


### newIsCap

type: `boolean`

default: `true`

Whether to enforce that constructor names start with an uppercase letter.


### newIsCapExceptionPattern

type: `[
  string,
  null
]`


A regex pattern to match exceptions for constructor names starting with an uppercase letter.


### newIsCapExceptions

type: `string[]`

default: `["Array", "Boolean", "Date", "Error", "Function", "Number", "Object", "RegExp", "String", "Symbol", "BigInt"]`

Exceptions to ignore for constructor names starting with an uppercase letter.


### properties

type: `boolean`

default: `true`

Whether to check member expressions (e.g., `obj.Method()`).
```