### PR TITLE
chore(vscode): introduce `oxc.path.oxlint` and deprecate `oxc.path.server`

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -62,7 +62,7 @@ export class ConfigService implements IDisposable {
   }
 
   public getUserServerBinPath(): string | undefined {
-    let bin = this.vsCodeConfig.binPath;
+    let bin = this.vsCodeConfig.binPathOxlint;
     if (!bin) {
       return;
     }

--- a/editors/vscode/client/VSCodeConfig.ts
+++ b/editors/vscode/client/VSCodeConfig.ts
@@ -4,7 +4,7 @@ import { ConfigService } from "./ConfigService";
 export class VSCodeConfig implements VSCodeConfigInterface {
   private _enable!: boolean;
   private _trace!: TraceLevel;
-  private _binPath: string | undefined;
+  private _binPathOxlint: string | undefined;
   private _nodePath: string | undefined;
   private _requireConfig!: boolean;
 
@@ -17,9 +17,14 @@ export class VSCodeConfig implements VSCodeConfigInterface {
   }
 
   public refresh(): void {
+    let binPathOxlint = this.configuration.get<string>("path.oxlint");
+    // fallback to deprecated 'path.server' setting
+    if (!binPathOxlint) {
+      binPathOxlint = this.configuration.get<string>("path.server");
+    }
     this._enable = this.configuration.get<boolean>("enable") ?? true;
     this._trace = this.configuration.get<TraceLevel>("trace.server") || "off";
-    this._binPath = this.configuration.get<string>("path.server");
+    this._binPathOxlint = binPathOxlint;
     this._nodePath = this.configuration.get<string>("path.node");
     this._requireConfig = this.configuration.get<boolean>("requireConfig") ?? false;
   }
@@ -42,13 +47,13 @@ export class VSCodeConfig implements VSCodeConfigInterface {
     return this.configuration.update("trace.server", value);
   }
 
-  get binPath(): string | undefined {
-    return this._binPath;
+  get binPathOxlint(): string | undefined {
+    return this._binPathOxlint;
   }
 
-  updateBinPath(value: string | undefined): PromiseLike<void> {
-    this._binPath = value;
-    return this.configuration.update("path.server", value);
+  updateBinPathOxlint(value: string | undefined): PromiseLike<void> {
+    this._binPathOxlint = value;
+    return this.configuration.update("path.oxlint", value);
   }
 
   get nodePath(): string | undefined {
@@ -90,11 +95,11 @@ interface VSCodeConfigInterface {
    */
   trace: TraceLevel;
   /**
-   * Path to LSP binary
-   * `oxc.path.server`
+   * Path to the `oxlint` binary
+   * `oxc.path.oxlint`
    * @default undefined
    */
-  binPath: string | undefined;
+  binPathOxlint: string | undefined;
 
   /**
    * Path to Node.js

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -195,7 +195,14 @@
         "oxc.path.server": {
           "type": "string",
           "scope": "window",
-          "markdownDescription": "Path to Oxc language server binary. Mostly for testing the language server."
+          "markdownDescription": "Path to Oxc language server binary. Mostly for testing the language server.",
+          "deprecated": true,
+          "markdownDeprecationMessage": "Use `oxc.path.oxlint` instead, targeting the `oxlint` binary."
+        },
+        "oxc.path.oxlint": {
+          "type": "string",
+          "scope": "window",
+          "markdownDescription": "Path to an Oxc linter binary. Will be used by the language server instead of the bundled one."
         },
         "oxc.path.node": {
           "type": "string",

--- a/editors/vscode/tests/VSCodeConfig.spec.ts
+++ b/editors/vscode/tests/VSCodeConfig.spec.ts
@@ -6,7 +6,7 @@ import { testSingleFolderMode } from './test-helpers.js';
 const conf = workspace.getConfiguration('oxc');
 
 suite('VSCodeConfig', () => {
-  const keys = ['enable', 'requireConfig', 'trace.server', 'path.server', 'path.node'];
+  const keys = ['enable', 'requireConfig', 'trace.server', 'path.server', 'path.oxlint', 'path.node'];
   setup(async () => {
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
@@ -21,8 +21,15 @@ suite('VSCodeConfig', () => {
     strictEqual(config.enable, true);
     strictEqual(config.requireConfig, false);
     strictEqual(config.trace, 'off');
-    strictEqual(config.binPath, '');
+    strictEqual(config.binPathOxlint, '');
     strictEqual(config.nodePath, '');
+  });
+
+  testSingleFolderMode('deprecated values are respected', async () => {
+    await conf.update('path.server', './deprecatedBinary');
+    const config = new VSCodeConfig();
+
+    strictEqual(config.binPathOxlint, './deprecatedBinary');
   });
 
   testSingleFolderMode('updating values updates the workspace configuration', async () => {
@@ -32,7 +39,7 @@ suite('VSCodeConfig', () => {
       config.updateEnable(false),
       config.updateRequireConfig(true),
       config.updateTrace('messages'),
-      config.updateBinPath('./binary'),
+      config.updateBinPathOxlint('./binary'),
       config.updateNodePath('./node'),
     ]);
 
@@ -41,7 +48,7 @@ suite('VSCodeConfig', () => {
     strictEqual(wsConfig.get('enable'), false);
     strictEqual(wsConfig.get('requireConfig'), true);
     strictEqual(wsConfig.get('trace.server'), 'messages');
-    strictEqual(wsConfig.get('path.server'), './binary');
+    strictEqual(wsConfig.get('path.oxlint'), './binary');
     strictEqual(wsConfig.get('path.node'), './node');
   });
 });


### PR DESCRIPTION
Preparing to remove the language server binary, renaming the setting.

related https://github.com/oxc-project/oxc/issues/15740