### PR TITLE
fix(ast/estree): convert `TSImportType` `argument` field to `Literal`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5213,7 +5213,7 @@ function deserializeTSImportType(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
@@ -5221,8 +5221,13 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    });
-  node.argument = deserializeTSType(pos + 8);
+    }),
+    source = deserializeTSType(pos + 8);
+  if (source.type === "TSLiteralType") {
+    source = source.literal;
+    source.parent = parent;
+  }
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1544,7 +1544,7 @@ export type TSTypeQueryExprName = TSImportType | TSTypeName;
 
 export interface TSImportType extends Span {
   type: "TSImportType";
-  argument: TSType;
+  source: StringLiteral;
   options: ObjectExpression | null;
   qualifier: TSImportTypeQualifier | null;
   typeArguments: TSTypeParameterInstantiation | null;

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1381,6 +1381,7 @@ pub enum TSTypeQueryExprName<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 pub struct TSImportType<'a> {
     pub span: Span,
+    #[estree(rename = "source", via = TSImportTypeSource)]
     pub argument: TSType<'a>,
     pub options: Option<Box<'a, ObjectExpression<'a>>>,
     pub qualifier: Option<TSImportTypeQualifier<'a>>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2982,7 +2982,7 @@ impl ESTree for TSImportType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSImportType"));
-        state.serialize_field("argument", &self.argument);
+        state.serialize_field("source", &crate::serialize::ts::TSImportTypeSource(self));
         state.serialize_field("options", &self.options);
         state.serialize_field("qualifier", &self.qualifier);
         state.serialize_field("typeArguments", &self.type_arguments);

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -503,6 +503,40 @@ impl ESTree for TSFunctionTypeParams<'_, '_> {
     }
 }
 
+/// Serializer for `source` field of `TSImportType`.
+///
+/// * Field is named `argument` in Oxc AST.
+/// * Serialized as a `StringLiteral` - all other values are illegal syntax.
+#[ast_meta]
+#[estree(
+    ts_type = "StringLiteral",
+    raw_deser = "
+        let source = DESER[TSType](POS_OFFSET.argument);
+        if (source.type === 'TSLiteralType') {
+            source = source.literal;
+            if (PARENT) source.parent = parent;
+        } else {
+            // Should be unreachable - illegal syntax
+        }
+        source
+    "
+)]
+pub struct TSImportTypeSource<'a, 'b>(pub &'b TSImportType<'a>);
+
+impl ESTree for TSImportTypeSource<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let source = &self.0.argument;
+        if let TSType::TSLiteralType(ts_lit_type) = source
+            && let TSLiteral::StringLiteral(str_lit) = &ts_lit_type.literal
+        {
+            str_lit.serialize(serializer);
+            return;
+        }
+        // Should be unreachable - illegal syntax
+        source.serialize(serializer);
+    }
+}
+
 /// Converter for [`TSParenthesizedType`].
 ///
 /// In raw transfer, do not produce a `TSParenthesizedType` node in AST if `PRESERVE_PARENS` is false.

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -3891,15 +3891,17 @@ function deserializeTSTypeQueryExprName(pos) {
 
 function deserializeTSImportType(pos) {
   let node = {
-    type: "TSImportType",
-    argument: null,
-    options: null,
-    qualifier: null,
-    typeArguments: null,
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-  };
-  node.argument = deserializeTSType(pos + 8);
+      type: "TSImportType",
+      source: null,
+      options: null,
+      qualifier: null,
+      typeArguments: null,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
+    },
+    source = deserializeTSType(pos + 8);
+  source.type === "TSLiteralType" && (source = source.literal);
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -4545,15 +4545,20 @@ function deserializeTSImportType(pos) {
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
       start,
       end,
       parent,
-    });
-  node.argument = deserializeTSType(pos + 8);
+    }),
+    source = deserializeTSType(pos + 8);
+  if (source.type === "TSLiteralType") {
+    source = source.literal;
+    source.parent = parent;
+  }
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -4293,15 +4293,17 @@ function deserializeTSImportType(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
       start,
       end,
       range: [start, end],
-    };
-  node.argument = deserializeTSType(pos + 8);
+    },
+    source = deserializeTSType(pos + 8);
+  source.type === "TSLiteralType" && (source = source.literal);
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -4770,7 +4770,7 @@ function deserializeTSImportType(pos) {
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
@@ -4778,8 +4778,13 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    });
-  node.argument = deserializeTSType(pos + 8);
+    }),
+    source = deserializeTSType(pos + 8);
+  if (source.type === "TSLiteralType") {
+    source = source.literal;
+    source.parent = parent;
+  }
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4144,15 +4144,17 @@ function deserializeTSTypeQueryExprName(pos) {
 
 function deserializeTSImportType(pos) {
   let node = {
-    type: "TSImportType",
-    argument: null,
-    options: null,
-    qualifier: null,
-    typeArguments: null,
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-  };
-  node.argument = deserializeTSType(pos + 8);
+      type: "TSImportType",
+      source: null,
+      options: null,
+      qualifier: null,
+      typeArguments: null,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
+    },
+    source = deserializeTSType(pos + 8);
+  source.type === "TSLiteralType" && (source = source.literal);
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -4806,15 +4806,20 @@ function deserializeTSImportType(pos) {
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
       start,
       end,
       parent,
-    });
-  node.argument = deserializeTSType(pos + 8);
+    }),
+    source = deserializeTSType(pos + 8);
+  if (source.type === "TSLiteralType") {
+    source = source.literal;
+    source.parent = parent;
+  }
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -4545,15 +4545,17 @@ function deserializeTSImportType(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
       start,
       end,
       range: [start, end],
-    };
-  node.argument = deserializeTSType(pos + 8);
+    },
+    source = deserializeTSType(pos + 8);
+  source.type === "TSLiteralType" && (source = source.literal);
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -5038,7 +5038,7 @@ function deserializeTSImportType(pos) {
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
-      argument: null,
+      source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
@@ -5046,8 +5046,13 @@ function deserializeTSImportType(pos) {
       end,
       range: [start, end],
       parent,
-    });
-  node.argument = deserializeTSType(pos + 8);
+    }),
+    source = deserializeTSType(pos + 8);
+  if (source.type === "TSLiteralType") {
+    source = source.literal;
+    source.parent = parent;
+  }
+  node.source = source;
   node.options = deserializeOptionBoxObjectExpression(pos + 24);
   node.qualifier = deserializeOptionTSImportTypeQualifier(pos + 32);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 48);

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -10712,7 +10712,7 @@ export class TSImportType {
     return constructU32(internal.pos + 4, internal.ast);
   }
 
-  get argument() {
+  get source() {
     const internal = this.#internal;
     return constructTSType(internal.pos + 8, internal.ast);
   }
@@ -10737,7 +10737,7 @@ export class TSImportType {
       type: "TSImportType",
       start: this.start,
       end: this.end,
-      argument: this.argument,
+      source: this.source,
       options: this.options,
       qualifier: this.qualifier,
       typeArguments: this.typeArguments,

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1537,7 +1537,7 @@ export type TSTypeQueryExprName = TSImportType | TSTypeName;
 
 export interface TSImportType extends Span {
   type: "TSImportType";
-  argument: TSType;
+  source: StringLiteral;
   options: ObjectExpression | null;
   qualifier: TSImportTypeQualifier | null;
   typeArguments: TSTypeParameterInstantiation | null;

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,67 +2,9 @@ commit: 669c25c0
 
 estree_typescript Summary:
 AST Parsed     : 9753/9753 (100.00%)
-Positive Passed: 9707/9753 (99.53%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCrossFileCopiedGeneratedImportType.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoInvalidCommentReuse2.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile2.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTripleSlashReferenceAmbientModule.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentExpressionIsExpressionNode.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeTypeofClassStaticLookup.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeWithUnparenthesizedGenericFunctionParsed.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedAsTypeWithErrors.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataImportType.ts
-
+Positive Passed: 9747/9753 (99.94%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/modulePreserveTopLevelAwait1.ts
 `await` is only allowed within async functions and at the top levels of modules
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequireAndImport.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeOnlyESMImportFromCJS.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
 
@@ -73,26 +15,4 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeImportType1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmit.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAssignment7.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbientMissing.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGenericTypes.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocal.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocalMissing.ts
 


### PR DESCRIPTION
Fixes #16074.

Convert `argument` field of `TSImportType` to `Literal` in TS-ESTree AST, and rename it to `source`. This follows the change made recently in TS-ESLint (https://github.com/typescript-eslint/typescript-eslint/pull/11591).