### PR TITLE
fix(formatter): revert  `FormatElement::BestFitting` printing logic

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -337,6 +337,14 @@ impl<'a> BestFittingElement<'a> {
         )
     }
 
+    /// Splits the variants into the most expanded and the remaining flat variants
+    pub fn split_to_most_expanded_and_flat_variants(
+        &self,
+    ) -> (&&[FormatElement<'a>], &[&[FormatElement<'a>]]) {
+        // SAFETY: We have already asserted that there are at least two variants for creating this struct.
+        unsafe { self.variants.split_last().unwrap_unchecked() }
+    }
+
     pub fn variants(&self) -> &[&'a [FormatElement<'a>]] {
         self.variants
     }

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -334,7 +334,10 @@ impl<'a> Printer<'a> {
         } else {
             self.state.measured_group_fits = true;
 
-            for variant in best_fitting.variants() {
+            let (most_expanded, remaining_variants) =
+                best_fitting.split_to_most_expanded_and_flat_variants();
+
+            for variant in remaining_variants {
                 // Test if this variant fits and if so, use it. Otherwise try the next
                 // variant.
 
@@ -365,7 +368,6 @@ impl<'a> Printer<'a> {
             }
 
             // No variant fits, take the last (most expanded) as fallback
-            let most_expanded = best_fitting.most_expanded();
             queue.extend_back(most_expanded);
             self.print_entry(queue, stack, indent_stack, args.with_print_mode(PrintMode::Expanded))
         }

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/expanded.ts.snap
@@ -12,9 +12,9 @@ const defaultColorDecoratorsEnablement = accessor
 ------------------
 const defaultColorDecoratorsEnablement = accessor
   .get(IConfigurationService)
-  .getValue<
-    "auto" | "always" | "never"
-  >("longlonglonglonglonglonglonglonglong");
+  .getValue<"auto" | "always" | "never">(
+    "longlonglonglonglonglonglonglonglong",
+  );
 
 -------------------
 { printWidth: 100 }


### PR DESCRIPTION
Revert the change made in https://github.com/oxc-project/oxc/pull/14983. Even though Prettier doesn't fix the bug yet, Prettier at least confirms that this is a bug in Prettier, so it would be better to revert it to avoid introducing weird formatting