### PR TITLE
fix(language_server): append rule to existing disable comment instead of creating duplicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "oxc_formatter",
  "oxc_linter",
  "oxc_parser",
+ "oxc_span",
  "papaya",
  "rustc-hash",
  "serde",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -43,6 +43,7 @@ tower-lsp-server = { workspace = true, features = ["proposed"] }
 
 [dev-dependencies]
 insta = { workspace = true }
+oxc_span = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
 
 [features]

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -67,15 +67,15 @@ Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
         start: Position {
-            line: 9,
-            character: 0,
+            line: 8,
+            character: 2,
         },
         end: Position {
-            line: 9,
-            character: 0,
+            line: 8,
+            character: 52,
         },
     },
-    new_text: "// oxlint-disable-next-line no-console\n",
+    new_text: " oxlint-disable-next-line no-debugger, no-for-loop, no-console",
 }
 
 


### PR DESCRIPTION
When using the 'Disable rule for this line' quick fix, if there's already a disable-next-line comment on the line above, append the new rule to the existing comment using comma separation instead of creating a new duplicate comment.

Fixes #16060