### PR TITLE
test(linter/plugins): use subpath imports in tests

### DIFF
--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from '../../../dist/index.js';
+import type { Plugin, Rule } from '#oxlint';
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from '../../../dist/index.js';
+import type { Plugin, Rule } from '#oxlint';
 
 const rule: Rule = {
   create(context) {


### PR DESCRIPTION
#15920 altered `import`s in tests to use `'#eslint'` subpath. Make recently-added tests follow the same pattern.