### PR TITLE
fix(oxfmt): Ignore unsupported options

### DIFF
--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing,
     EmbeddedLanguageFormatting, Expand, FormatOptions, IndentStyle, IndentWidth, LineEnding,
-    LineWidth, OperatorPosition, QuoteProperties, QuoteStyle, Semicolons, SortImports, SortOrder,
-    TrailingCommas,
+    LineWidth, QuoteProperties, QuoteStyle, Semicolons, SortImports, SortOrder, TrailingCommas,
 };
 
 /// Configuration options for the formatter.
@@ -59,12 +58,7 @@ pub struct Oxfmtrc {
     /// Put each attribute on a new line in JSX. (Default: false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub single_attribute_per_line: Option<bool>,
-    /// Experimental: Position of operators in expressions. (Default: "end")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental_operator_position: Option<OperatorPositionConfig>,
-    // TODO: Experimental: Use curious ternaries which move `?` after the condition. (Default: false)
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub experimental_ternaries: Option<bool>,
+
     /// Control whether formats quoted code embedded in the file. (Default: "auto")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedded_language_formatting: Option<EmbeddedLanguageFormattingConfig>,
@@ -121,14 +115,6 @@ pub enum ObjectWrapConfig {
     Preserve,
     Collapse,
     Always,
-}
-
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum OperatorPositionConfig {
-    Start,
-    #[default]
-    End,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema)]
@@ -351,13 +337,9 @@ impl Oxfmtrc {
             };
         }
 
+        // Not yet supported options:
         // [Prettier] experimentalOperatorPosition: "start" | "end"
-        if let Some(position) = self.experimental_operator_position {
-            options.experimental_operator_position = match position {
-                OperatorPositionConfig::Start => OperatorPosition::Start,
-                OperatorPositionConfig::End => OperatorPosition::End,
-            };
-        }
+        // [Prettier] experimentalTernaries: boolean
 
         if let Some(embedded_language_formatting) = self.embedded_language_formatting {
             options.embedded_language_formatting = match embedded_language_formatting {

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -55,17 +55,6 @@ expression: json
         }
       ]
     },
-    "experimentalOperatorPosition": {
-      "description": "Experimental: Position of operators in expressions. (Default: \"end\")",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/OperatorPositionConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "experimentalSortImports": {
       "description": "Experimental: Sort import statements. Disabled by default.",
       "anyOf": [
@@ -205,13 +194,6 @@ expression: json
         "preserve",
         "collapse",
         "always"
-      ]
-    },
-    "OperatorPositionConfig": {
-      "type": "string",
-      "enum": [
-        "start",
-        "end"
       ]
     },
     "QuotePropsConfig": {

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -51,17 +51,6 @@
         }
       ]
     },
-    "experimentalOperatorPosition": {
-      "description": "Experimental: Position of operators in expressions. (Default: \"end\")",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/OperatorPositionConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "experimentalSortImports": {
       "description": "Experimental: Sort import statements. Disabled by default.",
       "anyOf": [
@@ -201,13 +190,6 @@
         "preserve",
         "collapse",
         "always"
-      ]
-    },
-    "OperatorPositionConfig": {
-      "type": "string",
-      "enum": [
-        "start",
-        "end"
       ]
     },
     "QuotePropsConfig": {


### PR DESCRIPTION
Fixes #15930

Previously `experimentalOperatorPosition` was suggested in `.oxfmtrc` completion. But it is not actually used(not implemented yet).

As a first step, just ignore it. + Report error => #16088