### PR TITLE
fix(formatter): handle poor layout for grouped call arguments

### DIFF
--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -7,7 +7,9 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Comments, FormatElement, Formatter, SourceText, VecBuffer, format_element,
+        Comments, FormatElement, Formatter, SourceText, VecBuffer,
+        buffer::RemoveSoftLinesBuffer,
+        format_element,
         prelude::{
             FormatElements, Tag, empty_line, expand_parent, format_once, format_with, group,
             soft_block_indent, soft_line_break_or_space, space,
@@ -634,7 +636,13 @@ fn write_grouped_arguments<'a>(
             let is_grouped_argument = (group_layout.is_grouped_first() && index == 0)
                 || (group_layout.is_grouped_last() && index == last_index);
 
-            let format_argument = format_once(|f| {
+            // We have to get the lines before the argument has been formatted, because it relies on
+            // the comments before the argument. After formatting, the comments might marked as printed,
+            // which would lead to a wrong line count.
+            let lines_before = f.source_text().get_lines_before(argument.span(), f.comments());
+            let comma = (last_index != index).then_some(",");
+
+            let interned = f.intern(&format_once(|f| {
                 if is_grouped_argument {
                     match argument.as_ast_nodes() {
                         AstNodes::Function(function)
@@ -643,40 +651,40 @@ fn write_grouped_arguments<'a>(
                                     || function_has_only_simple_parameters(&function.params)) =>
                         {
                             has_cached = true;
-                            return FormatFunction::new_with_options(
-                                function,
-                                FormatFunctionOptions {
-                                    cache_mode: FunctionCacheMode::Cache,
-                                    ..FormatFunctionOptions::default()
-                                },
-                            )
-                            .fmt(f);
+                            return write!(
+                                f,
+                                [
+                                    FormatFunction::new_with_options(
+                                        function,
+                                        FormatFunctionOptions {
+                                            cache_mode: FunctionCacheMode::Cache,
+                                            ..FormatFunctionOptions::default()
+                                        },
+                                    ),
+                                    comma
+                                ]
+                            );
                         }
                         AstNodes::ArrowFunctionExpression(arrow) => {
                             has_cached = true;
-                            return FormatJsArrowFunctionExpression::new_with_options(
-                                arrow,
-                                FormatJsArrowFunctionExpressionOptions {
-                                    cache_mode: FunctionCacheMode::Cache,
-                                    ..FormatJsArrowFunctionExpressionOptions::default()
-                                },
-                            )
-                            .fmt(f);
+                            return write!(
+                                f,
+                                [
+                                    FormatJsArrowFunctionExpression::new_with_options(
+                                        arrow,
+                                        FormatJsArrowFunctionExpressionOptions {
+                                            cache_mode: FunctionCacheMode::Cache,
+                                            ..FormatJsArrowFunctionExpressionOptions::default()
+                                        },
+                                    ),
+                                    comma
+                                ]
+                            );
                         }
                         _ => {}
                     }
                 }
-                argument.fmt(f);
-            });
-
-            // We have to get the lines before the argument has been formatted, because it relies on
-            // the comments before the argument. After formatting, the comments might marked as printed,
-            // which would lead to a wrong line count.
-            let lines_before = f.source_text().get_lines_before(argument.span(), f.comments());
-
-            let interned = f.intern(&format_with(|f| {
-                format_argument.fmt(f);
-                write!(f, (last_index != index).then_some(","));
+                write!(f, [argument, comma]);
             }));
 
             let break_type =
@@ -715,46 +723,60 @@ fn write_grouped_arguments<'a>(
     // as first or last argument.
     let mut grouped = elements;
     if has_cached {
-        match group_layout {
+        let (argument, grouped_element) = match group_layout {
             GroupedCallArgumentLayout::GroupedFirstArgument => {
-                let argument = node.first().unwrap();
-                let interned = f.intern(&format_with(|f| {
-                    FormatGroupedFirstArgument { argument }.fmt(f);
-                    write!(f, (last_index != 0).then_some(","));
-                }));
-
-                // Turns out, using the grouped layout isn't a good fit because some parameters of the
-                // grouped function or arrow expression break. In that case, fall back to the all args expanded
-                // formatting.
-                // This back tracking is required because testing if the grouped argument breaks would also return `true`
-                // if any content of the function body breaks. But, as far as this is concerned, it's only interested if
-                // any content in the signature breaks.
-                // TODO: should figure out
-                // if matches!(interned, Err(FormatError::PoorLayout)) {
-                //     return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
-                // }
-
-                grouped.first_mut().unwrap().0 = interned;
+                (node.first().unwrap(), &mut grouped.first_mut().unwrap().0)
             }
             GroupedCallArgumentLayout::GroupedLastArgument => {
-                let argument = node.last().unwrap();
-                let interned = f.intern(&format_once(|f| {
-                    FormatGroupedLastArgument { argument, is_only: only_one_argument }.fmt(f);
-                }));
-
-                // Turns out, using the grouped layout isn't a good fit because some parameters of the
-                // grouped function or arrow expression break. In that case, fall back to the all args expanded
-                // formatting.
-                // This back tracking is required because testing if the grouped argument breaks would also return `true`
-                // if any content of the function body breaks. But, as far as this is concerned, it's only interested if
-                // any content in the signature breaks.
-                // TODO: should figure out
-                // if matches!(interned, Err(FormatError::PoorLayout)) {
-                //     return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
-                // }
-
-                grouped.last_mut().unwrap().0 = interned;
+                (node.last().unwrap(), &mut grouped.last_mut().unwrap().0)
             }
+        };
+
+        let function_params = match argument.as_ast_nodes() {
+            AstNodes::ArrowFunctionExpression(arrow) => Some(&arrow.params),
+            AstNodes::Function(function) => Some(&function.params),
+            _ => None,
+        };
+
+        // Turns out, using the grouped layout isn't a good fit because some parameters of the
+        // grouped function or arrow expression break. In that case, fall back to the all args expanded
+        // formatting.
+        // This back tracking is required because testing if the grouped argument breaks would also return `true`
+        // if any content of the function body breaks. But, as far as this is concerned, it's only interested if
+        // any content in the signature breaks.
+        //
+        // <https://github.com/biomejs/biome/blob/98ca2ae9f3b9b25a14d63b243223583aba6e4907/crates/biome_js_formatter/src/js/expressions/call_arguments.rs#L466-L482>
+        if let Some(params) = function_params {
+            let Some(cached_element) = f.context().get_cached_element(params.as_ref()) else {
+                unreachable!(
+                    "The parameters should have already been formatted and cached in the `FormatFunction` or `FormatJsArrowFunctionExpression`"
+                );
+            };
+
+            // Remove soft lines from the cached parameters and check if they would break.
+            // If they break even without soft lines, we need to use the expanded layout.
+            let interned = f.intern(&format_once(|f| {
+                RemoveSoftLinesBuffer::new(f).write_element(cached_element);
+            }));
+
+            if let Some(interned) = interned {
+                if interned.will_break() {
+                    return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
+                }
+
+                // No break; it should print the element without soft lines.
+                // It would be used in the `FormatFunction` or `FormatJsArrowFunctionExpression`.
+                f.context_mut().cache_element(params.as_ref(), interned);
+            }
+        }
+
+        *grouped_element = if group_layout.is_grouped_first() {
+            f.intern(&format_with(|f| {
+                FormatGroupedFirstArgument { argument }.fmt(f);
+                write!(f, (last_index != 0).then_some(","));
+            }))
+        } else {
+            f.intern(&FormatGroupedLastArgument { argument, is_only: only_one_argument })
         }
     }
 

--- a/crates/oxc_formatter/src/write/function.rs
+++ b/crates/oxc_formatter/src/write/function.rs
@@ -10,9 +10,7 @@ use super::{
 use crate::{
     ast_nodes::AstNode,
     format_args,
-    formatter::{
-        Buffer, Formatter, buffer::RemoveSoftLinesBuffer, prelude::*, trivia::FormatLeadingComments,
-    },
+    formatter::{Buffer, Formatter, prelude::*, trivia::FormatLeadingComments},
     write,
     write::{
         arrow_function_expression::FormatMaybeCachedFunctionBody, semicolon::OptionalSemicolon,
@@ -84,24 +82,6 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
             self.params(),
             self.options.cache_mode,
         )
-        .memoized();
-
-        let format_parameters = format_with(|f: &mut Formatter<'_, 'a>| {
-            if self.options.call_argument_layout.is_some() {
-                let mut buffer = RemoveSoftLinesBuffer::new(f);
-
-                let mut recording = buffer.start_recording();
-                write!(recording, format_parameters);
-                // let recorded = recording.stop();
-
-                // TODO: figure out
-                // if recorded.will_break() {
-                //     return Err(FormatError::PoorLayout);
-                // }
-            } else {
-                format_parameters.fmt(f);
-            }
-        })
         .memoized();
 
         let format_return_type = self

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,10 +1,9 @@
-js compatibility: 723/759 (95.26%)
+js compatibility: 729/759 (96.05%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| js/arrows/call.js | 💥💥 | 61.89% |
 | js/arrows/comment.js | 💥💥 | 88.89% |
 | js/comments/15661.js | 💥💥 | 55.17% |
 | js/comments/dangling_for.js | 💥💥 | 22.22% |
@@ -24,13 +23,8 @@ js compatibility: 723/759 (95.26%)
 | js/if/expr_and_same_line_comments.js | 💥 | 97.73% |
 | js/if/if_comments.js | 💥 | 76.00% |
 | js/if/trailing_comment.js | 💥 | 91.43% |
-| js/last-argument-expansion/assignment-pattern.js | 💥 | 0.00% |
-| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
-| js/last-argument-expansion/empty-lines.js | 💥 | 14.29% |
-| js/last-argument-expansion/issue-10708.js | 💥 | 0.00% |
-| js/last-argument-expansion/issue-7518.js | 💥 | 0.00% |
+| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
-| js/preserve-line/parameter-list.js | 💥 | 91.08% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 570/602 (94.68%)
+ts compatibility: 571/602 (94.85%)
 
 # Failed
 
@@ -8,7 +8,6 @@ ts compatibility: 570/602 (94.68%)
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/text-wrap/test.js | 💥 | 99.56% |
-| typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 77.78% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/as-const/as-const.ts | 💥 | 90.91% |


### PR DESCRIPTION
This PR is a follow-up on #16036 

Move `PoorLayout` handling from `Function` and `ArrowFunctionExpression` to call arguments