### PR TITLE
fix(traverse): remove `console.log` from build script

### DIFF
--- a/crates/oxc_traverse/scripts/lib/parse.mjs
+++ b/crates/oxc_traverse/scripts/lib/parse.mjs
@@ -363,7 +363,5 @@ function parseScopeArgsStr(argsStr, args, position) {
     position.throw(`Cannot parse scope args: '${argsStr}': ${err?.message || 'Unknown error'}`);
   }
 
-  console.log(args);
-
   return args;
 }


### PR DESCRIPTION
This must have been added for debugging and committed accidentally.