### PR TITLE
feat(ast_tools): add package.json and oxfmtrc.jsonc to CI watch list

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -55,4 +55,6 @@ src:
   - 'napi/parser/src/generated/raw_transfer_constants.rs'
   - 'napi/parser/src/raw_transfer_types.rs'
   - 'npm/oxc-types/types.d.ts'
+  - 'oxfmtrc.jsonc'
+  - 'package.json'
   - 'tasks/ast_tools/src/**'

--- a/tasks/ast_tools/src/output/yaml.rs
+++ b/tasks/ast_tools/src/output/yaml.rs
@@ -67,6 +67,9 @@ impl Output {
             "tasks/ast_tools/src/**",
             // Workflow which runs `ast_tools`
             ".github/workflows/ci.yml",
+            // Config files which affect `ast_tools`
+            "package.json",
+            "oxfmtrc.jsonc",
         ];
 
         // Add additional paths and dependency crate paths to `paths`, and sort


### PR DESCRIPTION
this change forces ast changes to run when package.json (oxfmt version) OR oxfmtrc.jsonc (oxfmt config) changes, hopefully avoiding failing CI due to this not running, and changes to either of those two happening