### PR TITLE
fix(formatter/sort_imports): Handle internal prefixes correctly

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
@@ -365,7 +365,7 @@ fn to_path_kind(source: &str) -> ImportPathKind {
     }
 
     // TODO: This can be changed via `options.internalPattern`
-    if source.starts_with('~') || source.starts_with('@') {
+    if source.starts_with("~/") || source.starts_with("@/") {
         return ImportPathKind::Internal;
     }
 

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -68,6 +68,22 @@ import c from "c";
 import("a");
 "#,
     );
+    assert_format(
+        r#"
+import internal from "~/internal";
+import internal2 from "@/internal2";
+import external from "external";
+import external2 from "@external2";
+"#,
+        r#"{ "experimentalSortImports": {} }"#,
+        r#"
+import external2 from "@external2";
+import external from "external";
+
+import internal2 from "@/internal2";
+import internal from "~/internal";
+"#,
+    );
 }
 
 #[test]


### PR DESCRIPTION
| |Before|After|
|-|-|-|
| `from "@scoped/foo"`| internal (🐛) | external (✨) |
| `from "@/foo"` | internal | internal |