### PR TITLE
perf(parser): inline precedence calculation

### DIFF
--- a/crates/oxc_parser/src/js/operator.rs
+++ b/crates/oxc_parser/src/js/operator.rs
@@ -7,6 +7,7 @@ use oxc_syntax::{
 
 use crate::lexer::Kind;
 
+#[inline]
 pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
     match kind {
         Kind::Question2 => Some(Precedence::NullishCoalescing),


### PR DESCRIPTION
Just checking the compiler works. This showed up in 1% of profiles, but I don't have a clever idea for optimizing at the moment.