### PR TITLE
refactor(napi/parser): remove unused `oxlint-disable` comment

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -57,8 +57,6 @@ async function runCaseInWorker(type, props) {
     if (!runCase) ({ runCase } = await import('./parse-raw-worker.ts'));
 
     type |= TEST_TYPE_PRETTY;
-    // Ref: https://github.com/oxc-project/oxc/pull/15785
-    // oxlint-disable-next-line
     await runCase({ type, props }, expect);
     throw new Error('Failed on worker but unexpectedly passed on main thread');
   }


### PR DESCRIPTION
This comment was previously needed, due to a bug in Oxlint, but that bug is now fixed.