### PR TITLE
fix(linter): fix prefer-string-raw fixer producing invalid JS for non-ASCII strings

### DIFF
--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_string_raw.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_string_raw.snap
@@ -77,3 +77,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──────
    ╰────
   help: Replace `'a\\b'` with ` String.raw`a\b``.
+
+  ⚠ eslint-plugin-unicorn(prefer-string-raw): `String.raw` should be used to avoid escaping `\`.
+   ╭─[prefer_string_raw.tsx:1:11]
+ 1 │ const a = 'c:\\someöäü\\path';
+   ·           ───────────────────
+   ╰────
+  help: Replace `'c:\\someöäü\\path'` with `String.raw`c:\someöäü\path``.


### PR DESCRIPTION
The fixer incorrectly used byte length with UTF-16 char_at() to check for
trailing backslashes. For strings with non-ASCII characters (e.g., ö, ä, ü),
this caused the check to fail, allowing fixes that produce invalid JavaScript
like `String.raw\`c:\someöäü\`\` where the backslash escapes the backtick.

Fixed by checking trailing backslashes on the decoded string value instead
of the raw source, using character iteration instead of byte indexing.