### PR TITLE
docs(linter): Fix config option docs for eslint/operator-assignment rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -27,8 +27,10 @@ fn operator_assignment_diagnostic(mode: Mode, span: Span, operator: &str) -> Oxc
 #[derive(Debug, Default, PartialEq, Clone, Copy, Serialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum Mode {
+    /// Requires assignment operator shorthand where possible.
     #[default]
     Always,
+    /// Disallows assignment operator shorthand.
     Never,
 }
 
@@ -38,18 +40,8 @@ impl Mode {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct OperatorAssignment {
-    /// This rule has a single string option:
-    /// * `always` requires assignment operator shorthand where possible
-    /// * `never` disallows assignment operator shorthand
-    ///
-    /// Example:
-    /// ```json
-    /// "eslint/operator-assignment": ["error", "always"]
-    /// "eslint/operator-assignment": ["error", "never"]
-    /// ```
     mode: Mode,
 }
 
@@ -102,7 +94,7 @@ declare_oxc_lint!(
     eslint,
     style,
     fix_dangerous,
-    config = OperatorAssignment,
+    config = Mode,
 );
 
 impl Rule for OperatorAssignment {


### PR DESCRIPTION
This was inaccurate previously as I had added this before string-only config options were supported for doc generation.

Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts one of the following string values:

### `"always"`

Requires assignment operator shorthand where possible.

### `"never"`

Disallows assignment operator shorthand.
```