### PR TITLE
chore(linter): Add a note on no-const-assign for TypeScript.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -7,10 +7,11 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_const_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected re-assignment of const variable {name}")).with_labels([
-        decl_span.label(format!("{name} is declared here as const")),
-        assign_span.label(format!("{name} is re-assigned here")),
-    ])
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of `const` variable {name}."))
+        .with_labels([
+            decl_span.label(format!("{name} is declared here as `const`.")),
+            assign_span.label(format!("{name} is re-assigned here.")),
+        ])
 }
 
 #[derive(Debug, Default, Clone)]
@@ -23,8 +24,11 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// We cannot modify variables that are declared using const keyword.
-    /// It will raise a runtime error.
+    /// We cannot modify variables that are declared using the `const` keyword,
+    /// as it will raise a runtime error.
+    ///
+    /// Note that this rule is not necessary for TypeScript
+    /// code, as TypeScript will already catch this as an error.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
@@ -1,202 +1,202 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; x = 1;
    ·       ┬      ┬
-   ·       │      ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │      ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:11]
  1 │ const {a: x} = {a: 0}; x = 1;
    ·           ┬            ┬
-   ·           │            ╰── x is re-assigned here
-   ·           ╰── x is declared here as const
+   ·           │            ╰── x is re-assigned here.
+   ·           ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; ({x} = {x: 1});
    ·       ┬        ┬
-   ·       │        ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │        ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; ({a: x = 1} = {});
    ·       ┬           ┬
-   ·       │           ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │           ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; x += 1;
    ·       ┬      ┬
-   ·       │      ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │      ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; ++x;
    ·       ┬        ┬
-   ·       │        ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │        ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable i
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable i.
    ╭─[no_const_assign.tsx:1:12]
  1 │ for (const i = 0; i < 10; ++i) { foo(i); }
    ·            ┬                ┬
-   ·            │                ╰── i is re-assigned here
-   ·            ╰── i is declared here as const
+   ·            │                ╰── i is re-assigned here.
+   ·            ╰── i is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; x = 1; x = 2;
    ·       ┬      ┬
-   ·       │      ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │      ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; x = 1; x = 2;
    ·       ┬             ┬
-   ·       │             ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │             ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; function foo() { x = x + 1; }
    ·       ┬                       ┬
-   ·       │                       ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │                       ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; function foo(a) { x = a; }
    ·       ┬                        ┬
-   ·       │                        ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │                        ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; while (true) { x = x + 1; }
    ·       ┬                     ┬
-   ·       │                     ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │                     ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const x = 0; function foo(a) { function bar(b) { x = b; } bar(123); }
    ·       ┬                                          ┬
-   ·       │                                          ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │                                          ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:1]
  1 │ x = 123; const x = 1;
    · ┬              ┬
-   · │              ╰── x is declared here as const
-   · ╰── x is re-assigned here
+   · │              ╰── x is declared here as `const`.
+   · ╰── x is re-assigned here.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable d
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:24]
  1 │ const [a, b, ...[c, ...d]] = [1, 2, 3, 4, 5]; d = 123
    ·                        ┬                      ┬
-   ·                        │                      ╰── d is re-assigned here
-   ·                        ╰── d is declared here as const
+   ·                        │                      ╰── d is re-assigned here.
+   ·                        ╰── d is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable d
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const d = 123; [a, b, ...[c, ...d]] = [1, 2, 3, 4, 5]
    ·       ┬                         ┬
-   ·       │                         ╰── d is re-assigned here
-   ·       ╰── d is declared here as const
+   ·       │                         ╰── d is re-assigned here.
+   ·       ╰── d is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable b
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable b.
    ╭─[no_const_assign.tsx:1:7]
  1 │ const b = 0; ({a, ...b} = {a: 1, c: 2, d: 3})
    ·       ┬              ┬
-   ·       │              ╰── b is re-assigned here
-   ·       ╰── b is declared here as const
+   ·       │              ╰── b is re-assigned here.
+   ·       ╰── b is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ using x = foo(); x = 1;
    ·       ┬          ┬
-   ·       │          ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │          ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
  1 │ await using x = foo(); x = 1;
    ·             ┬          ┬
-   ·             │          ╰── x is re-assigned here
-   ·             ╰── x is declared here as const
+   ·             │          ╰── x is re-assigned here.
+   ·             ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ using x = foo(); x ??= bar();
    ·       ┬          ┬
-   ·       │          ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │          ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
  1 │ await using x = foo(); x ||= bar();
    ·             ┬          ┬
-   ·             │          ╰── x is re-assigned here
-   ·             ╰── x is declared here as const
+   ·             │          ╰── x is re-assigned here.
+   ·             ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ using x = foo(); [x, y] = bar();
    ·       ┬           ┬
-   ·       │           ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │           ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
  1 │ await using x = foo(); [x = baz, y] = bar();
    ·             ┬           ┬
-   ·             │           ╰── x is re-assigned here
-   ·             ╰── x is declared here as const
+   ·             │           ╰── x is re-assigned here.
+   ·             ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
  1 │ using x = foo(); ({a: x} = bar());
    ·       ┬               ┬
-   ·       │               ╰── x is re-assigned here
-   ·       ╰── x is declared here as const
+   ·       │               ╰── x is re-assigned here.
+   ·       ╰── x is declared here as `const`.
    ╰────
 
-  ⚠ eslint(no-const-assign): Unexpected re-assignment of const variable x
+  ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
  1 │ await using x = foo(); ({a: x = baz} = bar());
    ·             ┬               ┬
-   ·             │               ╰── x is re-assigned here
-   ·             ╰── x is declared here as const
+   ·             │               ╰── x is re-assigned here.
+   ·             ╰── x is declared here as `const`.
    ╰────


### PR DESCRIPTION
The rule is unnecessary for TypeScript code, as the typechecker already catches `const` reassignments like this.