### PR TITLE
perf(parser): remove bounds check for getting strings from lexer

### DIFF
--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -270,6 +270,12 @@ impl<'a> Lexer<'a> {
             }
             _ => {}
         }
-        &source_text[start..end]
+        debug_assert!(start <= source_text.len());
+        debug_assert!(end <= source_text.len());
+        debug_assert!(start <= end);
+        debug_assert!(source_text.is_char_boundary(start));
+        debug_assert!(source_text.is_char_boundary(end));
+        // SAFETY: `token` is guaranteed to be within the source and on UTF-8 boundaries.
+        unsafe { source_text.get_unchecked(start..end) }
     }
 }


### PR DESCRIPTION
One profile of the parser showed that this function took up 1% of the time on `binder.ts`. It seemed like this is a case where we could possibly remove the bounds checks, since our tokens are guaranteed to be contained within the source string. Since this is called really often, it's worth optimizing.

+1% on all parser benchmarks: 

<img width="733" height="360" alt="image" src="https://github.com/user-attachments/assets/1f3428e7-0723-488b-9f6a-3f674669febc" />

