### PR TITLE
refactor(napi): prefer `oxlint-disable` over `eslint-disable`

### DIFF
--- a/napi/minify/webcontainer-fallback.cjs
+++ b/napi/minify/webcontainer-fallback.cjs
@@ -10,7 +10,7 @@ if (!fs.existsSync(bindingEntry)) {
   fs.rmSync(baseDir, { recursive: true, force: true });
   fs.mkdirSync(baseDir, { recursive: true });
   const bindingPkg = `@oxc-minify/binding-wasm32-wasi@${version}`;
-  // eslint-disable-next-line: no-console
+  // oxlint-disable-next-line no-console
   console.log(`[oxc-minify] Downloading ${bindingPkg} on WebContainer...`);
   childProcess.execFileSync('pnpm', ['i', bindingPkg], {
     cwd: baseDir,

--- a/napi/parser/src-js/webcontainer-fallback.cjs
+++ b/napi/parser/src-js/webcontainer-fallback.cjs
@@ -10,7 +10,7 @@ if (!fs.existsSync(bindingEntry)) {
   fs.rmSync(baseDir, { recursive: true, force: true });
   fs.mkdirSync(baseDir, { recursive: true });
   const bindingPkg = `@oxc-parser/binding-wasm32-wasi@${version}`;
-  // eslint-disable-next-line: no-console
+  // oxlint-disable-next-line no-console
   console.log(`[oxc-parser] Downloading ${bindingPkg} on WebContainer...`);
   childProcess.execFileSync('pnpm', ['i', bindingPkg], {
     cwd: baseDir,

--- a/napi/transform/webcontainer-fallback.cjs
+++ b/napi/transform/webcontainer-fallback.cjs
@@ -10,7 +10,7 @@ if (!fs.existsSync(bindingEntry)) {
   fs.rmSync(baseDir, { recursive: true, force: true });
   fs.mkdirSync(baseDir, { recursive: true });
   const bindingPkg = `@oxc-transform/binding-wasm32-wasi@${version}`;
-  // eslint-disable-next-line: no-console
+  // oxlint-disable-next-line no-console
   console.log(`[oxc-transform] Downloading ${bindingPkg} on WebContainer...`);
   childProcess.execFileSync('pnpm', ['i', bindingPkg], {
     cwd: baseDir,


### PR DESCRIPTION
Nit. Use `// oxlint-disable` comments in our own code, instead of `// eslint-disable`.