### PR TITLE
feat(parser): add diagnostic for JSX identifiers with hyphens

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1124,3 +1124,10 @@ pub fn identifier_expected_after_question_dot(span: Span) -> OxcDiagnostic {
         .with_label(span)
         .with_help("Add an identifier after '?.'")
 }
+
+#[cold]
+pub fn identifier_expected_jsx_no_hyphen(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Identifiers in JSX cannot contain hyphens")
+        .with_label(span)
+        .with_help("Remove the hyphen from the identifier")
+}

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -198,7 +198,7 @@ impl<'a> ParserImpl<'a> {
             let ident = self.parse_jsx_identifier();
             // `<foo.bar- />` is a syntax error.
             if ident.name.contains('-') {
-                let error = diagnostics::unexpected_token(ident.span);
+                let error = diagnostics::identifier_expected_jsx_no_hyphen(ident.span);
                 return self.fatal_error(error);
             }
             property = Some(ident);

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -3494,11 +3494,12 @@ Negative Passed: 120/120 (100.00%)
    ╰────
   help: Remove this `?`
 
-  × Unexpected token
+  × Identifiers in JSX cannot contain hyphens
    ╭─[misc/fail/oxc-5355.jsx:1:6]
  1 │ <Foo.bar-baz />
    ·      ───────
    ╰────
+  help: Remove the hyphen from the identifier
 
   × Optional declaration is not allowed here
    ╭─[misc/fail/oxc-5955-1.ts:1:8]


### PR DESCRIPTION
Instead of just emitting "unexpected token", provide a better error message that says exactly what is wrong and how to fix the error.