### PR TITLE
release(apps): oxlint v1.30.0 && oxfmt v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_language_server"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "env_logger",
  "futures",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_linter"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "bitflags 2.10.0",
  "constcat",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "oxfmt"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bpaf",
  "cow-utils",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "oxlint"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "bpaf",
  "cow-utils",

--- a/apps/oxfmt/CHANGELOG.md
+++ b/apps/oxfmt/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.15.0] - 2025-11-24
+
+### 🚀 Features
+
+- f9a502c oxfmt: `oxfmt --lsp` support (#15765) (leaysgur)
+
 ## [0.14.0] - 2025-11-17
 
 ### 🚀 Features

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxfmt"
-version = "0.14.0"
+version = "0.15.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt-app",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/oxlint/CHANGELOG.md
+++ b/apps/oxlint/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.30.0] - 2025-11-24
+
+### 💥 BREAKING CHANGES
+
+- cbb27fd ast: [**BREAKING**] Add `TSGlobalDeclaration` type (#15712) (overlookmotel)
+
+### 🚀 Features
+
+- 0c1f82b linter/plugins: Add `tokens` property to `Program` (#16020) (overlookmotel)
+- 9e61beb linter/plugins: Implement `SourceCode#getFirstToken()` (#16002) (Arsh)
+- 9a548dd linter/plugins: Implement `SourceCode#getLastTokens()` (#16000) (Arsh)
+- 0b6cb11 linter/plugins: Implement `SourceCode#getFirstTokens()` (#15976) (Arsh)
+- 166781e linter/plugins: Implement `SourceCode#getTokenAfter()` (#15973) (Arsh)
+- 6ae232b linter: Expose type errors via tsgolint (#15917) (camc314)
+- 2bfdd26 linter/plugins: Implement `SourceCode#getTokensAfter()` (#15971) (Arsh)
+- 45fffc1 linter/plugins: Implement `SourceCode#getTokenBefore()` (#15956) (Arsh)
+- 776e473 linter/plugins: Implement `SourceCode#getTokensBefore()` (#15955) (Arsh)
+- 986cac1 linter/plugins: Token-related `SourceCode` APIs (TS ESLint implementation) (#15861) (Arsh)
+- 4b9d8d2 linter/type-aware: Include range with tsconfig diagnostics (#15916) (camc314)
+
+### 🐛 Bug Fixes
+
+- 2bd3cb6 apps, editors, napi: Fix `oxlint-disable` comments (#16014) (overlookmotel)
+- a8a2032 linter: Support missing `range` for internal diagnostics (#15964) (camc314)
+- 9fa9ef2 linter: Gracefully fail when using import plugin, large file counf and JS plugins (#15864) (camc314)
+- c027398 linter/plugins: Correct bindings package names glob in TSDown config (#15871) (overlookmotel)
+- 46bd6bd linter/plugins: Pin `@typescript-eslint/scope-manager` dependency (#15807) (overlookmotel)
+- fba31fa linter: Patch `@typescript-eslint/scope manager` (#15214) (Arsh)
+
+### ⚡ Performance
+
+- 024b48a linter/plugins: Lazy-load tokens parsing code (#16011) (overlookmotel)
+- 15365c9 linter/plugins: Reduce var assignments (#15953) (overlookmotel)
+- 84d1f4f linter/plugins: Downgrade some checks to debug-only (#15922) (overlookmotel)
+
+### 📚 Documentation
+
+- 6c72e84 linter: Use backticks for code elements across more rule diagnostics (#15958) (connorshea)
+- a63dad7 linter/plugins: Add comment (#15952) (overlookmotel)
+- db6a110 linter/plugins: Fix JSDoc comment (#15884) (overlookmotel)
+- fbf0fd4 linter/plugins: Add JSDoc comments to `Plugin` and `Rule` types (#15815) (overlookmotel)
+- ac5e4b5 linter/plugins: Add JSDoc comments and improve comments (#15814) (overlookmotel)
+
 ## [1.29.0] - 2025-11-17
 
 ### 🚀 Features

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxlint"
-version = "1.29.0"
+version = "1.30.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-app",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/crates/oxc_formatter/CHANGELOG.md
+++ b/crates/oxc_formatter/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.15.0] - 2025-11-24
+
+### 💥 BREAKING CHANGES
+
+- a937890 formatter: [**BREAKING**] Default to `lineWidth: 100` (#15933) (leaysgur)
+- 03d5f5a formatter/sort-imports: [**BREAKING**] Change default order to `natural` with `natord` crate (#15828) (leaysgur)
+- cbb27fd ast: [**BREAKING**] Add `TSGlobalDeclaration` type (#15712) (overlookmotel)
+
+### 🚀 Features
+
+- 7818e22 formatter/sort-imports: Support `options.groups` (#15831) (leaysgur)
+
+### 🐛 Bug Fixes
+
+- 4817486 formatter: Revert  `FormatElement::BestFitting` printing logic (#16028) (Dunqing)
+- 5562dd6 formatter: Incorrect formatting method chain with trailing comments (#16027) (Dunqing)
+- 6d14c8b formatter: Comments in export class decorators are printing incorrectly (#15897) (Dunqing)
+- 683c764 formatter: Correct a few minor mismatched typescript tests (#15894) (Dunqing)
+- c11cc07 formatter: Improve formatting for default type on type parameters (#15893) (Dunqing)
+- 0bff596 formatter: Handle JSX expresssion dangling comment (#15890) (leaysgur)
+- 16a9dc8 formatter: Inconsistent printing of class extends and interface extends (#15892) (Dunqing)
+- 300b496 formatter: Inconsistent CallExpression and NewExpression around member chain and logical expression (#15858) (Dunqing)
+
+### ⚡ Performance
+
+- 65174cc formatter: Reduce the size of `TextWidth` to 4 byte (#15827) (Dunqing)
+- 4fe3aac formatter: Use `ArenaVec` and `ArenaBox` (#15420) (Dunqing)
+
 ## [0.14.0] - 2025-11-17
 
 ### 🚀 Features

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_formatter"
-version = "0.14.0"
+version = "0.15.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_language_server/CHANGELOG.md
+++ b/crates/oxc_language_server/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.30.0] - 2025-11-24
+
+### 🐛 Bug Fixes
+
+- e4ba07f language_server: Always write to memory file system (#15975) (Sysix)
+- 619a226 oxlint/lsp: Don't register `textDocument/formatting` capability (#15882) (Sysix)
+
 ## [1.29.0] - 2025-11-17
 
 ### 🚀 Features

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_language_server"
-version = "1.29.0"
+version = "1.30.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_linter/CHANGELOG.md
+++ b/crates/oxc_linter/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.30.0] - 2025-11-24
+
+### 💥 BREAKING CHANGES
+
+- cbb27fd ast: [**BREAKING**] Add `TSGlobalDeclaration` type (#15712) (overlookmotel)
+
+### 🚀 Features
+
+- 72660f7 linter: Support auto generate config document for tuple lint option (#15904) (Duc Nghiem Xuan)
+- 6ae232b linter: Expose type errors via tsgolint (#15917) (camc314)
+- 595867a oxlint: Generate markdownDescription fields for oxlint JSON schema. (#15959) (connorshea)
+- a21f9e4 linter: Implement unicorn/prefer-bigint-literals rule (#15923) (Michiel Vrins)
+- 4b9d8d2 linter/type-aware: Include range with tsconfig diagnostics (#15916) (camc314)
+
+### 🐛 Bug Fixes
+
+- 81f5360 linter/prefer-number-properties: Get fixer to replace entire call expr (#15979) (camc314)
+- a8a2032 linter: Support missing `range` for internal diagnostics (#15964) (camc314)
+- 6ab1a20 linter: Fix no_useless_spread producing invalid syntax when removing empty object spreads (#15905) (camc314)
+- be4b6df linter: Unicorn/prefer-string-replace-all incorrectly escapes backslashes (#15901) (camc314)
+- b622ef8 linter: Fix `oxc/bad_array_method_on_arguments` rule behavior. (#15854) (connorshea)
+- aa06c3f linter: Recognize NewExpression as value context in no-unused-private-class-members (#15843) (camc314)
+- e89c5ba typescript/prefer-namespace-keyword: Skip nested `TSModuleDeclaration`s (#15806) (overlookmotel)
+- 646d020 linter/exhaustive-dependencies: Prevent is_callee_of_call_expr flag from leaking into nested expressions (#15832) (camc314)
+- 50307c1 linter/jest: Ignore `expect` identifier in argument position (#15785) (camc314)
+
+### ⚡ Performance
+
+- a49f704 linter/typescript: Avoid searching source text unless required (#15805) (overlookmotel)
+
+### 📚 Documentation
+
+- 9a0ed13 linter: Fix config option docs for eslint/operator-assignment rule. (#16030) (connorshea)
+- 0b18005 linter: Add config docs generation for rules with Regex arguments (#15978) (connorshea)
+- 48d18e0 linter: Improve diagnostic message for promise/catch-or-return rule (#15980) (connorshea)
+- 6c72e84 linter: Use backticks for code elements across more rule diagnostics (#15958) (connorshea)
+- 1487271 linter: Add config option docs for `jsdoc/require-param` and `jsdoc/require-returns` rules (#15857) (connorshea)
+- 9b7b083 linter: Fix error in `curly` `"all"` example (#15801) (camc314)
+- 65a3520 linter: Improve diagnostic for consistent-type-definitions rule. (#15752) (connorshea)
+
 ## [1.29.0] - 2025-11-17
 
 ### 🚀 Features

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_linter"
-version = "1.29.0"
+version = "1.30.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.30.0] - 2025-11-24
+
+### 🚀 Features
+
+- 5569317 vscode: Add quick actions to status bar tooltip (#15962) (Sysix)
+- 220d01e editor: Improve the status bar item for the VS Code extension by adding a tooltip. (#15819) (connorshea)
+
+### 🐛 Bug Fixes
+
+- 2bd3cb6 apps, editors, napi: Fix `oxlint-disable` comments (#16014) (overlookmotel)
+
+### 📚 Documentation
+
+- 81ea642 vscode: Use markdownDescription for better formatting in VSCode Settings (#15889) (connorshea)
+
+### 🛡️ Security
+
+- f9b9276 deps: Update dependency rolldown to v1.0.0-beta.51 (#15856) (renovate[bot])
+
 ## [1.29.0] - 2025-11-17
 
 ### 🚀 Features

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "oxc-vscode",
   "description": "oxc vs code extension",
   "license": "MIT",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "icon": "icon.png",
   "publisher": "oxc",
   "displayName": "Oxc",

--- a/npm/oxfmt/CHANGELOG.md
+++ b/npm/oxfmt/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.15.0] - 2025-11-24
+
+### 💥 BREAKING CHANGES
+
+- a937890 formatter: [**BREAKING**] Default to `lineWidth: 100` (#15933) (leaysgur)
+
+### 🚀 Features
+
+- 7818e22 formatter/sort-imports: Support `options.groups` (#15831) (leaysgur)
+
 ## [0.14.0] - 2025-11-17
 
 ### 🚀 Features

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxfmt",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "Formatter for the JavaScript Oxidation Compiler",
   "keywords": [],

--- a/npm/oxlint/CHANGELOG.md
+++ b/npm/oxlint/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [1.30.0] - 2025-11-24
+
+### 🚀 Features
+
+- 595867a oxlint: Generate markdownDescription fields for oxlint JSON schema. (#15959) (connorshea)
+
 ## [1.29.0] - 2025-11-17
 
 ### 🚀 Features

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "type": "module",
   "description": "Linter for the JavaScript Oxidation Compiler",
   "keywords": [],


### PR DESCRIPTION
# Oxlint
### 💥 BREAKING CHANGES

- cbb27fd ast: [**BREAKING**] Add `TSGlobalDeclaration` type (#15712) (overlookmotel)

### 🚀 Features

- 72660f7 linter: Support auto generate config document for tuple lint option (#15904) (Duc Nghiem Xuan)
- 0c1f82b linter/plugins: Add `tokens` property to `Program` (#16020) (overlookmotel)
- 9e61beb linter/plugins: Implement `SourceCode#getFirstToken()` (#16002) (Arsh)
- 9a548dd linter/plugins: Implement `SourceCode#getLastTokens()` (#16000) (Arsh)
- 0b6cb11 linter/plugins: Implement `SourceCode#getFirstTokens()` (#15976) (Arsh)
- 166781e linter/plugins: Implement `SourceCode#getTokenAfter()` (#15973) (Arsh)
- 6ae232b linter: Expose type errors via tsgolint (#15917) (camc314)
- 2bfdd26 linter/plugins: Implement `SourceCode#getTokensAfter()` (#15971) (Arsh)
- 45fffc1 linter/plugins: Implement `SourceCode#getTokenBefore()` (#15956) (Arsh)
- 776e473 linter/plugins: Implement `SourceCode#getTokensBefore()` (#15955) (Arsh)
- 595867a oxlint: Generate markdownDescription fields for oxlint JSON schema. (#15959) (connorshea)
- 5569317 vscode: Add quick actions to status bar tooltip (#15962) (Sysix)
- 986cac1 linter/plugins: Token-related `SourceCode` APIs (TS ESLint implementation) (#15861) (Arsh)
- a21f9e4 linter: Implement unicorn/prefer-bigint-literals rule (#15923) (Michiel Vrins)
- 4b9d8d2 linter/type-aware: Include range with tsconfig diagnostics (#15916) (camc314)
- 220d01e editor: Improve the status bar item for the VS Code extension by adding a tooltip. (#15819) (connorshea)

### 🐛 Bug Fixes

- 2bd3cb6 apps, editors, napi: Fix `oxlint-disable` comments (#16014) (overlookmotel)
- 81f5360 linter/prefer-number-properties: Get fixer to replace entire call expr (#15979) (camc314)
- e4ba07f language_server: Always write to memory file system (#15975) (Sysix)
- a8a2032 linter: Support missing `range` for internal diagnostics (#15964) (camc314)
- 619a226 oxlint/lsp: Don't register `textDocument/formatting` capability (#15882) (Sysix)
- 6ab1a20 linter: Fix no_useless_spread producing invalid syntax when removing empty object spreads (#15905) (camc314)
- be4b6df linter: Unicorn/prefer-string-replace-all incorrectly escapes backslashes (#15901) (camc314)
- 9fa9ef2 linter: Gracefully fail when using import plugin, large file counf and JS plugins (#15864) (camc314)
- c027398 linter/plugins: Correct bindings package names glob in TSDown config (#15871) (overlookmotel)
- b622ef8 linter: Fix `oxc/bad_array_method_on_arguments` rule behavior. (#15854) (connorshea)
- aa06c3f linter: Recognize NewExpression as value context in no-unused-private-class-members (#15843) (camc314)
- e89c5ba typescript/prefer-namespace-keyword: Skip nested `TSModuleDeclaration`s (#15806) (overlookmotel)
- 646d020 linter/exhaustive-dependencies: Prevent is_callee_of_call_expr flag from leaking into nested expressions (#15832) (camc314)
- 46bd6bd linter/plugins: Pin `@typescript-eslint/scope-manager` dependency (#15807) (overlookmotel)
- fba31fa linter: Patch `@typescript-eslint/scope manager` (#15214) (Arsh)
- 50307c1 linter/jest: Ignore `expect` identifier in argument position (#15785) (camc314)

### ⚡ Performance

- 024b48a linter/plugins: Lazy-load tokens parsing code (#16011) (overlookmotel)
- 15365c9 linter/plugins: Reduce var assignments (#15953) (overlookmotel)
- 84d1f4f linter/plugins: Downgrade some checks to debug-only (#15922) (overlookmotel)
- a49f704 linter/typescript: Avoid searching source text unless required (#15805) (overlookmotel)

### 📚 Documentation

- 9a0ed13 linter: Fix config option docs for eslint/operator-assignment rule. (#16030) (connorshea)
- 0b18005 linter: Add config docs generation for rules with Regex arguments (#15978) (connorshea)
- 48d18e0 linter: Improve diagnostic message for promise/catch-or-return rule (#15980) (connorshea)
- 6c72e84 linter: Use backticks for code elements across more rule diagnostics (#15958) (connorshea)
- a63dad7 linter/plugins: Add comment (#15952) (overlookmotel)
- 81ea642 vscode: Use markdownDescription for better formatting in VSCode Settings (#15889) (connorshea)
- db6a110 linter/plugins: Fix JSDoc comment (#15884) (overlookmotel)
- 1487271 linter: Add config option docs for `jsdoc/require-param` and `jsdoc/require-returns` rules (#15857) (connorshea)
- fbf0fd4 linter/plugins: Add JSDoc comments to `Plugin` and `Rule` types (#15815) (overlookmotel)
- ac5e4b5 linter/plugins: Add JSDoc comments and improve comments (#15814) (overlookmotel)
- 9b7b083 linter: Fix error in `curly` `"all"` example (#15801) (camc314)
- 65a3520 linter: Improve diagnostic for consistent-type-definitions rule. (#15752) (connorshea)

### 🛡️ Security

- f9b9276 deps: Update dependency rolldown to v1.0.0-beta.51 (#15856) (renovate[bot])
# Oxfmt
### 💥 BREAKING CHANGES

- a937890 formatter: [**BREAKING**] Default to `lineWidth: 100` (#15933) (leaysgur)
- 03d5f5a formatter/sort-imports: [**BREAKING**] Change default order to `natural` with `natord` crate (#15828) (leaysgur)
- cbb27fd ast: [**BREAKING**] Add `TSGlobalDeclaration` type (#15712) (overlookmotel)

### 🚀 Features

- 7818e22 formatter/sort-imports: Support `options.groups` (#15831) (leaysgur)
- f9a502c oxfmt: `oxfmt --lsp` support (#15765) (leaysgur)

### 🐛 Bug Fixes

- 4817486 formatter: Revert  `FormatElement::BestFitting` printing logic (#16028) (Dunqing)
- 5562dd6 formatter: Incorrect formatting method chain with trailing comments (#16027) (Dunqing)
- 6d14c8b formatter: Comments in export class decorators are printing incorrectly (#15897) (Dunqing)
- 683c764 formatter: Correct a few minor mismatched typescript tests (#15894) (Dunqing)
- c11cc07 formatter: Improve formatting for default type on type parameters (#15893) (Dunqing)
- 0bff596 formatter: Handle JSX expresssion dangling comment (#15890) (leaysgur)
- 16a9dc8 formatter: Inconsistent printing of class extends and interface extends (#15892) (Dunqing)
- 300b496 formatter: Inconsistent CallExpression and NewExpression around member chain and logical expression (#15858) (Dunqing)

### ⚡ Performance

- 65174cc formatter: Reduce the size of `TextWidth` to 4 byte (#15827) (Dunqing)
- 4fe3aac formatter: Use `ArenaVec` and `ArenaBox` (#15420) (Dunqing)