### PR TITLE
refactor(formatter): replace `format_once` with `format_with` where possible

### DIFF
--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -404,7 +404,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
         write!(f, [soft_line_break_or_space(), "?", space()])?;
 
         let format_consequent = format_with(|f| {
-            let format_consequent_with_trailing_comments = format_once(|f| {
+            let format_consequent_with_trailing_comments = format_with(|f| {
                 let (start, end) = match self.conditional {
                     ConditionalLike::ConditionalExpression(conditional) => {
                         write!(f, FormatNodeWithoutTrailingComments(conditional.consequent()))?;
@@ -514,7 +514,7 @@ impl<'a> Format<'a> for FormatConditionalLike<'a, '_> {
         let format_inner = format_with(|f| {
             self.format_test(f, layout)?;
 
-            let format_tail_with_indent = format_once(|f| {
+            let format_tail_with_indent = format_with(|f| {
                 if is_jsx_chain
                     && let ConditionalLike::ConditionalExpression(conditional) = self.conditional
                 {

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -113,11 +113,11 @@ pub fn format_type_cast_comment_node<'a, T>(
 
     // https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/estree.js#L117-L120
     if is_object_or_array_expression && !f.comments().has_comment_before(span.start) {
-        write!(f, group(&format_args!("(", &format_once(|f| node.fmt(f)), ")")))?;
+        write!(f, group(&format_args!("(", &format_with(|f| node.fmt(f)), ")")))?;
     } else {
         write!(
             f,
-            group(&format_args!("(", soft_block_indent(&format_once(|f| node.fmt(f))), ")"))
+            group(&format_args!("(", soft_block_indent(&format_with(|f| node.fmt(f))), ")"))
         )?;
     }
 

--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -50,7 +50,7 @@ impl<'a> Format<'a> for ArrayElementList<'a, '_> {
                     .with_group_id(self.group_id)
                 {
                     filler.entry(
-                        &format_once(|f| {
+                        &format_with(|f| {
                             if f.source_text().get_lines_before(element.span(), f.comments()) > 1 {
                                 write!(f, empty_line())
                             } else if f

--- a/crates/oxc_formatter/src/write/array_pattern.rs
+++ b/crates/oxc_formatter/src/write/array_pattern.rs
@@ -32,7 +32,7 @@ impl<'a> Format<'a> for FormatArrayPattern<'a, '_> {
         } else {
             write!(
                 f,
-                group(&soft_block_indent(&format_once(|f| {
+                group(&soft_block_indent(&format_with(|f| {
                     let has_element = !self.elements.is_empty();
                     if has_element {
                         write_array_node(

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -496,7 +496,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                     let is_first = is_first_in_chain;
 
                     let formatted_signature = format_with(|f| {
-                        let format_leading_comments = format_once(|f| {
+                        let format_leading_comments = format_with(|f| {
                             if should_format_comments {
                                 // A grouped layout implies that the arrow chain is trying to be rendered
                                 // in a condensed, single-line format (at least the signatures, not
@@ -636,7 +636,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
 
         let group_id = f.group_id("arrow-chain");
 
-        let format_inner = format_once(|f| {
+        let format_inner = format_with(|f| {
             if has_initial_indent {
                 write!(
                     f,
@@ -716,13 +716,13 @@ fn format_signature<'a, 'b>(
     cache_mode: FunctionCacheMode,
 ) -> impl Format<'a> + 'b {
     format_with(move |f| {
-        let content = format_once(|f| {
+        let content = format_with(|f| {
             group(&format_args!(
                 maybe_space(!is_first_in_chain),
                 arrow.r#async().then_some("async "),
                 arrow.type_parameters(),
                 arrow.params(),
-                &format_once(|f| {
+                &format_with(|f| {
                     if let Some(return_type) = &arrow.return_type() {
                         group(&FormatNodeWithoutTrailingComments(return_type)).fmt(f)
                     } else {
@@ -760,8 +760,7 @@ fn format_signature<'a, 'b>(
         // Print comments before the fat arrow (`=>`)
         let comments_before_fat_arrow =
             f.context().comments().comments_before_character(arrow.params.span().end, b'=');
-        let content =
-            format_once(|f| FormatTrailingComments::Comments(comments_before_fat_arrow).fmt(f));
+        let content = FormatTrailingComments::Comments(comments_before_fat_arrow);
         write!(f, [FormatContentWithCacheMode::new(arrow.span, content, cache_mode)])
     })
 }
@@ -780,7 +779,7 @@ pub struct FormatMaybeCachedFunctionBody<'a, 'b> {
 
 impl<'a> Format<'a> for FormatMaybeCachedFunctionBody<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let content = format_once(|f| {
+        let content = format_with(|f| {
             if self.expression
                 && let AstNodes::ExpressionStatement(s) =
                     &self.body.statements().first().unwrap().as_ast_nodes()

--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -201,7 +201,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
         if is_inside_condition {
             return write!(
                 f,
-                [&format_once(|f| {
+                [&format_with(|f| {
                     format_flattened_logical_expression(*self, is_inside_condition, f)
                 })]
             );
@@ -231,7 +231,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
         if should_not_indent {
             return write!(
                 f,
-                [group(&format_once(|f| {
+                [group(&format_with(|f| {
                     // is_inside_condition is always false here (we returned early if true)
                     format_flattened_logical_expression(*self, false, f)
                 }))]
@@ -267,7 +267,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                 f,
                 [group(&format_args!(
                     first,
-                    indent(&format_once(|f| { f.join().entries(tail_parts.iter()).finish() }))
+                    indent(&format_with(|f| { f.join().entries(tail_parts.iter()).finish() }))
                 ))
                 .with_group_id(Some(group_id))]
             )
@@ -395,7 +395,7 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
                                 space(),
                                 operator.as_str(),
                                 soft_line_break_or_space(),
-                                format_once(|f| {
+                                format_with(|f| {
                                     // If the left side of the right logical expression is still a logical expression with
                                     // the same operator, we need to recursively format it inline.
                                     // This way, we can ensure that all parts are in the same group.

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -126,7 +126,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                 f,
                 [
                     l_paren_token,
-                    soft_block_indent(&format_once(|f| {
+                    soft_block_indent(&format_with(|f| {
                         f.join_with(soft_line_break_or_space())
                             .entries_with_trailing_separator(self.iter(), ",", trailing_operator)
                             .finish()
@@ -232,7 +232,7 @@ fn format_all_args_broken_out<'a, 'b>(
         buffer,
         [group(&format_args!(
             "(",
-            soft_block_indent(&format_once(move |f| {
+            soft_block_indent(&format_with(move |f| {
                 for (index, argument) in node.iter().enumerate() {
                     if index > 0 {
                         match f.source_text().get_lines_before(argument.span(), f.comments()) {
@@ -670,7 +670,7 @@ fn write_grouped_arguments<'a>(
             // which would lead to a wrong line count.
             let lines_before = f.source_text().get_lines_before(argument.span(), f.comments());
 
-            let interned = f.intern(&format_once(|f| {
+            let interned = f.intern(&format_with(|f| {
                 format_argument.fmt(f)?;
                 write!(f, (last_index != index).then_some(","))
             }));
@@ -717,7 +717,7 @@ fn write_grouped_arguments<'a>(
         match group_layout {
             GroupedCallArgumentLayout::GroupedFirstArgument => {
                 let argument = node.first().unwrap();
-                let interned = f.intern(&format_once(|f| {
+                let interned = f.intern(&format_with(|f| {
                     FormatGroupedFirstArgument { argument }.fmt(f)?;
                     write!(f, (last_index != 0).then_some(","))
                 }));
@@ -765,7 +765,7 @@ fn write_grouped_arguments<'a>(
             buffer,
             [
                 "(",
-                format_once(|f| {
+                format_with(|f| {
                     let mut joiner = f.join_with(soft_line_break_or_space());
 
                     for (i, (element, _)) in grouped.iter().enumerate() {
@@ -773,7 +773,7 @@ fn write_grouped_arguments<'a>(
                             || (group_layout.is_grouped_last() && i == last_index)
                         {
                             joiner.entry(
-                                &group(&format_once(|f| {
+                                &group(&format_with(|f| {
                                     if let Some(arg_element) = element.clone()? {
                                         f.write_element(arg_element)
                                     } else {
@@ -783,7 +783,7 @@ fn write_grouped_arguments<'a>(
                                 .should_expand(true),
                             );
                         } else {
-                            joiner.entry(&format_once(|f| {
+                            joiner.entry(&format_with(|f| {
                                 if let Some(arg_element) = element.clone()? {
                                     f.write_element(arg_element)
                                 } else {

--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -405,7 +405,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
                 });
 
                 let format_extends =
-                    format_once(|f| write!(f, [space(), "extends", space(), &format_super]));
+                    format_with(|f| write!(f, [space(), "extends", space(), &format_super]));
 
                 if group_mode {
                     write!(f, [soft_line_break_or_space(), group(&format_extends)])?;
@@ -430,7 +430,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
                         ]
                     )?;
                 } else {
-                    let format_inner = format_once(|f| {
+                    let format_inner = format_with(|f| {
                         write!(
                             f,
                             [
@@ -602,7 +602,7 @@ pub fn format_grouped_parameters_with_return_type_for_method<'a>(
 ) -> FormatResult<()> {
     write!(f, type_parameters)?;
 
-    group(&format_once(|f| {
+    group(&format_with(|f| {
         let format_parameters = params.memoized();
         let format_return_type = return_type.map(FormatNodeWithoutTrailingComments).memoized();
 

--- a/crates/oxc_formatter/src/write/decorators.rs
+++ b/crates/oxc_formatter/src/write/decorators.rs
@@ -26,7 +26,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
                 return write!(
                     f,
                     [group(&format_args!(
-                        format_once(|f| {
+                        format_with(|f| {
                             f.join_nodes_with_soft_line().entries(self.iter()).finish()
                         }),
                         soft_line_break_or_space()

--- a/crates/oxc_formatter/src/write/export_declarations.rs
+++ b/crates/oxc_formatter/src/write/export_declarations.rs
@@ -28,7 +28,7 @@ fn format_export_keyword_with_class_decorators<'a>(
 ) -> FormatResult<()> {
     // `@decorator export class Cls {}`
     //            ^ print leading comments here
-    let format_leading_comments = format_once(|f| {
+    let format_leading_comments = format_with(|f| {
         let comments = f.context().comments().comments_before(span.start);
         FormatLeadingComments::Comments(comments).fmt(f)
     });
@@ -181,7 +181,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
                 FormatSeparatedIter::new(self.iter(), ",")
                     .with_trailing_separator(trailing_separator)
                     .map(|specifier| {
-                        format_once(move |f| {
+                        format_with(move |f| {
                             // Should add empty line before the specifier if there are comments before it.
                             let specifier_span = specifier.span();
                             if f.context().comments().has_comment_before(specifier_span.start)

--- a/crates/oxc_formatter/src/write/function.rs
+++ b/crates/oxc_formatter/src/write/function.rs
@@ -42,7 +42,7 @@ impl<'a> Deref for FormatFunction<'a, '_> {
 
 impl<'a> Format<'a> for FormatFunction<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let head = format_once(|f| {
+        let head = format_with(|f| {
             write!(
                 f,
                 [
@@ -65,7 +65,7 @@ impl<'a> Format<'a> for FormatFunction<'a, '_> {
         )
         .memoized();
 
-        let format_parameters = format_once(|f: &mut Formatter<'_, 'a>| {
+        let format_parameters = format_with(|f: &mut Formatter<'_, 'a>| {
             if self.options.call_argument_layout.is_some() {
                 let mut buffer = RemoveSoftLinesBuffer::new(f);
 
@@ -87,7 +87,7 @@ impl<'a> Format<'a> for FormatFunction<'a, '_> {
         let format_return_type = self
             .return_type()
             .map(|return_type| {
-                let content = format_once(move |f| {
+                let content = format_with(move |f| {
                     let needs_space =
                         f.context().comments().has_comment_before(return_type.span.start);
                     write!(f, [maybe_space(needs_space), return_type])
@@ -98,7 +98,7 @@ impl<'a> Format<'a> for FormatFunction<'a, '_> {
 
         write!(
             f,
-            [group(&format_once(|f| {
+            [group(&format_with(|f| {
                 let params = &self.params;
                 // Inspect early, in case the `return_type` is formatted before `parameters`
                 // in `should_group_function_parameters`.

--- a/crates/oxc_formatter/src/write/function_type.rs
+++ b/crates/oxc_formatter/src/write/function_type.rs
@@ -34,7 +34,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructorType<'a>> {
                 r#abstract.then_some("abstract "),
                 "new",
                 space(),
-                &format_once(|f| {
+                &format_with(|f| {
                     format_grouped_parameters_with_return_type(
                         self.type_parameters(),
                         None,
@@ -64,7 +64,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSMethodSignature<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let format_inner = format_once(|f| {
+        let format_inner = format_with(|f| {
             match self.kind() {
                 TSMethodSignatureKind::Method => {}
                 TSMethodSignatureKind::Get => {
@@ -120,7 +120,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
             group(&format_args!(
                 "new",
                 space(),
-                &format_once(|f| {
+                &format_with(|f| {
                     format_grouped_parameters_with_return_type(
                         self.type_parameters(),
                         None,
@@ -144,7 +144,7 @@ pub fn format_grouped_parameters_with_return_type<'a>(
     is_function_or_constructor_type: bool,
     f: &mut Formatter<'_, 'a>,
 ) -> FormatResult<()> {
-    group(&format_once(|f| {
+    group(&format_with(|f| {
         let format_type_parameters = type_parameters.memoized();
         let format_parameters = params.memoized();
         let format_return_type = return_type.map(FormatNodeWithoutTrailingComments).memoized();

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -42,7 +42,7 @@ pub fn format_import_and_export_source_with_clause<'a>(
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let decl = &format_once(|f| {
+        let decl = &format_with(|f| {
             write!(f, ["import", space(), self.import_kind])?;
 
             if let Some(specifiers) = self.specifiers() {
@@ -113,7 +113,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                             let iter = FormatSeparatedIter::new(specifiers_iter, ",")
                                 .with_trailing_separator(trailing_separator)
                                 .map(|specifier| {
-                                    format_once(move |f| {
+                                    format_with(move |f| {
                                         // Should add empty line before the specifier if there are comments before it.
                                         let specifier_span = specifier.span();
                                         if f.context()
@@ -196,7 +196,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
             return write!(f, "{}");
         }
 
-        let format_inner = format_once(|f| {
+        let format_inner = format_with(|f| {
             let should_insert_space_around_brackets = f.options().bracket_spacing.value();
 
             write!(f, "{")?;
@@ -208,7 +208,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
                 write!(
                     f,
                     [soft_block_indent_with_maybe_space(
-                        &format_once(|f| {
+                        &format_with(|f| {
                             let trailing_separator =
                                 FormatTrailingCommas::ES5.trailing_separator(f.options());
 
@@ -226,7 +226,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
             } else {
                 write!(
                     f,
-                    [format_once(|f| {
+                    [format_with(|f| {
                         let maybe_space = maybe_space(f.options().bracket_spacing.value());
                         write!(f, [maybe_space])?;
 

--- a/crates/oxc_formatter/src/write/intersection_type.rs
+++ b/crates/oxc_formatter/src/write/intersection_type.rs
@@ -12,7 +12,7 @@ use crate::{
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let content = format_once(|f| format_intersection_types(self.types(), f));
+        let content = format_with(|f| format_intersection_types(self.types(), f));
         write!(f, [group(&content)])
     }
 }

--- a/crates/oxc_formatter/src/write/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/write/jsx/child_list.rs
@@ -273,7 +273,7 @@ impl FormatJsxChildList {
                     child_breaks = line_mode.is_some_and(LineMode::is_hard);
 
                     let child_should_be_suppressed = is_next_child_suppressed;
-                    let format_child = format_once(|f| {
+                    let format_child = format_with(|f| {
                         if child_should_be_suppressed {
                             FormatSuppressedNode(non_text.span()).fmt(f)
                         } else {
@@ -616,7 +616,7 @@ pub struct FormatMultilineChildren<'a> {
 
 impl<'a> Format<'a> for FormatMultilineChildren<'a> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let format_inner = format_once(|f| {
+        let format_inner = format_with(|f| {
             if let Some(elements) =
                 f.intern_vec(self.elements.borrow_mut().take_in(f.context().allocator()))
             {

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -103,7 +103,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
 
-        let format_tag = format_once(|f| {
+        let format_tag = format_with(|f| {
             if is_suppressed {
                 return FormatSuppressedNode(self.span()).fmt(f);
             }
@@ -170,9 +170,9 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                 write!(
                     f,
                     [
-                        &format_once(|f| { self.format_leading_comments(f) }),
+                        &format_with(|f| { self.format_leading_comments(f) }),
                         format_tag,
-                        &format_once(|f| { self.format_trailing_comments(f) }),
+                        &format_with(|f| { self.format_trailing_comments(f) }),
                     ]
                 )
             }
@@ -188,9 +188,9 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                     write!(
                         f,
                         [soft_block_indent(&format_args!(
-                            &format_once(|f| { self.format_leading_comments(f) }),
+                            &format_with(|f| { self.format_leading_comments(f) }),
                             format_tag,
-                            &format_once(|f| { self.format_trailing_comments(f) }),
+                            &format_with(|f| { self.format_trailing_comments(f) }),
                         ))]
                     )?;
 

--- a/crates/oxc_formatter/src/write/member_expression.rs
+++ b/crates/oxc_formatter/src/write/member_expression.rs
@@ -45,7 +45,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StaticMemberExpression<'a>> {
                     f,
                     [group(&indent(&format_args!(
                         soft_line_break(),
-                        &format_once(|f| {
+                        &format_with(|f| {
                             if f.comments().has_leading_own_line_comment(self.property.span.start) {
                                 let comments = f
                                     .context()

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -335,7 +335,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
         } else {
             write!(
                 f,
-                group(&soft_block_indent(&format_once(|f| {
+                group(&soft_block_indent(&format_with(|f| {
                     let has_element = !self.elements.is_empty();
                     if has_element {
                         write_array_node(
@@ -1391,7 +1391,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                 )?;
             } else {
                 let format_extends =
-                    format_once(|f| write!(f, [space(), "extends", space(), extends]));
+                    format_with(|f| write!(f, [space(), "extends", space(), extends]));
                 if group_mode {
                     write!(f, [soft_line_break_or_space(), group(&format_extends)])?;
                 } else {
@@ -1420,7 +1420,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
             if extends.is_empty() {
                 write!(f, [format_id, format_extends])?;
             } else if group_mode {
-                let indented = format_once(|f| write!(f, [format_id, indent(&format_extends)]));
+                let indented = format_with(|f| write!(f, [format_id, indent(&format_extends)]));
                 let heritage_id = f.group_id("heritageGroup");
                 write!(f, [group(&indented).with_group_id(Some(heritage_id)), space()])?;
             } else {
@@ -1687,7 +1687,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
                     f,
                     [
                         format_argument,
-                        &format_once(|f| {
+                        &format_with(|f| {
                             if self.options.is_some() {
                                 write!(f, [",", soft_line_break_or_space(), format_options])?;
                             }

--- a/crates/oxc_formatter/src/write/program.rs
+++ b/crates/oxc_formatter/src/write/program.rs
@@ -18,7 +18,7 @@ use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        let format_trailing_comments = format_once(|f| {
+        let format_trailing_comments = format_with(|f| {
             write!(f, FormatTrailingComments::Comments(f.context().comments().unprinted_comments()))
         });
 

--- a/crates/oxc_formatter/src/write/sequence_expression.rs
+++ b/crates/oxc_formatter/src/write/sequence_expression.rs
@@ -12,7 +12,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         let format_inner = format_with(|f| {
             let mut expressions = self.expressions().iter();
-            let separator = format_once(|f| {
+            let separator = format_with(|f| {
                 write!(f, [",", line_suffix_boundary(), soft_line_break_or_space()])
             })
             .memoized();

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -733,7 +733,7 @@ fn try_format_embedded_template<'a>(
     // - Indented content (each line will be indented)
     // - Hard line break (newline before closing backtick)
     // - Closing backtick
-    let format_content = format_once(|f: &mut Formatter<'_, 'a>| {
+    let format_content = format_with(|f: &mut Formatter<'_, 'a>| {
         let content = f.context().allocator().alloc_str(&formatted);
         for line in content.split('\n') {
             write!(f, [text(line), hard_line_break()])?;

--- a/crates/oxc_formatter/src/write/try_statement.rs
+++ b/crates/oxc_formatter/src/write/try_statement.rs
@@ -87,7 +87,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
         if leading_comment_with_break || trailing_comment_with_break {
             write!(
                 f,
-                soft_block_indent(&format_once(|f| {
+                soft_block_indent(&format_with(|f| {
                     write!(f, [FormatLeadingComments::Comments(leading_comments)])?;
                     let printed_len_before_pattern =
                         f.context().comments().printed_comments().len();

--- a/crates/oxc_formatter/src/write/type_parameters.rs
+++ b/crates/oxc_formatter/src/write/type_parameters.rs
@@ -119,7 +119,7 @@ impl<'a> Format<'a> for FormatTSTypeParameters<'a, '_> {
         } else {
             write!(
                 f,
-                [group(&format_args!("<", format_once(|f| {
+                [group(&format_args!("<", format_with(|f| {
                     if matches!(self.decl.grand_parent(), AstNodes::CallExpression(call) if is_test_call_expression(call))
                     {
                         f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit).finish()
@@ -165,7 +165,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
             false
         };
 
-        let format_params = format_once(|f| {
+        let format_params = format_with(|f| {
             f.join_with(&soft_line_break_or_space())
                 .entries_with_trailing_separator(params, ",", TrailingSeparator::Disallowed)
                 .finish()


### PR DESCRIPTION
`format_once` has slightly overhead as its `T` was wrapped by Cell to avoid double calling. So prefer to `format_with` when possible