### PR TITLE
fix(linter/plugins): perform length checks before continuing loops

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -484,13 +484,10 @@ export function getFirstTokens(node: Node, countOptions?: CountOptions | number 
       }
     } else {
       firstTokens = [];
-      for (let i = sliceStart; i < sliceEnd; i++) {
+      for (let i = sliceStart; i < sliceEnd && firstTokens.length < count; i++) {
         const token = nodeTokens[i];
         if (filter(token)) {
           firstTokens.push(token);
-          if (firstTokens.length === count) {
-            break;
-          }
         }
       }
     }
@@ -689,13 +686,10 @@ export function getLastTokens(node: Node, countOptions?: CountOptions | number |
     } else {
       lastTokens = [];
       // Count is the number of tokens within range from the end so we iterate in reverse
-      for (let i = sliceEnd - 1; i >= sliceStart; i--) {
+      for (let i = sliceEnd - 1; i >= sliceStart && lastTokens.length < count; i--) {
         const token = nodeTokens[i];
         if (filter(token)) {
           lastTokens.unshift(token);
-          if (lastTokens.length === count) {
-            break;
-          }
         }
       }
     }
@@ -899,13 +893,10 @@ export function getTokensBefore(
     } else {
       tokensBefore = [];
       // Count is the number of preceding tokens so we iterate in reverse
-      for (let i = sliceEnd - 1; i >= 0; i--) {
+      for (let i = sliceEnd - 1; i >= 0 && tokensBefore.length < count; i--) {
         const token = nodeTokens[i];
         if (filter(token)) {
           tokensBefore.unshift(token);
-        }
-        if (tokensBefore.length === count) {
-          break;
         }
       }
     }
@@ -1100,13 +1091,10 @@ export function getTokensAfter(
       }
     } else {
       nodeTokensAfter = [];
-      for (let i = sliceStart; i < nodeTokens.length; i++) {
+      for (let i = sliceStart; i < nodeTokens.length && nodeTokensAfter.length < count; i++) {
         const token = nodeTokens[i];
         if (filter(token)) {
           nodeTokensAfter.push(token);
-        }
-        if (nodeTokensAfter.length === count) {
-          break;
         }
       }
     }

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -196,6 +196,15 @@ describe('when calling getTokensBefore', () => {
     ).toEqual(['var', '=']);
   });
 
+  it('should retrieve zero tokens before a node with a filter when count is 0', () => {
+    expect(
+      getTokensBefore(BinaryExpression, {
+        count: 0,
+        filter: () => true,
+      }).map((token) => token.value),
+    ).toEqual([]);
+  });
+
   it('should retrieve no tokens before the root node', () => {
     expect(getTokensBefore(Program, { count: 1 }).map((token) => token.value)).toEqual([]);
   });
@@ -439,6 +448,15 @@ describe('when calling getTokensAfter', () => {
     ).toEqual(['a', 'b']);
   });
 
+  it('should retrieve zero tokens after a node with a filter when count is 0', () => {
+    expect(
+      getTokensAfter(VariableDeclaratorIdentifier, {
+        count: 0,
+        filter: () => true,
+      }).map((token) => token.value),
+    ).toEqual([]);
+  });
+
   it('should retrieve all tokens and comments after a node with includeComments option', () => {
     expect(
       getTokensAfter(VariableDeclaratorIdentifier, {
@@ -516,6 +534,15 @@ describe('when calling getFirstTokens', () => {
         includeComments: true,
       }).map((token) => token.value),
     ).toEqual(['a', 'D', '*', 'b']);
+  });
+
+  it("should retrieve zero tokens from a node's token stream with a filter when count is 0", () => {
+    expect(
+      getFirstTokens(BinaryExpression, {
+        count: 0,
+        filter: () => true,
+      }).map((token) => token.value),
+    ).toEqual([]);
   });
 
   it("should retrieve several tokens and comments from a node's token stream with includeComments and count options", () => {
@@ -690,6 +717,15 @@ describe('when calling getLastTokens', () => {
         filter: (t) => t.type === 'Identifier',
       }).map((token) => token.value),
     ).toEqual(['b']);
+  });
+
+  it("should retrieve zero tokens from the end of a node's token stream with a filter when count is 0", () => {
+    expect(
+      getLastTokens(BinaryExpression, {
+        count: 0,
+        filter: () => true,
+      }).map((token) => token.value),
+    ).toEqual([]);
   });
 
   it("should retrieve all tokens from the end of a node's token stream with includeComments option", () => {


### PR DESCRIPTION
- Some token methods accept a `count`, maximum number of tokens to return.
- In the filter + count case, it was implemented by checking array length _after_ populating it with each token.
- This worked for the common case, but not when `count` is less than `1`, in which case the array length could go past `count`.