### PR TITLE
refactor(formatter): make `Format::fmt` non-failable

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -9,7 +9,7 @@ use oxc_span::GetSpan;
 
 use crate::ast_nodes::AstNode;
 use crate::formatter::{
-    Format, FormatResult, Formatter,
+    Format, Formatter,
     trivia::{format_leading_comments, format_trailing_comments},
 };
 
@@ -850,12 +850,12 @@ impl<'a> AstNode<'a, Program<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1194,12 +1194,12 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1209,12 +1209,12 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1224,12 +1224,12 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1239,22 +1239,22 @@ impl<'a> AstNode<'a, LabelIdentifier<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ThisExpression> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1270,12 +1270,12 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1317,12 +1317,12 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
 }
 
 impl<'a> AstNode<'a, Elision> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1338,12 +1338,12 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1416,12 +1416,12 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
         self.inner.computed
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1486,12 +1486,12 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1537,12 +1537,12 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1562,12 +1562,12 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
         self.inner.lone_surrogates
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1633,12 +1633,12 @@ impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
         self.inner.optional
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1670,12 +1670,12 @@ impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
         self.inner.optional
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1707,12 +1707,12 @@ impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
         self.inner.optional
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1769,12 +1769,12 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
         self.inner.pure
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1826,12 +1826,12 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
         self.inner.pure
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1858,12 +1858,12 @@ impl<'a> AstNode<'a, MetaProperty<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1879,12 +1879,12 @@ impl<'a> AstNode<'a, SpreadElement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1937,12 +1937,12 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -1963,12 +1963,12 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2000,12 +2000,12 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2032,12 +2032,12 @@ impl<'a> AstNode<'a, PrivateInExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2069,12 +2069,12 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2112,12 +2112,12 @@ impl<'a> AstNode<'a, ConditionalExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2149,12 +2149,12 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2302,12 +2302,12 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2337,12 +2337,12 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2358,12 +2358,12 @@ impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2423,12 +2423,12 @@ impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2489,12 +2489,12 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2530,12 +2530,12 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
         self.inner.computed
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2551,22 +2551,22 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, Super> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2582,12 +2582,12 @@ impl<'a> AstNode<'a, AwaitExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2603,12 +2603,12 @@ impl<'a> AstNode<'a, ChainExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2661,12 +2661,12 @@ impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2855,12 +2855,12 @@ impl<'a> AstNode<'a, Directive<'a>> {
         self.inner.directive
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2870,12 +2870,12 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
         self.inner.value
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -2891,12 +2891,12 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3002,12 +3002,12 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3046,22 +3046,22 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
         self.inner.definite
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, EmptyStatement> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3077,12 +3077,12 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3122,12 +3122,12 @@ impl<'a> AstNode<'a, IfStatement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3154,12 +3154,12 @@ impl<'a> AstNode<'a, DoWhileStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3186,12 +3186,12 @@ impl<'a> AstNode<'a, WhileStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3253,12 +3253,12 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3325,12 +3325,12 @@ impl<'a> AstNode<'a, ForInStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3402,12 +3402,12 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3425,12 +3425,12 @@ impl<'a> AstNode<'a, ContinueStatement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3448,12 +3448,12 @@ impl<'a> AstNode<'a, BreakStatement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3471,12 +3471,12 @@ impl<'a> AstNode<'a, ReturnStatement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3503,12 +3503,12 @@ impl<'a> AstNode<'a, WithStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3535,12 +3535,12 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3570,12 +3570,12 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3602,12 +3602,12 @@ impl<'a> AstNode<'a, LabeledStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3623,12 +3623,12 @@ impl<'a> AstNode<'a, ThrowStatement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3675,12 +3675,12 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3709,12 +3709,12 @@ impl<'a> AstNode<'a, CatchClause<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3730,22 +3730,22 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, DebuggerStatement> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3780,12 +3780,12 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
         self.inner.optional
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3854,12 +3854,12 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3888,12 +3888,12 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3930,12 +3930,12 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
         self.inner.computed
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3964,12 +3964,12 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -3985,12 +3985,12 @@ impl<'a> AstNode<'a, BindingRestElement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4118,12 +4118,12 @@ impl<'a> AstNode<'a, Function<'a>> {
         self.inner.pife
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4157,12 +4157,12 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4204,12 +4204,12 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
         self.inner.r#override
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4237,12 +4237,12 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4322,12 +4322,12 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
         self.inner.pife
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4350,12 +4350,12 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4495,12 +4495,12 @@ impl<'a> AstNode<'a, Class<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4516,12 +4516,12 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4642,12 +4642,12 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
         self.inner.accessibility
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4751,12 +4751,12 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
         self.inner.accessibility
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4766,12 +4766,12 @@ impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4787,12 +4787,12 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4939,12 +4939,12 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
         self.inner.accessibility
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -4978,12 +4978,12 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
         self.inner.phase
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5035,12 +5035,12 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
         self.inner.import_kind
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5106,12 +5106,12 @@ impl<'a> AstNode<'a, ImportSpecifier<'a>> {
         self.inner.import_kind
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5127,12 +5127,12 @@ impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5148,12 +5148,12 @@ impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5174,12 +5174,12 @@ impl<'a> AstNode<'a, WithClause<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5206,12 +5206,12 @@ impl<'a> AstNode<'a, ImportAttribute<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5311,12 +5311,12 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5332,12 +5332,12 @@ impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5384,12 +5384,12 @@ impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
         self.inner.export_kind
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5421,12 +5421,12 @@ impl<'a> AstNode<'a, ExportSpecifier<'a>> {
         self.inner.export_kind
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5533,12 +5533,12 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5548,22 +5548,22 @@ impl<'a> AstNode<'a, BooleanLiteral> {
         self.inner.value
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, NullLiteral> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5583,12 +5583,12 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
         self.inner.base
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5608,12 +5608,12 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
         self.inner.lone_surrogates
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5633,12 +5633,12 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
         self.inner.base
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5653,12 +5653,12 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
         self.inner.raw
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5705,12 +5705,12 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5757,12 +5757,12 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5778,12 +5778,12 @@ impl<'a> AstNode<'a, JSXClosingElement<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5826,32 +5826,32 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXOpeningFragment> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXClosingFragment> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5928,12 +5928,12 @@ impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -5960,12 +5960,12 @@ impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6015,12 +6015,12 @@ impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6054,12 +6054,12 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
 }
 
 impl<'a> AstNode<'a, JSXEmptyExpression> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6114,12 +6114,12 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6135,12 +6135,12 @@ impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6216,12 +6216,12 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
         self.inner.name
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6279,12 +6279,12 @@ impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6299,12 +6299,12 @@ impl<'a> AstNode<'a, JSXText<'a>> {
         self.inner.raw
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6327,12 +6327,12 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6369,12 +6369,12 @@ impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6390,12 +6390,12 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6425,12 +6425,12 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6486,12 +6486,12 @@ impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6507,12 +6507,12 @@ impl<'a> AstNode<'a, TSLiteralType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6891,12 +6891,12 @@ impl<'a> AstNode<'a, TSConditionalType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6912,12 +6912,12 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6933,12 +6933,12 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6954,12 +6954,12 @@ impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -6980,12 +6980,12 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7001,12 +7001,12 @@ impl<'a> AstNode<'a, TSArrayType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7033,12 +7033,12 @@ impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7054,12 +7054,12 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7091,12 +7091,12 @@ impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
         self.inner.optional
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7112,12 +7112,12 @@ impl<'a> AstNode<'a, TSOptionalType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7133,12 +7133,12 @@ impl<'a> AstNode<'a, TSRestType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7178,142 +7178,142 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
 }
 
 impl<'a> AstNode<'a, TSAnyKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSStringKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSBooleanKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNumberKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNeverKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSIntrinsicKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSUnknownKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNullKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSUndefinedKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSVoidKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSSymbolKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSThisType> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSObjectKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSBigIntKeyword> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7343,12 +7343,12 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7409,12 +7409,12 @@ impl<'a> AstNode<'a, TSQualifiedName<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7432,12 +7432,12 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7500,12 +7500,12 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
         self.inner.r#const
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7523,12 +7523,12 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7579,12 +7579,12 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7614,12 +7614,12 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7683,12 +7683,12 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7704,12 +7704,12 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7754,12 +7754,12 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7846,12 +7846,12 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
         self.inner.r#static
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -7926,12 +7926,12 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8024,12 +8024,12 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8082,12 +8082,12 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8108,12 +8108,12 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8143,12 +8143,12 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8183,12 +8183,12 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8251,12 +8251,12 @@ impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8334,12 +8334,12 @@ impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
         self.inner.declare
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8366,12 +8366,12 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8387,12 +8387,12 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8408,12 +8408,12 @@ impl<'a> AstNode<'a, TSInferType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8443,12 +8443,12 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8546,12 +8546,12 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
             .as_ref()
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8604,12 +8604,12 @@ impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8667,12 +8667,12 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8717,12 +8717,12 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8781,12 +8781,12 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
         self.inner.readonly
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8813,12 +8813,12 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8845,12 +8845,12 @@ impl<'a> AstNode<'a, TSAsExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8877,12 +8877,12 @@ impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8909,12 +8909,12 @@ impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8946,12 +8946,12 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
         self.inner.import_kind
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -8996,12 +8996,12 @@ impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9017,12 +9017,12 @@ impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9038,12 +9038,12 @@ impl<'a> AstNode<'a, Decorator<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9059,12 +9059,12 @@ impl<'a> AstNode<'a, TSExportAssignment<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9082,12 +9082,12 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9114,12 +9114,12 @@ impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
         })
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9140,12 +9140,12 @@ impl<'a> AstNode<'a, JSDocNullableType<'a>> {
         self.inner.postfix
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
@@ -9166,21 +9166,21 @@ impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
         self.inner.postfix
     }
 
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSDocUnknownType> {
-    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_leading_comments(self.span()).fmt(f)
+    pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_leading_comments(self.span()).fmt(f);
     }
 
-    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f)
+    pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -7,344 +7,424 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
-    formatter::{Format, FormatResult, Formatter},
+    formatter::{Format, Formatter},
     parentheses::NeedsParentheses,
     utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
     write::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
 };
 
 impl<'a> Format<'a> for AstNode<'a, Program<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.write(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        self.write(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            Expression::BooleanLiteral(inner) => allocator
-                .alloc(AstNode::<BooleanLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::NullLiteral(inner) => allocator
-                .alloc(AstNode::<NullLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::NumericLiteral(inner) => allocator
-                .alloc(AstNode::<NumericLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::BigIntLiteral(inner) => allocator
-                .alloc(AstNode::<BigIntLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::RegExpLiteral(inner) => allocator
-                .alloc(AstNode::<RegExpLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TemplateLiteral(inner) => allocator
-                .alloc(AstNode::<TemplateLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::Identifier(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::MetaProperty(inner) => allocator
-                .alloc(AstNode::<MetaProperty> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::Super(inner) => allocator
-                .alloc(AstNode::<Super> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ArrayExpression(inner) => allocator
-                .alloc(AstNode::<ArrayExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ArrowFunctionExpression(inner) => allocator
-                .alloc(AstNode::<ArrowFunctionExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::AssignmentExpression(inner) => allocator
-                .alloc(AstNode::<AssignmentExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::AwaitExpression(inner) => allocator
-                .alloc(AstNode::<AwaitExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::BinaryExpression(inner) => allocator
-                .alloc(AstNode::<BinaryExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::CallExpression(inner) => allocator
-                .alloc(AstNode::<CallExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ChainExpression(inner) => allocator
-                .alloc(AstNode::<ChainExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ClassExpression(inner) => allocator
-                .alloc(AstNode::<Class> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ConditionalExpression(inner) => allocator
-                .alloc(AstNode::<ConditionalExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::FunctionExpression(inner) => allocator
-                .alloc(AstNode::<Function> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ImportExpression(inner) => allocator
-                .alloc(AstNode::<ImportExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::LogicalExpression(inner) => allocator
-                .alloc(AstNode::<LogicalExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::NewExpression(inner) => allocator
-                .alloc(AstNode::<NewExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ObjectExpression(inner) => allocator
-                .alloc(AstNode::<ObjectExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ParenthesizedExpression(inner) => allocator
-                .alloc(AstNode::<ParenthesizedExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::SequenceExpression(inner) => allocator
-                .alloc(AstNode::<SequenceExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TaggedTemplateExpression(inner) => allocator
-                .alloc(AstNode::<TaggedTemplateExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::ThisExpression(inner) => allocator
-                .alloc(AstNode::<ThisExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::UnaryExpression(inner) => allocator
-                .alloc(AstNode::<UnaryExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::UpdateExpression(inner) => allocator
-                .alloc(AstNode::<UpdateExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::YieldExpression(inner) => allocator
-                .alloc(AstNode::<YieldExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::PrivateInExpression(inner) => allocator
-                .alloc(AstNode::<PrivateInExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::JSXElement(inner) => allocator
-                .alloc(AstNode::<JSXElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::JSXFragment(inner) => allocator
-                .alloc(AstNode::<JSXFragment> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TSAsExpression(inner) => allocator
-                .alloc(AstNode::<TSAsExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TSSatisfiesExpression(inner) => allocator
-                .alloc(AstNode::<TSSatisfiesExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TSTypeAssertion(inner) => allocator
-                .alloc(AstNode::<TSTypeAssertion> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TSNonNullExpression(inner) => allocator
-                .alloc(AstNode::<TSNonNullExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::TSInstantiationExpression(inner) => allocator
-                .alloc(AstNode::<TSInstantiationExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Expression::V8IntrinsicExpression(inner) => allocator
-                .alloc(AstNode::<V8IntrinsicExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            Expression::BooleanLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<BooleanLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::NullLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<NullLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::NumericLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<NumericLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::BigIntLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<BigIntLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::RegExpLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<RegExpLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TemplateLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<TemplateLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::MetaProperty(inner) => {
+                allocator
+                    .alloc(AstNode::<MetaProperty> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::Super(inner) => {
+                allocator
+                    .alloc(AstNode::<Super> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ArrayExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ArrayExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ArrowFunctionExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ArrowFunctionExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::AssignmentExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<AssignmentExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::AwaitExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<AwaitExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::BinaryExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<BinaryExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::CallExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<CallExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ChainExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ChainExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ClassExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<Class> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ConditionalExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ConditionalExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::FunctionExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<Function> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ImportExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ImportExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::LogicalExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<LogicalExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::NewExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<NewExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ObjectExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ObjectExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ParenthesizedExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ParenthesizedExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::SequenceExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<SequenceExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TaggedTemplateExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TaggedTemplateExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::ThisExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ThisExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::UnaryExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<UnaryExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::UpdateExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<UpdateExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::YieldExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<YieldExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::PrivateInExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<PrivateInExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::JSXElement(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::JSXFragment(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXFragment> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TSAsExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSAsExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TSSatisfiesExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSSatisfiesExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TSTypeAssertion(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeAssertion> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TSNonNullExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNonNullExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::TSInstantiationExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSInstantiationExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Expression::V8IntrinsicExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<V8IntrinsicExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_member_expression!(Expression) => {
                 let inner = it.to_member_expression();
                 allocator
@@ -354,130 +434,146 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, IdentifierReference<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BindingIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, LabelIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ArrayExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, true, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, true, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ArrayExpressionElement::SpreadElement(inner) => allocator
-                .alloc(AstNode::<SpreadElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ArrayExpressionElement::Elision(inner) => allocator
-                .alloc(AstNode::<Elision> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ArrayExpressionElement::SpreadElement(inner) => {
+                allocator
+                    .alloc(AstNode::<SpreadElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ArrayExpressionElement::Elision(inner) => {
+                allocator
+                    .alloc(AstNode::<Elision> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(ArrayExpressionElement) => {
                 let inner = it.to_expression();
                 allocator
@@ -487,103 +583,117 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Elision> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ObjectExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, true, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, true, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ObjectPropertyKind::ObjectProperty(inner) => allocator
-                .alloc(AstNode::<ObjectProperty> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ObjectPropertyKind::SpreadProperty(inner) => allocator
-                .alloc(AstNode::<SpreadElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ObjectPropertyKind::ObjectProperty(inner) => {
+                allocator
+                    .alloc(AstNode::<ObjectProperty> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ObjectPropertyKind::SpreadProperty(inner) => {
+                allocator
+                    .alloc(AstNode::<SpreadElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ObjectProperty<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            PropertyKey::StaticIdentifier(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            PropertyKey::PrivateIdentifier(inner) => allocator
-                .alloc(AstNode::<PrivateIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            PropertyKey::StaticIdentifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            PropertyKey::PrivateIdentifier(inner) => {
+                allocator
+                    .alloc(AstNode::<PrivateIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(PropertyKey) => {
                 let inner = it.to_expression();
                 allocator
@@ -593,252 +703,278 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TemplateElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            MemberExpression::ComputedMemberExpression(inner) => allocator
-                .alloc(AstNode::<ComputedMemberExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            MemberExpression::StaticMemberExpression(inner) => allocator
-                .alloc(AstNode::<StaticMemberExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            MemberExpression::PrivateFieldExpression(inner) => allocator
-                .alloc(AstNode::<PrivateFieldExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            MemberExpression::ComputedMemberExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ComputedMemberExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            MemberExpression::StaticMemberExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<StaticMemberExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            MemberExpression::PrivateFieldExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<PrivateFieldExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, SpreadElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            Argument::SpreadElement(inner) => allocator
-                .alloc(AstNode::<SpreadElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            Argument::SpreadElement(inner) => {
+                allocator
+                    .alloc(AstNode::<SpreadElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(Argument) => {
                 let inner = it.to_expression();
                 allocator
@@ -848,162 +984,176 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
@@ -1016,7 +1166,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
             it @ match_assignment_target_pattern!(AssignmentTarget) => {
                 let inner = it.to_assignment_target_pattern();
@@ -1027,7 +1177,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
@@ -1035,50 +1185,60 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            SimpleAssignmentTarget::AssignmentTargetIdentifier(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            SimpleAssignmentTarget::TSAsExpression(inner) => allocator
-                .alloc(AstNode::<TSAsExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            SimpleAssignmentTarget::TSSatisfiesExpression(inner) => allocator
-                .alloc(AstNode::<TSSatisfiesExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            SimpleAssignmentTarget::TSNonNullExpression(inner) => allocator
-                .alloc(AstNode::<TSNonNullExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            SimpleAssignmentTarget::TSTypeAssertion(inner) => allocator
-                .alloc(AstNode::<TSTypeAssertion> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            SimpleAssignmentTarget::TSAsExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSAsExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            SimpleAssignmentTarget::TSSatisfiesExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSSatisfiesExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            SimpleAssignmentTarget::TSNonNullExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNonNullExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            SimpleAssignmentTarget::TSTypeAssertion(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeAssertion> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_member_expression!(SimpleAssignmentTarget) => {
                 let inner = it.to_member_expression();
                 allocator
@@ -1088,7 +1248,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
@@ -1096,77 +1256,89 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            AssignmentTargetPattern::ArrayAssignmentTarget(inner) => allocator
-                .alloc(AstNode::<ArrayAssignmentTarget> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            AssignmentTargetPattern::ObjectAssignmentTarget(inner) => allocator
-                .alloc(AstNode::<ObjectAssignmentTarget> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            AssignmentTargetPattern::ArrayAssignmentTarget(inner) => {
+                allocator
+                    .alloc(AstNode::<ArrayAssignmentTarget> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            AssignmentTargetPattern::ObjectAssignmentTarget(inner) => {
+                allocator
+                    .alloc(AstNode::<ObjectAssignmentTarget> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(inner) => allocator
-                .alloc(AstNode::<AssignmentTargetWithDefault> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(inner) => {
+                allocator
+                    .alloc(AstNode::<AssignmentTargetWithDefault> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
                 let inner = it.to_assignment_target();
                 allocator
@@ -1176,177 +1348,199 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(inner) => allocator
-                .alloc(AstNode::<AssignmentTargetPropertyIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner) => allocator
-                .alloc(AstNode::<AssignmentTargetPropertyProperty> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(inner) => {
+                allocator
+                    .alloc(AstNode::<AssignmentTargetPropertyIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner) => {
+                allocator
+                    .alloc(AstNode::<AssignmentTargetPropertyProperty> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Super> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ChainExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ChainElement::CallExpression(inner) => allocator
-                .alloc(AstNode::<CallExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ChainElement::TSNonNullExpression(inner) => allocator
-                .alloc(AstNode::<TSNonNullExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ChainElement::CallExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<CallExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ChainElement::TSNonNullExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNonNullExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_member_expression!(ChainElement) => {
                 let inner = it.to_member_expression();
                 allocator
@@ -1356,183 +1550,221 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            Statement::BlockStatement(inner) => allocator
-                .alloc(AstNode::<BlockStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::BreakStatement(inner) => allocator
-                .alloc(AstNode::<BreakStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ContinueStatement(inner) => allocator
-                .alloc(AstNode::<ContinueStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::DebuggerStatement(inner) => allocator
-                .alloc(AstNode::<DebuggerStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::DoWhileStatement(inner) => allocator
-                .alloc(AstNode::<DoWhileStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::EmptyStatement(inner) => allocator
-                .alloc(AstNode::<EmptyStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ExpressionStatement(inner) => allocator
-                .alloc(AstNode::<ExpressionStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ForInStatement(inner) => allocator
-                .alloc(AstNode::<ForInStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ForOfStatement(inner) => allocator
-                .alloc(AstNode::<ForOfStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ForStatement(inner) => allocator
-                .alloc(AstNode::<ForStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::IfStatement(inner) => allocator
-                .alloc(AstNode::<IfStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::LabeledStatement(inner) => allocator
-                .alloc(AstNode::<LabeledStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ReturnStatement(inner) => allocator
-                .alloc(AstNode::<ReturnStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::SwitchStatement(inner) => allocator
-                .alloc(AstNode::<SwitchStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::ThrowStatement(inner) => allocator
-                .alloc(AstNode::<ThrowStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::TryStatement(inner) => allocator
-                .alloc(AstNode::<TryStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::WhileStatement(inner) => allocator
-                .alloc(AstNode::<WhileStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Statement::WithStatement(inner) => allocator
-                .alloc(AstNode::<WithStatement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            Statement::BlockStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<BlockStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::BreakStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<BreakStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ContinueStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ContinueStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::DebuggerStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<DebuggerStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::DoWhileStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<DoWhileStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::EmptyStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<EmptyStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ExpressionStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ExpressionStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ForInStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ForInStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ForOfStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ForOfStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ForStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ForStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::IfStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<IfStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::LabeledStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<LabeledStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ReturnStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ReturnStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::SwitchStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<SwitchStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::ThrowStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<ThrowStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::TryStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<TryStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::WhileStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<WhileStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Statement::WithStatement(inner) => {
+                allocator
+                    .alloc(AstNode::<WithStatement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_declaration!(Statement) => {
                 let inner = it.to_declaration();
                 allocator
@@ -1542,7 +1774,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
             it @ match_module_declaration!(Statement) => {
                 let inner = it.to_module_declaration();
@@ -1553,229 +1785,271 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Directive<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Hashbang<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BlockStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            Declaration::VariableDeclaration(inner) => allocator
-                .alloc(AstNode::<VariableDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::FunctionDeclaration(inner) => allocator
-                .alloc(AstNode::<Function> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::ClassDeclaration(inner) => allocator
-                .alloc(AstNode::<Class> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSTypeAliasDeclaration(inner) => allocator
-                .alloc(AstNode::<TSTypeAliasDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSInterfaceDeclaration(inner) => allocator
-                .alloc(AstNode::<TSInterfaceDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSEnumDeclaration(inner) => allocator
-                .alloc(AstNode::<TSEnumDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSModuleDeclaration(inner) => allocator
-                .alloc(AstNode::<TSModuleDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSGlobalDeclaration(inner) => allocator
-                .alloc(AstNode::<TSGlobalDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            Declaration::TSImportEqualsDeclaration(inner) => allocator
-                .alloc(AstNode::<TSImportEqualsDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            Declaration::VariableDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<VariableDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::FunctionDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<Function> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::ClassDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<Class> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSTypeAliasDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeAliasDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSInterfaceDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSInterfaceDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSEnumDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSEnumDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSModuleDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSModuleDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSGlobalDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSGlobalDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            Declaration::TSImportEqualsDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSImportEqualsDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, VariableDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, VariableDeclarator<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, IfStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, DoWhileStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, WhileStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ForStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ForStatementInit::VariableDeclaration(inner) => allocator
-                .alloc(AstNode::<VariableDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ForStatementInit::VariableDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<VariableDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(ForStatementInit) => {
                 let inner = it.to_expression();
                 allocator
@@ -1785,37 +2059,41 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ForInStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ForStatementLeft::VariableDeclaration(inner) => allocator
-                .alloc(AstNode::<VariableDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ForStatementLeft::VariableDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<VariableDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_assignment_target!(ForStatementLeft) => {
                 let inner = it.to_assignment_target();
                 allocator
@@ -1825,347 +2103,388 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ForOfStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ContinueStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BreakStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ReturnStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, WithStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, SwitchStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, SwitchCase<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, LabeledStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ThrowStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TryStatement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, CatchClause<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, CatchParameter<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, DebuggerStatement> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BindingPatternKind<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            BindingPatternKind::BindingIdentifier(inner) => allocator
-                .alloc(AstNode::<BindingIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            BindingPatternKind::ObjectPattern(inner) => allocator
-                .alloc(AstNode::<ObjectPattern> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            BindingPatternKind::ArrayPattern(inner) => allocator
-                .alloc(AstNode::<ArrayPattern> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            BindingPatternKind::AssignmentPattern(inner) => allocator
-                .alloc(AstNode::<AssignmentPattern> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            BindingPatternKind::BindingIdentifier(inner) => {
+                allocator
+                    .alloc(AstNode::<BindingIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            BindingPatternKind::ObjectPattern(inner) => {
+                allocator
+                    .alloc(AstNode::<ObjectPattern> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            BindingPatternKind::ArrayPattern(inner) => {
+                allocator
+                    .alloc(AstNode::<ArrayPattern> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            BindingPatternKind::AssignmentPattern(inner) => {
+                allocator
+                    .alloc(AstNode::<AssignmentPattern> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AssignmentPattern<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ObjectPattern<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BindingProperty<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ArrayPattern<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 
-    fn fmt_with_options(
-        &self,
-        options: FormatFunctionOptions,
-        f: &mut Formatter<'_, 'a>,
-    ) -> FormatResult<()> {
+    fn fmt_with_options(&self, options: FormatFunctionOptions, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result = if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f)
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
-            self.write_with_options(options, f)
-        };
-        if needs_parentheses {
-            ")".fmt(f)?;
+            self.write_with_options(options, f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, FormalParameters<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, FormalParameter<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
@@ -2173,495 +2492,566 @@ impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
 impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
     for AstNode<'a, ArrowFunctionExpression<'a>>
 {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 
     fn fmt_with_options(
         &self,
         options: FormatJsArrowFunctionExpressionOptions,
         f: &mut Formatter<'_, 'a>,
-    ) -> FormatResult<()> {
+    ) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result = if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f)
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
-            self.write_with_options(options, f)
-        };
-        if needs_parentheses {
-            ")".fmt(f)?;
+            self.write_with_options(options, f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ClassBody<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ClassElement::StaticBlock(inner) => allocator
-                .alloc(AstNode::<StaticBlock> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ClassElement::MethodDefinition(inner) => allocator
-                .alloc(AstNode::<MethodDefinition> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ClassElement::PropertyDefinition(inner) => allocator
-                .alloc(AstNode::<PropertyDefinition> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ClassElement::AccessorProperty(inner) => allocator
-                .alloc(AstNode::<AccessorProperty> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ClassElement::TSIndexSignature(inner) => allocator
-                .alloc(AstNode::<TSIndexSignature> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ClassElement::StaticBlock(inner) => {
+                allocator
+                    .alloc(AstNode::<StaticBlock> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ClassElement::MethodDefinition(inner) => {
+                allocator
+                    .alloc(AstNode::<MethodDefinition> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ClassElement::PropertyDefinition(inner) => {
+                allocator
+                    .alloc(AstNode::<PropertyDefinition> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ClassElement::AccessorProperty(inner) => {
+                allocator
+                    .alloc(AstNode::<AccessorProperty> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ClassElement::TSIndexSignature(inner) => {
+                allocator
+                    .alloc(AstNode::<TSIndexSignature> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, MethodDefinition<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, PropertyDefinition<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, PrivateIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, StaticBlock<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ModuleDeclaration::ImportDeclaration(inner) => allocator
-                .alloc(AstNode::<ImportDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleDeclaration::ExportAllDeclaration(inner) => allocator
-                .alloc(AstNode::<ExportAllDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleDeclaration::ExportDefaultDeclaration(inner) => allocator
-                .alloc(AstNode::<ExportDefaultDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleDeclaration::ExportNamedDeclaration(inner) => allocator
-                .alloc(AstNode::<ExportNamedDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleDeclaration::TSExportAssignment(inner) => allocator
-                .alloc(AstNode::<TSExportAssignment> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleDeclaration::TSNamespaceExportDeclaration(inner) => allocator
-                .alloc(AstNode::<TSNamespaceExportDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ModuleDeclaration::ImportDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<ImportDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleDeclaration::ExportAllDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<ExportAllDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleDeclaration::ExportDefaultDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<ExportDefaultDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleDeclaration::ExportNamedDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<ExportNamedDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleDeclaration::TSExportAssignment(inner) => {
+                allocator
+                    .alloc(AstNode::<TSExportAssignment> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleDeclaration::TSNamespaceExportDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNamespaceExportDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ImportDeclarationSpecifier::ImportSpecifier(inner) => allocator
-                .alloc(AstNode::<ImportSpecifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ImportDeclarationSpecifier::ImportDefaultSpecifier(inner) => allocator
-                .alloc(AstNode::<ImportDefaultSpecifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner) => allocator
-                .alloc(AstNode::<ImportNamespaceSpecifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ImportDeclarationSpecifier::ImportSpecifier(inner) => {
+                allocator
+                    .alloc(AstNode::<ImportSpecifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(inner) => {
+                allocator
+                    .alloc(AstNode::<ImportDefaultSpecifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner) => {
+                allocator
+                    .alloc(AstNode::<ImportNamespaceSpecifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, WithClause<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportAttribute<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ImportAttributeKey::Identifier(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ImportAttributeKey::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ImportAttributeKey::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ImportAttributeKey::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.format_leading_comments(f)?;
-            FormatSuppressedNode(self.span()).fmt(f)?;
-            self.format_trailing_comments(f)
+            self.format_leading_comments(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            self.format_trailing_comments(f);
         } else {
-            self.write(f)
+            self.write(f);
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ExportDefaultDeclarationKind::FunctionDeclaration(inner) => allocator
-                .alloc(AstNode::<Function> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ExportDefaultDeclarationKind::ClassDeclaration(inner) => allocator
-                .alloc(AstNode::<Class> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(inner) => allocator
-                .alloc(AstNode::<TSInterfaceDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ExportDefaultDeclarationKind::FunctionDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<Function> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<Class> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSInterfaceDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(ExportDefaultDeclarationKind) => {
                 let inner = it.to_expression();
                 allocator
@@ -2671,7 +3061,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
@@ -2679,394 +3069,444 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            ModuleExportName::IdentifierName(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleExportName::IdentifierReference(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            ModuleExportName::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            ModuleExportName::IdentifierName(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleExportName::IdentifierReference(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            ModuleExportName::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        if format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        if format_type_cast_comment_node(self, false, f) {
+            return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result = self.write(f);
+        self.write(f);
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        result
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXOpeningElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXClosingElement<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXFragment<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        if format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        if format_type_cast_comment_node(self, false, f) {
+            return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result = self.write(f);
+        self.write(f);
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        result
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXOpeningFragment> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXClosingFragment> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXElementName::Identifier(inner) => allocator
-                .alloc(AstNode::<JSXIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXElementName::IdentifierReference(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXElementName::NamespacedName(inner) => allocator
-                .alloc(AstNode::<JSXNamespacedName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXElementName::MemberExpression(inner) => allocator
-                .alloc(AstNode::<JSXMemberExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXElementName::ThisExpression(inner) => allocator
-                .alloc(AstNode::<ThisExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXElementName::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXElementName::IdentifierReference(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXElementName::NamespacedName(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXNamespacedName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXElementName::MemberExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXMemberExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXElementName::ThisExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ThisExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXNamespacedName<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXMemberExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXMemberExpressionObject::IdentifierReference(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXMemberExpressionObject::MemberExpression(inner) => allocator
-                .alloc(AstNode::<JSXMemberExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXMemberExpressionObject::ThisExpression(inner) => allocator
-                .alloc(AstNode::<ThisExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXMemberExpressionObject::IdentifierReference(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXMemberExpressionObject::MemberExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXMemberExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXMemberExpressionObject::ThisExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ThisExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXExpression::EmptyExpression(inner) => allocator
-                .alloc(AstNode::<JSXEmptyExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXExpression::EmptyExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXEmptyExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_expression!(JSXExpression) => {
                 let inner = it.to_expression();
                 allocator
@@ -3076,867 +3516,1037 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXEmptyExpression> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXAttributeItem::Attribute(inner) => allocator
-                .alloc(AstNode::<JSXAttribute> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXAttributeItem::SpreadAttribute(inner) => allocator
-                .alloc(AstNode::<JSXSpreadAttribute> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXAttributeItem::Attribute(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXAttribute> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXAttributeItem::SpreadAttribute(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXSpreadAttribute> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXAttribute<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXAttributeName::Identifier(inner) => allocator
-                .alloc(AstNode::<JSXIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXAttributeName::NamespacedName(inner) => allocator
-                .alloc(AstNode::<JSXNamespacedName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXAttributeName::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXAttributeName::NamespacedName(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXNamespacedName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXAttributeValue::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXAttributeValue::ExpressionContainer(inner) => allocator
-                .alloc(AstNode::<JSXExpressionContainer> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXAttributeValue::Element(inner) => allocator
-                .alloc(AstNode::<JSXElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXAttributeValue::Fragment(inner) => allocator
-                .alloc(AstNode::<JSXFragment> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXAttributeValue::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXAttributeValue::ExpressionContainer(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXExpressionContainer> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXAttributeValue::Element(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXAttributeValue::Fragment(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXFragment> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            JSXChild::Text(inner) => allocator
-                .alloc(AstNode::<JSXText> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXChild::Element(inner) => allocator
-                .alloc(AstNode::<JSXElement> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXChild::Fragment(inner) => allocator
-                .alloc(AstNode::<JSXFragment> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXChild::ExpressionContainer(inner) => allocator
-                .alloc(AstNode::<JSXExpressionContainer> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            JSXChild::Spread(inner) => allocator
-                .alloc(AstNode::<JSXSpreadChild> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            JSXChild::Text(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXText> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXChild::Element(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXElement> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXChild::Fragment(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXFragment> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXChild::ExpressionContainer(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXExpressionContainer> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            JSXChild::Spread(inner) => {
+                allocator
+                    .alloc(AstNode::<JSXSpreadChild> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXSpreadChild<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSXText<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSThisParameter<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumBody<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumMember<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSEnumMemberName::Identifier(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSEnumMemberName::String(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSEnumMemberName::ComputedString(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSEnumMemberName::ComputedTemplateString(inner) => allocator
-                .alloc(AstNode::<TemplateLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSEnumMemberName::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSEnumMemberName::String(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSEnumMemberName::ComputedString(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSEnumMemberName::ComputedTemplateString(inner) => {
+                allocator
+                    .alloc(AstNode::<TemplateLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSLiteralType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSLiteral::BooleanLiteral(inner) => allocator
-                .alloc(AstNode::<BooleanLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSLiteral::NumericLiteral(inner) => allocator
-                .alloc(AstNode::<NumericLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSLiteral::BigIntLiteral(inner) => allocator
-                .alloc(AstNode::<BigIntLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSLiteral::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSLiteral::TemplateLiteral(inner) => allocator
-                .alloc(AstNode::<TemplateLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSLiteral::UnaryExpression(inner) => allocator
-                .alloc(AstNode::<UnaryExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSLiteral::BooleanLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<BooleanLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSLiteral::NumericLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<NumericLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSLiteral::BigIntLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<BigIntLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSLiteral::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSLiteral::TemplateLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<TemplateLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSLiteral::UnaryExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<UnaryExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSType::TSAnyKeyword(inner) => allocator
-                .alloc(AstNode::<TSAnyKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSBigIntKeyword(inner) => allocator
-                .alloc(AstNode::<TSBigIntKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSBooleanKeyword(inner) => allocator
-                .alloc(AstNode::<TSBooleanKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSIntrinsicKeyword(inner) => allocator
-                .alloc(AstNode::<TSIntrinsicKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSNeverKeyword(inner) => allocator
-                .alloc(AstNode::<TSNeverKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSNullKeyword(inner) => allocator
-                .alloc(AstNode::<TSNullKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSNumberKeyword(inner) => allocator
-                .alloc(AstNode::<TSNumberKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSObjectKeyword(inner) => allocator
-                .alloc(AstNode::<TSObjectKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSStringKeyword(inner) => allocator
-                .alloc(AstNode::<TSStringKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSSymbolKeyword(inner) => allocator
-                .alloc(AstNode::<TSSymbolKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSUndefinedKeyword(inner) => allocator
-                .alloc(AstNode::<TSUndefinedKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSUnknownKeyword(inner) => allocator
-                .alloc(AstNode::<TSUnknownKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSVoidKeyword(inner) => allocator
-                .alloc(AstNode::<TSVoidKeyword> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSArrayType(inner) => allocator
-                .alloc(AstNode::<TSArrayType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSConditionalType(inner) => allocator
-                .alloc(AstNode::<TSConditionalType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSConstructorType(inner) => allocator
-                .alloc(AstNode::<TSConstructorType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSFunctionType(inner) => allocator
-                .alloc(AstNode::<TSFunctionType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSImportType(inner) => allocator
-                .alloc(AstNode::<TSImportType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSIndexedAccessType(inner) => allocator
-                .alloc(AstNode::<TSIndexedAccessType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSInferType(inner) => allocator
-                .alloc(AstNode::<TSInferType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSIntersectionType(inner) => allocator
-                .alloc(AstNode::<TSIntersectionType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSLiteralType(inner) => allocator
-                .alloc(AstNode::<TSLiteralType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSMappedType(inner) => allocator
-                .alloc(AstNode::<TSMappedType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSNamedTupleMember(inner) => allocator
-                .alloc(AstNode::<TSNamedTupleMember> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTemplateLiteralType(inner) => allocator
-                .alloc(AstNode::<TSTemplateLiteralType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSThisType(inner) => allocator
-                .alloc(AstNode::<TSThisType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTupleType(inner) => allocator
-                .alloc(AstNode::<TSTupleType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTypeLiteral(inner) => allocator
-                .alloc(AstNode::<TSTypeLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTypeOperatorType(inner) => allocator
-                .alloc(AstNode::<TSTypeOperator> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTypePredicate(inner) => allocator
-                .alloc(AstNode::<TSTypePredicate> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTypeQuery(inner) => allocator
-                .alloc(AstNode::<TSTypeQuery> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSTypeReference(inner) => allocator
-                .alloc(AstNode::<TSTypeReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSUnionType(inner) => allocator
-                .alloc(AstNode::<TSUnionType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::TSParenthesizedType(inner) => allocator
-                .alloc(AstNode::<TSParenthesizedType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::JSDocNullableType(inner) => allocator
-                .alloc(AstNode::<JSDocNullableType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::JSDocNonNullableType(inner) => allocator
-                .alloc(AstNode::<JSDocNonNullableType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSType::JSDocUnknownType(inner) => allocator
-                .alloc(AstNode::<JSDocUnknownType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSType::TSAnyKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSAnyKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSBigIntKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSBigIntKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSBooleanKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSBooleanKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSIntrinsicKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSIntrinsicKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSNeverKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNeverKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSNullKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNullKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSNumberKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNumberKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSObjectKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSObjectKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSStringKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSStringKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSSymbolKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSSymbolKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSUndefinedKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSUndefinedKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSUnknownKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSUnknownKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSVoidKeyword(inner) => {
+                allocator
+                    .alloc(AstNode::<TSVoidKeyword> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSArrayType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSArrayType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSConditionalType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSConditionalType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSConstructorType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSConstructorType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSFunctionType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSFunctionType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSImportType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSImportType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSIndexedAccessType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSIndexedAccessType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSInferType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSInferType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSIntersectionType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSIntersectionType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSLiteralType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSLiteralType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSMappedType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSMappedType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSNamedTupleMember(inner) => {
+                allocator
+                    .alloc(AstNode::<TSNamedTupleMember> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTemplateLiteralType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTemplateLiteralType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSThisType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSThisType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTupleType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTupleType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTypeLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTypeOperatorType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeOperator> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTypePredicate(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypePredicate> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTypeQuery(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeQuery> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSTypeReference(inner) => {
+                allocator
+                    .alloc(AstNode::<TSTypeReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSUnionType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSUnionType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::TSParenthesizedType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSParenthesizedType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::JSDocNullableType(inner) => {
+                allocator
+                    .alloc(AstNode::<JSDocNullableType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::JSDocNonNullableType(inner) => {
+                allocator
+                    .alloc(AstNode::<JSDocNonNullableType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSType::JSDocUnknownType(inner) => {
+                allocator
+                    .alloc(AstNode::<JSDocUnknownType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSConditionalType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSUnionType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSIntersectionType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSParenthesizedType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSArrayType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTupleType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSOptionalType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSRestType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSTupleElement::TSOptionalType(inner) => allocator
-                .alloc(AstNode::<TSOptionalType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSTupleElement::TSRestType(inner) => allocator
-                .alloc(AstNode::<TSRestType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSTupleElement::TSOptionalType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSOptionalType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSTupleElement::TSRestType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSRestType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_ts_type!(TSTupleElement) => {
                 let inner = it.to_ts_type();
                 allocator
@@ -3946,615 +4556,719 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSAnyKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSStringKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSBooleanKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNumberKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNeverKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSIntrinsicKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSUnknownKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNullKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSUndefinedKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSVoidKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSSymbolKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSThisType> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSObjectKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSBigIntKeyword> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeReference<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSTypeName::IdentifierReference(inner) => allocator
-                .alloc(AstNode::<IdentifierReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSTypeName::QualifiedName(inner) => allocator
-                .alloc(AstNode::<TSQualifiedName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSTypeName::ThisExpression(inner) => allocator
-                .alloc(AstNode::<ThisExpression> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSTypeName::IdentifierReference(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSTypeName::QualifiedName(inner) => {
+                allocator
+                    .alloc(AstNode::<TSQualifiedName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSTypeName::ThisExpression(inner) => {
+                allocator
+                    .alloc(AstNode::<ThisExpression> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSQualifiedName<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameter<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSClassImplements<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceBody<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSPropertySignature<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSSignature::TSIndexSignature(inner) => allocator
-                .alloc(AstNode::<TSIndexSignature> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSSignature::TSPropertySignature(inner) => allocator
-                .alloc(AstNode::<TSPropertySignature> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSSignature::TSCallSignatureDeclaration(inner) => allocator
-                .alloc(AstNode::<TSCallSignatureDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSSignature::TSConstructSignatureDeclaration(inner) => allocator
-                .alloc(AstNode::<TSConstructSignatureDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSSignature::TSMethodSignature(inner) => allocator
-                .alloc(AstNode::<TSMethodSignature> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSSignature::TSIndexSignature(inner) => {
+                allocator
+                    .alloc(AstNode::<TSIndexSignature> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSSignature::TSPropertySignature(inner) => {
+                allocator
+                    .alloc(AstNode::<TSPropertySignature> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSSignature::TSCallSignatureDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSCallSignatureDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSSignature::TSConstructSignatureDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSConstructSignatureDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSSignature::TSMethodSignature(inner) => {
+                allocator
+                    .alloc(AstNode::<TSMethodSignature> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSMethodSignature<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypePredicate<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSTypePredicateName::Identifier(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSTypePredicateName::This(inner) => allocator
-                .alloc(AstNode::<TSThisType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSTypePredicateName::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSTypePredicateName::This(inner) => {
+                allocator
+                    .alloc(AstNode::<TSThisType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSModuleDeclarationName::Identifier(inner) => allocator
-                .alloc(AstNode::<BindingIdentifier> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSModuleDeclarationName::StringLiteral(inner) => allocator
-                .alloc(AstNode::<StringLiteral> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSModuleDeclarationName::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<BindingIdentifier> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSModuleDeclarationName::StringLiteral(inner) => {
+                allocator
+                    .alloc(AstNode::<StringLiteral> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSModuleDeclarationBody::TSModuleDeclaration(inner) => allocator
-                .alloc(AstNode::<TSModuleDeclaration> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSModuleDeclarationBody::TSModuleBlock(inner) => allocator
-                .alloc(AstNode::<TSModuleBlock> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
+                allocator
+                    .alloc(AstNode::<TSModuleDeclaration> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSModuleDeclarationBody::TSModuleBlock(inner) => {
+                allocator
+                    .alloc(AstNode::<TSModuleBlock> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleBlock<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeLiteral<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInferType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeQuery<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSTypeQueryExprName::TSImportType(inner) => allocator
-                .alloc(AstNode::<TSImportType> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSTypeQueryExprName::TSImportType(inner) => {
+                allocator
+                    .alloc(AstNode::<TSImportType> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
                 let inner = it.to_ts_type_name();
                 allocator
@@ -4564,212 +5278,238 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSImportType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSImportTypeQualifier::Identifier(inner) => allocator
-                .alloc(AstNode::<IdentifierName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
-            TSImportTypeQualifier::QualifiedName(inner) => allocator
-                .alloc(AstNode::<TSImportTypeQualifiedName> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSImportTypeQualifier::Identifier(inner) => {
+                allocator
+                    .alloc(AstNode::<IdentifierName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
+            TSImportTypeQualifier::QualifiedName(inner) => {
+                allocator
+                    .alloc(AstNode::<TSImportTypeQualifiedName> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSFunctionType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSConstructorType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSMappedType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
-            TSModuleReference::ExternalModuleReference(inner) => allocator
-                .alloc(AstNode::<TSExternalModuleReference> {
-                    inner,
-                    parent,
-                    allocator,
-                    following_span: self.following_span,
-                })
-                .fmt(f),
+            TSModuleReference::ExternalModuleReference(inner) => {
+                allocator
+                    .alloc(AstNode::<TSExternalModuleReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span: self.following_span,
+                    })
+                    .fmt(f);
+            }
             it @ match_ts_type_name!(TSModuleReference) => {
                 let inner = it.to_ts_type_name();
                 allocator
@@ -4779,127 +5519,145 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                         allocator,
                         following_span: self.following_span,
                     })
-                    .fmt(f)
+                    .fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNonNullExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Decorator<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSExportAssignment<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f)? {
-            return Ok(());
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
         }
-        self.format_leading_comments(f)?;
+        self.format_leading_comments(f);
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            "(".fmt(f)?;
+            "(".fmt(f);
         }
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
         if needs_parentheses {
-            ")".fmt(f)?;
+            ")".fmt(f);
         }
-        self.format_trailing_comments(f)?;
-        result
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSDocNullableType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, JSDocUnknownType> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f)?;
-        let result =
-            if is_suppressed { FormatSuppressedNode(self.span()).fmt(f) } else { self.write(f) };
-        self.format_trailing_comments(f)?;
-        result
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
     }
 }

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -36,7 +36,7 @@ use crate::{TrailingSeparator, write};
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![token("a,"), soft_line_break(), token("b")])
 /// ])?;
@@ -56,7 +56,7 @@ use crate::{TrailingSeparator, write};
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -92,7 +92,7 @@ pub const fn soft_line_break() -> Line {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("a,"),
@@ -123,7 +123,7 @@ pub const fn hard_line_break() -> Line {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// fn main() -> FormatResult<()> {
+/// fn test() {
 /// let elements = format!(
 ///     SimpleFormatContext::default(), [
 ///     group(&format_args![
@@ -155,7 +155,7 @@ pub const fn empty_line() -> Line {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("a,"),
@@ -177,7 +177,7 @@ pub const fn empty_line() -> Line {
 /// use biome_formatter::{format_args, format, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -215,8 +215,8 @@ impl Line {
 }
 
 impl Format<'_> for Line {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::Line(self.mode))
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::Line(self.mode));
     }
 }
 
@@ -239,7 +239,7 @@ impl std::fmt::Debug for Line {
 /// use biome_formatter::format;
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [token("Hello World")])?;
 ///
 /// assert_eq!(
@@ -257,7 +257,7 @@ impl std::fmt::Debug for Line {
 /// use biome_formatter::format;
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = format!(SimpleFormatContext::default(), [token("\"Hello\\tWorld\"")])?;
 ///
@@ -284,8 +284,8 @@ pub struct Token {
 }
 
 impl Format<'_> for Token {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::Token { text: self.text })
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::Token { text: self.text });
     }
 }
 
@@ -318,13 +318,13 @@ pub struct Text<'a> {
 }
 
 impl<'a> Format<'a> for Text<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         f.write_element(FormatElement::Text {
             text: self.text,
             width: self
                 .width
                 .unwrap_or_else(|| TextWidth::from_text(self.text, f.options().indent_width)),
-        })
+        });
     }
 }
 
@@ -351,7 +351,7 @@ fn debug_assert_no_newlines(text: &str) {
 /// use biome_formatter::{format};
 /// use biome_formatter::prelude::*;
 ///
-/// fn main() -> FormatResult<()> {
+/// fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     token("a"),
 ///     line_suffix(&token("c")),
@@ -379,10 +379,10 @@ pub struct LineSuffix<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for LineSuffix<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLineSuffix))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLineSuffix))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartLineSuffix));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndLineSuffix));
     }
 }
 
@@ -402,7 +402,7 @@ impl std::fmt::Debug for LineSuffix<'_, '_> {
 /// use biome_formatter::format;
 /// use biome_formatter::prelude::*;
 ///
-/// # fn  main() -> FormatResult<()> {
+/// # fn  main()  {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     token("a"),
 ///     line_suffix(&token("c")),
@@ -426,8 +426,8 @@ pub const fn line_suffix_boundary() -> LineSuffixBoundary {
 pub struct LineSuffixBoundary;
 
 impl Format<'_> for LineSuffixBoundary {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::LineSuffixBoundary)
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::LineSuffixBoundary);
     }
 }
 
@@ -460,7 +460,7 @@ impl Format<'_> for LineSuffixBoundary {
 ///     }
 /// }
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let formatted = format!(
 ///     SimpleFormatContext::default(),
 ///     [format_with(|f| {
@@ -511,10 +511,10 @@ pub struct FormatLabelled<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for FormatLabelled<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLabelled))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndLabelled));
     }
 }
 
@@ -532,7 +532,7 @@ impl std::fmt::Debug for FormatLabelled<'_, '_> {
 /// use biome_formatter::format;
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = format!(SimpleFormatContext::default(), [token("a"), space(), token("b")])?;
 ///
@@ -555,7 +555,7 @@ pub const fn space() -> Space {
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -584,7 +584,7 @@ pub const fn space() -> Space {
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -618,7 +618,7 @@ pub const fn hard_space() -> HardSpace {
 /// use biome_formatter::format;
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [token("a"), maybe_space(true), token("b")])?;
 /// let nospace = format!(SimpleFormatContext::default(), [token("a"), maybe_space(false), token("b")])?;
 ///
@@ -636,8 +636,8 @@ pub fn maybe_space(should_insert: bool) -> Option<Space> {
 pub struct Space;
 
 impl Format<'_> for Space {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::Space)
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::Space);
     }
 }
 
@@ -645,8 +645,8 @@ impl Format<'_> for Space {
 pub struct HardSpace;
 
 impl Format<'_> for HardSpace {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::HardSpace)
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::HardSpace);
     }
 }
 /// It adds a level of indentation to the given content
@@ -663,7 +663,7 @@ impl Format<'_> for HardSpace {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(SimpleFormatContext::default(), [
 ///     token("switch {"),
 ///     block_indent(&format_args![
@@ -690,7 +690,7 @@ impl Format<'_> for HardSpace {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{format, format_args};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(
 ///     SimpleFormatContext::default(),
 ///     [
@@ -726,10 +726,10 @@ pub struct Indent<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for Indent<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndent))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndent))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartIndent));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndIndent));
     }
 }
 
@@ -751,7 +751,7 @@ impl std::fmt::Debug for Indent<'_, '_> {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(SimpleFormatContext::default(), [
 ///     token("root"),
 ///     align(2, &format_args![
@@ -784,7 +784,7 @@ impl std::fmt::Debug for Indent<'_, '_> {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{format, format_args, IndentStyle, IndentWidth, SimpleFormatOptions};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 ///     let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///         indent_width: IndentWidth::try_from(8).unwrap(),
 ///         indent_style: IndentStyle::Space,
@@ -839,7 +839,7 @@ impl std::fmt::Debug for Indent<'_, '_> {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{format, format_args};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(
 ///     SimpleFormatContext::default(),
 ///     [
@@ -882,10 +882,10 @@ pub struct Dedent<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for Dedent<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartDedent(self.mode)))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndDedent(self.mode)))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartDedent(self.mode)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndDedent(self.mode)));
     }
 }
 
@@ -903,7 +903,7 @@ impl std::fmt::Debug for Dedent<'_, '_> {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(SimpleFormatContext::default(), [
 ///     token("root"),
 ///     indent(&format_args![
@@ -962,7 +962,7 @@ where
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format!(SimpleFormatContext::default(), [
 ///     token("a"),
 ///     hard_line_break(),
@@ -1007,7 +1007,7 @@ where
 /// use biome_formatter::{format, format_args, IndentStyle, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     indent_style: IndentStyle::Space,
 ///     indent_width: 4.try_into().unwrap(),
@@ -1065,10 +1065,10 @@ pub struct Align<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for Align<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndAlign))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndAlign));
     }
 }
 
@@ -1094,7 +1094,7 @@ impl std::fmt::Debug for Align<'_, '_> {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let block = format![
 ///     SimpleFormatContext::default(),
 ///     [
@@ -1132,7 +1132,7 @@ pub fn block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> 
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1163,7 +1163,7 @@ pub fn block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> 
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("["),
@@ -1200,7 +1200,7 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1233,7 +1233,7 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("{"),
@@ -1260,7 +1260,7 @@ pub fn soft_block_indent<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, '
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("{"),
@@ -1303,7 +1303,7 @@ pub fn soft_block_indent_with_maybe_space<'ast>(
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1337,7 +1337,7 @@ pub fn soft_block_indent_with_maybe_space<'ast>(
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("a"),
@@ -1370,7 +1370,7 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1404,7 +1404,7 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("a"),
@@ -1427,7 +1427,7 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(8).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1472,38 +1472,38 @@ enum IndentMode {
 }
 
 impl<'ast> Format<'ast> for BlockIndent<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         let snapshot = f.snapshot();
 
-        f.write_element(FormatElement::Tag(StartIndent))?;
+        f.write_element(FormatElement::Tag(StartIndent));
 
         match self.mode {
-            IndentMode::Soft => write!(f, soft_line_break())?,
-            IndentMode::Block => write!(f, hard_line_break())?,
+            IndentMode::Soft => write!(f, soft_line_break()),
+            IndentMode::Block => write!(f, hard_line_break()),
             IndentMode::SoftLineOrSpace | IndentMode::SoftSpace => {
-                write!(f, soft_line_break_or_space())?;
+                write!(f, soft_line_break_or_space());
             }
-            IndentMode::HardSpace => write!(f, [hard_space(), soft_line_break()])?,
+            IndentMode::HardSpace => write!(f, [hard_space(), soft_line_break()]),
         }
 
         let is_empty = {
             let mut recording = f.start_recording();
-            recording.write_fmt(Arguments::from(&self.content))?;
+            recording.write_fmt(Arguments::from(&self.content));
             recording.stop().is_empty()
         };
 
         if is_empty {
             f.restore_snapshot(snapshot);
-            return Ok(());
+            return;
         }
 
-        f.write_element(FormatElement::Tag(EndIndent))?;
+        f.write_element(FormatElement::Tag(EndIndent));
 
         match self.mode {
             IndentMode::Soft => write!(f, [soft_line_break()]),
             IndentMode::Block => write!(f, [hard_line_break()]),
             IndentMode::SoftSpace => write!(f, [soft_line_break_or_space()]),
-            IndentMode::SoftLineOrSpace | IndentMode::HardSpace => Ok(()),
+            IndentMode::SoftLineOrSpace | IndentMode::HardSpace => (),
         }
     }
 }
@@ -1532,7 +1532,7 @@ impl std::fmt::Debug for BlockIndent<'_, '_> {
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1564,7 +1564,7 @@ impl std::fmt::Debug for BlockIndent<'_, '_> {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("{"),
@@ -1606,7 +1606,7 @@ pub fn soft_space_or_block_indent<'ast>(content: &impl Format<'ast>) -> BlockInd
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("["),
@@ -1634,7 +1634,7 @@ pub fn soft_space_or_block_indent<'ast>(content: &impl Format<'ast>) -> BlockInd
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1693,16 +1693,16 @@ impl Group<'_, '_> {
 }
 
 impl<'ast> Format<'ast> for Group<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         let mode = if self.should_expand { GroupMode::Expand } else { GroupMode::Flat };
 
         f.write_element(FormatElement::Tag(StartGroup(
             tag::Group::new().with_id(self.group_id).with_mode(mode),
-        )))?;
+        )));
 
-        Arguments::from(&self.content).fmt(f)?;
+        Arguments::from(&self.content).fmt(f);
 
-        f.write_element(FormatElement::Tag(EndGroup))
+        f.write_element(FormatElement::Tag(EndGroup));
     }
 }
 
@@ -1726,7 +1726,7 @@ impl std::fmt::Debug for Group<'_, '_> {
 /// use biome_formatter::{format, format_args, LineWidth};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("["),
@@ -1740,7 +1740,7 @@ impl std::fmt::Debug for Group<'_, '_> {
 ///         ]),
 ///         token("]"),
 ///     ])
-/// ])?;
+/// ]);
 ///
 /// assert_eq!(
 ///     "[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]",
@@ -1760,8 +1760,8 @@ pub const fn expand_parent() -> ExpandParent {
 pub struct ExpandParent;
 
 impl Format<'_> for ExpandParent {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        f.write_element(FormatElement::ExpandParent)
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_element(FormatElement::ExpandParent);
     }
 }
 
@@ -1780,7 +1780,7 @@ impl Format<'_> for ExpandParent {
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("["),
@@ -1794,7 +1794,7 @@ impl Format<'_> for ExpandParent {
 ///         ]),
 ///         token("]"),
 ///     ])
-/// ])?;
+/// ]);
 ///
 /// assert_eq!(
 ///     "[1, 2, 3]",
@@ -1810,7 +1810,7 @@ impl Format<'_> for ExpandParent {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::printer::PrintWidth;
 ///
-/// fn main() -> FormatResult<()> {
+/// fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1829,7 +1829,7 @@ impl Format<'_> for ExpandParent {
 ///         ]),
 ///         token("]"),
 ///     ])
-/// ])?;
+/// ]);
 ///
 /// assert_eq!(
 ///     "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
@@ -1858,7 +1858,7 @@ where
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let formatted = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         token("["),
@@ -1887,7 +1887,7 @@ where
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
 ///     ..SimpleFormatOptions::default()
@@ -1945,7 +1945,7 @@ impl IfGroupBreaks<'_, '_> {
     /// use biome_formatter::{format, format_args, write, LineWidth, SimpleFormatOptions};
     /// use biome_formatter::prelude::*;
     ///
-    /// # fn main() -> FormatResult<()> {
+    /// # fn test() {
     /// let context = SimpleFormatContext::new(SimpleFormatOptions {
     ///     line_width: LineWidth::try_from(20).unwrap(),
     ///     ..SimpleFormatOptions::default()
@@ -1991,12 +1991,12 @@ impl IfGroupBreaks<'_, '_> {
 }
 
 impl<'ast> Format<'ast> for IfGroupBreaks<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         f.write_element(FormatElement::Tag(StartConditionalContent(
             Condition::new(self.mode).with_group_id(self.group_id),
-        )))?;
-        self.content.fmt(f)?;
-        f.write_element(FormatElement::Tag(EndConditionalContent))
+        )));
+        self.content.fmt(f);
+        f.write_element(FormatElement::Tag(EndConditionalContent));
     }
 }
 
@@ -2045,7 +2045,7 @@ impl std::fmt::Debug for IfGroupBreaks<'_, '_> {
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions, write};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let content = format_with(|f| {
 ///     let group_id = f.group_id("header");
 ///
@@ -2075,7 +2075,7 @@ impl std::fmt::Debug for IfGroupBreaks<'_, '_> {
 /// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions, write};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let content = format_with(|f| {
 ///     let group_id = f.group_id("header");
 ///
@@ -2112,10 +2112,10 @@ pub struct IndentIfGroupBreaks<'a, 'ast> {
 }
 
 impl<'ast> Format<'ast> for IndentIfGroupBreaks<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)))?;
-        Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks(self.group_id)))
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks(self.group_id)));
     }
 }
 
@@ -2136,11 +2136,11 @@ pub struct FormatWith<T> {
 
 impl<'ast, T> Format<'ast> for FormatWith<T>
 where
-    T: Fn(&mut Formatter<'_, 'ast>) -> FormatResult<()>,
+    T: Fn(&mut Formatter<'_, 'ast>),
 {
     #[inline(always)]
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        (self.formatter)(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        (self.formatter)(f);
     }
 }
 
@@ -2164,7 +2164,7 @@ impl<T> std::fmt::Debug for FormatWith<T> {
 /// }
 ///
 /// impl Format<SimpleFormatContext> for MyFormat {
-///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
 ///         write!(f, [
 ///             token("("),
 ///             block_indent(&format_with(|f| {
@@ -2181,7 +2181,7 @@ impl<T> std::fmt::Debug for FormatWith<T> {
 ///     }
 /// }
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let formatted = format!(SimpleFormatContext::default(), [MyFormat { items: vec!["a", "b", "c"]}])?;
 ///
 /// assert_eq!("(\n\ta b c\n)", formatted.print()?.as_code());
@@ -2190,7 +2190,7 @@ impl<T> std::fmt::Debug for FormatWith<T> {
 /// ```
 pub const fn format_with<'ast, T>(formatter: T) -> FormatWith<T>
 where
-    T: Fn(&mut Formatter<'_, 'ast>) -> FormatResult<()>,
+    T: Fn(&mut Formatter<'_, 'ast>),
 {
     FormatWith { formatter }
 }
@@ -2219,7 +2219,7 @@ where
 /// }
 ///
 /// impl Format<SimpleFormatContext> for MyFormat {
-///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
 ///         let mut values = generate_values();
 ///
 ///         let first = values.next();
@@ -2236,7 +2236,7 @@ where
 ///     }
 /// }
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn test() {
 /// let formatted = format!(SimpleFormatContext::default(), [MyFormat])?;
 ///
 /// assert_eq!("1\n\t2\n\t3\n\t4\n", formatted.print()?.as_code());
@@ -2264,7 +2264,7 @@ where
 /// ```
 pub const fn format_once<'ast, T>(formatter: T) -> FormatOnce<T>
 where
-    T: FnOnce(&mut Formatter<'_, 'ast>) -> FormatResult<()>,
+    T: FnOnce(&mut Formatter<'_, 'ast>),
 {
     FormatOnce { formatter: Cell::new(Some(formatter)) }
 }
@@ -2275,13 +2275,13 @@ pub struct FormatOnce<T> {
 
 impl<'ast, T> Format<'ast> for FormatOnce<T>
 where
-    T: FnOnce(&mut Formatter<'_, 'ast>) -> FormatResult<()>,
+    T: FnOnce(&mut Formatter<'_, 'ast>),
 {
     #[inline(always)]
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         let formatter = self.formatter.take().expect("Tried to format a `format_once` at least twice. This is not allowed. You may want to use `format_with` or `format.memoized` instead.");
 
-        (formatter)(f)
+        (formatter)(f);
     }
 }
 
@@ -2295,7 +2295,6 @@ impl<T> std::fmt::Debug for FormatOnce<T> {
 /// See [Formatter::join]
 #[must_use = "must eventually call `finish()` on Format builders"]
 pub struct JoinBuilder<'fmt, 'buf, 'ast, Separator> {
-    result: FormatResult<()>,
     fmt: &'fmt mut Formatter<'buf, 'ast>,
     with: Option<Separator>,
     has_elements: bool,
@@ -2307,26 +2306,24 @@ where
 {
     /// Creates a new instance that joins the elements without a separator
     pub(super) fn new(fmt: &'fmt mut Formatter<'buf, 'ast>) -> Self {
-        Self { result: Ok(()), fmt, has_elements: false, with: None }
+        Self { fmt, has_elements: false, with: None }
     }
 
     /// Creates a new instance that prints the passed separator between every two entries.
     pub(super) fn with_separator(fmt: &'fmt mut Formatter<'buf, 'ast>, with: Separator) -> Self {
-        Self { result: Ok(()), fmt, has_elements: false, with: Some(with) }
+        Self { fmt, has_elements: false, with: Some(with) }
     }
 
     /// Adds a new entry to the join output.
     pub fn entry(&mut self, entry: &dyn Format<'ast>) -> &mut Self {
-        self.result = self.result.and_then(|()| {
-            if let Some(with) = &self.with
-                && self.has_elements
-            {
-                with.fmt(self.fmt)?;
-            }
-            self.has_elements = true;
+        if let Some(with) = &self.with
+            && self.has_elements
+        {
+            with.fmt(self.fmt);
+        }
+        self.has_elements = true;
 
-            entry.fmt(self.fmt)
-        });
+        entry.fmt(self.fmt);
 
         self
     }
@@ -2365,8 +2362,9 @@ where
     }
 
     /// Finishes the output and returns any error encountered.
-    pub fn finish(&self) -> FormatResult<()> {
-        self.result
+    #[expect(clippy::unused_self)]
+    pub fn finish(&self) {
+        // TODO: remove this method
     }
 }
 
@@ -2374,7 +2372,6 @@ where
 /// to be separated by empty lines in the formatted output.
 #[must_use = "must eventually call `finish()` on Format builders"]
 pub struct JoinNodesBuilder<'fmt, 'buf, 'ast, Separator> {
-    result: FormatResult<()>,
     /// The separator to insert between nodes. Either a soft or hard line break
     separator: Separator,
     fmt: &'fmt mut Formatter<'buf, 'ast>,
@@ -2386,31 +2383,27 @@ where
     Separator: Format<'ast>,
 {
     pub(super) fn new(separator: Separator, fmt: &'fmt mut Formatter<'buf, 'ast>) -> Self {
-        Self { result: Ok(()), separator, fmt, has_elements: false }
+        Self { separator, fmt, has_elements: false }
     }
 
     /// Adds a new node with the specified formatted content to the output, respecting any new lines
     /// that appear before the node in the input source.
     pub fn entry(&mut self, span: Span, content: &dyn Format<'ast>) {
-        self.result = self.result.and_then(|()| {
-            if self.has_elements {
-                if self.has_lines_before(span) {
-                    write!(self.fmt, empty_line())?;
-                } else {
-                    self.separator.fmt(self.fmt)?;
-                }
+        if self.has_elements {
+            if self.has_lines_before(span) {
+                write!(self.fmt, empty_line());
+            } else {
+                self.separator.fmt(self.fmt);
             }
-            self.has_elements = true;
-            write!(self.fmt, content)
-        });
+        }
+        self.has_elements = true;
+        write!(self.fmt, content);
     }
 
     /// Writes an entry without adding a separating line break or empty line.
     pub fn entry_no_separator(&mut self, content: &dyn Format<'ast>) {
-        self.result = self.result.and_then(|()| {
-            self.has_elements = true;
-            write!(self.fmt, content)
-        });
+        self.has_elements = true;
+        write!(self.fmt, content);
     }
 
     /// Adds an iterator of entries to the output. Each entry is a `(node, content)` tuple.
@@ -2444,8 +2437,9 @@ where
         self
     }
 
-    pub fn finish(&self) -> FormatResult<()> {
-        self.result
+    #[expect(clippy::unused_self)]
+    pub fn finish(&self) {
+        // TODO: remove this method
     }
 
     /// Get the number of line breaks between two consecutive SyntaxNodes in the tree
@@ -2457,16 +2451,15 @@ where
 /// Builder to fill as many elements as possible on a single line.
 #[must_use = "must eventually call `finish()` on Format builders"]
 pub struct FillBuilder<'fmt, 'buf, 'ast> {
-    result: FormatResult<()>,
     fmt: &'fmt mut Formatter<'buf, 'ast>,
     empty: bool,
 }
 
 impl<'fmt, 'buf, 'ast> FillBuilder<'fmt, 'buf, 'ast> {
     pub(crate) fn new(fmt: &'fmt mut Formatter<'buf, 'ast>) -> Self {
-        let result = fmt.write_element(FormatElement::Tag(StartFill));
+        fmt.write_element(FormatElement::Tag(StartFill));
 
-        Self { result, fmt, empty: true }
+        Self { fmt, empty: true }
     }
 
     /// Adds an iterator of entries to the fill output. Uses the passed `separator` to separate any two items.
@@ -2484,26 +2477,24 @@ impl<'fmt, 'buf, 'ast> FillBuilder<'fmt, 'buf, 'ast> {
 
     /// Adds a new entry to the fill output. The `separator` isn't written if this is the first element in the list.
     pub fn entry(&mut self, separator: &dyn Format<'ast>, entry: &dyn Format<'ast>) -> &mut Self {
-        self.result = self.result.and_then(|()| {
-            if self.empty {
-                self.empty = false;
-            } else {
-                self.fmt.write_element(FormatElement::Tag(StartEntry))?;
-                separator.fmt(self.fmt)?;
-                self.fmt.write_element(FormatElement::Tag(EndEntry))?;
-            }
+        if self.empty {
+            self.empty = false;
+        } else {
+            self.fmt.write_element(FormatElement::Tag(StartEntry));
+            separator.fmt(self.fmt);
+            self.fmt.write_element(FormatElement::Tag(EndEntry));
+        }
 
-            self.fmt.write_element(FormatElement::Tag(StartEntry))?;
-            entry.fmt(self.fmt)?;
-            self.fmt.write_element(FormatElement::Tag(EndEntry))
-        });
+        self.fmt.write_element(FormatElement::Tag(StartEntry));
+        entry.fmt(self.fmt);
+        self.fmt.write_element(FormatElement::Tag(EndEntry));
 
         self
     }
 
     /// Finishes the output and returns any error encountered
-    pub fn finish(&mut self) -> FormatResult<()> {
-        self.result.and_then(|()| self.fmt.write_element(FormatElement::Tag(EndFill)))
+    pub fn finish(&mut self) {
+        self.fmt.write_element(FormatElement::Tag(EndFill));
     }
 }
 
@@ -2540,16 +2531,16 @@ impl<'fmt, 'ast> BestFitting<'fmt, 'ast> {
 }
 
 impl<'ast> Format<'ast> for BestFitting<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         let mut buffer = VecBuffer::new(f.state_mut());
         let variants = self.variants.items();
 
         let mut formatted_variants = Vec::with_capacity(variants.len());
 
         for variant in variants {
-            buffer.write_element(FormatElement::Tag(StartEntry))?;
-            buffer.write_fmt(Arguments::from(variant))?;
-            buffer.write_element(FormatElement::Tag(EndEntry))?;
+            buffer.write_element(FormatElement::Tag(StartEntry));
+            buffer.write_fmt(Arguments::from(variant));
+            buffer.write_element(FormatElement::Tag(EndEntry));
 
             formatted_variants.push(buffer.take_vec().into_bump_slice());
         }
@@ -2565,6 +2556,6 @@ impl<'ast> Format<'ast> for BestFitting<'_, 'ast> {
             ))
         };
 
-        f.write_element(element)
+        f.write_element(element);
     }
 }

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use super::super::prelude::*;
 use super::tag::Tag;
 use crate::formatter::prelude::tag::{DedentMode, GroupMode};
-use crate::{Format, FormatResult, formatter::FormatContext, formatter::Formatter};
+use crate::{Format, formatter::FormatContext, formatter::Formatter};
 
 use crate::{format, write};
 
@@ -152,15 +152,14 @@ impl std::fmt::Display for Document<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let allocator = Allocator::default();
         let context = FormatContext::dummy(&allocator);
-        let formatted =
-            format!(context, [self.elements]).expect("Formatting not to throw any FormatErrors");
+        let formatted = format!(context, [self.elements]);
 
         f.write_str(formatted.print().expect("Expected a valid document").as_code())
     }
 }
 
 impl<'a> Format<'a> for &[FormatElement<'a>] {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         use Tag::{
             EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
             EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
@@ -168,7 +167,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
             StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
         };
 
-        write!(f, [ContentArrayStart])?;
+        write!(f, [ContentArrayStart]);
 
         let mut tag_stack = Vec::new();
         let mut first_element = true;
@@ -179,7 +178,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
         while let Some(element) = iter.next() {
             if !first_element && !in_text && !element.is_end_tag() {
                 // Write a separator between every two elements
-                write!(f, [token(","), soft_line_break_or_space()])?;
+                write!(f, [token(","), soft_line_break_or_space()]);
             }
 
             first_element = false;
@@ -190,14 +189,14 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                 | FormatElement::Token { .. }
                 | FormatElement::Text { .. }) => {
                     if !in_text {
-                        write!(f, [token("\"")])?;
+                        write!(f, [token("\"")]);
                     }
 
                     in_text = true;
 
                     match element {
                         FormatElement::Space | FormatElement::HardSpace => {
-                            write!(f, [token(" ")])?;
+                            write!(f, [token(" ")]);
                         }
                         element if element.is_text() => {
                             // escape quotes
@@ -216,7 +215,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                 }
                                 _ => unreachable!(),
                             };
-                            f.write_element(new_element)?;
+                            f.write_element(new_element);
                         }
                         _ => unreachable!(),
                     }
@@ -224,50 +223,50 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                     let is_next_text = iter.peek().is_some_and(|e| e.is_text() || e.is_space());
 
                     if !is_next_text {
-                        write!(f, [token("\"")])?;
+                        write!(f, [token("\"")]);
                         in_text = false;
                     }
                 }
 
                 FormatElement::Line(mode) => match mode {
                     LineMode::SoftOrSpace => {
-                        write!(f, [token("soft_line_break_or_space")])?;
+                        write!(f, [token("soft_line_break_or_space")]);
                     }
                     LineMode::Soft => {
-                        write!(f, [token("soft_line_break")])?;
+                        write!(f, [token("soft_line_break")]);
                     }
                     LineMode::Hard => {
-                        write!(f, [token("hard_line_break")])?;
+                        write!(f, [token("hard_line_break")]);
                     }
                     LineMode::Empty => {
-                        write!(f, [token("empty_line")])?;
+                        write!(f, [token("empty_line")]);
                     }
                 },
                 FormatElement::ExpandParent => {
-                    write!(f, [token("expand_parent")])?;
+                    write!(f, [token("expand_parent")]);
                 }
 
                 FormatElement::LineSuffixBoundary => {
-                    write!(f, [token("line_suffix_boundary")])?;
+                    write!(f, [token("line_suffix_boundary")]);
                 }
 
                 FormatElement::BestFitting(best_fitting) => {
-                    write!(f, [token("best_fitting([")])?;
+                    write!(f, [token("best_fitting([")]);
                     f.write_elements([
                         FormatElement::Tag(StartIndent),
                         FormatElement::Line(LineMode::Hard),
-                    ])?;
+                    ]);
 
                     for variant in best_fitting.variants() {
-                        write!(f, [&**variant, hard_line_break()])?;
+                        write!(f, [&**variant, hard_line_break()]);
                     }
 
                     f.write_elements([
                         FormatElement::Tag(EndIndent),
                         FormatElement::Line(LineMode::Hard),
-                    ])?;
+                    ]);
 
-                    write!(f, [token("])")])?;
+                    write!(f, [token("])")]);
                 }
 
                 FormatElement::Interned(interned) => {
@@ -288,7 +287,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                     space(),
                                     &&**interned,
                                 ]
-                            )?;
+                            );
                         }
                         Some(reference) => {
                             write!(
@@ -298,7 +297,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                         .allocator()
                                         .alloc_str(&std::format!("<ref interned *{reference}>"))
                                 )]
-                            )?;
+                            );
                         }
                     }
                 }
@@ -324,7 +323,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                         ),
                                         token(">>"),
                                     ]
-                                )?;
+                                );
                                 first_element = false;
                                 continue;
                             }
@@ -349,7 +348,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                         ),
                                         token(">>")
                                     ]
-                                )?;
+                                );
                                 first_element = false;
                                 continue;
                             }
@@ -361,7 +360,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
 
                     match tag {
                         StartIndent => {
-                            write!(f, [token("indent(")])?;
+                            write!(f, [token("indent(")]);
                         }
 
                         StartDedent(mode) => {
@@ -370,7 +369,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                 DedentMode::Root => "dedentRoot",
                             };
 
-                            write!(f, [token(label), token("(")])?;
+                            write!(f, [token(label), token("(")]);
                         }
 
                         StartAlign(tag::Align(count)) => {
@@ -382,15 +381,15 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                     token(","),
                                     space(),
                                 ]
-                            )?;
+                            );
                         }
 
                         StartLineSuffix => {
-                            write!(f, [token("line_suffix(")])?;
+                            write!(f, [token("line_suffix(")]);
                         }
 
                         StartGroup(group) => {
-                            write!(f, [token("group(")])?;
+                            write!(f, [token("group(")]);
 
                             if let Some(group_id) = group.id() {
                                 write!(
@@ -404,16 +403,16 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                         token(","),
                                         space(),
                                     ]
-                                )?;
+                                );
                             }
 
                             match group.mode() {
                                 GroupMode::Flat => {}
                                 GroupMode::Expand => {
-                                    write!(f, [token("expand: true,"), space()])?;
+                                    write!(f, [token("expand: true,"), space()]);
                                 }
                                 GroupMode::Propagated => {
-                                    write!(f, [token("expand: propagated,"), space()])?;
+                                    write!(f, [token("expand: propagated,"), space()]);
                                 }
                             }
                         }
@@ -431,16 +430,16 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                     token(","),
                                     space(),
                                 ]
-                            )?;
+                            );
                         }
 
                         StartConditionalContent(condition) => {
                             match condition.mode {
                                 PrintMode::Flat => {
-                                    write!(f, [token("if_group_fits_on_line(")])?;
+                                    write!(f, [token("if_group_fits_on_line(")]);
                                 }
                                 PrintMode::Expanded => {
-                                    write!(f, [token("if_group_breaks(")])?;
+                                    write!(f, [token("if_group_breaks(")]);
                                 }
                             }
 
@@ -456,7 +455,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                         token(","),
                                         space(),
                                     ]
-                                )?;
+                                );
                             }
                         }
 
@@ -473,17 +472,17 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                                     token(","),
                                     space(),
                                 ]
-                            )?;
+                            );
                         }
 
                         StartFill => {
-                            write!(f, [token("fill(")])?;
+                            write!(f, [token("fill(")]);
                         }
 
                         StartEntry => {
                             // handled after the match for all start tags
                         }
-                        EndEntry => write!(f, [ContentArrayEnd])?,
+                        EndEntry => write!(f, [ContentArrayEnd]),
 
                         EndFill
                         | EndLabelled
@@ -494,12 +493,12 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         | EndGroup
                         | EndLineSuffix
                         | EndDedent(_) => {
-                            write!(f, [ContentArrayEnd, token(")")])?;
+                            write!(f, [ContentArrayEnd, token(")")]);
                         }
                     }
 
                     if tag.is_start() {
-                        write!(f, [ContentArrayStart])?;
+                        write!(f, [ContentArrayStart]);
                     }
                 }
             }
@@ -518,41 +517,41 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             .alloc_str(&std::format!("<START_WITHOUT_END<{top:?}>>"))
                     ),
                 ]
-            )?;
+            );
         }
 
-        write!(f, [ContentArrayEnd])
+        write!(f, [ContentArrayEnd]);
     }
 }
 
 struct ContentArrayStart;
 
 impl<'a> Format<'a> for ContentArrayStart {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         use Tag::{StartGroup, StartIndent};
 
-        write!(f, [token("[")])?;
+        write!(f, [token("[")]);
 
         f.write_elements([
             FormatElement::Tag(StartGroup(tag::Group::new())),
             FormatElement::Tag(StartIndent),
             FormatElement::Line(LineMode::Soft),
-        ])
+        ]);
     }
 }
 
 struct ContentArrayEnd;
 
 impl<'a> Format<'a> for ContentArrayEnd {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         use Tag::{EndGroup, EndIndent};
         f.write_elements([
             FormatElement::Tag(EndIndent),
             FormatElement::Line(LineMode::Soft),
             FormatElement::Tag(EndGroup),
-        ])?;
+        ]);
 
-        write!(f, [token("]")])
+        write!(f, [token("]")]);
     }
 }
 
@@ -670,7 +669,7 @@ impl FormatElements for [FormatElement<'_>] {
         }
 
         // Assert that the document ends at a tag with the specified kind;
-        let _ = self.end_tag(kind)?;
+        let _ = self.end_tag(kind);
 
         let mut depth = 0usize;
 

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -75,7 +75,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// use biome_formatter::format;
     /// use biome_formatter::prelude::*;
     ///
-    /// # fn main() -> FormatResult<()> {
+    /// # fn main()  {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.join()
     ///         .entry(&token("a"))
@@ -107,7 +107,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// use biome_formatter::{format, format_args};
     /// use biome_formatter::prelude::*;
     ///
-    /// # fn main() -> FormatResult<()> {
+    /// # fn main()  {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.join_with(&format_args!(token(","), space()))
     ///         .entry(&token("1"))
@@ -183,7 +183,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// use biome_formatter::prelude::*;
     /// use biome_formatter::{format, format_args};
     ///
-    /// # fn main() -> FormatResult<()> {
+    /// # fn main()  {
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.fill()
     ///         .entry(&soft_line_break_or_space(), &token("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
@@ -205,7 +205,7 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     /// use biome_formatter::prelude::*;
     /// use biome_formatter::{format, format_args};
     ///
-    /// # fn main() -> FormatResult<()> {
+    /// # fn main()  {
     /// let entries = vec![
     ///     token("<b>Important: </b>"),
     ///     token("Please do not commit memory bugs such as segfaults, buffer overflows, etc. otherwise you "),
@@ -229,15 +229,12 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
     }
 
     /// Formats `content` into an interned element without writing it to the formatter's buffer.
-    pub fn intern(
-        &mut self,
-        content: &dyn Format<'ast>,
-    ) -> FormatResult<Option<FormatElement<'ast>>> {
+    pub fn intern(&mut self, content: &dyn Format<'ast>) -> Option<FormatElement<'ast>> {
         let mut buffer = VecBuffer::new(self.state_mut());
-        crate::write!(&mut buffer, [content])?;
+        crate::write!(&mut buffer, [content]);
         let elements = buffer.into_vec();
 
-        Ok(self.intern_vec(elements))
+        self.intern_vec(elements)
     }
 
     #[expect(clippy::unused_self)] // Keep `self` the same as the original source
@@ -257,8 +254,8 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
 
 impl<'ast> Buffer<'ast> for Formatter<'_, 'ast> {
     #[inline(always)]
-    fn write_element(&mut self, element: FormatElement<'ast>) -> FormatResult<()> {
-        self.buffer.write_element(element)
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        self.buffer.write_element(element);
     }
 
     fn elements(&self) -> &[FormatElement<'ast>] {
@@ -266,11 +263,10 @@ impl<'ast> Buffer<'ast> for Formatter<'_, 'ast> {
     }
 
     #[inline(always)]
-    fn write_fmt(&mut self, arguments: Arguments<'_, 'ast>) -> FormatResult<()> {
+    fn write_fmt(&mut self, arguments: Arguments<'_, 'ast>) {
         for argument in arguments.items() {
-            argument.format(self)?;
+            argument.format(self);
         }
-        Ok(())
     }
 
     fn state(&self) -> &FormatState<'ast> {

--- a/crates/oxc_formatter/src/formatter/macros.rs
+++ b/crates/oxc_formatter/src/formatter/macros.rs
@@ -14,7 +14,7 @@
 /// use biome_formatter::{SimpleFormatContext, format, format_args};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let formatted = format!(SimpleFormatContext::default(), [
 ///     format_args!(token("Hello World"))
 /// ])?;
@@ -49,7 +49,7 @@ macro_rules! format_args {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{Buffer, FormatState, SimpleFormatContext, VecBuffer, write};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 /// write!(&mut buffer, [token("Hello"), space()])?;
@@ -86,7 +86,7 @@ macro_rules! write {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{FormatState, VecBuffer};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
@@ -161,7 +161,7 @@ macro_rules! format {
 /// use biome_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let formatted = format!(
 ///     SimpleFormatContext::default(),
 ///     [
@@ -249,7 +249,7 @@ macro_rules! format {
 /// use biome_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
 /// use biome_formatter::prelude::*;
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let formatted = format!(
 ///     SimpleFormatContext::default(),
 ///     [

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -157,7 +157,7 @@ pub type FormatResult<F> = Result<F, FormatError>;
 /// struct Paragraph(String);
 ///
 /// impl Format<SimpleFormatContext> for Paragraph {
-///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
 ///         write!(f, [
 ///             hard_line_break(),
 ///             text(&self.0, TextSize::from(0)),
@@ -166,7 +166,7 @@ pub type FormatResult<F> = Result<F, FormatError>;
 ///     }
 /// }
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let paragraph = Paragraph(String::from("test"));
 /// let formatted = format!(SimpleFormatContext::default(), [paragraph])?;
 ///
@@ -177,11 +177,11 @@ pub type FormatResult<F> = Result<F, FormatError>;
 pub trait Format<'ast, T = ()> {
     /// Formats the object using the given formatter.
     /// # Errors
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()>;
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>);
 
     /// Formats the object using the given formatter with additional options.
     /// # Errors
-    fn fmt_with_options(&self, _options: T, _f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn fmt_with_options(&self, _options: T, _f: &mut Formatter<'_, 'ast>) {
         unreachable!("Please implement it first.")
     }
 }
@@ -191,8 +191,8 @@ where
     T: ?Sized + Format<'ast>,
 {
     #[inline(always)]
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        Format::fmt(&**self, f)
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        Format::fmt(&**self, f);
     }
 }
 
@@ -201,8 +201,8 @@ where
     T: ?Sized + Format<'ast>,
 {
     #[inline(always)]
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        Format::fmt(&**self, f)
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        Format::fmt(&**self, f);
     }
 }
 
@@ -210,26 +210,24 @@ impl<'ast, T> Format<'ast> for Option<T>
 where
     T: Format<'ast>,
 {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        match self {
-            Some(value) => value.fmt(f),
-            None => Ok(()),
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        if let Some(value) = self {
+            value.fmt(f);
         }
     }
 }
 
 impl Format<'_> for () {
     #[inline]
-    fn fmt(&self, _: &mut Formatter) -> FormatResult<()> {
+    fn fmt(&self, _: &mut Formatter) {
         // Intentionally left empty
-        Ok(())
     }
 }
 
 impl Format<'_> for &'static str {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
-        crate::write!(f, builders::token(self))
+    fn fmt(&self, f: &mut Formatter) {
+        crate::write!(f, builders::token(self));
     }
 }
 
@@ -243,7 +241,7 @@ impl Format<'_> for &'static str {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{VecBuffer, format_args, FormatState, write, Formatted};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
@@ -262,7 +260,7 @@ impl Format<'_> for &'static str {
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{VecBuffer, format_args, FormatState, write, Formatted};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
@@ -276,8 +274,8 @@ impl Format<'_> for &'static str {
 /// ```
 ///
 #[inline(always)]
-pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> FormatResult<()> {
-    Formatter::new(output).write_fmt(args)
+pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) {
+    Formatter::new(output).write_fmt(args);
 }
 
 /// The `format` function takes an [`Arguments`] struct and returns the resulting formatting IR.
@@ -292,7 +290,7 @@ pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> 
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{format, format_args};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let formatted = format!(SimpleFormatContext::default(), [&format_args!(token("test"))])?;
 /// assert_eq!("test", formatted.print()?.as_code());
 /// # Ok(())
@@ -305,7 +303,7 @@ pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> 
 /// use biome_formatter::prelude::*;
 /// use biome_formatter::{format};
 ///
-/// # fn main() -> FormatResult<()> {
+/// # fn main()  {
 /// let formatted = format!(SimpleFormatContext::default(), [token("test")])?;
 /// assert_eq!("test", formatted.print()?.as_code());
 /// # Ok(())
@@ -314,7 +312,7 @@ pub fn write<'ast>(output: &mut dyn Buffer<'ast>, args: Arguments<'_, 'ast>) -> 
 pub fn format<'ast>(
     context: FormatContext<'ast>,
     arguments: Arguments<'_, 'ast>,
-) -> FormatResult<Formatted<'ast>> {
+) -> Formatted<'ast> {
     // Pre-allocate buffer at 40% of source length (source_len * 2 / 5).
     // Analysis of 4,891 VSCode files shows FormatElement buffer length is typically 19% of source (median),
     // with 95th percentile at 30-38% across all file sizes. This 0.4x multiplier avoids
@@ -324,10 +322,10 @@ pub fn format<'ast>(
     let mut state = FormatState::new(context);
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
-    buffer.write_fmt(arguments)?;
+    buffer.write_fmt(arguments);
 
     let document = Document::from(buffer.into_vec());
     document.propagate_expand();
 
-    Ok(Formatted::new(document, state.into_context()))
+    Formatted::new(document, state.into_context())
 }

--- a/crates/oxc_formatter/src/formatter/prelude.rs
+++ b/crates/oxc_formatter/src/formatter/prelude.rs
@@ -1,4 +1,4 @@
-pub use super::{Buffer as _, BufferExtensions, Format, Format as _, FormatResult};
+pub use super::{Buffer as _, BufferExtensions, Format, Format as _};
 pub use super::{
     builders::*,
     format_element::{

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -1322,7 +1322,7 @@ mod tests {
         root: &dyn Format<'a>,
         options: PrinterOptions,
     ) -> Printed {
-        let formatted = crate::format!(FormatContext::dummy(allocator), [root]).unwrap();
+        let formatted = crate::format!(FormatContext::dummy(allocator), [root]);
 
         Printer::new(options).print(formatted.document()).expect("Document to be valid")
     }
@@ -1588,8 +1588,7 @@ two lines`,
                     token("]"),
                 )),
             )
-            .finish()
-            .unwrap();
+            .finish();
 
         let document = Document::from(buffer.into_vec());
 
@@ -1626,7 +1625,7 @@ two lines`,
                                 &soft_line_break_or_space(),
                                 &format_args!(token("3"), if_group_breaks(&token(","))),
                             )
-                            .finish()
+                            .finish();
                     })),
                     token("]")
                 )),
@@ -1657,7 +1656,7 @@ two lines`,
                         if_group_breaks(&token("It measures with the 'if_group_breaks' variant because the referenced group breaks and that's just way too much text.")).with_group_id(Some(group_id)),
                     ))
                 ]
-            )
+            );
         });
 
         let printed = format(&allocator, &content);
@@ -1678,15 +1677,13 @@ two lines`,
             write!(
                 f,
                 [group(&token("Group with id-2")).with_group_id(Some(id_2)), hard_line_break()]
-            )?;
+            );
 
-            write!(
-                f,
-                [
-                    group(&token("Group with id-1 does not fit on the line because it exceeds the line width of 100 characters by..........")).with_group_id(Some(id_1)),
-                    hard_line_break()
-                ]
-            )?;
+            write!(f,
+            [
+                group(&token("Group with id-1 does not fit on the line because it exceeds the line width of 100 characters by..........")).with_group_id(Some(id_1)),
+                hard_line_break()
+            ]);
 
             write!(
                 f,
@@ -1695,7 +1692,7 @@ two lines`,
                     hard_line_break(),
                     if_group_breaks(&token("Group 1 breaks")).with_group_id(Some(id_1))
                 ]
-            )
+            );
         });
 
         let printed = format(&allocator, &content);
@@ -1735,7 +1732,7 @@ Group 1 breaks"
     }
 
     impl<'a> Format<'a> for FormatArrayElements<'a> {
-        fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+        fn fmt(&self, f: &mut Formatter<'_, 'a>) {
             write!(
                 f,
                 [group(&format_args!(
@@ -1749,7 +1746,7 @@ Group 1 breaks"
                     )),
                     token("]")
                 ))]
-            )
+            );
         }
     }
 }

--- a/crates/oxc_formatter/src/formatter/separated.rs
+++ b/crates/oxc_formatter/src/formatter/separated.rs
@@ -2,7 +2,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     formatter::{
-        Format, FormatResult, Formatter,
+        Format, Formatter,
         prelude::{group, if_group_breaks},
     },
     options::TrailingSeparator,
@@ -28,22 +28,22 @@ impl<T: GetSpan> GetSpan for FormatSeparatedElement<T> {
 }
 
 impl<'a, E: Format<'a> + GetSpan> Format<'a> for FormatSeparatedElement<E> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if self.options.nodes_grouped {
-            group(&self.element).fmt(f)?;
+            group(&self.element).fmt(f);
         } else {
-            self.element.fmt(f)?;
+            self.element.fmt(f);
         }
         if self.is_last {
             match self.options.trailing_separator {
                 TrailingSeparator::Allowed => {
-                    if_group_breaks(&self.separator).with_group_id(self.options.group_id).fmt(f)
+                    if_group_breaks(&self.separator).with_group_id(self.options.group_id).fmt(f);
                 }
                 TrailingSeparator::Mandatory => self.separator.fmt(f),
-                TrailingSeparator::Disallowed | TrailingSeparator::Omit => Ok(()),
+                TrailingSeparator::Disallowed | TrailingSeparator::Omit => (),
             }
         } else {
-            self.separator.fmt(f)
+            self.separator.fmt(f);
         }
     }
 }

--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, num::NonZeroUsize};
 
 use cow_utils::CowUtils;
 
-use crate::formatter::{Format, FormatResult, Formatter, prelude::*};
+use crate::formatter::{Format, Formatter, prelude::*};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NumberFormatOptions {
@@ -35,9 +35,9 @@ pub struct CleanedNumberLiteralText<'a> {
 }
 
 impl<'a> Format<'a> for CleanedNumberLiteralText<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let text = format_trimmed_number(self.text, self.options);
-        text_without_whitespace(f.context().allocator().alloc_str(&text)).fmt(f)
+        text_without_whitespace(f.context().allocator().alloc_str(&text)).fmt(f);
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -18,8 +18,8 @@
 //! ### Leading Comment Formatting ([`FormatLeadingComments`])
 //! ```rust,ignore
 //! // In AST node formatting:
-//! write!(f, [format_leading_comments(node.span)])?;
-//! write!(f, [node])?;
+//! write!(f, [format_leading_comments(node.span)]);
+//! write!(f, [node]);
 //! ```
 //!
 //! **Implementation**:
@@ -31,8 +31,8 @@
 //! ### Trailing Comment Formatting ([`FormatTrailingComments`])
 //! ```rust,ignore
 //! // In AST node formatting:
-//! write!(f, [node])?;
-//! write!(f, [format_trailing_comments(enclosing, preceding, following)])?;
+//! write!(f, [node]);
+//! write!(f, [format_trailing_comments(enclosing, preceding, following)]);
 //! ```
 //!
 //! **Implementation**:
@@ -48,7 +48,7 @@
 //!     "{",
 //!     format_dangling_comments(container.span).with_block_indent(),
 //!     "}"
-//! ])?;
+//! ]);
 //! ```
 //!
 //! **Implementation**:
@@ -103,15 +103,15 @@ pub enum FormatLeadingComments<'a> {
 }
 
 impl<'a> Format<'a> for FormatLeadingComments<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         fn format_leading_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
             f: &mut Formatter<'_, 'a>,
-        ) -> FormatResult<()> {
+        ) {
             let mut leading_comments_iter = comments.into_iter().peekable();
             while let Some(comment) = leading_comments_iter.next() {
                 f.context_mut().comments_mut().increment_printed_count();
-                write!(f, comment)?;
+                write!(f, comment);
 
                 match comment.kind {
                     CommentKind::Block => match f.source_text().lines_after(comment.span.end) {
@@ -125,31 +125,29 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
                                     )
                                 });
 
-                            write!(f, [maybe_space(!should_nestle)])?;
+                            write!(f, [maybe_space(!should_nestle)]);
                         }
                         1 => {
                             if f.source_text().get_lines_before(comment.span, f.comments()) == 0 {
-                                write!(f, [soft_line_break_or_space()])?;
+                                write!(f, [soft_line_break_or_space()]);
                             } else {
-                                write!(f, [hard_line_break()])?;
+                                write!(f, [hard_line_break()]);
                             }
                         }
-                        _ => write!(f, [empty_line()])?,
+                        _ => write!(f, [empty_line()]),
                     },
                     CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
-                        0 | 1 => write!(f, [hard_line_break()])?,
-                        _ => write!(f, [empty_line()])?,
+                        0 | 1 => write!(f, [hard_line_break()]),
+                        _ => write!(f, [empty_line()]),
                     },
                 }
             }
-
-            Ok(())
         }
 
         match self {
             Self::Node(span) => {
                 let leading_comments = f.context().comments().comments_before(span.start);
-                format_leading_comments_impl(leading_comments, f)
+                format_leading_comments_impl(leading_comments, f);
             }
             Self::Comments(comments) => format_leading_comments_impl(*comments, f),
         }
@@ -174,11 +172,11 @@ pub enum FormatTrailingComments<'a> {
 }
 
 impl<'a> Format<'a> for FormatTrailingComments<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         fn format_trailing_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
             f: &mut Formatter<'_, 'a>,
-        ) -> FormatResult<()> {
+        ) {
             let mut total_lines_before = 0;
             let mut previous_comment: Option<&Comment> = None;
 
@@ -221,33 +219,31 @@ impl<'a> Format<'a> for FormatTrailingComments<'a> {
                                     //    * docs
                                     //   */ [> still on the same line <]
                                     if previous_comment.copied().is_some_and(Comment::is_line) {
-                                        write!(f, [hard_line_break()])?;
+                                        write!(f, [hard_line_break()]);
                                     } else {
-                                        write!(f, [space()])?;
+                                        write!(f, [space()]);
                                     }
                                 }
-                                1 => write!(f, [hard_line_break()])?,
-                                _ => write!(f, [empty_line()])?,
+                                1 => write!(f, [hard_line_break()]),
+                                _ => write!(f, [empty_line()]),
                             }
 
-                            write!(f, [comment])
+                            write!(f, [comment]);
                         }))]
-                    )?;
+                    );
                 } else {
                     let content =
                         format_with(|f| write!(f, [maybe_space(!should_nestle), comment]));
 
                     if comment.is_line() {
-                        write!(f, [line_suffix(&content), expand_parent()])?;
+                        write!(f, [line_suffix(&content), expand_parent()]);
                     } else {
-                        write!(f, [content])?;
+                        write!(f, [content]);
                     }
                 }
 
                 previous_comment = Some(comment);
             }
-
-            Ok(())
         }
 
         match self {
@@ -258,7 +254,7 @@ impl<'a> Format<'a> for FormatTrailingComments<'a> {
                     *following_span,
                 );
 
-                format_trailing_comments_impl(comments, f)
+                format_trailing_comments_impl(comments, f);
             }
             Self::Comments(comments) => format_trailing_comments_impl(*comments, f),
         }
@@ -337,12 +333,12 @@ impl FormatDanglingComments<'_> {
 }
 
 impl<'a> Format<'a> for FormatDanglingComments<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         fn format_dangling_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
             indent: DanglingIndentMode,
             f: &mut Formatter<'_, 'a>,
-        ) -> FormatResult<()> {
+        ) {
             // Write all comments up to the first skipped token trivia or the token
             let format_dangling_comments = format_once(|f| {
                 let mut previous_comment: Option<&Comment> = None;
@@ -365,7 +361,7 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
                                 .then_some(hard_line_break()),
                             comment
                         ]
-                    )?;
+                    );
 
                     previous_comment = Some(comment);
                 }
@@ -373,21 +369,19 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
                 if matches!(indent, DanglingIndentMode::Soft)
                     && previous_comment.copied().is_some_and(Comment::is_line)
                 {
-                    write!(f, [hard_line_break()])?;
+                    write!(f, [hard_line_break()]);
                 }
-
-                Ok(())
             });
 
             match indent {
                 DanglingIndentMode::Block => {
-                    write!(f, [block_indent(&format_dangling_comments)])
+                    write!(f, [block_indent(&format_dangling_comments)]);
                 }
                 DanglingIndentMode::Soft => {
-                    write!(f, [group(&soft_block_indent(&format_dangling_comments))])
+                    write!(f, [group(&soft_block_indent(&format_dangling_comments))]);
                 }
                 DanglingIndentMode::None => {
-                    write!(f, [format_dangling_comments])
+                    write!(f, [format_dangling_comments]);
                 }
             }
         }
@@ -399,7 +393,7 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
                 f,
             ),
             FormatDanglingComments::Comments { comments, indent } => {
-                format_dangling_comments_impl(*comments, *indent, f)
+                format_dangling_comments_impl(*comments, *indent, f);
             }
         }
     }
@@ -435,8 +429,8 @@ impl FormatOnlyIfBreaks<'_, '_> {
 }
 
 impl<'ast> Format<'ast> for FormatOnlyIfBreaks<'_, 'ast> {
-    fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
-        write!(f, if_group_breaks(&self.content).with_group_id(self.group_id))?;
+    fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
+        write!(f, if_group_breaks(&self.content).with_group_id(self.group_id));
         // TODO: unsupported yet
         // if f.comments().has_skipped(self.span) {
         //     // Print the trivia otherwise
@@ -444,14 +438,13 @@ impl<'ast> Format<'ast> for FormatOnlyIfBreaks<'_, 'ast> {
         //         f,
         //         if_group_fits_on_line(&format_skipped_token_trivia(self.span))
         //             .with_group_id(self.group_id)
-        //     )?;
+        //     );
         // }
-        Ok(())
     }
 }
 impl<'a> Format<'a> for Comment {
     #[expect(clippy::cast_possible_truncation)]
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let source_text = f.source_text().text_for(&self.span).trim_end();
         if is_alignable_comment(source_text) {
             let mut source_offset = self.span.start;
@@ -460,7 +453,7 @@ impl<'a> Format<'a> for Comment {
 
             // `is_alignable_comment` only returns `true` for multiline comments
             let first_line = lines.next().unwrap();
-            write!(f, [text(first_line.trim_end())])?;
+            write!(f, [text(first_line.trim_end())]);
 
             source_offset += first_line.len() as u32;
 
@@ -469,14 +462,13 @@ impl<'a> Format<'a> for Comment {
                 f,
                 [&format_once(|f| {
                     for line in lines {
-                        write!(f, [hard_line_break(), " ", text(line.trim())])?;
+                        write!(f, [hard_line_break(), " ", text(line.trim())]);
                         source_offset += line.len() as u32;
                     }
-                    Ok(())
                 })]
-            )
+            );
         } else {
-            write!(f, [text(source_text)])
+            write!(f, [text(source_text)]);
         }
     }
 }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -84,8 +84,7 @@ impl<'a> Formatter<'a> {
         let mut formatted = formatter::format(
             context,
             formatter::Arguments::new(&[formatter::Argument::new(&program_node)]),
-        )
-        .unwrap();
+        );
 
         // Basic formatting and `document.propagate_expand()` are already done here.
         // Now apply additional transforms if enabled.

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -688,16 +688,14 @@ impl FormatTrailingCommas {
 }
 
 impl Format<'_> for FormatTrailingCommas {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter) {
         if f.options().trailing_commas.is_none() {
-            return Ok(());
+            return;
         }
 
         if matches!(self, FormatTrailingCommas::ES5) || f.options().trailing_commas.is_all() {
-            write!(f, [if_group_breaks(&token(","))])?;
+            write!(f, [if_group_breaks(&token(","))]);
         }
-
-        Ok(())
     }
 }
 

--- a/crates/oxc_formatter/src/utils/array.rs
+++ b/crates/oxc_formatter/src/utils/array.rs
@@ -1,7 +1,7 @@
 use oxc_span::{GetSpan, SPAN, Span};
 
 use crate::{
-    formatter::{FormatResult, Formatter, prelude::*},
+    formatter::{Formatter, prelude::*},
     options::FormatTrailingCommas,
     write,
 };
@@ -11,8 +11,7 @@ pub fn write_array_node<'a, 'b, N>(
     len: usize,
     array: impl IntoIterator<Item = Option<&'a N>> + 'b,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()>
-where
+) where
     N: Format<'a> + GetSpan + std::fmt::Debug + 'a,
 {
     // Specifically do not use format_separated as arrays need separators
@@ -68,24 +67,23 @@ where
             },
             &format_once(|f| {
                 if let Some(element) = element {
-                    write!(f, group(&element))?;
+                    write!(f, group(&element));
 
                     if is_disallow {
-                        Ok(())
                     } else if is_force || index != last_index {
-                        ",".fmt(f)
+                        ",".fmt(f);
                     } else {
-                        write!(f, FormatTrailingCommas::ES5)
+                        write!(f, FormatTrailingCommas::ES5);
                     }
                 } else {
                     has_seen_elision = true;
-                    write!(f, ",")
+                    write!(f, ",");
                 }
             }),
         );
     }
 
-    join.finish()
+    join.finish();
 }
 
 /// Determines if a trailing separator should be inserted after an array element

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -6,7 +6,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, BufferExtensions, Format, FormatResult, Formatter, VecBuffer,
+        Buffer, BufferExtensions, Format, Formatter, VecBuffer,
         prelude::{FormatElements, format_once, line_suffix_boundary, *},
         trivia::FormatTrailingComments,
     },
@@ -149,7 +149,7 @@ fn format_left_trailing_comments(
     start: u32,
     should_print_as_leading: bool,
     f: &mut Formatter<'_, '_>,
-) -> FormatResult<()> {
+) {
     let end_of_line_comments = f.context().comments().end_of_line_comments_after(start);
 
     let comments = if end_of_line_comments.is_empty() {
@@ -162,7 +162,7 @@ fn format_left_trailing_comments(
         end_of_line_comments
     };
 
-    FormatTrailingComments::Comments(comments).fmt(f)
+    FormatTrailingComments::Comments(comments).fmt(f);
 }
 
 fn should_print_as_leading(expr: &Expression) -> bool {
@@ -176,29 +176,29 @@ fn should_print_as_leading(expr: &Expression) -> bool {
 }
 
 impl<'a> AssignmentLike<'a, '_> {
-    fn write_left(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<bool> {
+    fn write_left(&self, f: &mut Formatter<'_, 'a>) -> bool {
         match self {
             AssignmentLike::VariableDeclarator(declarator) => {
                 if let Some(init) = &declarator.init {
-                    write!(f, [FormatNodeWithoutTrailingComments(&declarator.id())])?;
+                    write!(f, [FormatNodeWithoutTrailingComments(&declarator.id())]);
                     format_left_trailing_comments(
                         declarator.id.span().end,
                         should_print_as_leading(init),
                         f,
-                    )?;
+                    );
                 } else {
-                    write!(f, declarator.id())?;
+                    write!(f, declarator.id());
                 }
-                Ok(false)
+                false
             }
             AssignmentLike::AssignmentExpression(assignment) => {
-                write!(f, [FormatNodeWithoutTrailingComments(&assignment.left()),])?;
+                write!(f, [FormatNodeWithoutTrailingComments(&assignment.left()),]);
                 format_left_trailing_comments(
                     assignment.left.span().end,
                     should_print_as_leading(&assignment.right),
                     f,
-                )?;
-                Ok(false)
+                );
+                false
             }
             AssignmentLike::ObjectProperty(property) => {
                 const MIN_OVERLAP_FOR_BREAK: u8 = 3;
@@ -208,75 +208,74 @@ impl<'a> AssignmentLike<'a, '_> {
 
                 // Handle computed properties
                 if property.computed {
-                    write!(f, ["[", property.key(), "]"])?;
+                    write!(f, ["[", property.key(), "]"]);
                     if property.shorthand {
-                        Ok(false)
+                        false
                     } else {
-                        Ok(f.source_text().span_width(property.key.span()) + 2
-                            < text_width_for_break)
+                        f.source_text().span_width(property.key.span()) + 2 < text_width_for_break
                     }
                 } else if property.shorthand {
-                    write!(f, property.key())?;
-                    Ok(false)
+                    write!(f, property.key());
+                    false
                 } else {
-                    let width = write_member_name(property.key(), f)?;
+                    let width = write_member_name(property.key(), f);
 
-                    Ok(width < text_width_for_break)
+                    width < text_width_for_break
                 }
             }
             AssignmentLike::PropertyDefinition(property) => {
-                write!(f, [property.decorators()])?;
+                write!(f, [property.decorators()]);
 
                 if property.declare {
-                    write!(f, ["declare", space()])?;
+                    write!(f, ["declare", space()]);
                 }
                 if let Some(accessibility) = property.accessibility {
-                    write!(f, [accessibility.as_str(), space()])?;
+                    write!(f, [accessibility.as_str(), space()]);
                 }
                 if property.r#static {
-                    write!(f, ["static", space()])?;
+                    write!(f, ["static", space()]);
                 }
                 if property.r#type == PropertyDefinitionType::TSAbstractPropertyDefinition {
-                    write!(f, ["abstract", space()])?;
+                    write!(f, ["abstract", space()]);
                 }
                 if property.r#override {
-                    write!(f, ["override", space()])?;
+                    write!(f, ["override", space()]);
                 }
                 if property.readonly {
-                    write!(f, ["readonly", space()])?;
+                    write!(f, ["readonly", space()]);
                 }
 
                 // Write the property key
                 if property.computed {
-                    write!(f, ["[", property.key(), "]"])?;
+                    write!(f, ["[", property.key(), "]"]);
                 } else {
-                    format_property_key(property.key(), f)?;
+                    format_property_key(property.key(), f);
                 }
 
                 // Write optional, definite, and type annotation
                 if property.optional {
-                    write!(f, "?")?;
+                    write!(f, "?");
                 }
                 if property.definite {
-                    write!(f, "!")?;
+                    write!(f, "!");
                 }
                 if let Some(type_annotation) = property.type_annotation() {
-                    write!(f, type_annotation)?;
+                    write!(f, type_annotation);
                 }
 
-                Ok(false) // Class properties don't use "short" key logic
+                false // Class properties don't use "short" key logic
             }
             AssignmentLike::TSTypeAliasDeclaration(declaration) => {
-                write!(f, [declaration.declare.then_some("declare "), "type "])?;
+                write!(f, [declaration.declare.then_some("declare "), "type "]);
 
                 let start = if let Some(type_parameters) = &declaration.type_parameters() {
                     write!(
                         f,
                         [declaration.id(), FormatNodeWithoutTrailingComments(type_parameters)]
-                    )?;
+                    );
                     type_parameters.span.end
                 } else {
-                    write!(f, [FormatNodeWithoutTrailingComments(declaration.id())])?;
+                    write!(f, [FormatNodeWithoutTrailingComments(declaration.id())]);
                     declaration.id.span.end
                 };
 
@@ -284,69 +283,65 @@ impl<'a> AssignmentLike<'a, '_> {
                     start,
                     matches!(&declaration.type_annotation, TSType::TSTypeLiteral(_)),
                     f,
-                )?;
+                );
 
-                Ok(false)
+                false
             }
         }
     }
 
-    fn write_operator(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write_operator(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::VariableDeclarator(variable_declarator) if variable_declarator.init.is_some() => {
-                write!(f, [space(), "="])
+                write!(f, [space(), "="]);
             }
             Self::AssignmentExpression(assignment) => {
                 let operator = assignment.operator.as_str();
-                write!(f, [space(), operator])
+                write!(f, [space(), operator]);
             }
             Self::ObjectProperty(property) if !property.shorthand => {
-                write!(f, [":", space()])
+                write!(f, [":", space()]);
             }
             Self::PropertyDefinition(property_class_member)
                 if property_class_member.value().is_some() =>
             {
-                write!(f, [space(), "="])
+                write!(f, [space(), "="]);
             }
             Self::TSTypeAliasDeclaration(_) => {
-                write!(f, [space(), "="])
+                write!(f, [space(), "="]);
             }
-            _ => Ok(()),
+            _ => (),
         }
     }
 
-    fn write_right(
-        &self,
-        f: &mut Formatter<'_, 'a>,
-        layout: AssignmentLikeLayout,
-    ) -> FormatResult<()> {
+    fn write_right(&self, f: &mut Formatter<'_, 'a>, layout: AssignmentLikeLayout) {
         match self {
             Self::VariableDeclarator(declarator) => {
                 write!(
                     f,
                     [space(), with_assignment_layout(declarator.init().unwrap(), Some(layout))]
-                )
+                );
             }
             Self::AssignmentExpression(assignment) => {
                 let right = assignment.right();
-                write!(f, [space(), with_assignment_layout(right, Some(layout))])
+                write!(f, [space(), with_assignment_layout(right, Some(layout))]);
             }
             Self::ObjectProperty(property) => {
                 let value = property.value();
-                write!(f, [with_assignment_layout(value, Some(layout))])
+                write!(f, [with_assignment_layout(value, Some(layout))]);
             }
             Self::PropertyDefinition(property) => {
                 write!(
                     f,
                     [space(), with_assignment_layout(property.value().unwrap(), Some(layout))]
-                )
+                );
             }
             Self::TSTypeAliasDeclaration(declaration) => {
                 if let AstNodes::TSUnionType(union) = declaration.type_annotation().as_ast_nodes() {
-                    union.write(f)?;
-                    union.format_trailing_comments(f)
+                    union.write(f);
+                    union.format_trailing_comments(f);
                 } else {
-                    write!(f, [space(), declaration.type_annotation()])
+                    write!(f, [space(), declaration.type_annotation()]);
                 }
             }
         }
@@ -709,7 +704,7 @@ fn get_last_non_unary_argument<'a, 'b>(
 }
 
 impl<'a> Format<'a> for AssignmentLike<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let format_content = format_with(|f| {
             // We create a temporary buffer because the left hand side has to conditionally add
             // a group based on the layout, but the layout can only be computed by knowing the
@@ -723,7 +718,7 @@ impl<'a> Format<'a> for AssignmentLike<'a, '_> {
             // 3. we compute the layout
             // 4. we write the left node inside the main buffer based on the layout
             let mut buffer = VecBuffer::new(f.state_mut());
-            let is_left_short = self.write_left(&mut Formatter::new(&mut buffer))?;
+            let is_left_short = self.write_left(&mut Formatter::new(&mut buffer));
             let formatted_left = buffer.into_vec();
             let left_may_break = formatted_left.may_directly_break();
 
@@ -740,18 +735,18 @@ impl<'a> Format<'a> for AssignmentLike<'a, '_> {
                     &layout,
                     AssignmentLikeLayout::BreakLeftHandSide | AssignmentLikeLayout::OnlyLeft
                 ) {
-                    write!(f, [left])?;
+                    write!(f, [left]);
                 } else {
-                    write!(f, [group(&left)])?;
+                    write!(f, [group(&left)]);
                 }
 
                 if layout != AssignmentLikeLayout::SuppressedInitializer {
-                    self.write_operator(f)?;
+                    self.write_operator(f);
                 }
 
                 #[expect(clippy::match_same_arms)]
                 match layout {
-                    AssignmentLikeLayout::OnlyLeft => Ok(()),
+                    AssignmentLikeLayout::OnlyLeft => (),
                     AssignmentLikeLayout::Fluid => {
                         let group_id = f.group_id("assignment_like");
                         write!(
@@ -762,25 +757,25 @@ impl<'a> Format<'a> for AssignmentLike<'a, '_> {
                                 line_suffix_boundary(),
                                 indent_if_group_breaks(&right, group_id)
                             ]
-                        )
+                        );
                     }
                     AssignmentLikeLayout::BreakAfterOperator => {
-                        write!(f, [group(&soft_line_indent_or_space(&right))])
+                        write!(f, [group(&soft_line_indent_or_space(&right))]);
                     }
                     AssignmentLikeLayout::NeverBreakAfterOperator => {
-                        write!(f, [space(), right])
+                        write!(f, [space(), right]);
                     }
                     AssignmentLikeLayout::BreakLeftHandSide => {
-                        write!(f, [space(), group(&right)])
+                        write!(f, [space(), group(&right)]);
                     }
                     AssignmentLikeLayout::Chain => {
-                        write!(f, [soft_line_break_or_space(), right])
+                        write!(f, [soft_line_break_or_space(), right]);
                     }
                     AssignmentLikeLayout::ChainTail => {
-                        write!(f, [soft_line_indent_or_space(&right)])
+                        write!(f, [soft_line_indent_or_space(&right)]);
                     }
                     AssignmentLikeLayout::ChainTailArrowFunction => {
-                        write!(f, [space(), right])
+                        write!(f, [space(), right]);
                     }
                     AssignmentLikeLayout::SuppressedInitializer => {
                         unreachable!();
@@ -795,15 +790,15 @@ impl<'a> Format<'a> for AssignmentLike<'a, '_> {
                 | AssignmentLikeLayout::ChainTail
                 | AssignmentLikeLayout::SuppressedInitializer
                 | AssignmentLikeLayout::OnlyLeft => {
-                    write!(f, [&inner_content])
+                    write!(f, [&inner_content]);
                 }
                 _ => {
-                    write!(f, [group(&inner_content)])
+                    write!(f, [group(&inner_content)]);
                 }
             }
         });
 
-        write!(f, [format_content])
+        write!(f, [format_content]);
     }
 }
 
@@ -822,7 +817,7 @@ pub fn with_assignment_layout<'a, 'b>(
 }
 
 impl<'a> Format<'a> for WithAssignmentLayout<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self.expression.as_ast_nodes() {
             AstNodes::ArrowFunctionExpression(arrow) => arrow.fmt_with_options(
                 FormatJsArrowFunctionExpressionOptions {

--- a/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
+++ b/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
@@ -1,6 +1,6 @@
 use oxc_span::GetSpan;
 
-use crate::{Format, FormatResult, formatter::Formatter};
+use crate::{Format, formatter::Formatter};
 
 /// Generic wrapper for formatting a node without its trailing comments.
 ///
@@ -13,7 +13,7 @@ impl<'a, T> Format<'a> for FormatNodeWithoutTrailingComments<'_, T>
 where
     T: Format<'a> + GetSpan,
 {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let node_end = self.0.span().end;
 
         // Save the current comment view limit and temporarily restrict it
@@ -23,11 +23,9 @@ where
         // Format the node with the restricted comment view
         // This allows all comments within the node's span to be formatted normally,
         // but hides any trailing comments that come after it
-        let result = self.0.fmt(f);
+        self.0.fmt(f);
 
         // Restore the previous comment view limit
         f.context_mut().comments_mut().restore_view_limit(previous_limit);
-
-        result
     }
 }

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -10,7 +10,6 @@ use oxc_ast::ast::*;
 use crate::QuoteStyle;
 use crate::formatter::Comments;
 use crate::{
-    FormatResult,
     ast_nodes::AstNode,
     format_args,
     formatter::{Formatter, prelude::*},
@@ -88,27 +87,27 @@ pub enum WrapState {
 pub struct JsxSpace;
 
 impl<'a> Format<'a> for JsxSpace {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
             [
                 if_group_breaks(&format_args!(JsxRawSpace, soft_line_break())),
                 if_group_fits_on_line(&space())
             ]
-        )
+        );
     }
 }
 
 pub struct JsxRawSpace;
 
 impl<'a> Format<'a> for JsxRawSpace {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let jsx_space = match f.options().quote_style {
             QuoteStyle::Double => r#"{" "}"#,
             QuoteStyle::Single => "{' '}",
         };
 
-        write!(f, [token(jsx_space)])
+        write!(f, [token(jsx_space)]);
     }
 }
 
@@ -210,8 +209,8 @@ impl<'a> JsxWord<'a> {
 }
 
 impl<'a> Format<'a> for JsxWord<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [text_without_whitespace(self.text)])
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [text_without_whitespace(self.text)]);
     }
 }
 

--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{Format, FormatResult, Formatter, prelude::*, trivia::FormatLeadingComments},
+    formatter::{Format, Formatter, prelude::*, trivia::FormatLeadingComments},
     write,
 };
 use oxc_ast::ast::*;
@@ -68,7 +68,7 @@ impl ChainMember<'_, '_> {
 }
 
 impl<'a> Format<'a> for ChainMember<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::StaticMember(member) => {
                 write!(
@@ -81,25 +81,23 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                         ".",
                         member.property()
                     ]
-                )?;
+                );
 
                 // `A.b /* comment */ (c)` -> `A.b(/* comment */ c)`
                 if !matches!(member.parent, AstNodes::CallExpression(call) if call.type_arguments.is_none())
                 {
-                    member.format_trailing_comments(f)?;
+                    member.format_trailing_comments(f);
                 }
-
-                Ok(())
             }
             Self::TSNonNullExpression(e) => {
-                e.format_leading_comments(f)?;
-                write!(f, ["!"])?;
-                e.format_trailing_comments(f)
+                e.format_leading_comments(f);
+                write!(f, ["!"]);
+                e.format_trailing_comments(f);
             }
             Self::CallExpression { expression, position } => match *position {
                 CallExpressionPosition::Start => write!(f, expression),
                 CallExpressionPosition::Middle => {
-                    expression.format_leading_comments(f)?;
+                    expression.format_leading_comments(f);
                     write!(
                         f,
                         [
@@ -107,8 +105,8 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                             expression.type_arguments(),
                             expression.arguments()
                         ]
-                    )?;
-                    expression.format_trailing_comments(f)
+                    );
+                    expression.format_trailing_comments(f);
                 }
                 CallExpressionPosition::End => {
                     write!(
@@ -118,14 +116,14 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                             expression.type_arguments(),
                             expression.arguments(),
                         ]
-                    )
+                    );
                 }
             },
             Self::ComputedMember(member) => {
-                write!(f, line_suffix_boundary())?;
-                member.format_leading_comments(f)?;
-                FormatComputedMemberExpressionWithoutObject(member).fmt(f)?;
-                member.format_trailing_comments(f)
+                write!(f, line_suffix_boundary());
+                member.format_leading_comments(f);
+                FormatComputedMemberExpressionWithoutObject(member).fmt(f);
+                member.format_trailing_comments(f);
             }
             Self::Node(node) => write!(f, node),
         }
@@ -145,16 +143,16 @@ impl<'a> Deref for FormatComputedMemberExpressionWithoutObject<'a, '_> {
 }
 
 impl<'a> Format<'a> for FormatComputedMemberExpressionWithoutObject<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before_character(self.span.start, b'[');
         if !comments.is_empty() {
-            write!(f, [soft_line_break(), FormatLeadingComments::Comments(comments)])?;
+            write!(f, [soft_line_break(), FormatLeadingComments::Comments(comments)]);
         }
 
         if matches!(self.expression, Expression::NumericLiteral(_))
             && !f.comments().has_comment_before(self.span.end)
         {
-            write!(f, [self.optional().then_some("?."), "[", self.expression(), "]"])
+            write!(f, [self.optional().then_some("?."), "[", self.expression(), "]"]);
         } else {
             write!(
                 f,
@@ -164,7 +162,7 @@ impl<'a> Format<'a> for FormatComputedMemberExpressionWithoutObject<'a, '_> {
                     soft_block_indent(self.expression()),
                     "]"
                 ))
-            )
+            );
         }
     }
 }

--- a/crates/oxc_formatter/src/utils/member_chain/groups.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/groups.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell};
 use oxc_span::GetSpan;
 
 use super::chain_member::ChainMember;
-use crate::formatter::{Format, FormatResult, Formatter, prelude::*};
+use crate::formatter::{Format, Formatter, prelude::*};
 
 #[derive(Default)]
 pub(super) struct MemberChainGroupsBuilder<'a, 'b> {
@@ -112,8 +112,8 @@ impl<'a, 'b> TailChainGroups<'a, 'b> {
 }
 
 impl<'a> Format<'a> for TailChainGroups<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        f.join().entries(self.groups.iter()).finish()
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        f.join().entries(self.groups.iter()).finish();
     }
 }
 
@@ -148,20 +148,17 @@ impl<'a, 'b> MemberChainGroup<'a, 'b> {
         self.members.extend(members);
     }
 
-    pub(super) fn inspect(&self, tail: bool, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    pub(super) fn inspect(&self, tail: bool, f: &mut Formatter<'_, 'a>) {
         let mut cell = self.formatted.borrow_mut();
         if cell.is_none() {
-            let interned = f.intern(&FormatMemberChainGroup { group: self })?;
+            let interned = f.intern(&FormatMemberChainGroup { group: self });
 
             if tail {
                 self.set_needs_empty_line(self.needs_empty_line_before(f));
             }
 
-            if let Some(interned) = interned {
-                *cell = Some(interned);
-            }
+            *cell = interned;
         }
-        Ok(())
     }
 
     /// Tests if the formatted result of this group results in a [break](FormatElements::will_break).
@@ -236,12 +233,12 @@ impl std::fmt::Debug for MemberChainGroup<'_, '_> {
 }
 
 impl<'a> Format<'a> for MemberChainGroup<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if let Some(formatted) = self.formatted.borrow().as_ref() {
             return f.write_element(formatted.clone());
         }
 
-        FormatMemberChainGroup { group: self }.fmt(f)
+        FormatMemberChainGroup { group: self }.fmt(f);
     }
 }
 
@@ -250,7 +247,7 @@ pub struct FormatMemberChainGroup<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatMemberChainGroup<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        f.join().entries(self.group.members.iter()).finish()
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        f.join().entries(self.group.members.iter()).finish();
     }
 }

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -2,17 +2,14 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Buffer, Format, FormatResult,
+    Buffer, Format,
     ast_nodes::{AstNode, AstNodes},
     formatter::Formatter,
     utils::string::{FormatLiteralStringToken, StringLiteralParentKind},
     write,
 };
 
-pub fn format_property_key<'a>(
-    key: &AstNode<'a, PropertyKey<'a>>,
-    f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
     if let PropertyKey::StringLiteral(s) = key.as_ref() {
         // `"constructor"` property in the class should be kept quoted
         let kind = if matches!(key.parent, AstNodes::PropertyDefinition(_))
@@ -29,16 +26,16 @@ pub fn format_property_key<'a>(
             false,
             kind,
         )
-        .fmt(f)
+        .fmt(f);
     } else {
-        write!(f, key)
+        write!(f, key);
     }
 }
 
 pub fn write_member_name<'a>(
     key: &AstNode<'a, PropertyKey<'a>>,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<usize> {
+) -> usize {
     if let AstNodes::StringLiteral(string) = key.as_ast_nodes() {
         let format = FormatLiteralStringToken::new(
             f.source_text().text_for(string),
@@ -47,14 +44,14 @@ pub fn write_member_name<'a>(
         )
         .clean_text(f.context().source_type(), f.options());
 
-        string.format_leading_comments(f)?;
-        write!(f, format)?;
-        string.format_trailing_comments(f)?;
+        string.format_leading_comments(f);
+        write!(f, format);
+        string.format_trailing_comments(f);
 
-        Ok(format.width())
+        format.width()
     } else {
-        write!(f, key)?;
+        write!(f, key);
 
-        Ok(f.source_text().span_width(key.span()))
+        f.source_text().span_width(key.span())
     }
 }

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, FormatResult, Formatter,
+        Buffer, Format, Formatter,
         prelude::{format_once, soft_line_indent_or_space, space},
         trivia::FormatTrailingComments,
     },
@@ -32,16 +32,16 @@ impl<'a, 'b> FormatStatementBody<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatStatementBody<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if let AstNodes::EmptyStatement(empty) = self.body.as_ast_nodes() {
-            write!(f, empty)
+            write!(f, empty);
         } else if let AstNodes::BlockStatement(block) = self.body.as_ast_nodes() {
-            write!(f, [space()])?;
+            write!(f, [space()]);
             // Use `write` instead of `format` to avoid printing leading comments of the block.
             // Those comments should be printed inside the block statement.
-            block.write(f)
+            block.write(f);
         } else if self.force_space {
-            write!(f, [space(), self.body])
+            write!(f, [space(), self.body]);
         } else {
             write!(
                 f,
@@ -62,15 +62,15 @@ impl<'a> Format<'a> for FormatStatementBody<'a, '_> {
                         if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
                     );
                     if is_consequent_of_if_statement_parent {
-                        write!(f, FormatNodeWithoutTrailingComments(self.body))?;
+                        write!(f, FormatNodeWithoutTrailingComments(self.body));
                         let comments =
                             f.context().comments().end_of_line_comments_after(body_span.end);
-                        FormatTrailingComments::Comments(comments).fmt(f)
+                        FormatTrailingComments::Comments(comments).fmt(f);
                     } else {
-                        write!(f, self.body)
+                        write!(f, self.body);
                     }
                 }))]
-            )
+            );
         }
     }
 }

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -6,7 +6,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     FormatOptions, QuoteProperties, QuoteStyle,
-    formatter::{Format, FormatResult, Formatter, prelude::*},
+    formatter::{Format, Formatter, prelude::*},
 };
 
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
@@ -69,8 +69,8 @@ impl CleanedStringLiteralText<'_> {
 }
 
 impl<'a> Format<'a> for CleanedStringLiteralText<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        text(f.context().allocator().alloc_str(&self.text)).fmt(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        text(f.context().allocator().alloc_str(&self.text)).fmt(f);
     }
 }
 
@@ -301,8 +301,8 @@ impl<'a> LiteralStringNormalizer<'a> {
 }
 
 impl<'a> Format<'a> for FormatLiteralStringToken<'a> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.clean_text(f.context().source_type(), f.options()).fmt(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        self.clean_text(f.context().source_type(), f.options()).fmt(f);
     }
 }
 

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -1,7 +1,7 @@
 use oxc_span::Span;
 
 use crate::{
-    Buffer, Format, FormatResult,
+    Buffer, Format,
     formatter::{Formatter, prelude::*},
     write,
 };
@@ -9,13 +9,11 @@ use crate::{
 pub struct FormatSuppressedNode(pub Span);
 
 impl<'a> Format<'a> for FormatSuppressedNode {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [text(f.source_text().text_for(&self.0))])?;
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [text(f.source_text().text_for(&self.0))]);
 
         // The suppressed node contains comments that should be marked as printed.
         mark_comments_as_printed_before(self.0.end, f);
-
-        Ok(())
     }
 }
 

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -2,7 +2,7 @@ use oxc_ast::Comment;
 use oxc_span::GetSpan;
 
 use crate::{
-    Buffer, Format, FormatResult, format_args,
+    Buffer, Format, format_args,
     formatter::{Formatter, prelude::*, trivia::FormatLeadingComments},
     write,
 };
@@ -97,15 +97,15 @@ pub fn format_type_cast_comment_node<'a, T>(
     node: &(impl Format<'a, T> + GetSpan),
     is_object_or_array_expression: bool,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<bool> {
+) -> bool {
     // Check if this is a type cast node and get the comments to print
     let Some(type_cast_comments) = is_type_cast_node(node, f) else {
-        return Ok(false);
+        return false;
     };
 
     // Print the type cast comments if any
     if !type_cast_comments.is_empty() {
-        write!(f, [FormatLeadingComments::Comments(type_cast_comments)])?;
+        write!(f, [FormatLeadingComments::Comments(type_cast_comments)]);
     }
 
     let span = node.span();
@@ -113,15 +113,12 @@ pub fn format_type_cast_comment_node<'a, T>(
 
     // https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/estree.js#L117-L120
     if is_object_or_array_expression && !f.comments().has_comment_before(span.start) {
-        write!(f, group(&format_args!("(", &format_with(|f| node.fmt(f)), ")")))?;
+        write!(f, group(&format_args!("(", &format_with(|f| node.fmt(f)), ")")));
     } else {
-        write!(
-            f,
-            group(&format_args!("(", soft_block_indent(&format_with(|f| node.fmt(f))), ")"))
-        )?;
+        write!(f, group(&format_args!("(", soft_block_indent(&format_with(|f| node.fmt(f))), ")")));
     }
 
-    Ok(true)
+    true
 }
 
 /// Check if the source text has properly closed parentheses starting with '('.

--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -5,10 +5,7 @@ use oxc_span::GetSpan;
 use crate::{
     Expand, FormatTrailingCommas,
     ast_nodes::AstNode,
-    formatter::{
-        Buffer, Format, FormatResult, Formatter, GroupId, prelude::*,
-        separated::FormatSeparatedIter,
-    },
+    formatter::{Buffer, Format, Formatter, GroupId, prelude::*, separated::FormatSeparatedIter},
     utils::array::write_array_node,
     write,
 };
@@ -28,7 +25,7 @@ impl<'a, 'b> ArrayElementList<'a, 'b> {
 }
 
 impl<'a> Format<'a> for ArrayElementList<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let expand_lists = f.context().options().expand == Expand::Always;
         let layout = if expand_lists {
             ArrayLayout::OnePerLine
@@ -52,21 +49,21 @@ impl<'a> Format<'a> for ArrayElementList<'a, '_> {
                     filler.entry(
                         &format_with(|f| {
                             if f.source_text().get_lines_before(element.span(), f.comments()) > 1 {
-                                write!(f, empty_line())
+                                write!(f, empty_line());
                             } else if f
                                 .comments()
                                 .has_leading_own_line_comment(element.span().start)
                             {
-                                write!(f, hard_line_break())
+                                write!(f, hard_line_break());
                             } else {
-                                write!(f, soft_line_break_or_space())
+                                write!(f, soft_line_break_or_space());
                             }
                         }),
                         &element,
                     );
                 }
 
-                filler.finish()
+                filler.finish();
             }
             ArrayLayout::OnePerLine => write_array_node(
                 self.elements.len(),

--- a/crates/oxc_formatter/src/write/array_expression.rs
+++ b/crates/oxc_formatter/src/write/array_expression.rs
@@ -26,11 +26,11 @@ impl<'a, 'b> FormatArrayExpression<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatArrayExpression<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "[")?;
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "[");
 
         if self.array.elements().is_empty() {
-            write!(f, format_dangling_comments(self.array.span).with_block_indent())?;
+            write!(f, format_dangling_comments(self.array.span).with_block_indent());
         } else {
             let group_id = f.group_id("array");
             let should_expand = (!self.options.is_force_flat_mode && should_break(self.array))
@@ -43,10 +43,10 @@ impl<'a> Format<'a> for FormatArrayExpression<'a, '_> {
                 group(&soft_block_indent(&elements))
                     .with_group_id(Some(group_id))
                     .should_expand(should_expand)
-            )?;
+            );
         }
 
-        write!(f, "]")
+        write!(f, "]");
     }
 }
 

--- a/crates/oxc_formatter/src/write/array_pattern.rs
+++ b/crates/oxc_formatter/src/write/array_pattern.rs
@@ -4,7 +4,7 @@ use oxc_ast::ast::ArrayPattern;
 use oxc_span::GetSpan;
 
 use crate::{
-    Format, FormatResult,
+    Format,
     ast_nodes::AstNode,
     formatter::{Formatter, prelude::*, trivia::format_dangling_comments},
     utils::array::write_array_node,
@@ -24,11 +24,11 @@ impl<'a> Deref for FormatArrayPattern<'a, '_> {
 }
 
 impl<'a> Format<'a> for FormatArrayPattern<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "[")?;
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "[");
 
         if self.elements.is_empty() && self.rest.is_none() {
-            write!(f, [format_dangling_comments(self.span()).with_block_indent()])?;
+            write!(f, [format_dangling_comments(self.span()).with_block_indent()]);
         } else {
             write!(
                 f,
@@ -39,22 +39,21 @@ impl<'a> Format<'a> for FormatArrayPattern<'a, '_> {
                             self.elements.len() + usize::from(self.rest.is_some()),
                             self.elements().iter().map(AstNode::as_ref),
                             f,
-                        )?;
+                        );
                     }
                     if let Some(rest) = self.rest() {
-                        write!(f, [has_element.then_some(soft_line_break_or_space()), rest])?;
+                        write!(f, [has_element.then_some(soft_line_break_or_space()), rest]);
                     }
-                    Ok(())
                 })))
-            )?;
+            );
         }
 
-        write!(f, "]")
+        write!(f, "]");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ArrayPattern<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        FormatArrayPattern(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        FormatArrayPattern(self).fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -5,8 +5,8 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Buffer, Format, FormatError, FormatResult, Formatter, SourceText,
-        buffer::RemoveSoftLinesBuffer, prelude::*, trivia::FormatTrailingComments,
+        Buffer, Format, Formatter, SourceText, buffer::RemoveSoftLinesBuffer, prelude::*,
+        trivia::FormatTrailingComments,
     },
     options::FormatTrailingCommas,
     utils::{
@@ -22,16 +22,16 @@ use super::{FormatWrite, parameters::has_only_simple_parameters};
 impl<'a> FormatWrite<'a, FormatJsArrowFunctionExpressionOptions>
     for AstNode<'a, ArrowFunctionExpression<'a>>
 {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        FormatJsArrowFunctionExpression::new(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        FormatJsArrowFunctionExpression::new(self).fmt(f);
     }
 
     fn write_with_options(
         &self,
         options: FormatJsArrowFunctionExpressionOptions,
         f: &mut Formatter<'_, 'a>,
-    ) -> FormatResult<()> {
-        FormatJsArrowFunctionExpression::new_with_options(self, options).fmt(f)
+    ) {
+        FormatJsArrowFunctionExpression::new_with_options(self, options).fmt(f);
     }
 }
 
@@ -91,12 +91,12 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
     }
 
     #[inline]
-    pub fn format(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    pub fn format(&self, f: &mut Formatter<'_, 'a>) {
         let layout = ArrowFunctionLayout::for_arrow(self.arrow, self.options);
 
         match layout {
             ArrowFunctionLayout::Chain(chain) => {
-                write!(f, chain)
+                write!(f, chain);
             }
             ArrowFunctionLayout::Single(arrow) => {
                 let body = &arrow.body();
@@ -114,7 +114,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                             space(),
                             "=>"
                         ]
-                    )
+                    );
                 });
 
                 let format_body = FormatMaybeCachedFunctionBody {
@@ -155,7 +155,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                                     token(")")
                                 ))))
                             ))]
-                        )
+                        );
                     } else {
                         write!(
                             f,
@@ -168,7 +168,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                                     token(")")
                                 ))
                             ))]
-                        )
+                        );
                     };
                 }
 
@@ -186,7 +186,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                     });
 
                 if body_has_soft_line_break {
-                    write!(f, [formatted_signature, space(), format_body])
+                    write!(f, [formatted_signature, space(), format_body]);
                 } else {
                     let should_add_parens = arrow.expression && should_add_parens(body);
 
@@ -211,23 +211,21 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                                 group(&format_args!(
                                     soft_line_indent_or_hard_space(&format_with(|f| {
                                         if should_add_parens {
-                                            write!(f, if_group_fits_on_line(&"("))?;
+                                            write!(f, if_group_fits_on_line(&"("));
                                         }
 
-                                        write!(f, format_body)?;
+                                        write!(f, format_body);
 
                                         if should_add_parens {
-                                            write!(f, if_group_fits_on_line(&")"))?;
+                                            write!(f, if_group_fits_on_line(&")"));
                                         }
-
-                                        Ok(())
                                     })),
                                     is_last_call_arg
                                         .then_some(format_args!(FormatTrailingCommas::All,)),
                                     should_add_soft_line.then_some(format_args!(soft_line_break()))
                                 ))
                             ]
-                        )
+                        );
                     } else {
                         write!(
                             f,
@@ -236,23 +234,21 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                                 group(&format_args!(
                                     soft_line_indent_or_space(&format_with(|f| {
                                         if should_add_parens {
-                                            write!(f, if_group_fits_on_line(&"("))?;
+                                            write!(f, if_group_fits_on_line(&"("));
                                         }
 
-                                        write!(f, format_body)?;
+                                        write!(f, format_body);
 
                                         if should_add_parens {
-                                            write!(f, if_group_fits_on_line(&")"))?;
+                                            write!(f, if_group_fits_on_line(&")"));
                                         }
-
-                                        Ok(())
                                     })),
                                     is_last_call_arg
                                         .then_some(format_args!(FormatTrailingCommas::All,)),
                                     should_add_soft_line.then_some(format_args!(soft_line_break()))
                                 ))
                             ]
-                        )
+                        );
                     }
                 }
             }
@@ -261,8 +257,8 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.format(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        self.format(f);
     }
 }
 
@@ -433,7 +429,7 @@ impl<'a, 'b> ArrowChain<'a, 'b> {
 }
 
 impl<'a> Format<'a> for ArrowChain<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let ArrowChain { tail, expand_signatures, .. } = self;
 
         let tail_body = tail.body();
@@ -526,7 +522,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                                 // then we want to _force_ the line break so that the leading comments
                                 // don't inadvertently end up on the previous line after the fat arrow.
                                 if is_grouped_call_arg_layout {
-                                    write!(f, [space(), format_leading_comments(arrow.span())])
+                                    write!(f, [space(), format_leading_comments(arrow.span())]);
                                 } else {
                                     write!(
                                         f,
@@ -534,10 +530,8 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                                             soft_line_break_or_space(),
                                             format_leading_comments(arrow.span())
                                         ]
-                                    )
+                                    );
                                 }
-                            } else {
-                                Ok(())
                             }
                         });
 
@@ -557,7 +551,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                                     self.options.cache_mode
                                 )
                             ]
-                        )
+                        );
                     });
 
                     // Arrow chains indent a second level for every item other than the first:
@@ -571,22 +565,20 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                     // one additional level, as shown above.
                     if is_first_in_chain || has_initial_indent {
                         is_first_in_chain = false;
-                        write!(f, [formatted_signature])?;
+                        write!(f, [formatted_signature]);
                     } else {
-                        write!(f, [indent(&formatted_signature)])?;
+                        write!(f, [indent(&formatted_signature)]);
                     }
 
                     // The arrow of the tail is formatted outside of the group to ensure it never
                     // breaks from the body
                     if !std::ptr::eq(arrow, tail) {
-                        write!(f, [space(), "=>"])?;
+                        write!(f, [space(), "=>"]);
                     }
                 }
-
-                Ok(())
             });
 
-            group(&join_signatures).should_expand(*expand_signatures).fmt(f)
+            group(&join_signatures).should_expand(*expand_signatures).fmt(f);
         });
 
         let format_tail_body_inner = format_with(|f| {
@@ -608,7 +600,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                             soft_block_indent(&format_tail_body),
                             token(")")
                         ))))]
-                    )?;
+                    );
                 } else {
                     write!(
                         f,
@@ -617,7 +609,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                             soft_block_indent(&format_tail_body),
                             token(")")
                         ))]
-                    )?;
+                    );
                 }
             } else {
                 let should_add_parens = tail.expression && should_add_parens(tail_body);
@@ -629,12 +621,11 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                             format_tail_body,
                             if_group_fits_on_line(&token(")"))
                         ]
-                    )?;
+                    );
                 } else {
-                    write!(f, [format_tail_body])?;
+                    write!(f, [format_tail_body]);
                 }
             }
-            Ok(())
         });
 
         let format_tail_body = format_with(|f| {
@@ -649,9 +640,9 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                         soft_line_indent_or_space(&format_tail_body_inner),
                         should_add_soft_line.then_some(soft_line_break())
                     ]
-                )
+                );
             } else {
-                write!(f, [space(), format_tail_body_inner])
+                write!(f, [space(), format_tail_body_inner]);
             }
         });
 
@@ -664,32 +655,30 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                     [group(&indent(&format_args!(soft_line_break(), format_arrow_signatures)))
                         .with_group_id(Some(group_id))
                         .should_expand(break_signatures)]
-                )?;
+                );
             } else {
                 write!(
                     f,
                     group(&format_arrow_signatures)
                         .with_group_id(Some(group_id))
                         .should_expand(break_signatures)
-                )?;
+                );
             }
 
-            write!(f, [space(), "=>"])?;
+            write!(f, [space(), "=>"]);
 
             if is_grouped_call_arg_layout {
-                write!(f, [group(&format_tail_body)])?;
+                write!(f, [group(&format_tail_body)]);
             } else {
-                write!(f, [indent_if_group_breaks(&format_tail_body, group_id)])?;
+                write!(f, [indent_if_group_breaks(&format_tail_body, group_id)]);
             }
 
             if is_callee {
-                write!(f, [if_group_breaks(&soft_line_break()).with_group_id(Some(group_id))])?;
+                write!(f, [if_group_breaks(&soft_line_break()).with_group_id(Some(group_id))]);
             }
-
-            Ok(())
         });
 
-        write!(f, [group(&format_inner)])
+        write!(f, [group(&format_inner)]);
     }
 }
 
@@ -723,13 +712,6 @@ fn has_rest_object_or_array_parameter(params: &FormalParameters) -> bool {
 ///
 /// Formats the parameters and return type annotation without any soft line breaks if `is_first_or_last_call_argument` is `true`
 /// so that the parameters and return type are kept on the same line.
-///
-/// # Errors
-///
-/// Returns [`FormatError::PoorLayout`] if `is_first_or_last_call_argument` is `true` but the parameters
-/// or return type annotation contain any content that forces a [*group to break](FormatElements::will_break).
-///
-/// This error gets captured by FormatJsCallArguments.
 fn format_signature<'a, 'b>(
     arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
     is_first_or_last_call_argument: bool,
@@ -745,13 +727,11 @@ fn format_signature<'a, 'b>(
                 arrow.params(),
                 &format_with(|f| {
                     if let Some(return_type) = &arrow.return_type() {
-                        group(&FormatNodeWithoutTrailingComments(return_type)).fmt(f)
-                    } else {
-                        Ok(())
+                        group(&FormatNodeWithoutTrailingComments(return_type)).fmt(f);
                     }
                 })
             ))
-            .fmt(f)
+            .fmt(f);
         });
         let format_head = FormatContentWithCacheMode::new(arrow.params.span, content, cache_mode);
 
@@ -759,10 +739,11 @@ fn format_signature<'a, 'b>(
             let mut buffer = RemoveSoftLinesBuffer::new(f);
             let mut recording = buffer.start_recording();
 
-            write!(recording, format_head)?;
+            write!(recording, format_head);
 
             if recording.stop().will_break() {
-                return Err(FormatError::PoorLayout);
+                // TODO: figure out
+                // return Err(FormatError::PoorLayout);
             }
         } else {
             write!(
@@ -775,14 +756,14 @@ fn format_signature<'a, 'b>(
                     (!is_first_in_chain).then_some(soft_line_break_or_space()),
                     format_head
                 ]
-            )?;
+            );
         }
 
         // Print comments before the fat arrow (`=>`)
         let comments_before_fat_arrow =
             f.context().comments().comments_before_character(arrow.params.span().end, b'=');
         let content = FormatTrailingComments::Comments(comments_before_fat_arrow);
-        write!(f, [FormatContentWithCacheMode::new(arrow.span, content, cache_mode)])
+        write!(f, [FormatContentWithCacheMode::new(arrow.span, content, cache_mode)]);
     })
 }
 
@@ -799,7 +780,7 @@ pub struct FormatMaybeCachedFunctionBody<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatMaybeCachedFunctionBody<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let content = format_with(|f| {
             if self.expression
                 && let AstNodes::ExpressionStatement(s) =
@@ -807,8 +788,8 @@ impl<'a> Format<'a> for FormatMaybeCachedFunctionBody<'a, '_> {
             {
                 return s.expression().fmt(f);
             }
-            self.body.fmt(f)
+            self.body.fmt(f);
         });
-        FormatContentWithCacheMode::new(self.body.span, content, self.mode).fmt(f)
+        FormatContentWithCacheMode::new(self.body.span, content, self.mode).fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
@@ -3,13 +3,13 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    formatter::{FormatResult, Formatter, prelude::*},
+    formatter::{Formatter, prelude::*},
     write,
     write::FormatWrite,
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent);
         format_as_or_satisfies_expression(
             self.expression(),
@@ -17,12 +17,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
             is_callee_or_object,
             "as",
             f,
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent);
         format_as_or_satisfies_expression(
             self.expression(),
@@ -30,7 +30,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
             is_callee_or_object,
             "satisfies",
             f,
-        )
+        );
     }
 }
 
@@ -40,16 +40,16 @@ fn format_as_or_satisfies_expression<'a>(
     is_callee_or_object: bool,
     operation: &'static str,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     let format_inner = format_with(|f| {
-        write!(f, [expression, space(), token(operation)])?;
-        write!(f, [space(), type_annotation])
+        write!(f, [expression, space(), token(operation)]);
+        write!(f, [space(), type_annotation]);
     });
 
     if is_callee_or_object {
-        write!(f, [group(&soft_block_indent(&format_inner))])
+        write!(f, [group(&soft_block_indent(&format_inner))]);
     } else {
-        write!(f, [format_inner])
+        write!(f, [format_inner]);
     }
 }
 

--- a/crates/oxc_formatter/src/write/assignment_pattern_property_list.rs
+++ b/crates/oxc_formatter/src/write/assignment_pattern_property_list.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
-    formatter::{Format, FormatResult, Formatter},
+    formatter::{Format, Formatter},
     options::{FormatTrailingCommas, TrailingSeparator},
 };
 
@@ -23,7 +23,7 @@ impl GetSpan for AssignmentTargetPropertyListNode<'_, '_> {
 }
 
 impl<'a> Format<'a> for AssignmentTargetPropertyListNode<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             AssignmentTargetPropertyListNode::Property(property) => property.fmt(f),
             AssignmentTargetPropertyListNode::Rest(rest) => rest.fmt(f),
@@ -63,7 +63,7 @@ impl<'a, 'b> AssignmentTargetPropertyList<'a, 'b> {
 }
 
 impl<'a> Format<'a> for AssignmentTargetPropertyList<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let has_trailing_rest = self.rest.is_some();
         let trailing_separator = if has_trailing_rest {
             TrailingSeparator::Disallowed
@@ -79,6 +79,6 @@ impl<'a> Format<'a> for AssignmentTargetPropertyList<'a, '_> {
                 ",",
                 trailing_separator,
             )
-            .finish()
+            .finish();
     }
 }

--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -5,7 +5,7 @@ use oxc_syntax::precedence::{GetPrecedence, Precedence};
 use crate::{
     Format,
     ast_nodes::{AstNode, AstNodes},
-    formatter::{FormatResult, Formatter},
+    formatter::Formatter,
 };
 
 use crate::{format_args, formatter::prelude::*, write};
@@ -29,13 +29,13 @@ impl From<LogicalOperator> for BinaryLikeOperator {
 }
 
 impl Format<'_> for BinaryLikeOperator {
-    fn fmt(&self, f: &mut Formatter<'_, '_>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, '_>) {
         let operator = match self {
             Self::BinaryOperator(op) => op.as_str(),
             Self::LogicalOperator(op) => op.as_str(),
         };
 
-        write!(f, operator)
+        write!(f, operator);
     }
 }
 
@@ -193,7 +193,7 @@ impl<'a, 'b> TryFrom<&'b AstNode<'a, Expression<'a>>> for BinaryLikeExpression<'
 }
 
 impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let parent = self.parent();
         let is_inside_condition = self.is_inside_condition(parent);
 
@@ -202,7 +202,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
             return write!(
                 f,
                 [&format_with(|f| {
-                    format_flattened_logical_expression(*self, is_inside_condition, f)
+                    format_flattened_logical_expression(*self, is_inside_condition, f);
                 })]
             );
         }
@@ -219,7 +219,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                 f,
                 [group(&soft_block_indent(&format_once(|f| {
                     // is_inside_condition is always false here (we returned early if true)
-                    format_flattened_logical_expression(*self, false, f)
+                    format_flattened_logical_expression(*self, false, f);
                 })))]
             );
         }
@@ -233,7 +233,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                 f,
                 [group(&format_with(|f| {
                     // is_inside_condition is always false here (we returned early if true)
-                    format_flattened_logical_expression(*self, false, f)
+                    format_flattened_logical_expression(*self, false, f);
                 }))]
             );
         }
@@ -270,7 +270,7 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                     indent(&format_with(|f| { f.join().entries(tail_parts.iter()).finish() }))
                 ))
                 .with_group_id(Some(group_id))]
-            )
+            );
         });
 
         if last_is_jsx {
@@ -282,9 +282,9 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                     format_non_jsx_parts,
                     indent_if_group_breaks(&jsx_element, group_id),
                 ))]
-            )
+            );
         } else {
-            write!(f, format_non_jsx_parts)
+            write!(f, format_non_jsx_parts);
         }
     }
 }
@@ -313,31 +313,31 @@ fn format_flattened_logical_expression<'a>(
     binary: BinaryLikeExpression<'a, '_>,
     inside_condition: bool,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     fn format_recursive<'a>(
         binary: BinaryLikeExpression<'a, '_>,
         inside_condition: bool,
         f: &mut Formatter<'_, 'a>,
-    ) -> FormatResult<()> {
+    ) {
         let left = binary.left();
 
         if binary.can_flatten() {
             // Recursively format nested binary expressions
-            format_recursive(BinaryLikeExpression::try_from(left).unwrap(), inside_condition, f)?;
+            format_recursive(BinaryLikeExpression::try_from(left).unwrap(), inside_condition, f);
         } else {
             // Format the left terminal
-            write!(f, [group(left)])?;
+            write!(f, [group(left)]);
         }
 
         // Format the right side with operator
-        BinaryLeftOrRightSide::Right { parent: binary, inside_condition }.fmt(f)
+        BinaryLeftOrRightSide::Right { parent: binary, inside_condition }.fmt(f);
     }
 
-    format_recursive(binary, inside_condition, f)
+    format_recursive(binary, inside_condition, f);
 }
 
 impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::Left { parent } => write!(f, group(parent.left())),
             Self::Right {
@@ -412,13 +412,13 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
                                             ),
                                             *inside_parenthesis,
                                             f,
-                                        )
+                                        );
                                     } else {
-                                        left_child.fmt(f)
+                                        left_child.fmt(f);
                                     }
                                 })
                             ]
-                        )?;
+                        );
 
                         binary_like_expression =
                             BinaryLikeExpression::LogicalExpression(right_logical);
@@ -430,20 +430,20 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
                 let right = binary_like_expression.right();
 
                 let operator_and_right_expression = format_with(|f| {
-                    write!(f, [space(), binary_like_expression.operator()])?;
+                    write!(f, [space(), binary_like_expression.operator()]);
 
                     let should_inline = binary_like_expression.should_inline_logical_expression();
 
                     if should_inline {
-                        write!(f, [space()])?;
+                        write!(f, [space()]);
                         if f.comments().has_leading_own_line_comment(right.span().start) {
                             return write!(f, soft_line_indent_or_space(right));
                         }
                     } else {
-                        write!(f, [soft_line_break_or_space()])?;
+                        write!(f, [soft_line_break_or_space()]);
                     }
 
-                    write!(f, right)
+                    write!(f, right);
                 });
 
                 // Cache as_ast_nodes() calls to avoid repeated conversions
@@ -461,10 +461,10 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
 
                 match left_ast_nodes {
                     AstNodes::LogicalExpression(logical) => {
-                        logical.format_trailing_comments(f)?;
+                        logical.format_trailing_comments(f);
                     }
                     AstNodes::BinaryExpression(binary) => {
-                        binary.format_trailing_comments(f)?;
+                        binary.format_trailing_comments(f);
                     }
                     _ => {}
                 }
@@ -493,9 +493,9 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
                         })
                         .any(|comment| comment.is_line());
 
-                    write!(f, [group(&operator_and_right_expression).should_expand(should_break)])
+                    write!(f, [group(&operator_and_right_expression).should_expand(should_break)]);
                 } else {
-                    write!(f, [operator_and_right_expression])
+                    write!(f, [operator_and_right_expression]);
                 }
             }
         }

--- a/crates/oxc_formatter/src/write/binding_property_list.rs
+++ b/crates/oxc_formatter/src/write/binding_property_list.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
-    formatter::{Format, FormatResult, Formatter},
+    formatter::{Format, Formatter},
     options::{FormatTrailingCommas, TrailingSeparator},
 };
 
@@ -28,7 +28,7 @@ impl GetSpan for BindingPropertyListNode<'_, '_> {
 }
 
 impl<'a> Format<'a> for BindingPropertyListNode<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             BindingPropertyListNode::Property(property) => property.fmt(f),
             BindingPropertyListNode::Rest(rest) => rest.fmt(f),
@@ -63,7 +63,7 @@ impl<'a, 'b> BindingPropertyList<'a, 'b> {
 }
 
 impl<'a> Format<'a> for BindingPropertyList<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let has_trailing_rest = self.rest.is_some();
         let trailing_separator = if has_trailing_rest {
             TrailingSeparator::Disallowed
@@ -77,6 +77,6 @@ impl<'a> Format<'a> for BindingPropertyList<'a, '_> {
                 ",",
                 trailing_separator,
             )
-            .finish()
+            .finish();
     }
 }

--- a/crates/oxc_formatter/src/write/block_statement.rs
+++ b/crates/oxc_formatter/src/write/block_statement.rs
@@ -5,23 +5,23 @@ use super::FormatWrite;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{Buffer, FormatResult, Formatter, prelude::*},
+    formatter::{Buffer, Formatter, prelude::*},
     write,
 };
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Statement<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         f.join_nodes_with_hardline()
             .entries(
                 self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_))),
             )
-            .finish()
+            .finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "{")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "{");
 
         let comments_before_catch_clause = if let AstNodes::CatchClause(catch) = self.parent {
             f.context().get_cached_element(&catch.span)
@@ -33,9 +33,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
         // See reason in `[AstNode<'a, CatchClause<'a>>::write]`
         let formatted_comments_before_catch_clause = format_once(|f| {
             if let Some(comments) = comments_before_catch_clause {
-                f.write_element(comments)
-            } else {
-                Ok(())
+                f.write_element(comments);
             }
         });
 
@@ -54,17 +52,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
                         &formatted_comments_before_catch_clause,
                         format_dangling_comments(self.span)
                     ))
-                )?;
+                );
             } else if is_non_collapsible(self.parent) {
-                write!(f, hard_line_break())?;
+                write!(f, hard_line_break());
             }
         } else {
             write!(
                 f,
                 block_indent(&format_args!(&formatted_comments_before_catch_clause, self.body()))
-            )?;
+            );
         }
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -3,11 +3,11 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Buffer, Format, FormatResult, FormatTrailingCommas, TrailingSeparator,
+    Buffer, Format, FormatTrailingCommas, TrailingSeparator,
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Comments, FormatElement, FormatError, Formatter, SourceText, VecBuffer, format_element,
+        Comments, FormatElement, Formatter, SourceText, VecBuffer, format_element,
         prelude::{
             FormatElements, Tag, empty_line, expand_parent, format_once, format_with, group,
             soft_block_indent, soft_line_break_or_space, space,
@@ -36,7 +36,7 @@ use super::{
 };
 
 impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let l_paren_token = "(";
         let r_paren_token = ")";
 
@@ -91,7 +91,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                                 ",",
                                 TrailingSeparator::Omit,
                             )
-                            .finish()
+                            .finish();
                     }),
                     r_paren_token
                 ]
@@ -121,7 +121,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         }
 
         if let Some(group_layout) = arguments_grouped_layout(self, f) {
-            write_grouped_arguments(self, group_layout, f)
+            write_grouped_arguments(self, group_layout, f);
         } else if call_expression.is_some_and(|call| is_long_curried_call(call)) {
             let trailing_operator = FormatTrailingCommas::All.trailing_separator(f.options());
             write!(
@@ -131,13 +131,13 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                     soft_block_indent(&format_with(|f| {
                         f.join_with(soft_line_break_or_space())
                             .entries_with_trailing_separator(self.iter(), ",", trailing_operator)
-                            .finish()
+                            .finish();
                     })),
                     r_paren_token,
                 ]
-            )
+            );
         } else {
-            format_all_args_broken_out(self, false, f)
+            format_all_args_broken_out(self, false, f);
         }
     }
 }
@@ -190,25 +190,25 @@ pub fn is_function_composition_args(args: &[Argument<'_>]) -> bool {
 
 fn format_all_elements_broken_out<'a, 'b>(
     node: &'b AstNode<'a, ArenaVec<'a, Argument<'a>>>,
-    elements: impl Iterator<Item = (FormatResult<Option<FormatElement<'a>>>, usize)>,
+    elements: impl Iterator<Item = (Option<FormatElement<'a>>, usize)>,
     expand: bool,
     mut buffer: impl Buffer<'a>,
-) -> FormatResult<()> {
+) {
     write!(
         buffer,
         [group(&format_args!(
             "(",
             soft_block_indent(&format_once(move |f| {
                 for (index, (element, lines_before)) in elements.into_iter().enumerate() {
-                    if let Ok(Some(element)) = element {
+                    if let Some(element) = element {
                         if index > 0 {
                             match lines_before {
-                                0 | 1 => write!(f, [soft_line_break_or_space()])?,
-                                _ => write!(f, [empty_line()])?,
+                                0 | 1 => write!(f, [soft_line_break_or_space()]),
+                                _ => write!(f, [empty_line()]),
                             }
                         }
 
-                        f.write_element(element)?;
+                        f.write_element(element);
                     }
                 }
 
@@ -216,19 +216,19 @@ fn format_all_elements_broken_out<'a, 'b>(
                     f,
                     [(!matches!(node.parent, AstNodes::ImportExpression(_)))
                         .then_some(FormatTrailingCommas::All)]
-                )
+                );
             })),
             ")",
         ))
         .should_expand(expand)]
-    )
+    );
 }
 
 fn format_all_args_broken_out<'a, 'b>(
     node: &'b AstNode<'a, ArenaVec<'a, Argument<'a>>>,
     expand: bool,
     mut buffer: impl Buffer<'a>,
-) -> FormatResult<()> {
+) {
     let last_index = node.len() - 1;
     write!(
         buffer,
@@ -238,24 +238,24 @@ fn format_all_args_broken_out<'a, 'b>(
                 for (index, argument) in node.iter().enumerate() {
                     if index > 0 {
                         match f.source_text().get_lines_before(argument.span(), f.comments()) {
-                            0 | 1 => write!(f, [soft_line_break_or_space()])?,
-                            _ => write!(f, [empty_line()])?,
+                            0 | 1 => write!(f, [soft_line_break_or_space()]),
+                            _ => write!(f, [empty_line()]),
                         }
                     }
 
-                    write!(f, [argument, (index != last_index).then_some(",")])?;
+                    write!(f, [argument, (index != last_index).then_some(",")]);
                 }
 
                 write!(
                     f,
                     [(!matches!(node.parent, AstNodes::ImportExpression(_)))
                         .then_some(FormatTrailingCommas::All)]
-                )
+                );
             })),
             ")",
         ))
         .should_expand(expand)]
-    )
+    );
 }
 
 pub fn arguments_grouped_layout(
@@ -619,7 +619,7 @@ fn write_grouped_arguments<'a>(
     node: &AstNode<'a, ArenaVec<'a, Argument<'a>>>,
     group_layout: GroupedCallArgumentLayout,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     let last_index = node.len() - 1;
     let only_one_argument = last_index == 0;
     let mut non_grouped_breaks = false;
@@ -666,7 +666,7 @@ fn write_grouped_arguments<'a>(
                         _ => {}
                     }
                 }
-                argument.fmt(f)
+                argument.fmt(f);
             });
 
             // We have to get the lines before the argument has been formatted, because it relies on
@@ -675,17 +675,14 @@ fn write_grouped_arguments<'a>(
             let lines_before = f.source_text().get_lines_before(argument.span(), f.comments());
 
             let interned = f.intern(&format_with(|f| {
-                format_argument.fmt(f)?;
-                write!(f, (last_index != index).then_some(","))
+                format_argument.fmt(f);
+                write!(f, (last_index != index).then_some(","));
             }));
 
             let break_type =
                 if is_grouped_argument { &mut grouped_breaks } else { &mut non_grouped_breaks };
 
-            *break_type = *break_type
-                || interned
-                    .as_ref()
-                    .is_ok_and(|i| i.as_ref().is_some_and(FormatElement::will_break));
+            *break_type = *break_type || interned.as_ref().is_some_and(FormatElement::will_break);
 
             (interned, lines_before)
         })
@@ -700,11 +697,11 @@ fn write_grouped_arguments<'a>(
     // First write the most expanded variant because it needs `arguments`.
     let most_expanded = {
         let mut buffer = VecBuffer::new(f.state_mut());
-        buffer.write_element(FormatElement::Tag(Tag::StartEntry))?;
+        buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
-        format_all_elements_broken_out(node, elements.iter().cloned(), true, &mut buffer)?;
+        format_all_elements_broken_out(node, elements.iter().cloned(), true, &mut buffer);
 
-        buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
+        buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
         buffer.into_vec().into_bump_slice()
     };
@@ -722,8 +719,8 @@ fn write_grouped_arguments<'a>(
             GroupedCallArgumentLayout::GroupedFirstArgument => {
                 let argument = node.first().unwrap();
                 let interned = f.intern(&format_with(|f| {
-                    FormatGroupedFirstArgument { argument }.fmt(f)?;
-                    write!(f, (last_index != 0).then_some(","))
+                    FormatGroupedFirstArgument { argument }.fmt(f);
+                    write!(f, (last_index != 0).then_some(","));
                 }));
 
                 // Turns out, using the grouped layout isn't a good fit because some parameters of the
@@ -732,16 +729,17 @@ fn write_grouped_arguments<'a>(
                 // This back tracking is required because testing if the grouped argument breaks would also return `true`
                 // if any content of the function body breaks. But, as far as this is concerned, it's only interested if
                 // any content in the signature breaks.
-                if matches!(interned, Err(FormatError::PoorLayout)) {
-                    return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
-                }
+                // TODO: should figure out
+                // if matches!(interned, Err(FormatError::PoorLayout)) {
+                //     return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
+                // }
 
                 grouped.first_mut().unwrap().0 = interned;
             }
             GroupedCallArgumentLayout::GroupedLastArgument => {
                 let argument = node.last().unwrap();
                 let interned = f.intern(&format_once(|f| {
-                    FormatGroupedLastArgument { argument, is_only: only_one_argument }.fmt(f)
+                    FormatGroupedLastArgument { argument, is_only: only_one_argument }.fmt(f);
                 }));
 
                 // Turns out, using the grouped layout isn't a good fit because some parameters of the
@@ -750,9 +748,10 @@ fn write_grouped_arguments<'a>(
                 // This back tracking is required because testing if the grouped argument breaks would also return `true`
                 // if any content of the function body breaks. But, as far as this is concerned, it's only interested if
                 // any content in the signature breaks.
-                if matches!(interned, Err(FormatError::PoorLayout)) {
-                    return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
-                }
+                // TODO: should figure out
+                // if matches!(interned, Err(FormatError::PoorLayout)) {
+                //     return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
+                // }
 
                 grouped.last_mut().unwrap().0 = interned;
             }
@@ -763,7 +762,7 @@ fn write_grouped_arguments<'a>(
     let middle_variant = {
         let mut buffer = VecBuffer::new(f.state_mut());
 
-        buffer.write_element(FormatElement::Tag(Tag::StartEntry))?;
+        buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
         write!(
             buffer,
@@ -778,32 +777,28 @@ fn write_grouped_arguments<'a>(
                         {
                             joiner.entry(
                                 &group(&format_with(|f| {
-                                    if let Some(arg_element) = element.clone()? {
-                                        f.write_element(arg_element)
-                                    } else {
-                                        Ok(())
+                                    if let Some(arg_element) = element.clone() {
+                                        f.write_element(arg_element);
                                     }
                                 }))
                                 .should_expand(true),
                             );
                         } else {
                             joiner.entry(&format_with(|f| {
-                                if let Some(arg_element) = element.clone()? {
-                                    f.write_element(arg_element)
-                                } else {
-                                    Ok(())
+                                if let Some(arg_element) = element.clone() {
+                                    f.write_element(arg_element);
                                 }
                             }));
                         }
                     }
 
-                    joiner.finish()
+                    joiner.finish();
                 }),
                 ")"
             ]
-        )?;
+        );
 
-        buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
+        buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
         buffer.into_vec().into_bump_slice()
     };
@@ -811,13 +806,13 @@ fn write_grouped_arguments<'a>(
     // If the grouped content breaks, then we can skip the most_flat variant,
     // since we already know that it won't be fitting on a single line.
     let variants = if grouped_breaks {
-        write!(f, [expand_parent()])?;
+        write!(f, [expand_parent()]);
         ArenaVec::from_array_in([middle_variant, most_expanded], f.context().allocator())
     } else {
         // Write the most flat variant with the first or last argument grouped.
         let most_flat = {
             let mut buffer = VecBuffer::new(f.state_mut());
-            buffer.write_element(FormatElement::Tag(Tag::StartEntry))?;
+            buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
             write!(
                 buffer,
@@ -827,20 +822,18 @@ fn write_grouped_arguments<'a>(
                         f.join_with(soft_line_break_or_space())
                             .entries(grouped.into_iter().map(|(element, _)| {
                                 format_once(move |f| {
-                                    if let Some(element) = element? {
-                                        f.write_element(element)
-                                    } else {
-                                        Ok(())
+                                    if let Some(element) = element {
+                                        f.write_element(element);
                                     }
                                 })
                             }))
-                            .finish()
+                            .finish();
                     }),
                     ")",
                 ]
-            )?;
+            );
 
-            buffer.write_element(FormatElement::Tag(Tag::EndEntry))?;
+            buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
             buffer.into_vec().into_bump_slice()
         };
@@ -856,7 +849,7 @@ fn write_grouped_arguments<'a>(
     unsafe {
         f.write_element(FormatElement::BestFitting(
             format_element::BestFittingElement::from_vec_unchecked(variants),
-        ))
+        ));
     }
 }
 
@@ -866,7 +859,7 @@ struct FormatGroupedFirstArgument<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatGroupedFirstArgument<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self.argument.as_ast_nodes() {
             // Call the arrow function formatting but explicitly passes the call argument layout down
             // so that the arrow function formatting removes any soft line breaks between parameters and the return type.
@@ -879,7 +872,7 @@ impl<'a> Format<'a> for FormatGroupedFirstArgument<'a, '_> {
                         ..FormatJsArrowFunctionExpressionOptions::default()
                     },
                 )
-                .fmt(f)
+                .fmt(f);
             }
 
             // For all other nodes, use the normal formatting (which already has been cached)
@@ -897,7 +890,7 @@ struct FormatGroupedLastArgument<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatGroupedLastArgument<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         // For function and arrow expressions, re-format the node and pass the argument that it is the
         // last grouped argument. This changes the formatting of parameters, type parameters, and return types
         // to remove any soft line breaks.
@@ -912,7 +905,7 @@ impl<'a> Format<'a> for FormatGroupedLastArgument<'a, '_> {
                         call_argument_layout: Some(GroupedCallArgumentLayout::GroupedLastArgument),
                     },
                 )
-                .fmt(f)
+                .fmt(f);
             }
             AstNodes::ArrowFunctionExpression(arrow) => {
                 FormatJsArrowFunctionExpression::new_with_options(
@@ -923,7 +916,7 @@ impl<'a> Format<'a> for FormatGroupedLastArgument<'a, '_> {
                         ..FormatJsArrowFunctionExpressionOptions::default()
                     },
                 )
-                .fmt(f)
+                .fmt(f);
             }
             _ => self.argument.fmt(f),
         }

--- a/crates/oxc_formatter/src/write/decorators.rs
+++ b/crates/oxc_formatter/src/write/decorators.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Format, FormatResult,
+    Format,
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{Formatter, prelude::*},
@@ -13,9 +13,9 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if self.is_empty() {
-            return Ok(());
+            return;
         }
 
         // Check parent to determine formatting context
@@ -27,7 +27,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
                     f,
                     [group(&format_args!(
                         format_with(|f| {
-                            f.join_nodes_with_soft_line().entries(self.iter()).finish()
+                            f.join_nodes_with_soft_line().entries(self.iter()).finish();
                         }),
                         soft_line_break_or_space()
                     ))
@@ -36,19 +36,19 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
             }
             // Parameter decorators
             AstNodes::FormalParameter(_) => {
-                write!(f, should_expand_decorators(self, f).then_some(expand_parent()))?;
+                write!(f, should_expand_decorators(self, f).then_some(expand_parent()));
             }
             AstNodes::ExportNamedDeclaration(_) | AstNodes::ExportDefaultDeclaration(_) => {
-                write!(f, [hard_line_break()])?;
+                write!(f, [hard_line_break()]);
             }
             _ => {
-                write!(f, [expand_parent()])?;
+                write!(f, [expand_parent()]);
             }
         }
 
-        f.join_with(&soft_line_break_or_space()).entries(self.iter()).finish()?;
+        f.join_with(&soft_line_break_or_space()).entries(self.iter()).finish();
 
-        write!(f, [soft_line_break_or_space()])
+        write!(f, [soft_line_break_or_space()]);
     }
 }
 
@@ -68,8 +68,8 @@ fn is_identifier_or_static_member_only(callee: &Expression) -> bool {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Decorator<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["@"])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["@"]);
 
         // Determine if parentheses are required around decorator expressions
         let needs_parentheses = match &self.expression {
@@ -86,13 +86,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Decorator<'a>> {
         };
 
         if needs_parentheses {
-            write!(f, "(")?;
+            write!(f, "(");
         }
-        write!(f, [self.expression()])?;
+        write!(f, [self.expression()]);
         if needs_parentheses {
-            write!(f, ")")?;
+            write!(f, ")");
         }
-        Ok(())
     }
 }
 

--- a/crates/oxc_formatter/src/write/export_declarations.rs
+++ b/crates/oxc_formatter/src/write/export_declarations.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    FormatResult, FormatTrailingCommas,
+    FormatTrailingCommas,
     ast_nodes::{AstNode, AstNodes},
     formatter::{
         Formatter,
@@ -25,12 +25,12 @@ fn format_export_keyword_with_class_decorators<'a>(
     keyword: &'static str,
     declaration: &AstNodes<'a>,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     // `@decorator export class Cls {}`
     //            ^ print leading comments here
     let format_leading_comments = format_with(|f| {
         let comments = f.context().comments().comments_before(span.start);
-        FormatLeadingComments::Comments(comments).fmt(f)
+        FormatLeadingComments::Comments(comments).fmt(f);
     });
 
     if let AstNodes::Class(class) = declaration
@@ -43,7 +43,7 @@ fn format_export_keyword_with_class_decorators<'a>(
             write!(
                 f,
                 [class.decorators(), hard_line_break(), format_leading_comments, keyword, space()]
-            )
+            );
         } else {
             // `export @decorator class Cls {}`
             // decorators are placed after the export keyword
@@ -56,46 +56,46 @@ fn format_export_keyword_with_class_decorators<'a>(
                     class.decorators(),
                     hard_line_break()
                 ]
-            )
+            );
         }
     } else {
-        write!(f, [format_leading_comments, keyword, space()])
+        write!(f, [format_leading_comments, keyword, space()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_export_keyword_with_class_decorators(
             self.span,
             "export default",
             self.declaration().as_ast_nodes(),
             f,
-        )?;
+        );
 
-        write!(f, self.declaration())?;
+        write!(f, self.declaration());
         if self.declaration().is_expression() {
-            write!(f, OptionalSemicolon)?;
+            write!(f, OptionalSemicolon);
         }
 
-        self.format_trailing_comments(f)
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["export", space(), self.export_kind(), "*", space()])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["export", space(), self.export_kind(), "*", space()]);
         if let Some(name) = &self.exported() {
-            write!(f, ["as", space(), name, space()])?;
+            write!(f, ["as", space(), name, space()]);
         }
-        write!(f, ["from", space()])?;
+        write!(f, ["from", space()]);
 
-        format_import_and_export_source_with_clause(self.source(), self.with_clause(), f)?;
-        write!(f, [OptionalSemicolon])
+        format_import_and_export_source_with_clause(self.source(), self.with_clause(), f);
+        write!(f, [OptionalSemicolon]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let declaration = self.declaration();
         let export_kind = self.export_kind();
         let specifiers = self.specifiers();
@@ -107,11 +107,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
                 "export",
                 decl.as_ast_nodes(),
                 f,
-            )?;
-            write!(f, decl)?;
+            );
+            write!(f, decl);
         } else {
-            self.format_leading_comments(f)?;
-            write!(f, ["export", space()])?;
+            self.format_leading_comments(f);
+            write!(f, ["export", space()]);
 
             let needs_space = f.options().bracket_spacing.value();
             if specifiers.is_empty() {
@@ -135,17 +135,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
                             has_line_comment.then_some(soft_line_break()),
                             " "
                         ]
-                    )?;
+                    );
                 }
                 write!(
                     f,
                     [export_kind, "{", format_dangling_comments(self.span).with_block_indent()]
-                )?;
+                );
             } else if specifiers.len() == 1
                 && f.comments().comments_before_character(self.span.start, b'}').is_empty()
             {
                 let space = maybe_space(needs_space).memoized();
-                write!(f, [export_kind, "{", space, specifiers.first(), space])?;
+                write!(f, [export_kind, "{", space, specifiers.first(), space]);
             } else {
                 write!(
                     f,
@@ -154,27 +154,27 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
                         "{",
                         group(&soft_block_indent_with_maybe_space(specifiers, needs_space))
                     ]
-                )?;
+                );
             }
-            write!(f, "}")?;
+            write!(f, "}");
 
             let with_clause = self.with_clause();
             if let Some(source) = source {
-                write!(f, [space(), "from", space()])?;
-                format_import_and_export_source_with_clause(source, with_clause, f)?;
+                write!(f, [space(), "from", space()]);
+                format_import_and_export_source_with_clause(source, with_clause, f);
             }
         }
 
         if declaration.is_none_or(|d| matches!(d.as_ref(), Declaration::VariableDeclaration(_))) {
-            write!(f, OptionalSemicolon)?;
+            write!(f, OptionalSemicolon);
         }
 
-        self.format_trailing_comments(f)
+        self.format_trailing_comments(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_with(soft_line_break_or_space())
             .entries(
@@ -188,39 +188,39 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
                                 && f.source_text().get_lines_before(specifier_span, f.comments())
                                     > 1
                             {
-                                write!(f, [empty_line()])?;
+                                write!(f, [empty_line()]);
                             }
 
-                            write!(f, specifier)
+                            write!(f, specifier);
                         })
                     }),
             )
-            .finish()
+            .finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportSpecifier<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.exported.span().end);
-        write!(f, [FormatLeadingComments::Comments(comments)])?;
+        write!(f, [FormatLeadingComments::Comments(comments)]);
 
-        write!(f, [self.export_kind()])?;
+        write!(f, [self.export_kind()]);
         if self.local.span() == self.exported.span() {
-            write!(f, self.exported())
+            write!(f, self.exported());
         } else {
-            write!(f, [self.local(), space(), "as", space(), self.exported()])
+            write!(f, [self.local(), space(), "as", space(), self.exported()]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSExportAssignment<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["export = ", self.expression(), OptionalSemicolon])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["export = ", self.expression(), OptionalSemicolon]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["export as namespace ", self.id(), OptionalSemicolon])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["export as namespace ", self.id(), OptionalSemicolon]);
     }
 }

--- a/crates/oxc_formatter/src/write/function.rs
+++ b/crates/oxc_formatter/src/write/function.rs
@@ -11,8 +11,7 @@ use crate::{
     ast_nodes::AstNode,
     format_args,
     formatter::{
-        Buffer, FormatError, FormatResult, Formatter, buffer::RemoveSoftLinesBuffer, prelude::*,
-        trivia::FormatLeadingComments,
+        Buffer, Formatter, buffer::RemoveSoftLinesBuffer, prelude::*, trivia::FormatLeadingComments,
     },
     write,
     write::{
@@ -21,16 +20,12 @@ use crate::{
 };
 
 impl<'a> FormatWrite<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        FormatFunction::new(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        FormatFunction::new(self).fmt(f);
     }
 
-    fn write_with_options(
-        &self,
-        options: FormatFunctionOptions,
-        f: &mut Formatter<'_, 'a>,
-    ) -> FormatResult<()> {
-        FormatFunction::new_with_options(self, options).fmt(f)
+    fn write_with_options(&self, options: FormatFunctionOptions, f: &mut Formatter<'_, 'a>) {
+        FormatFunction::new_with_options(self, options).fmt(f);
     }
 }
 
@@ -67,7 +62,7 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
     }
 
     #[inline]
-    pub fn format(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    pub fn format(&self, f: &mut Formatter<'_, 'a>) {
         let head = format_with(|f| {
             write!(
                 f,
@@ -80,9 +75,9 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                     self.id(),
                     group(&self.type_parameters()),
                 ]
-            )
+            );
         });
-        FormatContentWithCacheMode::new(self.span, head, self.options.cache_mode).fmt(f)?;
+        FormatContentWithCacheMode::new(self.span, head, self.options.cache_mode).fmt(f);
 
         let format_parameters = FormatContentWithCacheMode::new(
             self.params.span,
@@ -96,16 +91,15 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                 let mut buffer = RemoveSoftLinesBuffer::new(f);
 
                 let mut recording = buffer.start_recording();
-                write!(recording, format_parameters)?;
-                let recorded = recording.stop();
+                write!(recording, format_parameters);
+                // let recorded = recording.stop();
 
-                if recorded.will_break() {
-                    return Err(FormatError::PoorLayout);
-                }
-
-                Ok(())
+                // TODO: figure out
+                // if recorded.will_break() {
+                //     return Err(FormatError::PoorLayout);
+                // }
             } else {
-                format_parameters.fmt(f)
+                format_parameters.fmt(f);
             }
         })
         .memoized();
@@ -116,7 +110,7 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                 let content = format_with(move |f| {
                     let needs_space =
                         f.context().comments().has_comment_before(return_type.span.start);
-                    write!(f, [maybe_space(needs_space), return_type])
+                    write!(f, [maybe_space(needs_space), return_type]);
                 });
                 FormatContentWithCacheMode::new(return_type.span, content, self.options.cache_mode)
             })
@@ -128,7 +122,7 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                 let params = &self.params;
                 // Inspect early, in case the `return_type` is formatted before `parameters`
                 // in `should_group_function_parameters`.
-                format_parameters.inspect(f)?;
+                format_parameters.inspect(f);
 
                 let group_parameters = should_group_function_parameters(
                     self.type_parameters.as_deref(),
@@ -136,17 +130,17 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                     self.return_type.as_deref(),
                     &format_return_type,
                     f,
-                )?;
+                );
 
                 if group_parameters {
-                    write!(f, [group(&format_parameters)])
+                    write!(f, [group(&format_parameters)]);
                 } else {
-                    write!(f, [format_parameters])
-                }?;
+                    write!(f, [format_parameters]);
+                }
 
-                write!(f, [format_return_type])
+                write!(f, [format_return_type]);
             }))]
-        )?;
+        );
 
         if let Some(body) = self.body() {
             write!(
@@ -159,34 +153,32 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                         expression: false
                     }
                 ]
-            )?;
+            );
         }
 
         if self.is_ts_declare_function() {
-            write!(f, [OptionalSemicolon])?;
+            write!(f, [OptionalSemicolon]);
         }
-
-        Ok(())
     }
 }
 
 impl<'a> Format<'a> for FormatFunction<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.format(f)
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        self.format(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, FunctionBody<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().block_comments_before(self.span.start);
-        write!(f, [space(), FormatLeadingComments::Comments(comments)])?;
+        write!(f, [space(), FormatLeadingComments::Comments(comments)]);
 
         let statements = self.statements();
         let directives = self.directives();
         if is_empty_block(statements) && directives.is_empty() {
-            write!(f, ["{", format_dangling_comments(self.span).with_block_indent(), "}"])
+            write!(f, ["{", format_dangling_comments(self.span).with_block_indent(), "}"]);
         } else {
-            write!(f, ["{", block_indent(&format_args!(directives, statements)), "}"])
+            write!(f, ["{", block_indent(&format_args!(directives, statements)), "}"]);
         }
     }
 }
@@ -199,28 +191,28 @@ pub fn should_group_function_parameters<'a>(
     return_type: Option<&TSTypeAnnotation<'a>>,
     formatted_return_type: &Memoized<'a, impl Format<'a>>,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<bool> {
+) -> bool {
     if let Some(type_parameters) = type_parameters {
         match type_parameters.params.len() {
             0 => {} // fall through
             1 => {
                 let first = type_parameters.params.iter().next().unwrap();
                 if first.constraint.is_some() || first.default.is_some() {
-                    return Ok(false);
+                    return false;
                 }
             }
-            _ => return Ok(false),
+            _ => return false,
         }
     }
 
     let return_type = match return_type {
         Some(return_type) => &return_type.type_annotation,
-        None => return Ok(false),
+        None => return false,
     };
 
-    Ok(parameter_count == 1
+    parameter_count == 1
         && (matches!(return_type, TSType::TSTypeLiteral(_) | TSType::TSMappedType(_))
-            || formatted_return_type.inspect(f)?.will_break()))
+            || formatted_return_type.inspect(f).will_break())
 }
 
 /// A wrapper that formats content and caches the result based on the given cache mode.
@@ -248,17 +240,14 @@ impl<'a, T> Format<'a> for FormatContentWithCacheMode<T>
 where
     T: Format<'a>,
 {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if matches!(self.cache_mode, FunctionCacheMode::NoCache) {
-            self.content.fmt(f)
+            self.content.fmt(f);
         } else if let Some(grouped) = f.context().get_cached_element(&self.key) {
-            f.write_element(grouped)
-        } else {
-            if let Ok(Some(grouped)) = f.intern(&self.content) {
-                f.context_mut().cache_element(&self.key, grouped.clone());
-                f.write_element(grouped)?;
-            }
-            Ok(())
+            f.write_element(grouped);
+        } else if let Some(grouped) = f.intern(&self.content) {
+            f.context_mut().cache_element(&self.key, grouped.clone());
+            f.write_element(grouped);
         }
     }
 }

--- a/crates/oxc_formatter/src/write/function_type.rs
+++ b/crates/oxc_formatter/src/write/function_type.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSFunctionType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_grouped_parameters_with_return_type(
             self.type_parameters(),
             self.this_param.as_deref(),
@@ -20,12 +20,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSFunctionType<'a>> {
             Some(self.return_type()),
             /* is_function_or_constructor_type */ true,
             f,
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructorType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let r#abstract = self.r#abstract();
 
         write!(
@@ -42,15 +42,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructorType<'a>> {
                         Some(self.return_type()),
                         /* is_function_or_constructor_type */ true,
                         f,
-                    )
+                    );
                 })
             ))
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_grouped_parameters_with_return_type(
             self.type_parameters(),
             self.this_param.as_deref(),
@@ -58,37 +58,37 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
             self.return_type(),
             /* is_function_or_constructor_type */ false,
             f,
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSMethodSignature<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| {
             match self.kind() {
                 TSMethodSignatureKind::Method => {}
                 TSMethodSignatureKind::Get => {
-                    write!(f, ["get", space()])?;
+                    write!(f, ["get", space()]);
                 }
                 TSMethodSignatureKind::Set => {
-                    write!(f, ["set", space()])?;
+                    write!(f, ["set", space()]);
                 }
             }
             if self.computed() {
-                write!(f, "[")?;
+                write!(f, "[");
             }
-            write!(f, self.key())?;
+            write!(f, self.key());
             if self.computed() {
-                write!(f, "]")?;
+                write!(f, "]");
             }
             if self.optional() {
-                write!(f, "?")?;
+                write!(f, "?");
             }
 
             let format_type_parameters = self.type_parameters().memoized();
             let format_parameters = self.params().memoized();
-            format_type_parameters.inspect(f)?;
-            format_parameters.inspect(f)?;
+            format_type_parameters.inspect(f);
+            format_parameters.inspect(f);
 
             let format_return_type = self.return_type().memoized();
 
@@ -98,23 +98,23 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMethodSignature<'a>> {
                 self.return_type.as_deref(),
                 &format_return_type,
                 f,
-            )?;
+            );
 
             if should_group_parameters {
-                write!(f, group(&format_args!(&format_type_parameters, &format_parameters)))?;
+                write!(f, group(&format_args!(&format_type_parameters, &format_parameters)));
             } else {
-                write!(f, [format_type_parameters, format_parameters])?;
+                write!(f, [format_type_parameters, format_parameters]);
             }
 
-            write!(f, group(&format_return_type))
+            write!(f, group(&format_return_type));
         });
 
-        write!(f, group(&format_inner))
+        write!(f, group(&format_inner));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
             group(&format_args!(
@@ -128,10 +128,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
                         self.return_type(),
                         /* is_function_or_constructor_type */ false,
                         f,
-                    )
+                    );
                 })
             ))
-        )
+        );
     }
 }
 
@@ -143,7 +143,7 @@ pub fn format_grouped_parameters_with_return_type<'a>(
     return_type: Option<&AstNode<'a, TSTypeAnnotation<'a>>>,
     is_function_or_constructor_type: bool,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     group(&format_with(|f| {
         let format_type_parameters = type_parameters.memoized();
         let format_parameters = params.memoized();
@@ -151,8 +151,8 @@ pub fn format_grouped_parameters_with_return_type<'a>(
 
         // Inspect early, in case the `return_type` is formatted before `parameters`
         // in `should_group_function_parameters`.
-        format_type_parameters.inspect(f)?;
-        format_parameters.inspect(f)?;
+        format_type_parameters.inspect(f);
+        format_parameters.inspect(f);
 
         let group_parameters = should_group_function_parameters(
             type_parameters.map(AsRef::as_ref),
@@ -160,15 +160,15 @@ pub fn format_grouped_parameters_with_return_type<'a>(
             return_type.map(AsRef::as_ref),
             &format_return_type,
             f,
-        )?;
+        );
 
         if group_parameters {
-            write!(f, [group(&format_args!(format_type_parameters, format_parameters))])
+            write!(f, [group(&format_args!(format_type_parameters, format_parameters))]);
         } else {
-            write!(f, [format_type_parameters, format_parameters])
-        }?;
+            write!(f, [format_type_parameters, format_parameters]);
+        }
 
-        write!(f, [is_function_or_constructor_type.then_some(space()), format_return_type])
+        write!(f, [is_function_or_constructor_type.then_some(space()), format_return_type]);
     }))
-    .fmt(f)
+    .fmt(f);
 }

--- a/crates/oxc_formatter/src/write/import_expression.rs
+++ b/crates/oxc_formatter/src/write/import_expression.rs
@@ -1,7 +1,6 @@
 use oxc_ast::ast::*;
 
 use crate::{
-    FormatResult,
     ast_nodes::AstNode,
     formatter::{Formatter, prelude::*},
     write,
@@ -10,13 +9,13 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["import"])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["import"]);
         if let Some(phase) = &self.phase() {
-            write!(f, [".", phase.as_str()])?;
+            write!(f, [".", phase.as_str()]);
         }
 
         // Use the same logic as CallExpression arguments formatting
-        write!(f, self.to_arguments())
+        write!(f, self.to_arguments());
     }
 }

--- a/crates/oxc_formatter/src/write/intersection_type.rs
+++ b/crates/oxc_formatter/src/write/intersection_type.rs
@@ -4,16 +4,16 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
-    formatter::{FormatResult, Formatter, prelude::*},
+    formatter::{Formatter, prelude::*},
     utils::typescript::is_object_like_type,
     write,
     write::FormatWrite,
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let content = format_with(|f| format_intersection_types(self.types(), f));
-        write!(f, [group(&content)])
+        write!(f, [group(&content)]);
     }
 }
 
@@ -21,7 +21,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
 fn format_intersection_types<'a>(
     node: &AstNode<'a, Vec<'a, TSType<'a>>>,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     let last_index = node.len().saturating_sub(1);
     let mut is_prev_object_like = false;
     let mut is_chain_indented = false;
@@ -31,15 +31,15 @@ fn format_intersection_types<'a>(
 
         // always inline first element
         if index == 0 {
-            write!(f, item)?;
+            write!(f, item);
         } else {
             // If no object is involved, go to the next line if it breaks
             if !(is_prev_object_like || is_object_like)
                 || f.comments().has_leading_own_line_comment(item.span().start)
             {
-                write!(f, soft_line_indent_or_space(item))?;
+                write!(f, soft_line_indent_or_space(item));
             } else {
-                write!(f, space())?;
+                write!(f, space());
 
                 if !is_prev_object_like || !is_object_like {
                     // indent if we move from object to non-object or vice versa, otherwise keep inline
@@ -47,20 +47,18 @@ fn format_intersection_types<'a>(
                 }
 
                 if is_chain_indented {
-                    write!(f, [indent(&item)])?;
+                    write!(f, [indent(&item)]);
                 } else {
-                    write!(f, item)?;
+                    write!(f, item);
                 }
             }
         }
 
         // Add separator if not the last element
         if index < last_index {
-            write!(f, [space(), "&"])?;
+            write!(f, [space(), "&"]);
         }
 
         is_prev_object_like = is_object_like;
     }
-
-    Ok(())
 }

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -3,7 +3,6 @@ use oxc_ast::ast::{JSXChild, JSXElement, JSXExpression, JSXExpressionContainer, 
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    FormatResult,
     ast_nodes::{AstNode, AstNodes},
     best_fitting, format_args,
     formatter::{Formatter, prelude::*, trivia::FormatTrailingComments},
@@ -33,19 +32,19 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
         }
     }
 
-    fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::Element(element) => element.format_leading_comments(f),
             Self::Fragment(fragment) => fragment.format_leading_comments(f),
         }
     }
 
-    fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
         if let AstNodes::ArrowFunctionExpression(arrow) = self.parent().parent().parent()
             && arrow.expression
         {
             let comments = f.context().comments().comments_before(arrow.span.end);
-            FormatTrailingComments::Comments(comments).fmt(f)
+            FormatTrailingComments::Comments(comments).fmt(f);
         } else {
             match self {
                 Self::Element(element) => element.format_trailing_comments(f),
@@ -100,7 +99,7 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
 }
 
 impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
 
         let format_tag = format_with(|f| {
@@ -115,14 +114,14 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
 
             match layout {
                 ElementLayout::NoChildren => {
-                    write!(f, [format_opening, format_closing])
+                    write!(f, [format_opening, format_closing]);
                 }
                 ElementLayout::Template(expression) => {
-                    write!(f, [format_opening, expression, format_closing])
+                    write!(f, [format_opening, expression, format_closing]);
                 }
                 ElementLayout::Default => {
                     let format_opening = format_opening.memoized();
-                    let opening_breaks = format_opening.inspect(f)?.will_break();
+                    let opening_breaks = format_opening.inspect(f).will_break();
 
                     let multiple_attributes = match self {
                         Self::Element(element) => element.opening_element.attributes.len() > 1,
@@ -138,11 +137,11 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                     let children = self.children();
                     let format_children = FormatJsxChildList::default()
                         .with_options(list_layout)
-                        .fmt_children(children, f)?;
+                        .fmt_children(children, f);
 
                     match format_children {
                         FormatChildrenResult::ForceMultiline(multiline) => {
-                            write!(f, [format_opening, multiline, format_closing])
+                            write!(f, [format_opening, multiline, format_closing]);
                         }
                         FormatChildrenResult::BestFitting { flat_children, expanded_children } => {
                             let format_closing = format_closing.memoized();
@@ -152,7 +151,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                                     format_args!(format_opening, flat_children, format_closing),
                                     format_args!(format_opening, expanded_children, format_closing)
                                 ]]
-                            )
+                            );
                         }
                     }
                 }
@@ -174,7 +173,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                         format_tag,
                         &format_with(|f| { self.format_trailing_comments(f) }),
                     ]
-                )
+                );
             }
             WrapState::WrapOnBreak => {
                 let should_expand = should_expand(self.parent());
@@ -182,7 +181,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
 
                 let format_inner = format_with(|f| {
                     if !needs_parentheses {
-                        write!(f, [if_group_breaks(&token("("))])?;
+                        write!(f, [if_group_breaks(&token("("))]);
                     }
 
                     write!(
@@ -192,16 +191,14 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                             format_tag,
                             &format_with(|f| { self.format_trailing_comments(f) }),
                         ))]
-                    )?;
+                    );
 
                     if !needs_parentheses {
-                        write!(f, [if_group_breaks(&token(")"))])?;
+                        write!(f, [if_group_breaks(&token(")"))]);
                     }
-
-                    Ok(())
                 });
 
-                write!(f, [group(&format_inner).should_expand(should_expand)])
+                write!(f, [group(&format_inner).should_expand(should_expand)]);
             }
         }
     }
@@ -240,27 +237,27 @@ pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
 }
 
 impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
-    fn fmt_opening(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt_opening(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::Element(element) => {
                 let is_self_closing = element.closing_element().is_none();
                 let opening_formatter =
                     FormatOpeningElement::new(element.opening_element(), is_self_closing);
-                write!(f, opening_formatter)
+                write!(f, opening_formatter);
             }
             Self::Fragment(fragment) => {
-                write!(f, fragment.opening_fragment())
+                write!(f, fragment.opening_fragment());
             }
         }
     }
 
-    fn fmt_closing(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt_closing(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::Element(element) => {
-                write!(f, element.closing_element())
+                write!(f, element.closing_element());
             }
             Self::Fragment(fragment) => {
-                write!(f, fragment.closing_fragment())
+                write!(f, fragment.closing_fragment());
             }
         }
     }

--- a/crates/oxc_formatter/src/write/jsx/mod.rs
+++ b/crates/oxc_formatter/src/write/jsx/mod.rs
@@ -11,7 +11,7 @@ use opening_element::FormatOpeningElement;
 use oxc_span::GetSpan;
 
 use crate::{
-    AttributePosition, Format, FormatResult,
+    AttributePosition, Format,
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
@@ -25,19 +25,19 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXElement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        AnyJsxTagWithChildren::Element(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        AnyJsxTagWithChildren::Element(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningElement<'a>> {
-    fn write(&self, _f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, _f: &mut Formatter<'_, 'a>) {
         unreachable!("`AnyJsxTagWithChildren` will print it.")
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingElement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let name = self.name();
         let mut name_has_leading_comment = false;
         let mut name_has_own_line_leading_comment = false;
@@ -49,66 +49,66 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingElement<'a>> {
 
         let format_name = format_with(|f| {
             if name_has_own_line_leading_comment {
-                write!(f, [hard_line_break()])?;
+                write!(f, [hard_line_break()]);
             } else if name_has_leading_comment {
-                write!(f, [space()])?;
+                write!(f, [space()]);
             }
             if name_has_own_line_leading_comment {
-                write!(f, [block_indent(&name), hard_line_break()])
+                write!(f, [block_indent(&name), hard_line_break()]);
             } else {
-                write!(f, [name])
+                write!(f, [name]);
             }
         });
 
-        write!(f, ["</", &format_name, ">",])
+        write!(f, ["</", &format_name, ">",]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXFragment<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        AnyJsxTagWithChildren::Fragment(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        AnyJsxTagWithChildren::Fragment(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningFragment> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
         let has_own_line_comment = comments.iter().any(|c| c.is_line());
 
         let format_comments = format_with(|f| {
             if has_own_line_comment {
-                write!(f, [hard_line_break()])?;
+                write!(f, [hard_line_break()]);
             }
 
             write!(
                 f,
                 [FormatDanglingComments::Comments { comments, indent: DanglingIndentMode::None }]
-            )
+            );
         });
 
         write!(
             f,
             ["<", indent(&format_comments), has_own_line_comment.then_some(hard_line_break()), ">"]
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingFragment> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
         let has_own_line_comment = comments.iter().any(|c| c.is_line());
 
         let format_comments = format_with(|f| {
             if has_own_line_comment {
-                write!(f, [hard_line_break()])?;
+                write!(f, [hard_line_break()]);
             } else if !comments.is_empty() {
-                write!(f, [space()])?;
+                write!(f, [space()]);
             }
 
             write!(
                 f,
                 [FormatDanglingComments::Comments { comments, indent: DanglingIndentMode::None }]
-            )
+            );
         });
 
         write!(
@@ -119,24 +119,24 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingFragment> {
                 has_own_line_comment.then_some(hard_line_break()),
                 ">"
             ]
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXNamespacedName<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.namespace(), ":", self.name()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.namespace(), ":", self.name()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXMemberExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.object(), ".", self.property()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.object(), ".", self.property()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let has_comment = |f: &mut Formatter<'_, '_>| {
             let expression_span = self.expression.span();
             f.comments().has_comment_before(expression_span.start)
@@ -149,7 +149,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
                 let comments = f.context().comments().comments_before(self.span.end);
                 let has_line_comment = comments.iter().any(|c| c.is_line());
 
-                write!(f, ["{"])?;
+                write!(f, ["{"]);
 
                 if has_line_comment {
                     write!(
@@ -162,7 +162,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
                             format_dangling_comments(self.span).with_block_indent(),
                             hard_line_break()
                         ]
-                    )?;
+                    );
                 } else {
                     write!(
                         f,
@@ -170,10 +170,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
                             comments,
                             indent: DanglingIndentMode::None
                         },]
-                    )?;
+                    );
                 }
 
-                write!(f, ["}"])
+                write!(f, ["}"]);
             } else {
                 let is_conditional_or_binary = matches!(
                     self.expression,
@@ -186,22 +186,22 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
                     && (is_conditional_or_binary || should_inline_jsx_expression(self));
 
                 if should_inline {
-                    write!(f, ["{", self.expression(), line_suffix_boundary(), "}"])
+                    write!(f, ["{", self.expression(), line_suffix_boundary(), "}"]);
                 } else {
                     write!(
                         f,
                         [group(&format_args!(
                             "{",
                             soft_block_indent(&format_with(|f| {
-                                write!(f, [self.expression()])?;
+                                write!(f, [self.expression()]);
                                 let comments =
                                     f.context().comments().comments_before(self.span.end);
-                                write!(f, [FormatTrailingComments::Comments(comments)])
+                                write!(f, [FormatTrailingComments::Comments(comments)]);
                             })),
                             line_suffix_boundary(),
                             "}"
                         ))]
-                    )
+                    );
                 }
             }
         } else {
@@ -209,21 +209,21 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
             let should_inline = !has_comment(f) && should_inline_jsx_expression(self);
 
             if should_inline {
-                write!(f, ["{", self.expression(), line_suffix_boundary(), "}"])
+                write!(f, ["{", self.expression(), line_suffix_boundary(), "}"]);
             } else {
                 write!(
                     f,
                     [group(&format_args!(
                         "{",
                         soft_block_indent(&format_with(|f| {
-                            write!(f, [self.expression()])?;
+                            write!(f, [self.expression()]);
                             let comments = f.context().comments().comments_before(self.span.end);
-                            write!(f, [FormatTrailingComments::Comments(comments)])
+                            write!(f, [FormatTrailingComments::Comments(comments)]);
                         })),
                         line_suffix_boundary(),
                         "}"
                     ))]
-                )
+                );
             }
         }
     }
@@ -290,85 +290,82 @@ pub fn should_inline_jsx_expression(container: &JSXExpressionContainer<'_>) -> b
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXEmptyExpression> {
-    fn write(&self, _f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        Ok(())
-    }
+    fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let line_break = if f.options().attribute_position == AttributePosition::Multiline {
             hard_line_break()
         } else {
             soft_line_break_or_space()
         };
 
-        f.join_with(&line_break).entries(self.iter()).finish()
+        f.join_with(&line_break).entries(self.iter()).finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXAttribute<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.name())?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.name());
         if let Some(value) = &self.value() {
-            write!(f, ["=", value])?;
+            write!(f, ["=", value]);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let has_comment = comments.has_comment_before(self.argument.span().start)
             || comments.has_comment_in_range(self.argument.span().end, self.span.end);
         let format_inner = format_with(|f| {
-            write!(f, [format_leading_comments(self.argument.span()), "..."])?;
-            self.argument().fmt(f)
+            write!(f, [format_leading_comments(self.argument.span()), "..."]);
+            self.argument().fmt(f);
         });
 
-        write!(f, ["{"])?;
+        write!(f, ["{"]);
 
         if has_comment {
-            write!(f, [soft_block_indent(&format_inner)])?;
+            write!(f, [soft_block_indent(&format_inner)]);
         } else {
-            write!(f, [format_inner])?;
+            write!(f, [format_inner]);
         }
 
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXIdentifier<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text_without_whitespace(self.name().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let has_comment = comments.has_comment_before(self.expression.span().start)
             || comments.has_comment_in_range(self.expression.span().end, self.span.end);
         let format_inner = format_with(|f| {
-            write!(f, [format_leading_comments(self.expression.span()), "..."])?;
-            self.expression().fmt(f)
+            write!(f, [format_leading_comments(self.expression.span()), "..."]);
+            self.expression().fmt(f);
         });
 
-        write!(f, "{")?;
+        write!(f, "{");
 
         if has_comment {
-            write!(f, [soft_block_indent(&format_inner)])?;
+            write!(f, [soft_block_indent(&format_inner)]);
         } else {
-            write!(f, [format_inner])?;
+            write!(f, [format_inner]);
         }
 
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXText<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text(self.value().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text(self.value().as_str()));
     }
 }

--- a/crates/oxc_formatter/src/write/jsx/opening_element.rs
+++ b/crates/oxc_formatter/src/write/jsx/opening_element.rs
@@ -4,7 +4,6 @@ use oxc_ast::ast::{JSXAttributeItem, JSXAttributeValue, JSXOpeningElement, Strin
 use oxc_span::GetSpan;
 
 use crate::{
-    FormatResult,
     ast_nodes::AstNode,
     formatter::{Formatter, prelude::*, trivia::FormatTrailingComments},
     write,
@@ -68,7 +67,7 @@ fn is_multiline_string_literal_attribute(attribute: &JSXAttributeItem<'_>) -> bo
 }
 
 impl<'a> Format<'a> for FormatOpeningElement<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let layout = self.compute_layout(f);
 
         let attributes = self.attributes();
@@ -78,45 +77,45 @@ impl<'a> Format<'a> for FormatOpeningElement<'a, '_> {
 
         match layout {
             OpeningElementLayout::Inline => {
-                write!(f, [format_open, space(), format_close])
+                write!(f, [format_open, space(), format_close]);
             }
             OpeningElementLayout::SingleStringAttribute => {
                 let attribute_spacing = if self.is_self_closing { Some(space()) } else { None };
                 write!(
                     f,
                     [format_open, space(), self.attributes(), attribute_spacing, format_close]
-                )
+                );
             }
             OpeningElementLayout::IndentAttributes {
                 name_has_comment,
                 last_attribute_has_comment,
             } => {
                 let format_inner = format_with(|f| {
-                    write!(f, [format_open, soft_line_indent_or_space(&self.attributes())])?;
+                    write!(f, [format_open, soft_line_indent_or_space(&self.attributes())]);
 
                     let comments = f.context().comments().comments_before(self.span.end);
-                    FormatTrailingComments::Comments(comments).fmt(f)?;
+                    FormatTrailingComments::Comments(comments).fmt(f);
 
                     let force_bracket_same_line = f.options().bracket_same_line.value();
                     let wants_bracket_same_line = attributes.is_empty() && !name_has_comment;
 
                     if self.is_self_closing {
-                        write!(f, [soft_line_break_or_space(), format_close])
+                        write!(f, [soft_line_break_or_space(), format_close]);
                     } else if last_attribute_has_comment {
-                        write!(f, [soft_line_break(), format_close])
+                        write!(f, [soft_line_break(), format_close]);
                     } else if (force_bracket_same_line && !self.attributes.is_empty())
                         || wants_bracket_same_line
                     {
-                        write!(f, [format_close])
+                        write!(f, [format_close]);
                     } else {
-                        write!(f, [soft_line_break(), format_close])
+                        write!(f, [soft_line_break(), format_close]);
                     }
                 });
 
                 let has_multiline_string_attribute = attributes
                     .iter()
                     .any(|attribute| is_multiline_string_literal_attribute(attribute));
-                write!(f, [group(&format_inner).should_expand(has_multiline_string_attribute)])
+                write!(f, [group(&format_inner).should_expand(has_multiline_string_attribute)]);
             }
         }
     }

--- a/crates/oxc_formatter/src/write/mapped_type.rs
+++ b/crates/oxc_formatter/src/write/mapped_type.rs
@@ -1,7 +1,6 @@
 use oxc_ast::ast::{TSMappedType, TSMappedTypeModifierOperator};
 
 use crate::{
-    FormatResult,
     ast_nodes::AstNode,
     formatter::{Formatter, SourceText, prelude::*, trivia::FormatLeadingComments},
     utils::suppressed::FormatSuppressedNode,
@@ -12,7 +11,7 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.comments().is_suppressed(self.type_parameter.span.start) {
             return write!(f, FormatSuppressedNode(self.span));
         }
@@ -29,7 +28,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
                     } else {
                         f.context().comments().comments_before_character(self.span.start, b'[')
                     };
-                write!(f, FormatLeadingComments::Comments(comments))?;
+                write!(f, FormatLeadingComments::Comments(comments));
             }
 
             if let Some(readonly) = self.readonly() {
@@ -38,23 +37,23 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
                     TSMappedTypeModifierOperator::Plus => "+",
                     TSMappedTypeModifierOperator::Minus => "-",
                 };
-                write!(f, [prefix, "readonly", space()])?;
+                write!(f, [prefix, "readonly", space()]);
             }
 
             let format_inner_inner = format_with(|f| {
-                write!(f, "[")?;
-                write!(f, type_parameter.name())?;
+                write!(f, "[");
+                write!(f, type_parameter.name());
                 if let Some(constraint) = &type_parameter.constraint() {
-                    write!(f, [space(), "in", space(), constraint])?;
+                    write!(f, [space(), "in", space(), constraint]);
                 }
                 if let Some(default) = &type_parameter.default() {
-                    write!(f, [space(), "=", space(), default])?;
+                    write!(f, [space(), "=", space(), default]);
                 }
                 if let Some(name_type) = &name_type {
-                    write!(f, [space(), "as", space(), name_type])?;
+                    write!(f, [space(), "as", space(), name_type]);
                 }
-                type_parameter.format_trailing_comments(f)?;
-                write!(f, "]")?;
+                type_parameter.format_trailing_comments(f);
+                write!(f, "]");
                 if let Some(optional) = self.optional() {
                     write!(
                         f,
@@ -63,16 +62,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
                             TSMappedTypeModifierOperator::Plus => "+?",
                             TSMappedTypeModifierOperator::Minus => "-?",
                         }
-                    )?;
+                    );
                 }
-                Ok(())
             });
 
-            write!(f, [group(&format_inner_inner)])?;
+            write!(f, [group(&format_inner_inner)]);
             if let Some(type_annotation) = &self.type_annotation() {
-                write!(f, [":", space(), type_annotation])?;
+                write!(f, [":", space(), type_annotation]);
             }
-            write!(f, if_group_breaks(&OptionalSemicolon))
+            write!(f, if_group_breaks(&OptionalSemicolon));
         });
 
         let should_insert_space_around_brackets = f.options().bracket_spacing.value();
@@ -87,7 +85,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
                 .should_expand(should_expand),
                 "}",
             ]
-        )
+        );
     }
 }
 

--- a/crates/oxc_formatter/src/write/member_expression.rs
+++ b/crates/oxc_formatter/src/write/member_expression.rs
@@ -5,9 +5,7 @@ use crate::{
     JsLabels,
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{
-        Buffer, Format, FormatResult, Formatter, prelude::*, trivia::FormatLeadingComments,
-    },
+    formatter::{Buffer, Format, Formatter, prelude::*, trivia::FormatLeadingComments},
     utils::member_chain::chain_member::FormatComputedMemberExpressionWithoutObject,
     write,
 };
@@ -15,17 +13,17 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.object())?;
-        FormatComputedMemberExpressionWithoutObject(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.object());
+        FormatComputedMemberExpressionWithoutObject(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, StaticMemberExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_member_chain = {
             let mut recording = f.start_recording();
-            write!(recording, [self.object()])?;
+            write!(recording, [self.object()]);
             recording.stop().has_label(LabelId::of(JsLabels::MemberChain))
         };
 
@@ -35,9 +33,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StaticMemberExpression<'a>> {
                     format_with(|f| write!(f, [operator_token(self.optional()), self.property()]));
 
                 if is_member_chain {
-                    write!(f, [labelled(LabelId::of(JsLabels::MemberChain), &format_no_break)])
+                    write!(f, [labelled(LabelId::of(JsLabels::MemberChain), &format_no_break)]);
                 } else {
-                    write!(f, [format_no_break])
+                    write!(f, [format_no_break]);
                 }
             }
             StaticMemberLayout::BreakAfterObject => {
@@ -54,14 +52,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StaticMemberExpression<'a>> {
                                 write!(
                                     f,
                                     [FormatLeadingComments::Comments(comments), soft_line_break()]
-                                )?;
+                                );
                             }
-                            Ok(())
                         }),
                         operator_token(self.optional()),
                         self.property(),
                     )))]
-                )
+                );
             }
         }
     }
@@ -156,7 +153,7 @@ fn layout<'a>(
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.object(), self.optional().then_some("?"), ".", self.field()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.object(), self.optional().then_some("?"), ".", self.field()]);
     }
 }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     best_fitting, format_args,
     formatter::{
-        Buffer, Format, FormatResult, Formatter,
+        Buffer, Format, Formatter,
         prelude::*,
         separated::FormatSeparatedIter,
         token::number::{NumberFormatOptions, format_number_token},
@@ -90,79 +90,77 @@ use self::{
 };
 
 pub trait FormatWrite<'ast, T = ()> {
-    fn write(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()>;
-    fn write_with_options(&self, _options: T, _f: &mut Formatter<'_, 'ast>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'ast>);
+    fn write_with_options(&self, _options: T, _f: &mut Formatter<'_, 'ast>) {
         unreachable!("Please implement it first.");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierName<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text_without_whitespace(self.name().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierReference<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text_without_whitespace(self.name().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingIdentifier<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text_without_whitespace(self.name().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabelIdentifier<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, text_without_whitespace(self.name().as_str()))
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ThisExpression> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "this")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "this");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ArrayExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        FormatArrayExpression::new(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        FormatArrayExpression::new(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Elision> {
-    fn write(&self, _f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        Ok(())
-    }
+    fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ObjectLike::ObjectExpression(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ObjectLike::ObjectExpression(self).fmt(f);
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line()
             .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish()
+            .finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_accessor = match &self.kind() {
             PropertyKind::Init => false,
             PropertyKind::Get => {
-                write!(f, ["get", space()])?;
+                write!(f, ["get", space()]);
                 true
             }
             PropertyKind::Set => {
-                write!(f, ["set", space()])?;
+                write!(f, ["set", space()]);
                 true
             }
         };
@@ -175,15 +173,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
             };
 
             if value.r#async() {
-                write!(f, ["async", space()])?;
+                write!(f, ["async", space()]);
             }
             if value.generator() {
-                write!(f, "*")?;
+                write!(f, "*");
             }
             if self.computed {
-                write!(f, ["[", self.key(), "]"])?;
+                write!(f, ["[", self.key(), "]"]);
             } else {
-                format_property_key(self.key(), f)?;
+                format_property_key(self.key(), f);
             }
 
             format_grouped_parameters_with_return_type_for_method(
@@ -192,21 +190,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
                 value.params(),
                 value.return_type(),
                 f,
-            )?;
+            );
 
             if let Some(body) = &value.body() {
-                write!(f, [space(), body])?;
+                write!(f, [space(), body]);
             }
-
-            Ok(())
         } else {
-            write!(f, AssignmentLike::ObjectProperty(self))
+            write!(f, AssignmentLike::ObjectProperty(self));
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let callee = self.callee();
         let type_arguments = self.type_arguments();
         let arguments = self.arguments();
@@ -226,61 +222,60 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
             && !is_simple_module_import(self.arguments(), f.comments())
             && !is_test_call_expression(self)
         {
-            MemberChain::from_call_expression(self, f).fmt(f)
+            MemberChain::from_call_expression(self, f).fmt(f);
         } else {
             let format_inner = format_with(|f| {
                 if self.type_arguments.is_some() {
-                    write!(f, [callee])?;
+                    write!(f, [callee]);
                 } else {
-                    write!(f, [FormatNodeWithoutTrailingComments(callee)])?;
+                    write!(f, [FormatNodeWithoutTrailingComments(callee)]);
                 }
-                write!(f, [optional.then_some("?."), type_arguments, arguments])
+                write!(f, [optional.then_some("?."), type_arguments, arguments]);
             });
             if matches!(callee.as_ref(), Expression::CallExpression(_)) {
-                write!(f, [group(&format_inner)])
+                write!(f, [group(&format_inner)]);
             } else {
-                write!(f, [format_inner])
+                write!(f, [format_inner]);
             }
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, NewExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["new", space(), self.callee(), self.type_arguments(), self.arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["new", space(), self.callee(), self.type_arguments(), self.arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, MetaProperty<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.meta(), ".", self.property()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.meta(), ".", self.property()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SpreadElement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["...", self.argument()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["...", self.argument()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, UpdateExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.prefix() {
-            write!(f, self.operator().as_str())?;
+            write!(f, self.operator().as_str());
         }
-        write!(f, self.argument())?;
+        write!(f, self.argument());
         if !self.prefix() {
-            write!(f, self.operator().as_str())?;
+            write!(f, self.operator().as_str());
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.operator().as_str())?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.operator().as_str());
         if self.operator().is_keyword() {
-            write!(f, space())?;
+            write!(f, space());
         }
         let Span { start, end, .. } = self.argument.span();
         if f.comments().has_comment_before(start)
@@ -289,49 +284,49 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
             write!(
                 f,
                 [group(&format_args!(token("("), soft_block_indent(self.argument()), token(")")))]
-            )
+            );
         } else {
-            write!(f, self.argument())
+            write!(f, self.argument());
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BinaryExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        BinaryLikeExpression::BinaryExpression(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        BinaryLikeExpression::BinaryExpression(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, PrivateInExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.left(), space(), "in", space(), self.right()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.left(), space(), "in", space(), self.right()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LogicalExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        BinaryLikeExpression::LogicalExpression(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        BinaryLikeExpression::LogicalExpression(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ConditionalExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ConditionalLike::ConditionalExpression(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ConditionalLike::ConditionalExpression(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        AssignmentLike::AssignmentExpression(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        AssignmentLike::AssignmentExpression(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "[")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "[");
 
         if self.elements.is_empty() && self.rest.is_none() {
-            write!(f, [format_dangling_comments(self.span()).with_block_indent()])?;
+            write!(f, [format_dangling_comments(self.span()).with_block_indent()]);
         } else {
             write!(
                 f,
@@ -342,70 +337,67 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
                             self.elements.len() + usize::from(self.rest.is_some()),
                             self.elements().iter().map(AstNode::as_ref),
                             f,
-                        )?;
+                        );
                     }
                     if let Some(rest) = self.rest() {
-                        write!(f, [has_element.then_some(soft_line_break_or_space()), rest])?;
+                        write!(f, [has_element.then_some(soft_line_break_or_space()), rest]);
                     }
-                    Ok(())
                 })))
-            )?;
+            );
         }
 
-        write!(f, "]")
+        write!(f, "]");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ObjectPatternLike::ObjectAssignmentTarget(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ObjectPatternLike::ObjectAssignmentTarget(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["...", self.target()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["...", self.target()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.binding(), space(), "=", space(), self.init()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.binding(), space(), "=", space(), self.init()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.binding())?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.binding());
         if let Some(expr) = &self.init() {
-            write!(f, [space(), "=", space(), expr])?;
+            write!(f, [space(), "=", space(), expr]);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.computed() {
-            write!(f, "[")?;
+            write!(f, "[");
         }
-        write!(f, self.name())?;
+        write!(f, self.name());
         if self.computed() {
-            write!(f, "]")?;
+            write!(f, "]");
         }
-        write!(f, [":", space(), self.binding()])?;
-        Ok(())
+        write!(f, [":", space(), self.binding()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Super> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "super")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "super");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| write!(f, ["await", space(), self.argument()]));
 
         let is_callee_or_object = match self.parent {
@@ -437,30 +429,30 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
                     return write!(f, [group(&indented)]);
                 }
 
-                write!(f, [indented])
+                write!(f, [indented]);
             } else {
-                write!(f, [group(&indented)])
+                write!(f, [group(&indented)]);
             };
         }
 
-        write!(f, [format_inner])
+        write!(f, [format_inner]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ChainExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.expression().fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        self.expression().fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
-    fn write(&self, _f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, _f: &mut Formatter<'_, 'a>) {
         unreachable!("No `ParenthesizedExpression` as we disabled `preserve_parens` in the parser")
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if matches!(
             self.parent,
             AstNodes::DoWhileStatement(_)
@@ -471,9 +463,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
                 | AstNodes::ForOfStatement(_)
                 | AstNodes::WithStatement(_)
         ) {
-            write!(f, ";")
-        } else {
-            Ok(())
+            write!(f, ";");
         }
     }
 }
@@ -554,26 +544,26 @@ fn expression_statement_needs_semicolon<'a>(
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         // Check if we need a leading semicolon to prevent ASI issues
         if f.options().semicolons == Semicolons::AsNeeded
             && expression_statement_needs_semicolon(self, f)
         {
-            write!(f, ";")?;
+            write!(f, ";");
         }
 
-        write!(f, [self.expression(), OptionalSemicolon])
+        write!(f, [self.expression(), OptionalSemicolon]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let body = self.body();
-        write!(f, group(&format_args!("do", FormatStatementBody::new(body))))?;
+        write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
         if matches!(body.as_ref(), Statement::BlockStatement(_)) {
-            write!(f, space())?;
+            write!(f, space());
         } else {
-            write!(f, hard_line_break())?;
+            write!(f, hard_line_break());
         }
         write!(
             f,
@@ -585,7 +575,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
                 ")",
                 OptionalSemicolon
             ]
-        )
+        );
     }
 }
 
@@ -613,30 +603,27 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
 /// This ensures compatibility with [Prettier's comment handling for empty statements](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/printer-methods.js#L15).
 struct FormatCommentForEmptyStatement<'a, 'b>(&'b AstNode<'a, Statement<'a>>);
 impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if let AstNodes::EmptyStatement(empty) = self.0.as_ast_nodes() {
             let comments = f.context().comments().comments_before(empty.span.start);
-            FormatTrailingComments::Comments(comments).fmt(f)?;
-            empty.format_trailing_comments(f)
-        } else {
-            Ok(())
+            FormatTrailingComments::Comments(comments).fmt(f);
+            empty.format_trailing_comments(f);
         }
     }
 }
 
 struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
 impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, FormatNodeWithoutTrailingComments(self.0))?;
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, FormatNodeWithoutTrailingComments(self.0));
         let comments = f.context().comments().comments_before_character(self.0.span().end, b')');
         if !comments.is_empty() {
-            write!(f, [space(), FormatTrailingComments::Comments(comments)])?;
+            write!(f, [space(), FormatTrailingComments::Comments(comments)]);
         }
-        Ok(())
     }
 }
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let body = self.body();
         write!(
             f,
@@ -651,12 +638,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
                 ")",
                 FormatStatementBody::new(body)
             ))
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let init = self.init();
         let test = self.test();
         let update = self.update();
@@ -674,7 +661,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
                         },
                         soft_line_break_or_space()
                     ]
-                )?;
+                );
             }
             return write!(f, [group(&format_args!("for", space(), "(;;)", format_body))]);
         }
@@ -702,14 +689,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
                     ")",
                     format_body
                 ]
-            )
+            );
         });
-        write!(f, group(&format_inner))
+        write!(f, group(&format_inner));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         let body = self.body();
         write!(
@@ -730,12 +717,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
                     FormatStatementBody::new(body)
                 ))
             ]
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
 
         let r#await = self.r#await();
@@ -743,9 +730,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
         let right = self.right();
         let body = self.body();
         let format_inner = format_with(|f| {
-            write!(f, "for")?;
+            write!(f, "for");
             if r#await {
-                write!(f, [space(), "await"])?;
+                write!(f, [space(), "await"]);
             }
             write!(
                 f,
@@ -761,14 +748,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
                     ")",
                     FormatStatementBody::new(body)
                 ]
-            )
+            );
         });
-        write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)])
+        write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let test = self.test();
         let consequent = self.consequent();
         let alternate = self.alternate();
@@ -786,7 +773,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                 ")",
                 FormatStatementBody::new(consequent),
             ))
-        )?;
+        );
         if let Some(alternate) = alternate {
             let alternate_start = alternate.span().start;
             let comments = f.context().comments().comments_before(alternate_start);
@@ -806,15 +793,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                 matches!(consequent.as_ref(), Statement::BlockStatement(_)) && !has_line_comment;
 
             if else_on_same_line {
-                write!(f, space())?;
+                write!(f, space());
             } else {
-                write!(f, hard_line_break())?;
+                write!(f, hard_line_break());
             }
 
             if has_dangling_comments {
                 if has_line_comment {
-                    write!(f, FormatTrailingComments::Comments(comments))?;
-                    write!(f, hard_line_break())?;
+                    write!(f, FormatTrailingComments::Comments(comments));
+                    write!(f, hard_line_break());
                 } else {
                     write!(
                         f,
@@ -822,8 +809,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                             comments,
                             indent: DanglingIndentMode::None
                         }
-                    )?;
-                    write!(f, space())?;
+                    );
+                    write!(f, space());
                 }
             }
 
@@ -836,34 +823,33 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                         Statement::IfStatement(_)
                     )))
                 ]
-            )?;
+            );
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "continue")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "continue");
         if let Some(label) = self.label() {
-            write!(f, [space(), label])?;
+            write!(f, [space(), label]);
         }
-        write!(f, OptionalSemicolon)
+        write!(f, OptionalSemicolon);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "break")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "break");
         if let Some(label) = self.label() {
-            write!(f, [space(), label])?;
+            write!(f, [space(), label]);
         }
-        write!(f, OptionalSemicolon)
+        write!(f, OptionalSemicolon);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
             group(&format_args!(
@@ -874,18 +860,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
                 ")",
                 FormatStatementBody::new(self.body())
             ))
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.body.span().start);
-        FormatLeadingComments::Comments(comments).fmt(f)?;
+        FormatLeadingComments::Comments(comments).fmt(f);
 
         let label = self.label();
         let body = self.body();
-        write!(f, [label, ":"])?;
+        write!(f, [label, ":"]);
         if matches!(body.as_ref(), Statement::EmptyStatement(_)) {
             let empty_comments = f.context().comments().comments_before(self.span.end);
             write!(
@@ -896,40 +882,39 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
                     // If the body is an empty statement, force semicolon insertion
                     ";"
                 ]
-            )
+            );
         } else {
-            write!(f, [space(), body])
+            write!(f, [space(), body]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, DebuggerStatement> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["debugger", OptionalSemicolon])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["debugger", OptionalSemicolon]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingPattern<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.kind())?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.kind());
         if self.optional() {
-            write!(f, "?")?;
+            write!(f, "?");
         } else if let AstNodes::VariableDeclarator(declarator) = self.parent {
-            write!(f, declarator.definite.then_some("!"))?;
+            write!(f, declarator.definite.then_some("!"));
         }
         if let Some(type_annotation) = &self.type_annotation() {
-            write!(f, type_annotation)?;
+            write!(f, type_annotation);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentPattern<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let left = self.left().memoized();
         // Format `left` early before writing leading comments, so that comments
         // inside `left` are not treated as leading comments of `= right`
-        left.inspect(f)?;
+        left.inspect(f);
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         write!(
             f,
@@ -941,31 +926,31 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentPattern<'a>> {
                 space(),
                 self.right()
             ]
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectPattern<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ObjectPatternLike::ObjectPattern(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ObjectPatternLike::ObjectPattern(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingProperty<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let group_id = f.group_id("assignment");
         let format_inner = format_with(|f| {
             if self.computed() {
-                write!(f, "[")?;
+                write!(f, "[");
             }
             if !self.shorthand() {
-                write!(f, self.key())?;
+                write!(f, self.key());
             }
             if self.computed() {
-                write!(f, "]")?;
+                write!(f, "]");
             }
             if self.shorthand() {
-                write!(f, self.value())
+                write!(f, self.value());
             } else {
                 write!(
                     f,
@@ -975,59 +960,58 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BindingProperty<'a>> {
                         line_suffix_boundary(),
                         indent_if_group_breaks(&self.value(), group_id)
                     ]
-                )
+                );
             }
         });
-        write!(f, group(&format_inner))
+        write!(f, group(&format_inner));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingRestElement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["...", self.argument()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["...", self.argument()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, YieldExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["yield", self.delegate().then_some("*")])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["yield", self.delegate().then_some("*")]);
         if let Some(argument) = &self.argument() {
-            write!(f, [space(), FormatAdjacentArgument(argument)])?;
+            write!(f, [space(), FormatAdjacentArgument(argument)]);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["%", self.name(), self.arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["%", self.name(), self.arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BooleanLiteral> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, if self.value() { "true" } else { "false" })
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, if self.value() { "true" } else { "false" });
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, NullLiteral> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "null")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "null");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, NumericLiteral<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_number_token(
             f.source_text().text_for(self),
             NumberFormatOptions::keep_one_trailing_decimal_zero(),
         )
-        .fmt(f)
+        .fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_jsx = matches!(self.parent, AstNodes::JSXAttribute(_));
         FormatLiteralStringToken::new(
             f.source_text().text_for(self),
@@ -1035,21 +1019,21 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
             is_jsx,
             StringLiteralParentKind::Expression,
         )
-        .fmt(f)
+        .fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
             text(f.context().allocator().alloc_str(&self.raw().unwrap().cow_to_ascii_lowercase()))
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, RegExpLiteral<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let raw = self.raw().unwrap().as_str();
         let (pattern, flags) = raw.rsplit_once('/').unwrap();
         // TODO: print the flags without allocation.
@@ -1057,261 +1041,258 @@ impl<'a> FormatWrite<'a> for AstNode<'a, RegExpLiteral<'a>> {
         flags.sort_unstable();
         let flags = flags.iter().collect::<String>();
         let s = StringBuilder::from_strs_array_in([pattern, "/", &flags], f.context().allocator());
-        write!(f, text(s.into_str()))
+        write!(f, text(s.into_str()));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare() {
-            write!(f, ["declare", space()])?;
+            write!(f, ["declare", space()]);
         }
         if self.r#const() {
-            write!(f, ["const", space()])?;
+            write!(f, ["const", space()]);
         }
-        write!(f, ["enum", space(), self.id(), space(), "{", self.body(), "}"])
+        write!(f, ["enum", space(), self.id(), space(), "{", self.body(), "}"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumBody<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.members().is_empty() {
             write!(
                 f,
                 group(&format_args!(format_dangling_comments(self.span()), soft_line_break()))
-            )
+            );
         } else {
-            write!(f, block_indent(self.members()))
+            write!(f, block_indent(self.members()));
         }
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line()
             .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish()
+            .finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let id = self.id();
         let is_computed = matches!(id.as_ref(), TSEnumMemberName::ComputedTemplateString(_));
 
         if is_computed {
-            write!(f, "[")?;
+            write!(f, "[");
         }
 
-        write!(f, [id])?;
+        write!(f, [id]);
 
         if is_computed {
-            write!(f, "]")?;
+            write!(f, "]");
         }
 
         if let Some(init) = self.initializer() {
-            write!(f, [space(), "=", space(), init])?;
+            write!(f, [space(), "=", space(), init]);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         match self.parent {
             AstNodes::TSFunctionType(_) | AstNodes::TSConstructorType(_) => {
-                write!(f, ["=>", space(), self.type_annotation()])
+                write!(f, ["=>", space(), self.type_annotation()]);
             }
             AstNodes::TSTypePredicate(_) => {
-                write!(f, [self.type_annotation()])
+                write!(f, [self.type_annotation()]);
             }
             _ => {
-                write!(f, [":", space(), self.type_annotation()])
+                write!(f, [":", space(), self.type_annotation()]);
             }
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSLiteralType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        self.literal().fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        self.literal().fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSConditionalType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ConditionalLike::TSConditionalType(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ConditionalLike::TSConditionalType(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSParenthesizedType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["(", self.type_annotation(), ")"])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["(", self.type_annotation(), ")"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeOperator<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let needs_parentheses = self.needs_parentheses(f);
         if needs_parentheses {
-            write!(f, "(")?;
+            write!(f, "(");
         }
 
-        write!(f, [self.operator().to_str(), hard_space(), self.type_annotation()])?;
+        write!(f, [self.operator().to_str(), hard_space(), self.type_annotation()]);
 
         if needs_parentheses {
-            write!(f, ")")?;
+            write!(f, ")");
         }
-
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSArrayType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.element_type(), "[]"])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.element_type(), "[]"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.object_type(), "[", self.index_type(), "]"])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.object_type(), "[", self.index_type(), "]"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.label())?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.label());
         if self.optional() {
-            write!(f, "?")?;
+            write!(f, "?");
         }
-        write!(f, [":", space(), self.element_type()])
+        write!(f, [":", space(), self.element_type()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSOptionalType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.type_annotation(), "?"])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.type_annotation(), "?"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSRestType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["...", self.type_annotation()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["...", self.type_annotation()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSAnyKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "any")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "any");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSStringKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "string")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "string");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSBooleanKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "boolean")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "boolean");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNumberKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "number")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "number");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNeverKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "never")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "never");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIntrinsicKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "intrinsic")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "intrinsic");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSUnknownKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "unknown")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "unknown");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNullKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "null")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "null");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSUndefinedKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "undefined")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "undefined");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSVoidKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "void")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "void");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSSymbolKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "symbol")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "symbol");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSThisType> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "this")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "this");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSObjectKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "object")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "object");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSBigIntKeyword> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "bigint")
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "bigint");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeReference<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.type_name(), self.type_arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.type_name(), self.type_arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSQualifiedName<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.left(), ".", self.right()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.left(), ".", self.right()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        FormatTSTypeParameters::new(self, FormatTSTypeParametersOptions::default()).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        FormatTSTypeParameters::new(self, FormatTSTypeParametersOptions::default()).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [AssignmentLike::TSTypeAliasDeclaration(self), OptionalSemicolon])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [AssignmentLike::TSTypeAliasDeclaration(self), OptionalSemicolon]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let id = self.id();
         let type_parameters = self.type_parameters();
         let extends = self.extends();
@@ -1325,9 +1306,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
 
         let format_id = format_with(|f| {
             if type_parameters.is_none() && extends.is_empty() {
-                FormatNodeWithoutTrailingComments(id).fmt(f)?;
+                FormatNodeWithoutTrailingComments(id).fmt(f);
             } else {
-                write!(f, [id])?;
+                write!(f, [id]);
             }
 
             if let Some(type_parameters) = type_parameters {
@@ -1341,15 +1322,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                             is_type_or_interface_decl: true
                         }
                     )
-                )?;
+                );
             }
-
-            Ok(())
         });
 
         let format_extends = format_with(|f| {
             let Some(first_extend) = extends.as_ref().first() else {
-                return Ok(());
+                return;
             };
 
             let has_leading_own_line_comment =
@@ -1361,7 +1340,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                     FormatTrailingComments::Comments(
                         f.context().comments().comments_before(first_extend.span().start)
                     )
-                )?;
+                );
             }
 
             if extends.len() > 1 {
@@ -1372,14 +1351,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                         "extends",
                         group(&soft_line_indent_or_space(extends))
                     ]
-                )?;
+                );
             } else {
                 let format_extends =
                     format_with(|f| write!(f, [space(), "extends", space(), extends]));
                 if group_mode {
-                    write!(f, [soft_line_break_or_space(), group(&format_extends)])?;
+                    write!(f, [soft_line_break_or_space(), group(&format_extends)]);
                 } else {
-                    write!(f, format_extends)?;
+                    write!(f, format_extends);
                 }
             }
 
@@ -1387,70 +1366,67 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                 f.context().comments().has_leading_own_line_comment(self.body.span().start);
 
             if !has_leading_own_line_comment {
-                write!(f, [space()])?;
-                body.format_leading_comments(f)?;
+                write!(f, [space()]);
+                body.format_leading_comments(f);
             }
-
-            Ok(())
         });
 
         let content = format_with(|f| {
             if self.declare() {
-                write!(f, ["declare", space()])?;
+                write!(f, ["declare", space()]);
             }
 
-            write!(f, ["interface", space()])?;
+            write!(f, ["interface", space()]);
 
             if extends.is_empty() {
-                write!(f, [format_id, format_extends])?;
+                write!(f, [format_id, format_extends]);
             } else if group_mode {
                 let indented = format_with(|f| write!(f, [format_id, indent(&format_extends)]));
                 let heritage_id = f.group_id("heritageGroup");
-                write!(f, [group(&indented).with_group_id(Some(heritage_id)), space()])?;
+                write!(f, [group(&indented).with_group_id(Some(heritage_id)), space()]);
             } else {
-                write!(f, [&format_args!(format_id, format_extends)])?;
+                write!(f, [&format_args!(format_id, format_extends)]);
             }
 
-            write!(f, [space()])?;
+            write!(f, [space()]);
             // Avoid printing leading comments of body
-            body.write(f)
+            body.write(f);
         });
 
-        write!(f, group(&content))
+        write!(f, group(&content));
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceBody<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [space(), "{"])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [space(), "{"]);
 
         if self.body.is_empty() {
-            write!(f, format_dangling_comments(self.span).with_block_indent())?;
+            write!(f, format_dangling_comments(self.span).with_block_indent());
         } else {
-            write!(f, block_indent(&self.body()))?;
+            write!(f, block_indent(&self.body()));
         }
 
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSPropertySignature<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.readonly() {
-            write!(f, ["readonly", space()])?;
+            write!(f, ["readonly", space()]);
         }
         if self.computed() {
-            write!(f, ["[", self.key(), "]"])?;
+            write!(f, ["[", self.key(), "]"]);
         } else {
-            format_property_key(self.key(), f)?;
+            format_property_key(self.key(), f);
         }
         if self.optional() {
-            write!(f, "?")?;
+            write!(f, "?");
         }
         if let Some(type_annotation) = &self.type_annotation() {
-            write!(f, type_annotation)?;
+            write!(f, type_annotation);
         }
-        Ok(())
     }
 }
 
@@ -1466,19 +1442,19 @@ impl GetSpan for FormatTSSignature<'_, '_> {
 }
 
 impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if f.comments().is_suppressed(self.signature.span().start) {
             return write!(f, [self.signature]);
         }
 
-        write!(f, [&self.signature])?;
+        write!(f, [&self.signature]);
 
         match f.options().semicolons {
             Semicolons::Always => {
                 if self.next_signature.is_none() {
-                    write!(f, [if_group_breaks(&token(";"))])?;
+                    write!(f, [if_group_breaks(&token(";"))]);
                 } else {
-                    token(";").fmt(f)?;
+                    token(";").fmt(f);
                 }
             }
             Semicolons::AsNeeded => {
@@ -1506,19 +1482,17 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
                     });
 
                 if needs_semicolon {
-                    write!(f, [";"])?;
+                    write!(f, [";"]);
                 } else if self.next_signature.is_some() {
-                    write!(f, [if_group_fits_on_line(&token(";"))])?;
+                    write!(f, [if_group_fits_on_line(&token(";"))]);
                 }
             }
         }
-
-        Ok(())
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let mut joiner = f.join_nodes_with_soft_line();
 
         let mut iter = self.iter().peekable();
@@ -1528,12 +1502,12 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
                 &FormatTSSignature { signature, next_signature: iter.peek().copied() },
             );
         }
-        joiner.finish()
+        joiner.finish();
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let last_index = self.len().saturating_sub(1);
         let mut joiner = f.join_with(soft_line_break_or_space());
 
@@ -1549,45 +1523,44 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
             }
         }
 
-        joiner.finish()
+        joiner.finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.expression(), self.type_arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.expression(), self.type_arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypePredicate<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.asserts() {
-            write!(f, ["asserts", space()])?;
+            write!(f, ["asserts", space()]);
         }
-        write!(f, [self.parameter_name()])?;
+        write!(f, [self.parameter_name()]);
         if let Some(type_annotation) = self.type_annotation() {
-            write!(f, [space(), "is", space(), type_annotation])?;
+            write!(f, [space(), "is", space(), type_annotation]);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare() {
-            write!(f, ["declare", space()])?;
+            write!(f, ["declare", space()]);
         }
 
-        write!(f, self.kind().as_str())?;
+        write!(f, self.kind().as_str());
 
-        write!(f, [space(), self.id()])?;
+        write!(f, [space(), self.id()]);
 
         if let Some(body) = self.body() {
             let mut body = body;
             loop {
                 match body.as_ast_nodes() {
                     AstNodes::TSModuleDeclaration(b) => {
-                        write!(f, [".", b.id()])?;
+                        write!(f, [".", b.id()]);
                         if let Some(b) = &b.body() {
                             body = b;
                         } else {
@@ -1595,7 +1568,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
                         }
                     }
                     AstNodes::TSModuleBlock(body) => {
-                        write!(f, [space(), body])?;
+                        write!(f, [space(), body]);
                         break;
                     }
                     _ => {
@@ -1604,61 +1577,59 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
                 }
             }
         } else {
-            write!(f, OptionalSemicolon)?;
+            write!(f, OptionalSemicolon);
         }
-
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare {
-            write!(f, ["declare", space()])?;
+            write!(f, ["declare", space()]);
         }
         let comments_before_global = f.context().comments().comments_before(self.global_span.start);
-        write!(f, FormatLeadingComments::Comments(comments_before_global))?;
-        write!(f, ["global", space(), self.body()])
+        write!(f, FormatLeadingComments::Comments(comments_before_global));
+        write!(f, ["global", space(), self.body()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleBlock<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let directives = self.directives();
         let body = self.body();
         let span = self.span();
 
-        write!(f, "{")?;
+        write!(f, "{");
         if body.is_empty() && directives.is_empty() {
-            write!(f, [format_dangling_comments(span).with_block_indent()])?;
+            write!(f, [format_dangling_comments(span).with_block_indent()]);
         } else {
-            write!(f, [block_indent(&format_args!(directives, body))])?;
+            write!(f, [block_indent(&format_args!(directives, body))]);
         }
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeLiteral<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ObjectLike::TSTypeLiteral(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ObjectLike::TSTypeLiteral(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSInferType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["infer ", self.type_parameter()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["infer ", self.type_parameter()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeQuery<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["typeof ", self.expr_name(), self.type_arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["typeof ", self.expr_name(), self.type_arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["import("])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["import("]);
 
         let has_comment = f.context().comments().has_comment_before(self.source.span().start);
 
@@ -1673,47 +1644,46 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
                         format_argument,
                         &format_with(|f| {
                             if self.options.is_some() {
-                                write!(f, [",", soft_line_break_or_space(), format_options])?;
+                                write!(f, [",", soft_line_break_or_space(), format_options]);
                             }
-                            Ok(())
                         }),
                     ]
-                )
+                );
             });
             if has_comment {
-                write!(f, [&soft_block_indent(&format_inner)])?;
+                write!(f, [&soft_block_indent(&format_inner)]);
             } else if self.options().is_some() {
-                write!(f, [best_fitting!(format_inner, &soft_block_indent(&format_inner))])?;
+                write!(f, [best_fitting!(format_inner, &soft_block_indent(&format_inner))]);
             } else {
-                write!(f, [format_inner])?;
+                write!(f, [format_inner]);
             }
         } else {
-            write!(f, self.source())?;
+            write!(f, self.source());
         }
 
-        write!(f, ")")?;
+        write!(f, ")");
         if let Some(qualified_name) = &self.qualifier() {
-            write!(f, [".", qualified_name])?;
+            write!(f, [".", qualified_name]);
         }
-        write!(f, self.type_arguments())
+        write!(f, self.type_arguments());
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.left(), ".", self.right()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.left(), ".", self.right()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAssertion<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let break_after_cast = !matches!(
             self.expression,
             Expression::ArrayExpression(_) | Expression::ObjectExpression(_)
         );
 
         let format_cast = format_with(|f| {
-            write!(f, ["<", group(&soft_block_indent(&self.type_annotation())), ">",])
+            write!(f, ["<", group(&soft_block_indent(&self.type_annotation())), ">",]);
         });
 
         if break_after_cast {
@@ -1734,47 +1704,45 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAssertion<'a>> {
                     ),
                     format_args!(format_cast, format_expression)
                 ]]
-            )
+            );
         } else {
-            write!(f, [format_cast, self.expression()])
+            write!(f, [format_cast, self.expression()]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSNonNullExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.expression(), "!"])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.expression(), "!"]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, [self.expression(), self.type_arguments()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, [self.expression(), self.type_arguments()]);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNullableType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.postfix() {
-            write!(f, [self.type_annotation(), "?"])
+            write!(f, [self.type_annotation(), "?"]);
         } else {
-            write!(f, ["?", self.type_annotation()])
+            write!(f, ["?", self.type_annotation()]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.postfix() {
-            write!(f, [self.type_annotation(), "!"])
+            write!(f, [self.type_annotation(), "!"]);
         } else {
-            write!(f, ["!", self.type_annotation()])
+            write!(f, ["!", self.type_annotation()]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSDocUnknownType> {
-    fn write(&self, _f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        Ok(())
-    }
+    fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }

--- a/crates/oxc_formatter/src/write/object_like.rs
+++ b/crates/oxc_formatter/src/write/object_like.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, FormatResult, Formatter,
+        Buffer, Format, Formatter,
         prelude::{format_with, group, soft_block_indent_with_maybe_space},
         trivia::format_dangling_comments,
     },
@@ -72,7 +72,7 @@ impl<'a> ObjectLike<'a, '_> {
         }
     }
 
-    fn write_members(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write_members(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::ObjectExpression(o) => o.properties().fmt(f),
             Self::TSTypeLiteral(o) => o.members().fmt(f),
@@ -81,13 +81,13 @@ impl<'a> ObjectLike<'a, '_> {
 }
 
 impl<'a> Format<'a> for ObjectLike<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let members = format_with(|f| self.write_members(f));
 
-        write!(f, "{")?;
+        write!(f, "{");
 
         if self.members_are_empty() {
-            write!(f, format_dangling_comments(self.span()).with_block_indent())?;
+            write!(f, format_dangling_comments(self.span()).with_block_indent());
         } else {
             let should_insert_space_around_brackets = f.options().bracket_spacing.value();
             let should_expand = (f.options().expand == Expand::Auto
@@ -108,12 +108,12 @@ impl<'a> Format<'a> for ObjectLike<'a, '_> {
                 soft_block_indent_with_maybe_space(&members, should_insert_space_around_brackets);
 
             if should_hug {
-                write!(f, inner)?;
+                write!(f, inner);
             } else {
-                write!(f, [group(&inner).should_expand(should_expand)])?;
+                write!(f, [group(&inner).should_expand(should_expand)]);
             }
         }
 
-        write!(f, "}")
+        write!(f, "}");
     }
 }

--- a/crates/oxc_formatter/src/write/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/write/object_pattern_like.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, FormatResult, Formatter,
+        Buffer, Format, Formatter,
         prelude::{format_with, group, soft_block_indent_with_maybe_space},
         trivia::format_dangling_comments,
     },
@@ -125,18 +125,18 @@ impl<'a> ObjectPatternLike<'a, '_> {
         }
     }
 
-    fn write_properties(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write_properties(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::ObjectPattern(o) => BindingPropertyList::new(o.properties(), o.rest()).fmt(f),
             Self::ObjectAssignmentTarget(o) => {
-                AssignmentTargetPropertyList::new(o.properties(), o.rest()).fmt(f)
+                AssignmentTargetPropertyList::new(o.properties(), o.rest()).fmt(f);
             }
         }
     }
 }
 
 impl<'a> Format<'a> for ObjectPatternLike<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let should_insert_space_around_brackets = f.options().bracket_spacing.value();
         let format_properties = format_with(|f| {
             write!(
@@ -145,24 +145,24 @@ impl<'a> Format<'a> for ObjectPatternLike<'a, '_> {
                     &format_with(|f| self.write_properties(f)),
                     should_insert_space_around_brackets
                 )
-            )
+            );
         });
 
-        write!(f, ["{"])?;
+        write!(f, ["{"]);
 
         match self.layout(f) {
             ObjectPatternLayout::Empty => {
-                write!(f, format_dangling_comments(self.span()).with_block_indent())?;
+                write!(f, format_dangling_comments(self.span()).with_block_indent());
             }
             ObjectPatternLayout::Inline => {
-                write!(f, format_properties)?;
+                write!(f, format_properties);
             }
             ObjectPatternLayout::Group { expand } => {
-                write!(f, group(&format_properties).should_expand(expand))?;
+                write!(f, group(&format_properties).should_expand(expand));
             }
         }
 
-        write!(f, "}")
+        write!(f, "}");
     }
 }
 

--- a/crates/oxc_formatter/src/write/parameters.rs
+++ b/crates/oxc_formatter/src/write/parameters.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator, AstNodes},
     format_args,
-    formatter::{Format, FormatResult, Formatter, prelude::*, trivia::FormatTrailingComments},
+    formatter::{Format, Formatter, prelude::*, trivia::FormatTrailingComments},
     options::{FormatTrailingCommas, TrailingSeparator},
     utils::call_expression::is_test_call_expression,
     write,
@@ -23,12 +23,12 @@ pub fn get_this_param<'a>(parent: &AstNodes<'a>) -> Option<&'a AstNode<'a, TSThi
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         // `function foo /**/ () {}`
         //               ^^^ keep comments printed before parameters
         let comments = f.context().comments().comments_before(self.span.start);
         if !comments.is_empty() {
-            write!(f, [space(), FormatTrailingComments::Comments(comments)])?;
+            write!(f, [space(), FormatTrailingComments::Comments(comments)]);
         }
 
         let parentheses_not_needed = if let AstNodes::ArrowFunctionExpression(arrow) = self.parent {
@@ -63,15 +63,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
         };
 
         if !parentheses_not_needed {
-            write!(f, "(")?;
+            write!(f, "(");
         }
 
         match layout {
             ParameterLayout::NoParameters => {
-                write!(f, format_dangling_comments(self.span()).with_soft_block_indent())?;
+                write!(f, format_dangling_comments(self.span()).with_soft_block_indent());
             }
             ParameterLayout::Hug => {
-                write!(f, ParameterList::with_layout(self, this_param, layout))?;
+                write!(f, ParameterList::with_layout(self, this_param, layout));
             }
             ParameterLayout::Default => {
                 write!(
@@ -79,31 +79,29 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
                     soft_block_indent(&format_args!(&ParameterList::with_layout(
                         self, this_param, layout
                     )))
-                )?;
+                );
             }
         }
 
         if !parentheses_not_needed {
-            write!(f, [")"])?;
+            write!(f, [")"]);
         }
-
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let content = format_with(|f| {
             if let Some(accessibility) = self.accessibility() {
-                write!(f, [accessibility.as_str(), space()])?;
+                write!(f, [accessibility.as_str(), space()]);
             }
             if self.r#override() {
-                write!(f, ["override", space()])?;
+                write!(f, ["override", space()]);
             }
             if self.readonly() {
-                write!(f, ["readonly", space()])?;
+                write!(f, ["readonly", space()]);
             }
-            write!(f, self.pattern())
+            write!(f, self.pattern());
         });
 
         let is_hug_parameter = matches!(self.parent, AstNodes::FormalParameters(params) if {
@@ -118,18 +116,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
         let decorators = self.decorators();
 
         if is_hug_parameter && decorators.is_empty() {
-            write!(f, [&content])
+            write!(f, [&content]);
         } else if decorators.is_empty() {
-            write!(f, [group(&content)])
+            write!(f, [group(&content)]);
         } else {
-            write!(f, [group(&decorators), group(&content)])
+            write!(f, [group(&decorators), group(&content)]);
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSThisParameter<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["this", self.type_annotation()])
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["this", self.type_annotation()]);
     }
 }
 
@@ -150,7 +148,7 @@ impl GetSpan for Parameter<'_, '_> {
 }
 
 impl<'a> Format<'a> for Parameter<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::This(param) => param.fmt(f),
             Self::Formal(param) => param.fmt(f),
@@ -234,7 +232,7 @@ impl<'a, 'b> ParameterList<'a, 'b> {
 }
 
 impl<'a> Format<'a> for ParameterList<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match self.layout {
             None | Some(ParameterLayout::Default | ParameterLayout::NoParameters) => {
                 let has_trailing_rest = self.list.rest().is_some();
@@ -260,7 +258,7 @@ impl<'a> Format<'a> for ParameterList<'a, '_> {
                         ",",
                         trailing_separator,
                     )
-                    .finish()
+                    .finish();
             }
             Some(ParameterLayout::Hug) => {
                 let mut join = f.join_with(space());
@@ -269,7 +267,7 @@ impl<'a> Format<'a> for ParameterList<'a, '_> {
                     ",",
                     TrailingSeparator::Omit,
                 );
-                join.finish()
+                join.finish();
             }
         }
     }

--- a/crates/oxc_formatter/src/write/program.rs
+++ b/crates/oxc_formatter/src/write/program.rs
@@ -6,7 +6,7 @@ use oxc_span::GetSpan;
 use oxc_syntax::identifier::ZWNBSP;
 
 use crate::{
-    Buffer, Format, FormatResult,
+    Buffer, Format,
     ast_nodes::AstNode,
     formatter::{prelude::*, trivia::FormatTrailingComments},
     utils::string::{FormatLiteralStringToken, StringLiteralParentKind},
@@ -17,9 +17,12 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_trailing_comments = format_with(|f| {
-            write!(f, FormatTrailingComments::Comments(f.context().comments().unprinted_comments()))
+            write!(
+                f,
+                FormatTrailingComments::Comments(f.context().comments().unprinted_comments())
+            );
         });
 
         write!(
@@ -37,7 +40,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
                 format_trailing_comments,
                 hard_line_break()
             ]
-        )
+        );
     }
 }
 
@@ -51,7 +54,7 @@ impl<'a> Deref for FormatProgramBody<'a, '_> {
 }
 
 impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let mut join = f.join_nodes_with_hardline();
         for stmt in
             self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_)))
@@ -87,18 +90,18 @@ impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
 
             join.entry(span, stmt);
         }
-        join.finish()
+        join.finish();
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let Some(last_directive) = self.last() else {
             // No directives, no extra new line
-            return Ok(());
+            return;
         };
 
-        f.join_nodes_with_hardline().entries(self).finish()?;
+        f.join_nodes_with_hardline().entries(self).finish();
 
         // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
         // JsDirectiveList, for example:
@@ -120,12 +123,12 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
         };
 
         let need_extra_empty_line = f.source_text().lines_after(end) > 1;
-        write!(f, if need_extra_empty_line { empty_line() } else { hard_line_break() })
+        write!(f, if need_extra_empty_line { empty_line() } else { hard_line_break() });
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
             [
@@ -137,18 +140,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
                 ),
                 OptionalSemicolon
             ]
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Hashbang<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, ["#!", text(self.value().as_str().trim_end())])?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, ["#!", text(self.value().as_str().trim_end())]);
 
         if f.source_text().lines_after(self.span.end) > 1 {
-            write!(f, [empty_line()])
+            write!(f, [empty_line()]);
         } else {
-            write!(f, [hard_line_break()])
+            write!(f, [hard_line_break()]);
         }
     }
 }

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -2,7 +2,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Format, FormatResult,
+    Format,
     ast_nodes::AstNode,
     format_args,
     formatter::{Formatter, prelude::*},
@@ -13,14 +13,14 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ReturnAndThrowStatement::ReturnStatement(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ReturnAndThrowStatement::ReturnStatement(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        ReturnAndThrowStatement::ThrowStatement(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        ReturnAndThrowStatement::ThrowStatement(self).fmt(f);
     }
 }
 
@@ -56,11 +56,11 @@ impl<'a, 'b> ReturnAndThrowStatement<'a, 'b> {
 }
 
 impl<'a> Format<'a> for ReturnAndThrowStatement<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, self.keyword())?;
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, self.keyword());
 
         if let Some(argument) = self.argument() {
-            write!(f, [space(), FormatAdjacentArgument(argument)])?;
+            write!(f, [space(), FormatAdjacentArgument(argument)]);
         }
 
         let dangling_comments = f.context().comments().comments_before(self.span().end);
@@ -69,31 +69,29 @@ impl<'a> Format<'a> for ReturnAndThrowStatement<'a, '_> {
             dangling_comments.last().is_some_and(|comment| comment.is_line());
 
         if is_last_comment_line {
-            write!(f, OptionalSemicolon)?;
+            write!(f, OptionalSemicolon);
         }
 
         if !dangling_comments.is_empty() {
-            write!(f, [space(), format_dangling_comments(self.span())])?;
+            write!(f, [space(), format_dangling_comments(self.span())]);
         }
 
         if !is_last_comment_line {
-            write!(f, OptionalSemicolon)?;
+            write!(f, OptionalSemicolon);
         }
-
-        Ok(())
     }
 }
 
 pub struct FormatAdjacentArgument<'a, 'b>(pub &'b AstNode<'a, Expression<'a>>);
 
 impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let argument = self.0;
 
         if !matches!(argument.as_ref(), Expression::JSXElement(_) | Expression::JSXFragment(_))
             && has_argument_leading_comments(argument, f)
         {
-            write!(f, [token("("), &block_indent(&argument), token(")")])
+            write!(f, [token("("), &block_indent(&argument), token(")")]);
         } else if argument.is_binaryish() {
             write!(
                 f,
@@ -102,11 +100,11 @@ impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
                     soft_block_indent(&argument),
                     if_group_breaks(&token(")"))
                 ))]
-            )
+            );
         } else if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-            write!(f, [group(&format_args!(token("("), soft_block_indent(&argument), token(")")))])
+            write!(f, [group(&format_args!(token("("), soft_block_indent(&argument), token(")")))]);
         } else {
-            write!(f, argument)
+            write!(f, argument);
         }
     }
 }

--- a/crates/oxc_formatter/src/write/semicolon.rs
+++ b/crates/oxc_formatter/src/write/semicolon.rs
@@ -1,5 +1,5 @@
 use crate::{
-    formatter::{Buffer, Format, FormatResult, Formatter},
+    formatter::{Buffer, Format, Formatter},
     options::Semicolons,
     write,
 };
@@ -7,10 +7,10 @@ use crate::{
 pub struct OptionalSemicolon;
 
 impl<'a> Format<'a> for OptionalSemicolon {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         match f.options().semicolons {
             Semicolons::Always => write!(f, ";"),
-            Semicolons::AsNeeded => Ok(()),
+            Semicolons::AsNeeded => (),
         }
     }
 }
@@ -18,7 +18,9 @@ impl<'a> Format<'a> for OptionalSemicolon {
 pub struct MaybeOptionalSemicolon(pub bool);
 
 impl<'a> Format<'a> for MaybeOptionalSemicolon {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        if self.0 { OptionalSemicolon.fmt(f) } else { Ok(()) }
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        if self.0 {
+            OptionalSemicolon.fmt(f);
+        }
     }
 }

--- a/crates/oxc_formatter/src/write/sequence_expression.rs
+++ b/crates/oxc_formatter/src/write/sequence_expression.rs
@@ -2,44 +2,44 @@ use oxc_ast::ast::*;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    formatter::{Format, FormatResult, Formatter, prelude::*},
+    formatter::{Format, Formatter, prelude::*},
     write,
 };
 
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| {
             let mut expressions = self.expressions().iter();
             let separator = format_with(|f| {
-                write!(f, [",", line_suffix_boundary(), soft_line_break_or_space()])
+                write!(f, [",", line_suffix_boundary(), soft_line_break_or_space()]);
             })
             .memoized();
 
-            write!(f, [expressions.next()])?;
+            write!(f, [expressions.next()]);
 
             if self.expressions.len() > 1 {
-                write!(f, [",", line_suffix_boundary()])?;
+                write!(f, [",", line_suffix_boundary()]);
             }
 
             let rest = format_once(|f| {
-                write!(f, soft_line_break_or_space())?;
+                write!(f, soft_line_break_or_space());
                 let mut joiner = f.join_with(separator);
                 joiner.entries(expressions);
-                joiner.finish()
+                joiner.finish();
             });
 
             if matches!(self.parent, AstNodes::ForStatement(_))
                 || (matches!(self.parent, AstNodes::ExpressionStatement(statement)
                     if !statement.is_arrow_function_body()))
             {
-                write!(f, [indent(&rest)])
+                write!(f, [indent(&rest)]);
             } else {
-                rest.fmt(f)
+                rest.fmt(f);
             }
         });
 
-        write!(f, group(&format_inner))
+        write!(f, group(&format_inner));
     }
 }

--- a/crates/oxc_formatter/src/write/switch_statement.rs
+++ b/crates/oxc_formatter/src/write/switch_statement.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Format, FormatResult,
+    Format,
     ast_nodes::AstNode,
     format_args,
     formatter::{
@@ -18,7 +18,7 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let discriminant = self.discriminant();
         let cases = self.cases();
         let format_cases =
@@ -36,23 +36,23 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
                 block_indent(&format_cases),
                 "}"
             ]
-        )
+        );
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, SwitchCase<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        f.join_nodes_with_hardline().entries(self).finish()
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        f.join_nodes_with_hardline().entries(self).finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_default = if let Some(test) = self.test() {
-            write!(f, ["case", space(), test, ":"])?;
+            write!(f, ["case", space(), test, ":"]);
             false
         } else {
-            write!(f, ["default", ":"])?;
+            write!(f, ["default", ":"]);
             true
         };
 
@@ -92,7 +92,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
             // Print nothing to ensure that trailing comments on the same line
             // are printed on the same line. The parent list formatter takes
             // care of inserting a hard line break between cases.
-            return Ok(());
+            return;
         }
 
         // Whether the first statement in the clause is a BlockStatement, and
@@ -127,15 +127,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
                             indent: DanglingIndentMode::None
                         },
                     ]
-                )?;
+                );
             }
         }
 
         if is_single_block_statement {
-            write!(f, [FormatStatementBody::new(first_statement)])
+            write!(f, [FormatStatementBody::new(first_statement)]);
         } else {
             // no line break needed after because it is added by the indent in the switch statement
-            write!(f, indent(&format_args!(hard_line_break(), consequent)))
+            write!(f, indent(&format_args!(hard_line_break(), consequent)));
         }
     }
 }

--- a/crates/oxc_formatter/src/write/try_statement.rs
+++ b/crates/oxc_formatter/src/write/try_statement.rs
@@ -2,7 +2,6 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    FormatResult,
     ast_nodes::AstNode,
     formatter::{
         Formatter,
@@ -15,27 +14,26 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TryStatement<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let block = self.block();
         let handler = self.handler();
         let finalizer = self.finalizer();
-        write!(f, ["try", space()])?;
+        write!(f, ["try", space()]);
 
         // Use `write` rather than `write!` in order to avoid printing leading comments for `block`.
-        block.write(f)?;
+        block.write(f);
         if let Some(handler) = handler {
-            write!(f, [space(), handler])?;
+            write!(f, [space(), handler]);
         }
         if let Some(finalizer) = finalizer {
-            write!(f, [space(), "finally", space()])?;
-            finalizer.write(f)?;
+            write!(f, [space(), "finally", space()]);
+            finalizer.write(f);
         }
-        Ok(())
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, CatchClause<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let leading_comments = comments.comments_before(self.span.start);
         let has_line_comment = leading_comments.iter().any(|comment| {
@@ -52,24 +50,24 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchClause<'a>> {
             // Comments before the catch clause should be printed in the block statement.
             // We cache them here to avoid the `params` printing them accidentally.
             let printed_comments = f.intern(&FormatLeadingComments::Comments(leading_comments));
-            if let Ok(Some(comments)) = printed_comments {
+            if let Some(comments) = printed_comments {
                 f.context_mut().cache_element(&self.span, comments);
             }
         } else if !leading_comments.is_empty() {
             // otherwise, print them before `catch`
-            write!(f, [FormatTrailingComments::Comments(leading_comments), space()])?;
+            write!(f, [FormatTrailingComments::Comments(leading_comments), space()]);
         }
 
-        write!(f, ["catch", space(), self.param(), space()])?;
+        write!(f, ["catch", space(), self.param(), space()]);
 
         // Use `write` rather than `write!` in order to avoid printing leading comments for `block`.
-        self.body().write(f)
+        self.body().write(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "(")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "(");
 
         let span = self.pattern.span();
 
@@ -88,28 +86,27 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
             write!(
                 f,
                 soft_block_indent(&format_with(|f| {
-                    write!(f, [FormatLeadingComments::Comments(leading_comments)])?;
+                    write!(f, [FormatLeadingComments::Comments(leading_comments)]);
                     let printed_len_before_pattern =
                         f.context().comments().printed_comments().len();
-                    write!(f, self.pattern())?;
+                    write!(f, self.pattern());
                     if trailing_comments.is_empty() ||
-                        // The `pattern` cannot print comments that are below it, so we need to check whether there
-                        // are any trailing comments that haven't been printed yet. If there are, print them.
-                        f.context().comments().printed_comments().len() - printed_len_before_pattern
-                            == trailing_comments.len()
+                    // The `pattern` cannot print comments that are below it, so we need to check whether there
+                    // are any trailing comments that haven't been printed yet. If there are, print them.
+                    f.context().comments().printed_comments().len() - printed_len_before_pattern
+                        == trailing_comments.len()
                     {
-                        Ok(())
                     } else {
-                        write!(f, FormatTrailingComments::Comments(trailing_comments))
+                        write!(f, FormatTrailingComments::Comments(trailing_comments));
                     }
                 }))
-            )?;
+            );
         } else {
-            write!(f, self.pattern())?;
+            write!(f, self.pattern());
         }
 
-        self.format_trailing_comments(f)?;
+        self.format_trailing_comments(f);
 
-        write!(f, ")")
+        write!(f, ")");
     }
 }

--- a/crates/oxc_formatter/src/write/tuple_type.rs
+++ b/crates/oxc_formatter/src/write/tuple_type.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 
 use crate::{
-    Expand, Format, FormatResult, FormatTrailingCommas,
+    Expand, Format, FormatTrailingCommas,
     ast_nodes::AstNode,
     formatter::{Formatter, prelude::*, trivia::format_dangling_comments},
     write,
@@ -11,27 +11,27 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line()
             .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish()
+            .finish();
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTupleType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        write!(f, "[")?;
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        write!(f, "[");
 
         let element_types = self.element_types();
         if element_types.is_empty() {
-            write!(f, [format_dangling_comments(self.span).with_block_indent()])?;
+            write!(f, [format_dangling_comments(self.span).with_block_indent()]);
         } else {
             let should_expand = f.options().expand == Expand::Always;
 
-            write!(f, [group(&soft_block_indent(&element_types)).should_expand(should_expand)])?;
+            write!(f, [group(&soft_block_indent(&element_types)).should_expand(should_expand)]);
         }
 
-        write!(f, "]")
+        write!(f, "]");
     }
 }

--- a/crates/oxc_formatter/src/write/type_parameters.rs
+++ b/crates/oxc_formatter/src/write/type_parameters.rs
@@ -5,7 +5,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Buffer, Format, FormatResult, Formatter, GroupId,
+        Buffer, Format, Formatter, GroupId,
         prelude::*,
         trivia::{DanglingIndentMode, FormatDanglingComments},
     },
@@ -20,17 +20,17 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.r#const() {
-            write!(f, ["const", space()])?;
+            write!(f, ["const", space()]);
         }
         if self.r#in() {
-            write!(f, ["in", space()])?;
+            write!(f, ["in", space()]);
         }
         if self.out() {
-            write!(f, ["out", space()])?;
+            write!(f, ["out", space()]);
         }
-        write!(f, self.name())?;
+        write!(f, self.name());
 
         if let Some(constraint) = &self.constraint() {
             let group_id = f.group_id("constraint");
@@ -47,7 +47,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
                     .with_group_id(Some(group_id)),
                     indent_if_group_breaks(&constraint, group_id)
                 ]
-            )?;
+            );
         }
         if let Some(default) = &self.default() {
             let group_id = f.group_id("default");
@@ -60,14 +60,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
                     line_suffix_boundary(),
                     indent_if_group_breaks(&default, group_id)
                 ]
-            )?;
+            );
         }
-        Ok(())
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         // Type parameter lists of arrow function expressions have to include at least one comma
         // to avoid any ambiguity with JSX elements.
         // Thus, we have to add a trailing comma when there is a single type parameter.
@@ -87,7 +86,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
 
         f.join_with(soft_line_break_or_space())
             .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish()
+            .finish();
     }
 }
 
@@ -112,31 +111,31 @@ impl<'a, 'b> FormatTSTypeParameters<'a, 'b> {
 }
 
 impl<'a> Format<'a> for FormatTSTypeParameters<'a, '_> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let params = self.decl.params();
         if params.is_empty() && self.options.is_type_or_interface_decl {
-            write!(f, "<>")
+            write!(f, "<>");
         } else {
             write!(
                 f,
                 [group(&format_args!("<", format_with(|f| {
                     if matches!(self.decl.grand_parent(), AstNodes::CallExpression(call) if is_test_call_expression(call))
                     {
-                        f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit).finish()
+                        f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit).finish();
                     } else {
-                        soft_block_indent(&params).fmt(f)
-                    }?;
+                        soft_block_indent(&params).fmt(f);
+                    }
 
-                    format_dangling_comments(self.decl.span).with_soft_block_indent().fmt(f)
+                    format_dangling_comments(self.decl.span).with_soft_block_indent().fmt(f);
                 }), ">"))
                     .with_group_id(self.options.group_id)]
-            )
+            );
         }
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let params = self.params();
 
         if params.is_empty() {
@@ -168,15 +167,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
         let format_params = format_with(|f| {
             f.join_with(&soft_line_break_or_space())
                 .entries_with_trailing_separator(params, ",", TrailingSeparator::Disallowed)
-                .finish()
+                .finish();
         });
 
         let should_inline = !is_arrow_function_vars && first_arg_can_be_hugged;
 
         if should_inline {
-            write!(f, ["<", format_params, ">"])
+            write!(f, ["<", format_params, ">"]);
         } else {
-            write!(f, [group(&format_args!("<", soft_block_indent(&format_params), ">"))])
+            write!(f, [group(&format_args!("<", soft_block_indent(&format_params), ">"))]);
         }
     }
 }

--- a/crates/oxc_formatter/src/write/union_type.rs
+++ b/crates/oxc_formatter/src/write/union_type.rs
@@ -6,7 +6,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        FormatResult, Formatter,
+        Formatter,
         prelude::*,
         trivia::{FormatLeadingComments, FormatTrailingComments},
     },
@@ -17,7 +17,7 @@ use crate::{
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let types = self.types();
 
         // ```ts
@@ -73,21 +73,21 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             };
 
             if has_leading_comments {
-                write!(f, FormatLeadingComments::Comments(leading_comments))?;
+                write!(f, FormatLeadingComments::Comments(leading_comments));
             }
 
             let leading_soft_line_break_or_space = should_indent && !has_leading_comments;
 
             let separator = format_with(|f| {
                 if leading_soft_line_break_or_space {
-                    write!(f, [soft_line_break_or_space()])?;
+                    write!(f, [soft_line_break_or_space()]);
                 }
-                write!(f, [token("|"), space()])
+                write!(f, [token("|"), space()]);
             });
 
-            write!(f, [if_group_breaks(&separator)])?;
+            write!(f, [if_group_breaks(&separator)]);
 
-            format_union_types(types, suppressed_node_span, false, f)
+            format_union_types(types, suppressed_node_span, false, f);
         });
 
         let content = format_with(|f| {
@@ -115,15 +115,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                         soft_line_break(),
                         if_group_breaks(&token(")"))
                     ]
-                )
+                );
             } else if should_indent {
-                write!(f, [indent(&types)])
+                write!(f, [indent(&types)]);
             } else {
-                write!(f, [types])
+                write!(f, [types]);
             }
         });
 
-        write!(f, [group(&content)])
+        write!(f, [group(&content)]);
     }
 }
 
@@ -132,26 +132,26 @@ fn format_union_types<'a>(
     mut suppressed_node_span: Span,
     should_hug: bool,
     f: &mut Formatter<'_, 'a>,
-) -> FormatResult<()> {
+) {
     let mut node_iter = node.iter().peekable();
     while let Some(element) = node_iter.next() {
         let element_span = element.span();
 
         if suppressed_node_span == element_span {
             let comments = f.context().comments().comments_before(suppressed_node_span.start);
-            FormatLeadingComments::Comments(comments).fmt(f)?;
+            FormatLeadingComments::Comments(comments).fmt(f);
             let needs_parentheses = element.needs_parentheses(f);
             if needs_parentheses {
-                write!(f, "(")?;
+                write!(f, "(");
             }
-            write!(f, [FormatSuppressedNode(element_span)])?;
+            write!(f, [FormatSuppressedNode(element_span)]);
             if needs_parentheses {
-                write!(f, ")")?;
+                write!(f, ")");
             }
         } else if should_hug {
-            write!(f, [element])?;
+            write!(f, [element]);
         } else {
-            write!(f, [align(2, &element)])?;
+            write!(f, [align(2, &element)]);
         }
 
         if let Some(next_node_span) = node_iter.peek().map(GetSpan::span) {
@@ -161,7 +161,7 @@ fn format_union_types<'a>(
 
             let comments_before_separator =
                 f.context().comments().comments_before_character(element_span.end, b'|');
-            FormatTrailingComments::Comments(comments_before_separator).fmt(f)?;
+            FormatTrailingComments::Comments(comments_before_separator).fmt(f);
 
             // ```ts
             // type Some = A |
@@ -179,15 +179,15 @@ fn format_union_types<'a>(
             // before `|` instead of after it.
             if f.comments().has_leading_own_line_comment(next_node_span.start) {
                 let comments = f.context().comments().comments_before(next_node_span.start);
-                FormatTrailingComments::Comments(comments).fmt(f)?;
+                FormatTrailingComments::Comments(comments).fmt(f);
             }
 
             if should_hug {
-                write!(f, [space()])?;
+                write!(f, [space()]);
             } else {
-                write!(f, [soft_line_break_or_space()])?;
+                write!(f, [soft_line_break_or_space()]);
             }
-            write!(f, ["|"])?;
+            write!(f, ["|"]);
         } else if let AstNodes::TSUnionType(parent) = element.parent
             && parent.needs_parentheses(f)
         {
@@ -200,13 +200,11 @@ fn format_union_types<'a>(
             //```
             // TODO: We may need to tweak `AstNode<'a, Vec<'a, T>>` iterator as some of Vec's last elements should have the following span.
             let comments = f.context().comments().end_of_line_comments_after(element_span.end);
-            write!(f, FormatTrailingComments::Comments(comments))?;
+            write!(f, FormatTrailingComments::Comments(comments));
         }
 
         if node_iter.peek().is_some() {
-            write!(f, space())?;
+            write!(f, space());
         }
     }
-
-    Ok(())
 }

--- a/crates/oxc_formatter/src/write/variable_declaration.rs
+++ b/crates/oxc_formatter/src/write/variable_declaration.rs
@@ -7,9 +7,7 @@ use crate::write::semicolon::MaybeOptionalSemicolon;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{
-        Buffer, Format, FormatResult, Formatter, prelude::*, separated::FormatSeparatedIter,
-    },
+    formatter::{Buffer, Format, Formatter, prelude::*, separated::FormatSeparatedIter},
     options::TrailingSeparator,
     write,
 };
@@ -17,7 +15,7 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
         let semicolon = match self.parent {
             AstNodes::ExportNamedDeclaration(_) => false,
             AstNodes::ForStatement(stmt) => {
@@ -30,7 +28,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
         };
 
         if self.declare() {
-            write!(f, ["declare", space()])?;
+            write!(f, ["declare", space()]);
         }
 
         write!(
@@ -41,12 +39,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
                 self.declarations(),
                 MaybeOptionalSemicolon(semicolon)
             ))
-        )
+        );
     }
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let length = self.len();
 
         let is_parent_for_loop = matches!(
@@ -58,9 +56,9 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
 
         let format_separator = format_with(|f| {
             if !is_parent_for_loop && has_any_initializer {
-                write!(f, hard_line_break())
+                write!(f, hard_line_break());
             } else {
-                write!(f, soft_line_break_or_space())
+                write!(f, soft_line_break_or_space());
             }
         });
 
@@ -77,20 +75,20 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
         write!(
             f,
             indent(&format_once(|f| {
-                write!(f, first_declarator)?;
+                write!(f, first_declarator);
 
                 if length > 1 {
-                    write!(f, format_separator)?;
+                    write!(f, format_separator);
                 }
 
-                f.join_with(format_separator).entries(declarators).finish()
+                f.join_with(format_separator).entries(declarators).finish();
             }))
-        )
+        );
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclarator<'a>> {
-    fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
-        AssignmentLike::VariableDeclarator(self).fmt(f)
+    fn write(&self, f: &mut Formatter<'_, 'a>) {
+        AssignmentLike::VariableDeclarator(self).fmt(f);
     }
 }

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -112,7 +112,7 @@ impl Generator for FormatterAstNodesGenerator {
             ///@@line_break
             use crate::ast_nodes::AstNode;
             use crate::formatter::{
-                Format, FormatResult, Formatter,
+                Format, Formatter,
                 trivia::{format_leading_comments, format_trailing_comments},
             };
 
@@ -351,21 +351,21 @@ fn generate_struct_impls(
             #(#methods)*
 
             ///@@line_break
-            pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+            pub fn format_leading_comments(&self, f: &mut Formatter<'_, 'a>) {
                 format_leading_comments(
                     self.span()
                 )
-                .fmt(f)
+                .fmt(f);
             }
 
             ///@@line_break
-            pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+            pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
                 format_trailing_comments(
                     self.parent.span(),
                     self.inner.span(),
                     self.following_span,
                 )
-                .fmt(f)
+                .fmt(f);
             }
         }
     }

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -83,7 +83,7 @@ impl Generator for FormatterFormatGenerator {
 
             ///@@line_break
             use crate::{
-                formatter::{Format, FormatResult, Formatter},
+                formatter::{Format, Formatter},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
                 utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
@@ -114,7 +114,7 @@ fn generate_struct_implementation(
         quote! {}
     } else {
         quote! {
-            self.format_leading_comments(f)?;
+            self.format_leading_comments(f);
         }
     };
 
@@ -122,7 +122,7 @@ fn generate_struct_implementation(
         quote! {}
     } else {
         quote! {
-            self.format_trailing_comments(f)?;
+            self.format_trailing_comments(f);
         }
     };
 
@@ -132,7 +132,7 @@ fn generate_struct_implementation(
         quote! {
             let needs_parentheses = self.needs_parentheses(f);
             if needs_parentheses {
-                "(".fmt(f)?;
+                "(".fmt(f);
             }
         }
     } else {
@@ -142,7 +142,7 @@ fn generate_struct_implementation(
     let needs_parentheses_after = if needs_parentheses {
         quote! {
             if needs_parentheses {
-                ")".fmt(f)?;
+                ")".fmt(f);
             }
         }
     } else {
@@ -152,11 +152,11 @@ fn generate_struct_implementation(
     let generate_fmt_implementation = |has_options: bool| {
         let write_call = if has_options {
             quote! {
-                self.write_with_options(options, f)
+                self.write_with_options(options, f);
             }
         } else {
             quote! {
-                self.write(f)
+                self.write(f);
             }
         };
 
@@ -174,9 +174,9 @@ fn generate_struct_implementation(
         } else if trailing_comments.is_empty() {
             quote! {
                 if is_suppressed {
-                     self.format_leading_comments(f)?;
-                    FormatSuppressedNode(self.span()).fmt(f)?;
-                     self.format_trailing_comments(f)
+                     self.format_leading_comments(f);
+                    FormatSuppressedNode(self.span()).fmt(f);
+                     self.format_trailing_comments(f);
                 } else {
                     #write_call
                 }
@@ -184,7 +184,7 @@ fn generate_struct_implementation(
         } else {
             quote! {
                 if is_suppressed {
-                    FormatSuppressedNode(self.span()).fmt(f)
+                    FormatSuppressedNode(self.span()).fmt(f);
                 } else {
                     #write_call
                 }
@@ -208,8 +208,8 @@ fn generate_struct_implementation(
             });
 
             quote! {
-                if #suppressed_check_for_typecast format_type_cast_comment_node(self, #is_object_or_array_argument, f)? {
-                    return Ok(());
+                if #suppressed_check_for_typecast format_type_cast_comment_node(self, #is_object_or_array_argument, f) {
+                    return;
                 }
             }
         });
@@ -226,10 +226,9 @@ fn generate_struct_implementation(
                 #type_cast_comment_formatting
                 #leading_comments
                 #needs_parentheses_before
-                let result = #write_implementation;
+                #write_implementation
                 #needs_parentheses_after
                 #trailing_comments
-                result
             }
         }
     };
@@ -241,7 +240,7 @@ fn generate_struct_implementation(
         let implementation = generate_fmt_implementation(true);
         quote! {
             ///@@line_break
-            fn fmt_with_options(&self, options: #fmt_options, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+            fn fmt_with_options(&self, options: #fmt_options, f: &mut Formatter<'_, 'a>) {
                 #implementation
             }
         }
@@ -254,7 +253,7 @@ fn generate_struct_implementation(
     quote! {
         ///@@line_break
         impl<'a> Format<'a #option_type> for #type_ty {
-            fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+            fn fmt(&self, f: &mut Formatter<'_, 'a>) {
                 #fmt_implementation
             }
 
@@ -280,7 +279,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     parent,
                     allocator,
                     following_span: self.following_span,
-                }).fmt(f)
+                }).fmt(f);
             },
         })
     });
@@ -303,7 +302,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     parent,
                     allocator,
                     following_span: self.following_span,
-                }).fmt(f)
+                }).fmt(f);
             },
         };
 
@@ -323,7 +322,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
         ///@@line_break
         impl<'a> Format<'a> for #node_type {
             #[inline]
-            fn fmt(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
+            fn fmt(&self, f: &mut Formatter<'_, 'a>) {
                 let allocator = self.allocator;
                 #parent;
                 match self.inner {

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,9 +1,10 @@
-js compatibility: 729/759 (96.05%)
+js compatibility: 723/759 (95.26%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| js/arrows/call.js | 💥💥 | 61.89% |
 | js/arrows/comment.js | 💥💥 | 88.89% |
 | js/comments/15661.js | 💥💥 | 55.17% |
 | js/comments/dangling_for.js | 💥💥 | 22.22% |
@@ -23,8 +24,13 @@ js compatibility: 729/759 (96.05%)
 | js/if/expr_and_same_line_comments.js | 💥 | 97.73% |
 | js/if/if_comments.js | 💥 | 76.00% |
 | js/if/trailing_comment.js | 💥 | 91.43% |
-| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
+| js/last-argument-expansion/assignment-pattern.js | 💥 | 0.00% |
+| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
+| js/last-argument-expansion/empty-lines.js | 💥 | 14.29% |
+| js/last-argument-expansion/issue-10708.js | 💥 | 0.00% |
+| js/last-argument-expansion/issue-7518.js | 💥 | 0.00% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
+| js/preserve-line/parameter-list.js | 💥 | 91.08% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 571/602 (94.85%)
+ts compatibility: 570/602 (94.68%)
 
 # Failed
 
@@ -8,6 +8,7 @@ ts compatibility: 571/602 (94.85%)
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |
+| typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 77.78% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/as-const/as-const.ts | 💥 | 90.91% |


### PR DESCRIPTION
This PR is a follow-up to https://github.com/astral-sh/ruff/pull/6613. 

### Why can we do it

https://github.com/oxc-project/oxc/blob/622e000934d97ade5588f1e8cc3badde96e7328e/crates/oxc_formatter/src/formatter/diagnostics.rs#L11-L29


We can also make it non-failable since the entire program only has two points that can trigger an error, neither of which needs to interrupt the program immediately, and both can be improved to avoid making FormatResult everywhere



1. `FormatError::PoorLayout`

This error may occur only when handling call arguments, and only the first or the last argument is a `Function` or `ArrowFunctionExpression`. The error may be thrown during the formatting of them. I commented out the related logic of this in this PR and fixed it in #16093 to make it easier to review

2. `FormatError::InvalidDocument`

This is a printer error, but it may also occur only when we format `TaggedTemplateExpression`. There is a formatting logic that will format the template expression and print the IR immediately. If the IR we generated is incorrect, then the error will occur, but this is quite rare! So it's not worth using `FormatResult` everywhere to handle it. Currently, I just `unwrap` it. If we really need to handle it, we can store the error somewhere and return it after formatting in the future.

https://github.com/oxc-project/oxc/blob/78cd5910985cece594e74884717f77ad75347b8a/crates/oxc_formatter/src/write/template.rs#L602-L603

### Key changes

The most significant change is:

```diff
pub trait Format<'ast, T = ()> {
    - fn fmt(&self, f: &mut Formatter<'_, 'ast>) -> FormatResult<()>;
    + fn fmt(&self, f: &mut Formatter<'_, 'ast>);
}
```

All remaining changes to the order stem from the above change:

1. Remove all `FormatResult` usages
2. Remove all `?` operators that pair with the `format!` macro
4. Commented out `PoorLayout` related logic, which is going to be fixed in the #16093 

### Benefits

We don't need to deal with `Option`, and removing all `Option` handling makes the code cleaner and more readable. Of course, the performance improved a little bit


