### PR TITLE
chore(editor): Improve VS Code extension dev experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,16 @@
     {
       "type": "extensionHost",
       "request": "launch",
-      "name": "Launch Client",
+      "name": "Launch VS Code Extension",
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"],
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/editors/vscode/dist/*.js"],
       "env": {
-        "SERVER_PATH_DEV": "${workspaceRoot}/editors/vscode/target/debug/oxc_language_server",
+        "SERVER_PATH_DEV": "${workspaceFolder}/editors/vscode/target/debug/oxc_language_server",
         "RUST_LOG": "debug"
-      }
+      },
+      "preLaunchTask": "pnpm build:dev"
     },
     {
       "type": "lldb",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,6 +71,19 @@
         "panel": "dedicated",
         "reveal": "never"
       }
+    },
+    {
+      "type": "shell",
+      "command": "cd ./editors/vscode && pnpm build:dev",
+      "windows": {
+        "command": "cd ./editors/vscode; pnpm build:dev"
+      },
+      "label": "pnpm build:dev",
+      "group": "build",
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "always"
+      }
     }
   ]
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -246,6 +246,7 @@
   "scripts": {
     "preinstall": "[ -f icon.png ] || curl https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/square.png --output icon.png",
     "build": "pnpm run server:build:release && pnpm run compile && pnpm run package",
+    "build:dev": "pnpm run server:build:debug && pnpm run compile && pnpm run package",
     "compile": "rolldown -c rolldown.config.ts",
     "watch": "pnpm run compile --watch",
     "package": "vsce package --no-dependencies -o oxc_language_server.vsix",


### PR DESCRIPTION
Improve the experience of launching the VS Code extension for development purposes. Now it will build it for you automatically when launching the editor extension, rather than you needing to build it yourself.

We could also maybe keep a launch setup that doesn't do this alongside this one, if others prefer using that workflow.

See this video for the workflow of building+launching this from the debug menu in VS Code:

https://github.com/user-attachments/assets/738368d4-88fd-424b-ab96-4b1cfed38491