### PR TITLE
refactor(linter/plugins): reimplement `isSpaceBetween()` `isSpaceBetweenTokens()` using tokens

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1727,8 +1727,22 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   // The "between" range
   let rangeStart: number, rangeEnd: number;
 
+  // Find the range between the two nodes/tokens.
+  //
   // Unlike other methods which require the user to pass the nodes in order of appearance,
-  // `isSpaceBetween()` is invariant over the sequence of the two nodes
+  // `isSpaceBetween()` is invariant over the sequence of the two nodes.
+  //
+  // 1 node/token can completely enclose another, but they can't *partially* overlap.
+  // ```
+  // Possible:
+  // |------------|
+  //    |------|
+  //
+  // Impossible:
+  // |------------|
+  //       |------------|
+  // ```
+  // We use that invariant to reduce this to a single branch.
   if (range1[0] < range2[0]) {
     rangeStart = range1[1];
     rangeEnd = range2[0];
@@ -1802,8 +1816,10 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
   // The "between" range
   let rangeStart: number, rangeEnd: number;
 
+  // Find the range between the two nodes/tokens.
   // Unlike other methods which require the user to pass the nodes in order of appearance,
-  // `isSpaceBetween()` is invariant over the sequence of the two nodes
+  // `isSpaceBetweenTokens()` is invariant over the sequence of the two nodes.
+  // See comment in `isSpaceBetween` about why this is a single branch.
   if (range1[0] < range2[0]) {
     rangeStart = range1[1];
     rangeEnd = range2[0];

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1710,11 +1710,6 @@ const JSX_WHITESPACE_REGEXP = /\s/u;
  * Checks for whitespace *between tokens*, not including whitespace *inside tokens*.
  * e.g. Returns `false` for `isSpaceBetween(x, y)` in `x+" "+y`.
  *
- * TODO: Implementation is not quite right at present.
- * We don't use tokens, so return `true` for `isSpaceBetween(x, y)` in `x+" "+y`, but should return `false`.
- * Note: `checkInsideOfJSXText === false` in ESLint's implementation of `sourceCode.isSpaceBetween`. hmmmmmm
- * https://github.com/eslint/eslint/blob/523c076866400670fb2192a3f55dbf7ad3469247/lib/languages/js/source-code/source-code.js#L182-L230
- *
  * @param first - The first node or token to check between.
  * @param second - The second node or token to check between.
  * @returns `true` if there is a whitespace character between
@@ -1789,8 +1784,6 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
  * e.g. Returns `true` for `isSpaceBetweenTokens(x, slash)` in `<X>a b</X>`.
  *
  * @deprecated Use `sourceCode.isSpaceBetween` instead.
- *
- * TODO: Implementation is not quite right at present, for same reasons as `SourceCode#isSpaceBetween`.
  *
  * @param first - The first node or token to check between.
  * @param second - The second node or token to check between.

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1751,9 +1751,9 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
     rangeStart = range2[1];
   }
 
-  // Binary search for the first token past `rangeStart`
+  // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
-  // the token will be the first token between the two nodes
+  // the token will be the first token between the two nodes.
   let tokenBetweenIndex = tokensWithCommentsLength;
   for (let lo = 0; lo < tokenBetweenIndex; ) {
     const mid = (lo + tokenBetweenIndex) >> 1;
@@ -1824,9 +1824,9 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
     rangeStart = range2[1];
   }
 
-  // Binary search for the first token past `rangeStart`
+  // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
-  // the token will be the first token between the two nodes
+  // the token will be the first token between the two nodes.
   let tokenBetweenIndex = tokensWithCommentsLength;
   for (let lo = 0; lo < tokenBetweenIndex; ) {
     const mid = (lo + tokenBetweenIndex) >> 1;

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1740,13 +1740,13 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   //       |------------|
   // ```
   // We use that invariant to reduce this to a single branch.
-  let rangeStart: number, rangeEnd: number;
-  if (range1[0] < range2[0]) {
+  let rangeStart: number = range1[0],
+    rangeEnd: number = range2[0];
+  if (rangeStart < rangeEnd) {
     rangeStart = range1[1];
-    rangeEnd = range2[0];
   } else {
+    rangeEnd = rangeStart;
     rangeStart = range2[1];
-    rangeEnd = range1[0];
   }
 
   // Binary search for the first token past `rangeStart`
@@ -1811,13 +1811,13 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
   // Unlike other methods which require the user to pass the nodes in order of appearance,
   // `isSpaceBetweenTokens()` is invariant over the sequence of the two nodes.
   // See comment in `isSpaceBetween` about why this is a single branch.
-  let rangeStart: number, rangeEnd: number;
-  if (range1[0] < range2[0]) {
+  let rangeStart: number = range1[0],
+    rangeEnd: number = range2[0];
+  if (rangeStart < rangeEnd) {
     rangeStart = range1[1];
-    rangeEnd = range2[0];
   } else {
+    rangeEnd = rangeStart;
     rangeStart = range2[1];
-    rangeEnd = range1[0];
   }
 
   // Binary search for the first token past `rangeStart`

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1716,8 +1716,10 @@ const JSX_WHITESPACE_REGEXP = /\s/u;
  *   any of the tokens found between the two given nodes or tokens.
  */
 export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean {
-  if (tokens === null) initTokens();
-  if (tokensWithComments === null) initTokensWithComments();
+  if (tokensWithComments === null) {
+    if (tokens === null) initTokens();
+    initTokensWithComments();
+  }
   debugAssertIsNonNull(tokensWithComments);
 
   const tokensWithCommentsLength = tokensWithComments.length,
@@ -1799,8 +1801,10 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
  *   any of the tokens found between the two given nodes or tokens.
  */
 export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): boolean {
-  if (tokens === null) initTokens();
-  if (tokensWithComments === null) initTokensWithComments();
+  if (tokensWithComments === null) {
+    if (tokens === null) initTokens();
+    initTokensWithComments();
+  }
   debugAssertIsNonNull(tokensWithComments);
 
   const tokensWithCommentsLength = tokensWithComments.length,

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1724,9 +1724,6 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
     range1 = first.range,
     range2 = second.range;
 
-  // The "between" range
-  let rangeStart: number, rangeEnd: number;
-
   // Find the range between the two nodes/tokens.
   //
   // Unlike other methods which require the user to pass the nodes in order of appearance,
@@ -1743,6 +1740,7 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   //       |------------|
   // ```
   // We use that invariant to reduce this to a single branch.
+  let rangeStart: number, rangeEnd: number;
   if (range1[0] < range2[0]) {
     rangeStart = range1[1];
     rangeEnd = range2[0];
@@ -1813,13 +1811,11 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
     range1 = first.range,
     range2 = second.range;
 
-  // The "between" range
-  let rangeStart: number, rangeEnd: number;
-
   // Find the range between the two nodes/tokens.
   // Unlike other methods which require the user to pass the nodes in order of appearance,
   // `isSpaceBetweenTokens()` is invariant over the sequence of the two nodes.
   // See comment in `isSpaceBetween` about why this is a single branch.
+  let rangeStart: number, rangeEnd: number;
   if (range1[0] < range2[0]) {
     rangeStart = range1[1];
     rangeEnd = range2[0];

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1714,7 +1714,7 @@ const WHITESPACE_REGEXP = /\s/;
  *
  * TODO: Implementation is not quite right at present.
  * We don't use tokens, so return `true` for `isSpaceBetween(x, y)` in `x+" "+y`, but should return `false`.
- * Note: `checkInsideOfJSXText === false` in ESLint's implementation of `sourceCode.isSpaceBetween`.
+ * Note: `checkInsideOfJSXText === false` in ESLint's implementation of `sourceCode.isSpaceBetween`. hmmmmmm
  * https://github.com/eslint/eslint/blob/523c076866400670fb2192a3f55dbf7ad3469247/lib/languages/js/source-code/source-code.js#L182-L230
  *
  * @param nodeOrToken1 - The first node or token to check between.

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1770,13 +1770,9 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
     const { range } = tokensWithComments[tokenBetweenIndex];
     const tokenStart = range[0];
     // The first token of the later node should undergo the check in the second branch
-    if (tokenStart > rangeEnd) {
-      break;
-    } else if (tokenStart !== lastTokenEnd) {
-      return true;
-    } else {
-      lastTokenEnd = range[1];
-    }
+    if (tokenStart > rangeEnd) break;
+    if (tokenStart !== lastTokenEnd) return true;
+    lastTokenEnd = range[1];
   }
 
   return false;
@@ -1846,16 +1842,11 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
       tokenStart = range[0];
 
     // The first token of the later node should undergo the check in the second branch
-    if (tokenStart > rangeEnd) {
-      break;
-    } else if (
-      tokenStart !== lastTokenEnd ||
-      (type === "JSXText" && JSX_WHITESPACE_REGEXP.test(value))
-    ) {
+    if (tokenStart > rangeEnd) break;
+    if (tokenStart !== lastTokenEnd || (type === "JSXText" && JSX_WHITESPACE_REGEXP.test(value))) {
       return true;
-    } else {
-      lastTokenEnd = range[1];
     }
+    lastTokenEnd = range[1];
   }
 
   return false;

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1722,8 +1722,7 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   }
   debugAssertIsNonNull(tokensWithComments);
 
-  const tokensWithCommentsLength = tokensWithComments.length,
-    range1 = first.range,
+  const range1 = first.range,
     range2 = second.range;
 
   // Find the range between the two nodes/tokens.
@@ -1754,6 +1753,7 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
   // the token will be the first token between the two nodes.
+  const tokensWithCommentsLength = tokensWithComments.length;
   let tokenBetweenIndex = tokensWithCommentsLength;
   for (let lo = 0; lo < tokenBetweenIndex; ) {
     const mid = (lo + tokenBetweenIndex) >> 1;
@@ -1807,8 +1807,7 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
   }
   debugAssertIsNonNull(tokensWithComments);
 
-  const tokensWithCommentsLength = tokensWithComments.length,
-    range1 = first.range,
+  const range1 = first.range,
     range2 = second.range;
 
   // Find the range between the two nodes/tokens.
@@ -1827,6 +1826,7 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
   // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
   // the token will be the first token between the two nodes.
+  const tokensWithCommentsLength = tokensWithComments.length;
   let tokenBetweenIndex = tokensWithCommentsLength;
   for (let lo = 0; lo < tokenBetweenIndex; ) {
     const mid = (lo + tokenBetweenIndex) >> 1;

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -1842,12 +1842,16 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
     tokenBetweenIndex < tokensWithCommentsLength;
     tokenBetweenIndex++
   ) {
-    const { range, type, value } = tokensWithComments[tokenBetweenIndex],
+    const token = tokensWithComments[tokenBetweenIndex],
+      { range } = token,
       tokenStart = range[0];
 
     // The first token of the later node should undergo the check in the second branch
     if (tokenStart > rangeEnd) break;
-    if (tokenStart !== lastTokenEnd || (type === "JSXText" && JSX_WHITESPACE_REGEXP.test(value))) {
+    if (
+      tokenStart !== lastTokenEnd ||
+      (token.type === "JSXText" && JSX_WHITESPACE_REGEXP.test(token.value))
+    ) {
       return true;
     }
     lastTokenEnd = range[1];

--- a/apps/oxlint/test/fixtures/isSpaceBetween/files/index.js
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/files/index.js
@@ -21,6 +21,5 @@ newlineAfter
 // prettier-ignore
 nested = 7 + 8;
 
-// We should return `false` for `isSpaceBetween(beforeString, afterString)`, but we currently return `true`
 // prettier-ignore
 beforeString," ",afterString;

--- a/apps/oxlint/test/fixtures/isSpaceBetween/files/index.jsx
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/files/index.jsx
@@ -1,9 +1,7 @@
 <Foo>aaa</Foo>;
 
-// We should return `false` for `isSpaceBetween(openingElement, closingElement)`, but we currently return `true`
 <Bar>b c</Bar>;
 
-// We should return `false` for `isSpaceBetween(openingElement, closingElement)`, but we currently return `true`
 // prettier-ignore
 <Qux>d
 e</Qux>;

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -168,13 +168,13 @@
     `----
 
   x test-plugin(is-space-between):
-  | isSpaceBetween(beforeString, afterString): true
-  | isSpaceBetweenTokens(beforeString, afterString): true
-  | isSpaceBetween(afterString, beforeString): true
-  | isSpaceBetweenTokens(afterString, beforeString): true
-    ,-[files/index.js:26:1]
- 25 | // prettier-ignore
- 26 | beforeString," ",afterString;
+  | isSpaceBetween(beforeString, afterString): false
+  | isSpaceBetweenTokens(beforeString, afterString): false
+  | isSpaceBetween(afterString, beforeString): false
+  | isSpaceBetweenTokens(afterString, beforeString): false
+    ,-[files/index.js:25:1]
+ 24 | // prettier-ignore
+ 25 | beforeString," ",afterString;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
@@ -190,26 +190,26 @@
    `----
 
   x test-plugin(is-space-between):
-  | isSpaceBetween(openingElement, closingElement): true
+  | isSpaceBetween(openingElement, closingElement): false
   | isSpaceBetweenTokens(openingElement, closingElement): true
-  | isSpaceBetween(closingElement, openingElement): true
+  | isSpaceBetween(closingElement, openingElement): false
   | isSpaceBetweenTokens(closingElement, openingElement): true
-   ,-[files/index.jsx:4:1]
- 3 | // We should return `false` for `isSpaceBetween(openingElement, closingElement)`, but we currently return `true`
- 4 | <Bar>b c</Bar>;
+   ,-[files/index.jsx:3:1]
+ 2 | 
+ 3 | <Bar>b c</Bar>;
    : ^^^^^^^^^^^^^^
- 5 | 
+ 4 | 
    `----
 
   x test-plugin(is-space-between):
-  | isSpaceBetween(openingElement, closingElement): true
+  | isSpaceBetween(openingElement, closingElement): false
   | isSpaceBetweenTokens(openingElement, closingElement): true
-  | isSpaceBetween(closingElement, openingElement): true
+  | isSpaceBetween(closingElement, openingElement): false
   | isSpaceBetweenTokens(closingElement, openingElement): true
-   ,-[files/index.jsx:8:1]
- 7 |     // prettier-ignore
- 8 | ,-> <Qux>d
- 9 | `-> e</Qux>;
+   ,-[files/index.jsx:6:1]
+ 5 |     // prettier-ignore
+ 6 | ,-> <Qux>d
+ 7 | `-> e</Qux>;
    `----
 
 Found 0 warnings and 13 errors.

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, vi, expect, beforeEach } from "vitest";
-import { isSpaceBetween } from "../src-js/plugins/tokens.js";
+import { isSpaceBetween, isSpaceBetweenTokens } from "../src-js/plugins/tokens.js";
 import { resetSourceAndAst } from "../src-js/plugins/source_code";
 import { parse } from "@typescript-eslint/typescript-estree";
 import type { Node } from "../src-js/plugins/types.js";
@@ -22,39 +22,65 @@ beforeEach(() => {
   sourceText = null;
 });
 
-// https://github.com/eslint/eslint/blob/df5566f826d9f5740546e473aa6876b1f7d2f12c/tests/lib/languages/js/source-code/source-code.js#L721-L745
-describe("should return true when there is at least one whitespace character between two nodes", () => {
-  for (const [code, expected] of [
-    ["let foo = bar;let baz = qux;", false],
-    ["let foo = bar;/**/let baz = qux;", false],
-    ["let foo = bar;/* */let baz = qux;", false],
-    ["let foo = bar; let baz = qux;", true],
-    ["let foo = bar; /**/let baz = qux;", true],
-    ["let foo = bar; /* */let baz = qux;", true],
-    ["let foo = bar;/**/ let baz = qux;", true],
-    ["let foo = bar;/* */ let baz = qux;", true],
-    ["let foo = bar; /**/ let baz = qux;", true],
-    ["let foo = bar; /* */ let baz = qux;", true],
-    ["let foo = bar;\tlet baz = qux;", true],
-    ["let foo = bar;\t/**/let baz = qux;", true],
-    ["let foo = bar;\t/* */let baz = qux;", true],
-    ["let foo = bar;/**/\tlet baz = qux;", true],
-    ["let foo = bar;/* */\tlet baz = qux;", true],
-    ["let foo = bar;\t/**/\tlet baz = qux;", true],
-    ["let foo = bar;\t/* */\tlet baz = qux;", true],
-    ["let foo = bar;\nlet baz = qux;", true],
-    ["let foo = bar;\n/**/let baz = qux;", true],
-    ["let foo = bar;\n/* */let baz = qux;", true],
-    ["let foo = bar;/**/\nlet baz = qux;", true],
-    ["let foo = bar;/* */\nlet baz = qux;", true],
-    ["let foo = bar;\n/**/\nlet baz = qux;", true],
-    ["let foo = bar;\n/* */\nlet baz = qux;", true],
-    ["let foo = 1;let foo2 = 2; let foo3 = 3;", true],
-  ] satisfies [string, boolean][]) {
-    it(`should return ${expected} for ${code}`, () => {
-      const { body } = parse(code, { range: true, sourceType: "module" });
-      sourceText = code;
-      expect(isSpaceBetween(body[0] as any as Node, body.at(-1) as any as Node)).toBe(expected);
+describe("isSpaceBetween()", () => {
+  // https://github.com/eslint/eslint/blob/df5566f826d9f5740546e473aa6876b1f7d2f12c/tests/lib/languages/js/source-code/source-code.js#L721-L745
+  describe("should return true when there is at least one whitespace character between two nodes", () => {
+    for (const [code, expected] of [
+      ["let foo = bar;let baz = qux;", false],
+      ["let foo = bar;/**/let baz = qux;", false],
+      ["let foo = bar;/* */let baz = qux;", false],
+      ["let foo = bar; let baz = qux;", true],
+      ["let foo = bar; /**/let baz = qux;", true],
+      ["let foo = bar; /* */let baz = qux;", true],
+      ["let foo = bar;/**/ let baz = qux;", true],
+      ["let foo = bar;/* */ let baz = qux;", true],
+      ["let foo = bar; /**/ let baz = qux;", true],
+      ["let foo = bar; /* */ let baz = qux;", true],
+      ["let foo = bar;\tlet baz = qux;", true],
+      ["let foo = bar;\t/**/let baz = qux;", true],
+      ["let foo = bar;\t/* */let baz = qux;", true],
+      ["let foo = bar;/**/\tlet baz = qux;", true],
+      ["let foo = bar;/* */\tlet baz = qux;", true],
+      ["let foo = bar;\t/**/\tlet baz = qux;", true],
+      ["let foo = bar;\t/* */\tlet baz = qux;", true],
+      ["let foo = bar;\nlet baz = qux;", true],
+      ["let foo = bar;\n/**/let baz = qux;", true],
+      ["let foo = bar;\n/* */let baz = qux;", true],
+      ["let foo = bar;/**/\nlet baz = qux;", true],
+      ["let foo = bar;/* */\nlet baz = qux;", true],
+      ["let foo = bar;\n/**/\nlet baz = qux;", true],
+      ["let foo = bar;\n/* */\nlet baz = qux;", true],
+      ["let foo = 1;let foo2 = 2; let foo3 = 3;", true],
+    ] satisfies [string, boolean][]) {
+      it(`should return ${expected} for ${code}`, () => {
+        const { body } = parse(code, { range: true, sourceType: "module" });
+        sourceText = code;
+        expect(isSpaceBetween(body[0] as any as Node, body.at(-1) as any as Node)).toBe(expected);
+      });
+    }
+  });
+});
+
+describe("isSpaceBetweenTokens()", () => {
+  // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/source-code.js#L2166-L2206
+  it("JSXText tokens that contain only whitespaces should be handled as space", () => {
+    sourceText = "let jsx = <div>\n   {content}\n</div>";
+    const ast = parse(sourceText, {
+      range: true,
+      sourceType: "module",
+      jsx: true,
     });
-  }
+    // @ts-expect-error
+    const jsx = ast.body[0].declarations[0].init;
+    const interpolation = jsx.children[1];
+
+    expect(isSpaceBetweenTokens(jsx.openingElement, interpolation)).toBe(true);
+
+    expect(isSpaceBetweenTokens(interpolation, jsx.closingElement)).toBe(true);
+
+    // Reversed order
+    expect(isSpaceBetweenTokens(interpolation, jsx.openingElement)).toBe(true);
+
+    expect(isSpaceBetweenTokens(jsx.closingElement, interpolation)).toBe(true);
+  });
 });

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -4,13 +4,16 @@ import { resetSourceAndAst } from "../src-js/plugins/source_code";
 import { parse } from "@typescript-eslint/typescript-estree";
 import type { Node } from "../src-js/plugins/types.js";
 
-let sourceText!: string;
+let sourceText: string | null = null;
 
 vi.mock("../src-js/plugins/source_code.ts", async (importOriginal) => {
   const original: any = await importOriginal();
   return {
     ...original,
-    get sourceText() {
+    get sourceText(): string {
+      if (sourceText === null) {
+        throw new Error("Must set `sourceText` before calling token methods");
+      }
       return sourceText;
     },
   };
@@ -18,7 +21,6 @@ vi.mock("../src-js/plugins/source_code.ts", async (importOriginal) => {
 
 beforeEach(() => {
   resetSourceAndAst();
-  // @ts-expect-error
   sourceText = null;
 });
 

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -83,4 +83,59 @@ describe("isSpaceBetweenTokens()", () => {
 
     expect(isSpaceBetweenTokens(jsx.closingElement, interpolation)).toBe(true);
   });
+
+  // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/source-code.js#L2208-L2233
+  it("JSXText tokens that contain both letters and whitespaces should be handled as space", () => {
+    sourceText = "let jsx = <div>\n   Hello\n</div>";
+    const ast = parse(sourceText, {
+      range: true,
+      sourceType: "module",
+      jsx: true,
+    });
+    // @ts-expect-error
+    const jsx = ast.body[0].declarations[0].init;
+
+    expect(isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement)).toBe(true);
+
+    // Reversed order
+    expect(isSpaceBetweenTokens(jsx.closingElement, jsx.openingElement)).toBe(true);
+  });
+
+  // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/source-code.js#L2235-L2261
+  it("JSXText tokens that contain only letters should NOT be handled as space", () => {
+    sourceText = "let jsx = <div>Hello</div>";
+    const ast = parse(sourceText, {
+      range: true,
+      sourceType: "module",
+      jsx: true,
+    });
+    // @ts-expect-error
+    const jsx = ast.body[0].declarations[0].init;
+
+    expect(isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement)).toBe(false);
+
+    // Reversed order
+    expect(isSpaceBetweenTokens(jsx.closingElement, jsx.openingElement)).toBe(false);
+  });
+
+  // https://github.com/eslint/eslint/blob/v9.39.1/tests/lib/languages/js/source-code/source-code.js#L2263-L2300
+  it("should return false either of the arguments' location is inside the other one", () => {
+    sourceText = "let foo = bar;";
+    const ast = parse(sourceText, {
+        range: true,
+        tokens: true,
+        sourceType: "module",
+        jsx: true,
+      }),
+      body = ast.body as any as Node[],
+      tokens = ast.tokens;
+
+    expect(isSpaceBetweenTokens(tokens[0], body[0])).toBe(false);
+
+    expect(isSpaceBetweenTokens(tokens.at(-1)!, body[0])).toBe(false);
+
+    expect(isSpaceBetweenTokens(body[0], tokens[0])).toBe(false);
+
+    expect(isSpaceBetweenTokens(body[0], tokens.at(-1)!)).toBe(false);
+  });
 });

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi, expect, beforeEach } from "vitest";
 import { isSpaceBetween, isSpaceBetweenTokens } from "../src-js/plugins/tokens.js";
 import { resetSourceAndAst } from "../src-js/plugins/source_code";
 import { parse } from "@typescript-eslint/typescript-estree";
+
 import type { Node } from "../src-js/plugins/types.js";
 
 let sourceText: string | null = null;

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -7,7 +7,7 @@ import type { Node } from "../src-js/plugins/types.js";
 let sourceText: string | null = null;
 
 vi.mock("../src-js/plugins/source_code.ts", async (importOriginal) => {
-  const original: any = await importOriginal();
+  const original: Record<string, unknown> = await importOriginal();
   return {
     ...original,
     get sourceText(): string {
@@ -55,9 +55,10 @@ describe("isSpaceBetween()", () => {
       ["let foo = 1;let foo2 = 2; let foo3 = 3;", true],
     ] satisfies [string, boolean][]) {
       it(`should return ${expected} for ${code}`, () => {
-        const { body } = parse(code, { range: true, sourceType: "module" });
         sourceText = code;
-        expect(isSpaceBetween(body[0] as any as Node, body.at(-1) as any as Node)).toBe(expected);
+        const ast = parse(sourceText, { range: true, sourceType: "module" }),
+          body = ast.body as unknown as Node[];
+        expect(isSpaceBetween(body[0]!, body.at(-1)!)).toBe(expected);
       });
     }
   });
@@ -129,7 +130,7 @@ describe("isSpaceBetweenTokens()", () => {
         sourceType: "module",
         jsx: true,
       }),
-      body = ast.body as any as Node[],
+      body = ast.body as unknown as Node[],
       tokens = ast.tokens;
 
     expect(isSpaceBetweenTokens(tokens[0], body[0])).toBe(false);

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, vi, expect, beforeEach } from "vitest";
+import { isSpaceBetween } from "../src-js/plugins/tokens.js";
+import { resetSourceAndAst } from "../src-js/plugins/source_code";
+import { parse } from "@typescript-eslint/typescript-estree";
+import type { Node } from "../src-js/plugins/types.js";
+
+let sourceText!: string;
+
+vi.mock("../src-js/plugins/source_code.ts", async (importOriginal) => {
+  const original: any = await importOriginal();
+  return {
+    ...original,
+    get sourceText() {
+      return sourceText;
+    },
+  };
+});
+
+beforeEach(() => {
+  resetSourceAndAst();
+  // @ts-expect-error
+  sourceText = null;
+});
+
+// https://github.com/eslint/eslint/blob/df5566f826d9f5740546e473aa6876b1f7d2f12c/tests/lib/languages/js/source-code/source-code.js#L721-L745
+describe("should return true when there is at least one whitespace character between two nodes", () => {
+  for (const [code, expected] of [
+    ["let foo = bar;let baz = qux;", false],
+    ["let foo = bar;/**/let baz = qux;", false],
+    ["let foo = bar;/* */let baz = qux;", false],
+    ["let foo = bar; let baz = qux;", true],
+    ["let foo = bar; /**/let baz = qux;", true],
+    ["let foo = bar; /* */let baz = qux;", true],
+    ["let foo = bar;/**/ let baz = qux;", true],
+    ["let foo = bar;/* */ let baz = qux;", true],
+    ["let foo = bar; /**/ let baz = qux;", true],
+    ["let foo = bar; /* */ let baz = qux;", true],
+    ["let foo = bar;\tlet baz = qux;", true],
+    ["let foo = bar;\t/**/let baz = qux;", true],
+    ["let foo = bar;\t/* */let baz = qux;", true],
+    ["let foo = bar;/**/\tlet baz = qux;", true],
+    ["let foo = bar;/* */\tlet baz = qux;", true],
+    ["let foo = bar;\t/**/\tlet baz = qux;", true],
+    ["let foo = bar;\t/* */\tlet baz = qux;", true],
+    ["let foo = bar;\nlet baz = qux;", true],
+    ["let foo = bar;\n/**/let baz = qux;", true],
+    ["let foo = bar;\n/* */let baz = qux;", true],
+    ["let foo = bar;/**/\nlet baz = qux;", true],
+    ["let foo = bar;/* */\nlet baz = qux;", true],
+    ["let foo = bar;\n/**/\nlet baz = qux;", true],
+    ["let foo = bar;\n/* */\nlet baz = qux;", true],
+    ["let foo = 1;let foo2 = 2; let foo3 = 3;", true],
+  ] satisfies [string, boolean][]) {
+    it(`should return ${expected} for ${code}`, () => {
+      const { body } = parse(code, { range: true, sourceType: "module" });
+      sourceText = code;
+      expect(isSpaceBetween(body[0] as any as Node, body.at(-1) as any as Node)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
- Follow up to https://github.com/oxc-project/oxc/pull/15498 and https://github.com/oxc-project/oxc/pull/15861
- Note: JSX special case (as part of the `isSpaceBetweenTokens()` method) is being removed in ESLint v10 (see [eslint/eslint#20137](https://github.com/eslint/eslint/pull/20137/files#diff-e85eaebdcf6af45c06572019cbd900cff91518c789049c3bd0e8724c18645ab0))

### Tasks:
- [x] Token-based reimplementation of `isSpaceBetween()`
- [x] Token-based reimplementation of `isSpaceBetweenTokens()`
- [x] Pass existing tests from #15498
- [x] New tests for JS syntax
- [x] New tests for JSX syntax