### PR TITLE
feat(parser): improve diagnostic for unexpected optional declarations

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1110,3 +1110,10 @@ pub fn expect_switch_clause(span: Span) -> OxcDiagnostic {
         .with_label(span.label("`case` or `default` clause expected here"))
         .with_help("If this is intended to be the condition for the switch statement, add `case` before it.")
 }
+
+#[cold]
+pub fn unexpected_optional_declaration(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Optional declaration is not allowed here")
+        .with_label(span)
+        .with_help("Remove the `?`")
+}

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -118,7 +118,7 @@ impl<'a> ParserImpl<'a> {
                 None
             };
             let optional = if self.at(Kind::Question) {
-                self.error(diagnostics::unexpected_token(self.cur_token().span()));
+                self.error(diagnostics::unexpected_optional_declaration(self.cur_token().span()));
                 self.bump_any();
                 true
             } else {

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -3273,51 +3273,57 @@ Negative Passed: 120/120 (100.00%)
    ·        ─────
    ╰────
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:1:8]
  1 │ const a? = "A"
    ·        ─
  2 │ const [b]? = ["B"]
    ╰────
+  help: Remove the `?`
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:2:10]
  1 │ const a? = "A"
  2 │ const [b]? = ["B"]
    ·          ─
  3 │ const { c }? = { c: "C" }
    ╰────
+  help: Remove the `?`
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:3:12]
  2 │ const [b]? = ["B"]
  3 │ const { c }? = { c: "C" }
    ·            ─
  4 │ 
    ╰────
+  help: Remove the `?`
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:5:13]
  4 │ 
  5 │ const d     ? = "A"
    ·             ─
  6 │ const [e, f]      ? = ["B"]
    ╰────
+  help: Remove the `?`
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:6:19]
  5 │ const d     ? = "A"
  6 │ const [e, f]      ? = ["B"]
    ·                   ─
  7 │ const { g, h }       ? = { c: "C" }
    ╰────
+  help: Remove the `?`
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-2253.ts:7:22]
  6 │ const [e, f]      ? = ["B"]
  7 │ const { g, h }       ? = { c: "C" }
    ·                      ─
    ╰────
+  help: Remove the `?`
 
   × Empty parenthesized expression
    ╭─[misc/fail/oxc-232.js:1:5]
@@ -3494,12 +3500,13 @@ Negative Passed: 120/120 (100.00%)
    ·      ───────
    ╰────
 
-  × Unexpected token
+  × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-5955-1.ts:1:8]
  1 │ const x?: number = 1;
    ·        ─
  2 │ 
    ╰────
+  help: Remove the `?`
 
   × Unexpected token
    ╭─[misc/fail/oxc-5955-2.ts:3:8]


### PR DESCRIPTION
Currently we just emit "unexpected token", but we actually have a good amount of context here to provide better help + error message.