### PR TITLE
refactor(linter): Remove unnecessary methods on Tester

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -532,7 +532,5 @@ fn test() {
         (r#"<Input type="image" />"#, None, None),
     ];
 
-    Tester::new(AltText::NAME, AltText::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(AltText::NAME, AltText::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -383,7 +383,6 @@ fn test() {
     ];
 
     Tester::new(AriaUnsupportedElements::NAME, AriaUnsupportedElements::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -182,7 +182,5 @@ fn test() {
         (r#"<h1><CustomInput type="hidden" /></h1>"#, None, Some(settings())),
     ];
 
-    Tester::new(HeadingHasContent::NAME, HeadingHasContent::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(HeadingHasContent::NAME, HeadingHasContent::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -139,7 +139,5 @@ fn test() {
         ("<HTMLTop />", None, Some(settings())),
     ];
 
-    Tester::new(HtmlHasLang::NAME, HtmlHasLang::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(HtmlHasLang::NAME, HtmlHasLang::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -162,7 +162,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(IframeHasTitle::NAME, IframeHasTitle::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(IframeHasTitle::NAME, IframeHasTitle::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -292,7 +292,5 @@ fn test() {
         (r"<Image alt='Word2' />;", Some(array()), None),
     ];
 
-    Tester::new(ImgRedundantAlt::NAME, ImgRedundantAlt::PLUGIN, pass, fail)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(ImgRedundantAlt::NAME, ImgRedundantAlt::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -111,8 +111,5 @@ fn test() {
         (r"<h1 scope='bar' />;", r"<h1  />;", Some(settings())),
     ];
 
-    Tester::new(Scope::NAME, Scope::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .with_jsx_a11y_plugin(true)
-        .test_and_snapshot();
+    Tester::new(Scope::NAME, Scope::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -234,7 +234,5 @@ fn test() {
 			     "#,
     ];
 
-    Tester::new(GoogleFontDisplay::NAME, GoogleFontDisplay::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
-        .test_and_snapshot();
+    Tester::new(GoogleFontDisplay::NAME, GoogleFontDisplay::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -119,6 +119,5 @@ fn test() {
     ];
 
     Tester::new(GoogleFontPreconnect::NAME, GoogleFontPreconnect::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -165,7 +165,7 @@ fn test() {
 
     let pass = vec![
         r#"import Script from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <Script id="test-script">
@@ -174,7 +174,7 @@ fn test() {
 			        )
 			      }"#,
         r#"import Script from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <Script
@@ -186,14 +186,14 @@ fn test() {
 			        )
 			      }"#,
         r#"import Script from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <Script src="https://example.com" />
 			        )
 			      }"#,
         r#"import MyScript from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <MyScript id="test-script">
@@ -202,7 +202,7 @@ fn test() {
 			        )
 			      }"#,
         r#"import MyScript from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <MyScript
@@ -214,7 +214,7 @@ fn test() {
 			        )
 			      }"#,
         r#"import Script from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <Script {...{ strategy: "lazyOnload" }} id={"test-script"}>
@@ -223,7 +223,7 @@ fn test() {
 			        )
 			      }"#,
         r#"import Script from 'next/script';
-			
+
 			      export default function TestPage() {
 			        return (
 			          <Script {...{ strategy: "lazyOnload", id: "test-script" }}>
@@ -244,7 +244,7 @@ fn test() {
 
     let fail = vec![
         r"import Script from 'next/script';
-			
+
 			        export default function TestPage() {
 			          return (
 			            <Script>
@@ -253,7 +253,7 @@ fn test() {
 			          )
 			        }",
         r"import Script from 'next/script';
-			
+
 			        export default function TestPage() {
 			          return (
 			            <Script
@@ -264,7 +264,7 @@ fn test() {
 			          )
 			        }",
         r"import MyScript from 'next/script';
-			
+
 			        export default function TestPage() {
 			          return (
 			            <MyScript>
@@ -273,7 +273,7 @@ fn test() {
 			          )
 			        }",
         r"import MyScript from 'next/script';
-			
+
 			        export default function TestPage() {
 			          return (
 			            <MyScript
@@ -285,7 +285,5 @@ fn test() {
 			        }",
     ];
 
-    Tester::new(InlineScriptId::NAME, InlineScriptId::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
-        .test_and_snapshot();
+    Tester::new(InlineScriptId::NAME, InlineScriptId::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -169,7 +169,7 @@ fn test() {
 
     let pass = vec![
         r#"import Script from 'next/script'
-			
+
 			      export class Blah extends Head {
 			        render() {
 			          return (
@@ -184,7 +184,7 @@ fn test() {
 			                  window.dataLayer = window.dataLayer || [];
 			                  function gtag(){window.dataLayer.push(arguments);}
 			                  gtag('js', new Date());
-			
+
 			                  gtag('config', 'GA_MEASUREMENT_ID');
 			                `}
 			              </Script>
@@ -193,7 +193,7 @@ fn test() {
 			        }
 			    }"#,
         r#"import Script from 'next/script'
-			
+
 			      export class Blah extends Head {
 			        render() {
 			          return (
@@ -204,7 +204,7 @@ fn test() {
 			                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 			                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-			
+
 			                    ga('create', 'UA-XXXXX-Y', 'auto');
 			                    ga('send', 'pageview');
 			                })`}
@@ -214,7 +214,7 @@ fn test() {
 			        }
 			    }"#,
         r#"import Script from 'next/script'
-			
+
 			        export class Blah extends Head {
 			        render() {
 			            return (
@@ -298,7 +298,7 @@ fn test() {
 			                        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 			                        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-			
+
 			                        ga('create', 'UA-XXXXX-Y', 'auto');
 			                        ga('send', 'pageview');
 			                    `,
@@ -336,7 +336,7 @@ fn test() {
 			                gtag('config', 'UA-148481588-2');`,
 			            };
 			          }
-			
+
 			          render() {
 			            return (
 			              <div>
@@ -349,7 +349,5 @@ fn test() {
 			      }",
     ];
 
-    Tester::new(NextScriptForGa::NAME, NextScriptForGa::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
-        .test_and_snapshot();
+    Tester::new(NextScriptForGa::NAME, NextScriptForGa::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -85,7 +85,7 @@ fn test() {
     let pass = vec![
         r"
 			      let myModule = {};
-			
+
 			      export default function MyComponent() {
 			        return <></>
 			      }
@@ -95,7 +95,7 @@ fn test() {
     let fail = vec![
         r"
 			      let module = {};
-			
+
 			      export default function MyComponent() {
 			        return <></>
 			      }
@@ -103,6 +103,5 @@ fn test() {
     ];
 
     Tester::new(NoAssignModuleVariable::NAME, NoAssignModuleVariable::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -165,89 +165,88 @@ fn test() {
 
     let pass = vec![
         r"
-			    export default async function MyComponent() {
-			      return <></>
-			    }
-			    ",
+                export default async function MyComponent() {
+                  return <></>
+                }
+                ",
         r#"
-			    "use client"
-			
-			    export default async function myFunction() {
-			      return ''
-			    }
-			    "#,
+                "use client"
+
+                export default async function myFunction() {
+                  return ''
+                }
+                "#,
         r"
-			    async function MyComponent() {
-			      return <></>
-			    }
-			
-			    export default MyComponent
-			    ",
+                async function MyComponent() {
+                  return <></>
+                }
+
+                export default MyComponent
+                ",
         r#"
-			    "use client"
-			
-			    async function myFunction() {
-			      return ''
-			    }
-			
-			    export default myFunction
-			    "#,
+                "use client"
+
+                async function myFunction() {
+                  return ''
+                }
+
+                export default myFunction
+                "#,
         r#"
-			    "use client"
-			
-			    const myFunction = () => {
-			      return ''
-			    }
-			
-			    export default myFunction
-			    "#,
+                "use client"
+
+                const myFunction = () => {
+                  return ''
+                }
+
+                export default myFunction
+                "#,
     ];
 
     let fail = vec![
         r#"
-			      "use client"
-			
-			      export default async function MyComponent() {
-			        return <></>
-			      }
-			      "#,
+                  "use client"
+
+                  export default async function MyComponent() {
+                    return <></>
+                  }
+                  "#,
         r#"
-			      "use client"
-			
-			      export default async function MyFunction() {
-			        return ''
-			      }
-			      "#,
+                  "use client"
+
+                  export default async function MyFunction() {
+                    return ''
+                  }
+                  "#,
         r#"
-			      "use client"
-			
-			      async function MyComponent() {
-			        return <></>
-			      }
-			
-			      export default MyComponent
-			      "#,
+                  "use client"
+
+                  async function MyComponent() {
+                    return <></>
+                  }
+
+                  export default MyComponent
+                  "#,
         r#"
-			      "use client"
-			
-			      async function MyFunction() {
-			        return ''
-			      }
-			
-			      export default MyFunction
-			      "#,
+                  "use client"
+
+                  async function MyFunction() {
+                    return ''
+                  }
+
+                  export default MyFunction
+                  "#,
         r#"
-			      "use client"
-			
-			      const MyFunction = async () => {
-			        return '123'
-			      }
-			
-			      export default MyFunction
-			      "#,
+                  "use client"
+
+                  const MyFunction = async () => {
+                    return '123'
+                  }
+
+                  export default MyFunction
+                  "#,
     ];
 
     Tester::new(NoAsyncClientComponent::NAME, NoAsyncClientComponent::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -195,7 +195,5 @@ fn test() {
 			      </div>"#,
     ];
 
-    Tester::new(NoCssTags::NAME, NoCssTags::PLUGIN, pass, fail)
-        .with_nextjs_plugin(true)
-        .test_and_snapshot();
+    Tester::new(NoCssTags::NAME, NoCssTags::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -124,6 +124,5 @@ fn test() {
 
     Tester::new(NoExportsAssign::NAME, NoExportsAssign::PLUGIN, pass, fail)
         .expect_fix(fix)
-        .with_node_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -93,7 +93,5 @@ fn test() {
         r"const Foo = () => { const Icon = <svg />; return (<IconButton icon={Icon} />) }",
     ];
 
-    Tester::new(JsxNoJsxAsProp::NAME, JsxNoJsxAsProp::PLUGIN, pass, fail)
-        .with_react_perf_plugin(true)
-        .test_and_snapshot();
+    Tester::new(JsxNoJsxAsProp::NAME, JsxNoJsxAsProp::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -142,6 +142,5 @@ fn test() {
     ];
 
     Tester::new(JsxNoNewArrayAsProp::NAME, JsxNoNewArrayAsProp::PLUGIN, pass, fail)
-        .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -189,6 +189,5 @@ fn test() {
     ];
 
     Tester::new(JsxNoNewFunctionAsProp::NAME, JsxNoNewFunctionAsProp::PLUGIN, pass, fail)
-        .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -165,6 +165,5 @@ fn test() {
     ];
 
     Tester::new(JsxNoNewObjectAsProp::NAME, JsxNoNewObjectAsProp::PLUGIN, pass, fail)
-        .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/nextjs_no_assign_module_variable.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_assign_module_variable.snap
@@ -6,6 +6,6 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │                   let module = {};
    ·                       ──────
- 3 │             
+ 3 │ 
    ╰────
   help: See https://nextjs.org/docs/messages/no-assign-module-variable

--- a/crates/oxc_linter/src/snapshots/nextjs_no_async_client_component.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_async_client_component.snap
@@ -2,8 +2,8 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
-   ╭─[no_async_client_component.tsx:4:40]
- 3 │             
+   ╭─[no_async_client_component.tsx:4:49]
+ 3 │ 
  4 │                   export default async function MyComponent() {
    ·                                                 ───────────
  5 │                     return <></>
@@ -11,8 +11,8 @@ source: crates/oxc_linter/src/tester.rs
   help: See: https://nextjs.org/docs/messages/no-async-client-component
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
-   ╭─[no_async_client_component.tsx:4:40]
- 3 │             
+   ╭─[no_async_client_component.tsx:4:49]
+ 3 │ 
  4 │                   export default async function MyFunction() {
    ·                                                 ──────────
  5 │                     return ''
@@ -20,8 +20,8 @@ source: crates/oxc_linter/src/tester.rs
   help: See: https://nextjs.org/docs/messages/no-async-client-component
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
-   ╭─[no_async_client_component.tsx:4:25]
- 3 │             
+   ╭─[no_async_client_component.tsx:4:34]
+ 3 │ 
  4 │                   async function MyComponent() {
    ·                                  ───────────
  5 │                     return <></>
@@ -29,8 +29,8 @@ source: crates/oxc_linter/src/tester.rs
   help: See: https://nextjs.org/docs/messages/no-async-client-component
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
-   ╭─[no_async_client_component.tsx:4:25]
- 3 │             
+   ╭─[no_async_client_component.tsx:4:34]
+ 3 │ 
  4 │                   async function MyFunction() {
    ·                                  ──────────
  5 │                     return ''
@@ -38,8 +38,8 @@ source: crates/oxc_linter/src/tester.rs
   help: See: https://nextjs.org/docs/messages/no-async-client-component
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
-   ╭─[no_async_client_component.tsx:4:16]
- 3 │             
+   ╭─[no_async_client_component.tsx:4:25]
+ 3 │ 
  4 │                   const MyFunction = async () => {
    ·                         ──────────
  5 │                     return '123'

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -321,26 +321,6 @@ impl Tester {
         self
     }
 
-    pub fn with_jsx_a11y_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::JSX_A11Y, yes);
-        self
-    }
-
-    pub fn with_nextjs_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::NEXTJS, yes);
-        self
-    }
-
-    pub fn with_react_perf_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::REACT_PERF, yes);
-        self
-    }
-
-    pub fn with_node_plugin(mut self, yes: bool) -> Self {
-        self.plugins.set(LintPlugins::NODE, yes);
-        self
-    }
-
     /// Add cases that should fix problems found in the source code.
     ///
     /// These cases will fail if no fixes are produced or if the fixed source


### PR DESCRIPTION
These `with_x_plugin` methods are not necessary for any of these plugins, and so can be safely removed. They're not used consistently anyway.