### PR TITLE
ci(lint): enable `no-console` rule

### DIFF
--- a/.github/scripts/check-conformance-changes.js
+++ b/.github/scripts/check-conformance-changes.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// oxlint-disable no-console
+
 /**
  * Check if conformance tests should run based on changed files.
  * Uses cargo tree to determine dependencies of oxc_coverage crate.

--- a/.github/scripts/generate-benchmark-matrix.js
+++ b/.github/scripts/generate-benchmark-matrix.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// oxlint-disable no-console
+
 /**
  * Generate a dynamic matrix for benchmark jobs based on affected components.
  * This script determines which benchmark components need to run based on changed files.

--- a/.github/scripts/get-changed-files.js
+++ b/.github/scripts/get-changed-files.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// oxlint-disable no-console
+
 /**
  * Get changed files from GitHub events (pull request or push).
  * This module provides a reusable function for detecting changed files.

--- a/.github/scripts/utils.js
+++ b/.github/scripts/utils.js
@@ -2,6 +2,8 @@
  * Common utilities for GitHub Actions scripts
  */
 
+// oxlint-disable no-console
+
 const { execSync } = require('child_process');
 
 /**

--- a/apps/oxfmt/scripts/build.js
+++ b/apps/oxfmt/scripts/build.js
@@ -1,3 +1,5 @@
+// oxlint-disable no-console
+
 import { execSync } from 'node:child_process';
 import { copyFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/apps/oxlint/scripts/build.ts
+++ b/apps/oxlint/scripts/build.ts
@@ -1,3 +1,5 @@
+// oxlint-disable no-console
+
 import { execSync } from 'node:child_process';
 import { copyFileSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/crates/oxc_traverse/scripts/build.mjs
+++ b/crates/oxc_traverse/scripts/build.mjs
@@ -44,6 +44,7 @@ await Promise.all([
 async function writeToFile(filename, code) {
   code = `${PREAMBLE}${code}`;
   const path = pathJoin(outputDirPath, filename);
+  // oxlint-disable-next-line no-console
   console.log('Writing:', path);
   await writeFile(path, code);
   await execAsync(`rustfmt ${JSON.stringify(path)}`);

--- a/napi/parser/example.js
+++ b/napi/parser/example.js
@@ -25,5 +25,5 @@ const file = args.positionals[0] ?? 'test.js';
 
 const code = fs.readFileSync(file, 'utf-8');
 const result = parseSync(file, code, args.values);
-// oxlint-disable-next-line typescript-eslint/no-misused-spread
+// oxlint-disable-next-line no-console, typescript-eslint/no-misused-spread
 console.dir({ ...result }, { depth: Infinity });

--- a/napi/parser/scripts/visitor-keys.js
+++ b/napi/parser/scripts/visitor-keys.js
@@ -1,4 +1,5 @@
 import { visitorKeys } from '@typescript-eslint/visitor-keys';
 
 const keys = Object.entries(visitorKeys).map(([name, keys]) => ({ name, keys }));
+// oxlint-disable-next-line no-console
 console.log(JSON.stringify(keys));

--- a/npm/oxfmt/scripts/generate-packages.js
+++ b/npm/oxfmt/scripts/generate-packages.js
@@ -1,5 +1,7 @@
 // Code copied from [Rome](https://github.com/rome/tools/blob/lsp/v0.28.0/npm/rome/scripts/generate-packages.mjs)
 
+// oxlint-disable no-console
+
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/npm/oxlint/scripts/generate-packages.js
+++ b/npm/oxlint/scripts/generate-packages.js
@@ -1,5 +1,7 @@
 // Code copied from [Rome](https://github.com/rome/tools/blob/lsp/v0.28.0/npm/rome/scripts/generate-packages.mjs)
 
+// oxlint-disable no-console
+
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -16,6 +16,9 @@
     "correctness": "error",
     "perf": "error"
   },
+  "rules": {
+    "no-console": "error"
+  },
   "overrides": [
     {
       "files": ["**/editors/vscode/tests/*.spec.ts"],

--- a/tasks/lint_rules/src/main.mjs
+++ b/tasks/lint_rules/src/main.mjs
@@ -1,3 +1,5 @@
+// oxlint-disable no-console
+
 import { parseArgs } from 'node:util';
 import { ALL_TARGET_PLUGINS, createESLintLinter, loadTargetPluginRules } from './eslint-rules.mjs';
 import { renderMarkdown } from './markdown-renderer.mjs';

--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -345,8 +345,12 @@ export const updateImplementedStatus = async (ruleEntries) => {
 
   for (const name of implementedRuleNames) {
     const rule = ruleEntries.get(name);
-    if (rule) rule.isImplemented = true;
-    else console.log(`👀 ${name} is implemented but not found in their rules`);
+    if (rule) {
+      rule.isImplemented = true;
+    } else {
+      // oxlint-disable-next-line no-console
+      console.log(`👀 ${name} is implemented but not found in their rules`);
+    }
   }
 };
 

--- a/tasks/transform_conformance/reporter.mjs
+++ b/tasks/transform_conformance/reporter.mjs
@@ -1,3 +1,5 @@
+// oxlint-disable no-console
+
 import { join as pathJoin } from 'path';
 import { JsonReporter } from 'vitest/reporters';
 


### PR DESCRIPTION
Enable `no-console` rule in our linting setup. Add `oxlint-disable` comments where we do want to log (in scripts).