### PR TITLE
refactor(vscode): add `ToolInterface.getBinary`

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -53,8 +53,18 @@ export async function activate(context: ExtensionContext) {
   configService.onConfigChange = async function onConfigChange(event) {
     await linter.onConfigChange(event, configService, statusBarItemHandler);
   };
+  const binaryPath = await linter.getBinary(context, outputChannel, configService);
 
-  await linter.activate(context, outputChannel, configService, statusBarItemHandler);
+  // For the linter this should never happen, but just in case.
+  if (!binaryPath) {
+    statusBarItemHandler.setColorAndIcon('statusBarItem.errorBackground', 'error');
+    statusBarItemHandler.updateToolTooltip('linter', 'Error: No valid oxc language server binary found.');
+    statusBarItemHandler.show();
+    outputChannel.error('No valid oxc language server binary found.');
+    return;
+  }
+
+  await linter.activate(context, binaryPath, outputChannel, configService, statusBarItemHandler);
   // Show status bar item after activation
   statusBarItemHandler.show();
 }

--- a/editors/vscode/client/tools/ToolInterface.ts
+++ b/editors/vscode/client/tools/ToolInterface.ts
@@ -4,10 +4,19 @@ import StatusBarItemHandler from '../StatusBarItemHandler';
 
 export default interface ToolInterface {
   /**
+   * Gets the path to the tool's language server binary (if applicable).
+   */
+  getBinary(
+    context: ExtensionContext,
+    outputChannel: LogOutputChannel,
+    configService: ConfigService,
+  ): Promise<string | undefined>;
+  /**
    * Activates the tool and initializes any necessary resources.
    */
   activate(
     context: ExtensionContext,
+    binaryPath: string,
     outputChannel: LogOutputChannel,
     configService: ConfigService,
     statusBarItemHandler: StatusBarItemHandler,


### PR DESCRIPTION
The extension needs to check if the binaries are the same. Should probably never happen, but my first tests are targeting the same server and fails because of the same `oxc.X` command from the two language server.