### PR TITLE
refactor(vscode): move restart & toggle lsp server to `linter.ts`

### DIFF
--- a/editors/vscode/client/commands.ts
+++ b/editors/vscode/client/commands.ts
@@ -1,9 +1,9 @@
 const commandPrefix = "oxc";
 
 export const enum OxcCommands {
-  RestartServer = `${commandPrefix}.restartServer`,
   ShowOutputChannel = `${commandPrefix}.showOutputChannel`,
-  ToggleEnable = `${commandPrefix}.toggleEnable`,
   // only for linter.ts usage
+  RestartServer = `${commandPrefix}.restartServer`,
+  ToggleEnable = `${commandPrefix}.toggleEnable`,
   ApplyAllFixesFile = `${commandPrefix}.applyAllFixesFile`,
 }

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -15,18 +15,8 @@ export async function activate(context: ExtensionContext) {
     log: true,
   });
 
-  const restartCommand = commands.registerCommand(OxcCommands.RestartServer, async () => {
-    await linter.restartClient();
-  });
-
   const showOutputCommand = commands.registerCommand(OxcCommands.ShowOutputChannel, () => {
     outputChannel.show();
-  });
-
-  const toggleEnable = commands.registerCommand(OxcCommands.ToggleEnable, async () => {
-    await configService.vsCodeConfig.updateEnable(!configService.vsCodeConfig.enable);
-
-    await linter.toggleClient(configService);
   });
 
   const onDidChangeWorkspaceFoldersDispose = workspace.onDidChangeWorkspaceFolders(
@@ -43,9 +33,7 @@ export async function activate(context: ExtensionContext) {
   const statusBarItemHandler = new StatusBarItemHandler(context.extension.packageJSON?.version);
 
   context.subscriptions.push(
-    restartCommand,
     showOutputCommand,
-    toggleEnable,
     configService,
     outputChannel,
     onDidChangeWorkspaceFoldersDispose,

--- a/editors/vscode/client/tools/ToolInterface.ts
+++ b/editors/vscode/client/tools/ToolInterface.ts
@@ -28,16 +28,6 @@ export default interface ToolInterface {
   deactivate(): Promise<void>;
 
   /**
-   * Toggles the tool's active state based on configuration.
-   */
-  toggleClient(configService: ConfigService): Promise<void>;
-
-  /**
-   * Restart the tool.
-   */
-  restartClient(): Promise<void>;
-
-  /**
    * Handles configuration changes.
    */
   onConfigChange(

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -78,6 +78,16 @@ export default class LinterTool implements ToolInterface {
       ? (await workspace.findFiles(`**/.oxlintrc.json`, "**/node_modules/**", 1)).length > 0
       : true;
 
+    const restartCommand = commands.registerCommand(OxcCommands.RestartServer, async () => {
+      await this.restartClient();
+    });
+
+    const toggleEnable = commands.registerCommand(OxcCommands.ToggleEnable, async () => {
+      await configService.vsCodeConfig.updateEnable(!configService.vsCodeConfig.enable);
+
+      await this.toggleClient(configService);
+    });
+
     const applyAllFixesFile = commands.registerCommand(OxcCommands.ApplyAllFixesFile, async () => {
       if (!this.client) {
         window.showErrorMessage("oxc client not found");
@@ -101,7 +111,7 @@ export default class LinterTool implements ToolInterface {
       await this.client.sendRequest(ExecuteCommandRequest.type, params);
     });
 
-    context.subscriptions.push(applyAllFixesFile);
+    context.subscriptions.push(restartCommand, toggleEnable, applyAllFixesFile);
 
     const run: Executable = runExecutable(binaryPath, configService.vsCodeConfig.nodePath);
     const serverOptions: ServerOptions = {

--- a/editors/vscode/tests/commands.spec.ts
+++ b/editors/vscode/tests/commands.spec.ts
@@ -36,8 +36,8 @@ suite('commands', () => {
     ];
 
     deepStrictEqual([
-      'oxc.restartServer',
       'oxc.showOutputChannel',
+      'oxc.restartServer',
       'oxc.toggleEnable',
       'oxc.applyAllFixesFile', // TODO: only if linter tests are enabled
       ...extraCommands,


### PR DESCRIPTION
Add separate commands for linter server restart and the future formatter server.