### PR TITLE
feat(parser): add diagnostic for expected ident after optional chain

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1117,3 +1117,10 @@ pub fn unexpected_optional_declaration(span: Span) -> OxcDiagnostic {
         .with_label(span)
         .with_help("Remove the `?`")
 }
+
+#[cold]
+pub fn identifier_expected_after_question_dot(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Identifier expected after '?.'")
+        .with_label(span)
+        .with_help("Add an identifier after '?.'")
+}

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -987,7 +987,7 @@ impl<'a> ParserImpl<'a> {
 
             if let Some(span) = question_dot_span {
                 // We parsed `?.` but then failed to parse anything, so report a missing identifier here.
-                let error = diagnostics::unexpected_token(span);
+                let error = diagnostics::identifier_expected_after_question_dot(span);
                 return self.fatal_error(error);
             }
 

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -14698,11 +14698,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try inserting a semicolon here
 
-  × Unexpected token
+  × Identifier expected after '?.'
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain-invalid/input.ts:1:2]
  1 │ f?.<string>[1];
    ·  ──
    ╰────
+  help: Add an identifier after '?.'
 
   × TS(1099): Type argument list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-function/input.ts:1:4]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -3532,32 +3532,36 @@ Negative Passed: 120/120 (100.00%)
  5 │   }
    ╰────
 
-  × Unexpected token
+  × Identifier expected after '?.'
    ╭─[misc/fail/oxc-9497.js:2:8]
  1 │ let repro = {};
  2 │ repro.f?.
    ·        ──
    ╰────
+  help: Add an identifier after '?.'
 
-  × Unexpected token
+  × Identifier expected after '?.'
    ╭─[misc/fail/oxc-9525-1.js:1:2]
  1 │ x?.;
    ·  ──
    ╰────
+  help: Add an identifier after '?.'
 
-  × Unexpected token
+  × Identifier expected after '?.'
    ╭─[misc/fail/oxc-9525-2.js:1:3]
  1 │ [x?.];
    ·   ──
    ╰────
+  help: Add an identifier after '?.'
 
-  × Unexpected token
+  × Identifier expected after '?.'
    ╭─[misc/fail/oxc-9525-3.js:2:4]
  1 │ () => {
  2 │   x?.
    ·    ──
  3 │ }
    ╰────
+  help: Add an identifier after '?.'
 
   × The keyword 'let' is reserved
    ╭─[misc/fail/oxc.js:3:1]


### PR DESCRIPTION
Currently we just emit "unexpected token", but we actually have a good amount of context here to provide better help + error message.