### PR TITLE
fix(oxfmt): Fix JS-ish file detection

### DIFF
--- a/apps/oxfmt/test/__snapshots__/extensions.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/extensions.test.ts.snap
@@ -9,7 +9,7 @@ exit code: 0
 Checking formatting...
 
 All matched files use the correct format.
-Finished in <variable>ms on 11 files using 1 threads.
+Finished in <variable>ms on 12 files using 1 threads.
 --- STDERR ---------
 
 --------------------"

--- a/apps/oxfmt/test/fixtures/extensions/Jakefile
+++ b/apps/oxfmt/test/fixtures/extensions/Jakefile
@@ -1,2 +1,2 @@
-desc("Jake build task")
-task("default", function() {})
+desc("Jake build task");
+task("default", function () {});


### PR DESCRIPTION
```sh
npx prettier --support-info | jq '.languages[] | select(.name == "JavaScript")'
```
↓
```jsonc
  // ...
  "extensions": [
    ".js",
    "._js",
    ".bones",
    ".cjs",
    ".es",
    ".es6",
    ".gs",
    ".jake",
    ".javascript",
    ".jsb",
    ".jscad",
    ".jsfl",
    ".jslib",
    ".jsm",
    ".jspre",
    ".jss",
    ".mjs",
    ".njs",
    ".pac",
    ".sjs",
    ".ssjs",
    ".xsjs",
    ".xsjslib",
    ".start.frag",
    ".end.frag",
    ".wxs"
  ],
  "filenames": [
    "Jakefile",
    "start.frag",
    "end.frag"
  ],
```