### PR TITLE
feat(ast)!: rename `TSImportType` `argument` field to `source`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1381,8 +1381,8 @@ pub enum TSTypeQueryExprName<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 pub struct TSImportType<'a> {
     pub span: Span,
-    #[estree(rename = "source", via = TSImportTypeSource)]
-    pub argument: TSType<'a>,
+    #[estree(via = TSImportTypeSource)]
+    pub source: TSType<'a>,
     pub options: Option<Box<'a, ObjectExpression<'a>>>,
     pub qualifier: Option<TSImportTypeQualifier<'a>>,
     pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1452,7 +1452,7 @@ const _: () = {
     assert!(size_of::<TSImportType>() == 56);
     assert!(align_of::<TSImportType>() == 8);
     assert!(offset_of!(TSImportType, span) == 0);
-    assert!(offset_of!(TSImportType, argument) == 8);
+    assert!(offset_of!(TSImportType, source) == 8);
     assert!(offset_of!(TSImportType, options) == 24);
     assert!(offset_of!(TSImportType, qualifier) == 32);
     assert!(offset_of!(TSImportType, type_arguments) == 48);
@@ -3068,7 +3068,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(size_of::<TSImportType>() == 32);
     assert!(align_of::<TSImportType>() == 4);
     assert!(offset_of!(TSImportType, span) == 0);
-    assert!(offset_of!(TSImportType, argument) == 8);
+    assert!(offset_of!(TSImportType, source) == 8);
     assert!(offset_of!(TSImportType, options) == 16);
     assert!(offset_of!(TSImportType, qualifier) == 20);
     assert!(offset_of!(TSImportType, type_arguments) == 28);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -10621,7 +10621,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `argument`
+    /// * `source`
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
@@ -10629,7 +10629,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_import_type<T1, T2>(
         self,
         span: Span,
-        argument: TSType<'a>,
+        source: TSType<'a>,
         options: T1,
         qualifier: Option<TSImportTypeQualifier<'a>>,
         type_arguments: T2,
@@ -10640,7 +10640,7 @@ impl<'a> AstBuilder<'a> {
     {
         TSType::TSImportType(self.alloc_ts_import_type(
             span,
-            argument,
+            source,
             options,
             qualifier,
             type_arguments,
@@ -14016,7 +14016,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `argument`
+    /// * `source`
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
@@ -14024,7 +14024,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_query_expr_name_import_type<T1, T2>(
         self,
         span: Span,
-        argument: TSType<'a>,
+        source: TSType<'a>,
         options: T1,
         qualifier: Option<TSImportTypeQualifier<'a>>,
         type_arguments: T2,
@@ -14035,7 +14035,7 @@ impl<'a> AstBuilder<'a> {
     {
         TSTypeQueryExprName::TSImportType(self.alloc_ts_import_type(
             span,
-            argument,
+            source,
             options,
             qualifier,
             type_arguments,
@@ -14049,7 +14049,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `argument`
+    /// * `source`
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
@@ -14057,7 +14057,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_import_type<T1, T2>(
         self,
         span: Span,
-        argument: TSType<'a>,
+        source: TSType<'a>,
         options: T1,
         qualifier: Option<TSImportTypeQualifier<'a>>,
         type_arguments: T2,
@@ -14068,7 +14068,7 @@ impl<'a> AstBuilder<'a> {
     {
         TSImportType {
             span,
-            argument,
+            source,
             options: options.into_in(self.allocator),
             qualifier,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -14082,7 +14082,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `argument`
+    /// * `source`
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
@@ -14090,7 +14090,7 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_import_type<T1, T2>(
         self,
         span: Span,
-        argument: TSType<'a>,
+        source: TSType<'a>,
         options: T1,
         qualifier: Option<TSImportTypeQualifier<'a>>,
         type_arguments: T2,
@@ -14100,7 +14100,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.ts_import_type(span, argument, options, qualifier, type_arguments),
+            self.ts_import_type(span, source, options, qualifier, type_arguments),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7468,7 +7468,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
             span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
+            source: CloneIn::clone_in(&self.source, allocator),
             options: CloneIn::clone_in(&self.options, allocator),
             qualifier: CloneIn::clone_in(&self.qualifier, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -7478,7 +7478,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
+            source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
             options: CloneIn::clone_in_with_semantic_ids(&self.options, allocator),
             qualifier: CloneIn::clone_in_with_semantic_ids(&self.qualifier, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2329,7 +2329,7 @@ impl ContentEq for TSTypeQueryExprName<'_> {
 
 impl ContentEq for TSImportType<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.options, &other.options)
             && ContentEq::content_eq(&self.qualifier, &other.qualifier)
             && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2642,7 +2642,7 @@ impl<'a> Dummy<'a> for TSImportType<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            argument: Dummy::dummy(allocator),
+            source: Dummy::dummy(allocator),
             options: Dummy::dummy(allocator),
             qualifier: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -505,13 +505,12 @@ impl ESTree for TSFunctionTypeParams<'_, '_> {
 
 /// Serializer for `source` field of `TSImportType`.
 ///
-/// * Field is named `argument` in Oxc AST.
-/// * Serialized as a `StringLiteral` - all other values are illegal syntax.
+/// Serialized as a `StringLiteral` - all other values are illegal syntax.
 #[ast_meta]
 #[estree(
     ts_type = "StringLiteral",
     raw_deser = "
-        let source = DESER[TSType](POS_OFFSET.argument);
+        let source = DESER[TSType](POS_OFFSET.source);
         if (source.type === 'TSLiteralType') {
             source = source.literal;
             if (PARENT) source.parent = parent;
@@ -525,7 +524,7 @@ pub struct TSImportTypeSource<'a, 'b>(pub &'b TSImportType<'a>);
 
 impl ESTree for TSImportTypeSource<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let source = &self.0.argument;
+        let source = &self.0.source;
         if let TSType::TSLiteralType(ts_lit_type) = source
             && let TSLiteral::StringLiteral(str_lit) = &ts_lit_type.literal
         {

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3955,7 +3955,7 @@ pub mod walk {
         let kind = AstKind::TSImportType(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.argument);
+        visitor.visit_ts_type(&it.source);
         if let Some(options) = &it.options {
             visitor.visit_object_expression(options);
         }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4164,7 +4164,7 @@ pub mod walk_mut {
         let kind = AstType::TSImportType;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.argument);
+        visitor.visit_ts_type(&mut it.source);
         if let Some(options) = &mut it.options {
             visitor.visit_object_expression(options);
         }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3515,7 +3515,7 @@ impl Gen for TSTypeQueryExprName<'_> {
 impl Gen for TSImportType<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("import(");
-        self.argument.print(p, ctx);
+        self.source.print(p, ctx);
         if let Some(options) = &self.options {
             p.print_str(", ");
             options.print_expr(p, Precedence::Lowest, ctx);

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -8483,7 +8483,7 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
 
 impl<'a> AstNode<'a, TSImportType<'a>> {
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn source(&self) -> &AstNode<'a, TSType<'a>> {
         let following_span = self
             .inner
             .options
@@ -8493,7 +8493,7 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
             .or_else(|| self.inner.type_arguments.as_deref().map(GetSpan::span))
             .or(self.following_span);
         self.allocator.alloc(AstNode {
-            inner: &self.inner.argument,
+            inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
             following_span,

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1660,9 +1660,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) -> FormatResult<()> {
         write!(f, ["import("])?;
 
-        let has_comment = f.context().comments().has_comment_before(self.argument.span().start);
+        let has_comment = f.context().comments().has_comment_before(self.source.span().start);
 
-        let format_argument = self.argument().memoized();
+        let format_argument = self.source().memoized();
         let format_options = self.options().memoized();
 
         if has_comment || self.options().is_some() {
@@ -1688,7 +1688,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
                 write!(f, [format_inner])?;
             }
         } else {
-            write!(f, self.argument())?;
+            write!(f, self.source())?;
         }
 
         write!(f, ")")?;

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -282,7 +282,7 @@ pub(crate) enum AncestorType {
     TSInferTypeTypeParameter = 258,
     TSTypeQueryExprName = 259,
     TSTypeQueryTypeArguments = 260,
-    TSImportTypeArgument = 261,
+    TSImportTypeSource = 261,
     TSImportTypeOptions = 262,
     TSImportTypeQualifier = 263,
     TSImportTypeTypeArguments = 264,
@@ -819,8 +819,7 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSTypeQueryExprName as u16,
     TSTypeQueryTypeArguments(TSTypeQueryWithoutTypeArguments<'a, 't>) =
         AncestorType::TSTypeQueryTypeArguments as u16,
-    TSImportTypeArgument(TSImportTypeWithoutArgument<'a, 't>) =
-        AncestorType::TSImportTypeArgument as u16,
+    TSImportTypeSource(TSImportTypeWithoutSource<'a, 't>) = AncestorType::TSImportTypeSource as u16,
     TSImportTypeOptions(TSImportTypeWithoutOptions<'a, 't>) =
         AncestorType::TSImportTypeOptions as u16,
     TSImportTypeQualifier(TSImportTypeWithoutQualifier<'a, 't>) =
@@ -1749,7 +1748,7 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_import_type(self) -> bool {
         matches!(
             self,
-            Self::TSImportTypeArgument(_)
+            Self::TSImportTypeSource(_)
                 | Self::TSImportTypeOptions(_)
                 | Self::TSImportTypeQualifier(_)
                 | Self::TSImportTypeTypeArguments(_)
@@ -2139,7 +2138,7 @@ impl<'a, 't> Ancestor<'a, 't> {
                 | Self::TSTypeParameterConstraint(_)
                 | Self::TSTypeParameterDefault(_)
                 | Self::TSTypeAliasDeclarationTypeAnnotation(_)
-                | Self::TSImportTypeArgument(_)
+                | Self::TSImportTypeSource(_)
                 | Self::TSMappedTypeNameType(_)
                 | Self::TSMappedTypeTypeAnnotation(_)
                 | Self::TSTemplateLiteralTypeTypes(_)
@@ -2474,7 +2473,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSInferTypeTypeParameter(a) => a.address(),
             Self::TSTypeQueryExprName(a) => a.address(),
             Self::TSTypeQueryTypeArguments(a) => a.address(),
-            Self::TSImportTypeArgument(a) => a.address(),
+            Self::TSImportTypeSource(a) => a.address(),
             Self::TSImportTypeOptions(a) => a.address(),
             Self::TSImportTypeQualifier(a) => a.address(),
             Self::TSImportTypeTypeArguments(a) => a.address(),
@@ -14311,7 +14310,7 @@ impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeArguments<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_IMPORT_TYPE_SPAN: usize = offset_of!(TSImportType, span);
-pub(crate) const OFFSET_TS_IMPORT_TYPE_ARGUMENT: usize = offset_of!(TSImportType, argument);
+pub(crate) const OFFSET_TS_IMPORT_TYPE_SOURCE: usize = offset_of!(TSImportType, source);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_OPTIONS: usize = offset_of!(TSImportType, options);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_QUALIFIER: usize = offset_of!(TSImportType, qualifier);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS: usize =
@@ -14319,12 +14318,12 @@ pub(crate) const OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS: usize =
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSImportTypeWithoutArgument<'a, 't>(
+pub struct TSImportTypeWithoutSource<'a, 't>(
     pub(crate) *const TSImportType<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSImportTypeWithoutArgument<'a, 't> {
+impl<'a, 't> TSImportTypeWithoutSource<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SPAN) as *const Span) }
@@ -14355,7 +14354,7 @@ impl<'a, 't> TSImportTypeWithoutArgument<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSImportTypeWithoutArgument<'a, 't> {
+impl<'a, 't> GetAddress for TSImportTypeWithoutSource<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         unsafe { Address::from_ptr(self.0) }
@@ -14376,10 +14375,8 @@ impl<'a, 't> TSImportTypeWithoutOptions<'a, 't> {
     }
 
     #[inline]
-    pub fn argument(self) -> &'t TSType<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
-        }
+    pub fn source(self) -> &'t TSType<'a> {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SOURCE) as *const TSType<'a>) }
     }
 
     #[inline]
@@ -14420,10 +14417,8 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
     }
 
     #[inline]
-    pub fn argument(self) -> &'t TSType<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
-        }
+    pub fn source(self) -> &'t TSType<'a> {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SOURCE) as *const TSType<'a>) }
     }
 
     #[inline]
@@ -14464,10 +14459,8 @@ impl<'a, 't> TSImportTypeWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn argument(self) -> &'t TSType<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
-        }
+    pub fn source(self) -> &'t TSType<'a> {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SOURCE) as *const TSType<'a>) }
     }
 
     #[inline]

--- a/crates/oxc_traverse/src/generated/scopes_collector.rs
+++ b/crates/oxc_traverse/src/generated/scopes_collector.rs
@@ -1895,7 +1895,7 @@ impl<'a> Visit<'a> for ChildScopeCollector {
 
     #[inline]
     fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
-        self.visit_ts_type(&it.argument);
+        self.visit_ts_type(&it.source);
         if let Some(options) = &it.options {
             self.visit_object_expression(options);
         }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5183,12 +5183,12 @@ unsafe fn walk_ts_import_type<'a, State, Tr: Traverse<'a, State>>(
     ctx: &mut TraverseCtx<'a, State>,
 ) {
     traverser.enter_ts_import_type(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSImportTypeArgument(
-        ancestor::TSImportTypeWithoutArgument(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSImportTypeSource(
+        ancestor::TSImportTypeWithoutSource(node, PhantomData),
     ));
     walk_ts_type(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *mut TSType,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_SOURCE) as *mut TSType,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_OPTIONS)


### PR DESCRIPTION
Rename `argument` field of `TSImportType` to `source`. This matches TS-ESTree and also aligns with `ImportExpression`.