### PR TITLE
refactor(formatter): remove unneeded `JoinBuilder::finish` and `JoinNodesBuilder::finish` methods

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -2360,12 +2360,6 @@ where
 
         self
     }
-
-    /// Finishes the output and returns any error encountered.
-    #[expect(clippy::unused_self)]
-    pub fn finish(&self) {
-        // TODO: remove this method
-    }
 }
 
 /// Builder to join together nodes that ensures that nodes separated by empty lines continue
@@ -2435,11 +2429,6 @@ where
             self.entry(content.span(), &content);
         }
         self
-    }
-
-    #[expect(clippy::unused_self)]
-    pub fn finish(&self) {
-        // TODO: remove this method
     }
 
     /// Get the number of line breaks between two consecutive SyntaxNodes in the tree

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -1738,10 +1738,10 @@ Group 1 breaks"
                 [group(&format_args!(
                     token("["),
                     soft_block_indent(&format_args!(
-                        format_with(|f| f
-                            .join_with(format_args!(token(","), soft_line_break_or_space()))
-                            .entries(&self.items)
-                            .finish()),
+                        format_with(|f| {
+                            f.join_with(format_args!(token(","), soft_line_break_or_space()))
+                                .entries(&self.items);
+                        }),
                         if_group_breaks(&token(",")),
                     )),
                     token("]")

--- a/crates/oxc_formatter/src/utils/array.rs
+++ b/crates/oxc_formatter/src/utils/array.rs
@@ -82,8 +82,6 @@ pub fn write_array_node<'a, 'b, N>(
             }),
         );
     }
-
-    join.finish();
 }
 
 /// Determines if a trailing separator should be inserted after an array element

--- a/crates/oxc_formatter/src/utils/member_chain/groups.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/groups.rs
@@ -113,7 +113,7 @@ impl<'a, 'b> TailChainGroups<'a, 'b> {
 
 impl<'a> Format<'a> for TailChainGroups<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        f.join().entries(self.groups.iter()).finish();
+        f.join().entries(self.groups.iter());
     }
 }
 
@@ -248,6 +248,6 @@ pub struct FormatMemberChainGroup<'a, 'b> {
 
 impl<'a> Format<'a> for FormatMemberChainGroup<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        f.join().entries(self.group.members.iter()).finish();
+        f.join().entries(self.group.members.iter());
     }
 }

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -200,7 +200,7 @@ impl<'a> Format<'a> for MemberChain<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let has_comment = self.has_comment(f);
         let format_one_line = format_with(|f| {
-            f.join().entries(iter::once(&self.head).chain(self.tail.iter())).finish();
+            f.join().entries(iter::once(&self.head).chain(self.tail.iter()));
         });
 
         self.inspect_member_chain_groups(f);

--- a/crates/oxc_formatter/src/write/assignment_pattern_property_list.rs
+++ b/crates/oxc_formatter/src/write/assignment_pattern_property_list.rs
@@ -70,15 +70,13 @@ impl<'a> Format<'a> for AssignmentTargetPropertyList<'a, '_> {
         } else {
             FormatTrailingCommas::ES5.trailing_separator(f.options())
         };
-        f.join_nodes_with_soft_line()
-            .entries_with_trailing_separator(
-                AssignmentTargetPropertyListIter {
-                    properties: self.properties.iter(),
-                    rest: self.rest,
-                },
-                ",",
-                trailing_separator,
-            )
-            .finish();
+        f.join_nodes_with_soft_line().entries_with_trailing_separator(
+            AssignmentTargetPropertyListIter {
+                properties: self.properties.iter(),
+                rest: self.rest,
+            },
+            ",",
+            trailing_separator,
+        );
     }
 }

--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -250,7 +250,12 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
         if (inline_logical_expression && !flattened)
             || (!inline_logical_expression && should_indent_if_inlines)
         {
-            return write!(f, [group(&format_once(|f| { f.join().entries(parts).finish() }))]);
+            return write!(
+                f,
+                [group(&format_once(|f| {
+                    f.join().entries(parts);
+                }))]
+            );
         }
 
         // `parts` is guaranteed to have at least 2 elements (Left + Right)
@@ -267,7 +272,9 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                 f,
                 [group(&format_args!(
                     first,
-                    indent(&format_with(|f| { f.join().entries(tail_parts.iter()).finish() }))
+                    indent(&format_with(|f| {
+                        f.join().entries(tail_parts.iter());
+                    }))
                 ))
                 .with_group_id(Some(group_id))]
             );

--- a/crates/oxc_formatter/src/write/binding_property_list.rs
+++ b/crates/oxc_formatter/src/write/binding_property_list.rs
@@ -71,12 +71,10 @@ impl<'a> Format<'a> for BindingPropertyList<'a, '_> {
             FormatTrailingCommas::ES5.trailing_separator(f.options())
         };
 
-        f.join_nodes_with_soft_line()
-            .entries_with_trailing_separator(
-                BindingPropertyListIter { properties: self.properties.iter(), rest: self.rest },
-                ",",
-                trailing_separator,
-            )
-            .finish();
+        f.join_nodes_with_soft_line().entries_with_trailing_separator(
+            BindingPropertyListIter { properties: self.properties.iter(), rest: self.rest },
+            ",",
+            trailing_separator,
+        );
     }
 }

--- a/crates/oxc_formatter/src/write/block_statement.rs
+++ b/crates/oxc_formatter/src/write/block_statement.rs
@@ -11,11 +11,9 @@ use crate::{
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Statement<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        f.join_nodes_with_hardline()
-            .entries(
-                self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_))),
-            )
-            .finish();
+        f.join_nodes_with_hardline().entries(
+            self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_))),
+        );
     }
 }
 

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -87,13 +87,11 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                 [
                     l_paren_token,
                     format_with(|f| {
-                        f.join_with(space())
-                            .entries_with_trailing_separator(
-                                self.iter(),
-                                ",",
-                                TrailingSeparator::Omit,
-                            )
-                            .finish();
+                        f.join_with(space()).entries_with_trailing_separator(
+                            self.iter(),
+                            ",",
+                            TrailingSeparator::Omit,
+                        );
                     }),
                     r_paren_token
                 ]
@@ -131,9 +129,11 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                 [
                     l_paren_token,
                     soft_block_indent(&format_with(|f| {
-                        f.join_with(soft_line_break_or_space())
-                            .entries_with_trailing_separator(self.iter(), ",", trailing_operator)
-                            .finish();
+                        f.join_with(soft_line_break_or_space()).entries_with_trailing_separator(
+                            self.iter(),
+                            ",",
+                            trailing_operator,
+                        );
                     })),
                     r_paren_token,
                 ]
@@ -813,8 +813,6 @@ fn write_grouped_arguments<'a>(
                             }));
                         }
                     }
-
-                    joiner.finish();
                 }),
                 ")"
             ]
@@ -841,15 +839,15 @@ fn write_grouped_arguments<'a>(
                 [
                     "(",
                     format_once(|f| {
-                        f.join_with(soft_line_break_or_space())
-                            .entries(grouped.into_iter().map(|(element, _)| {
+                        f.join_with(soft_line_break_or_space()).entries(grouped.into_iter().map(
+                            |(element, _)| {
                                 format_once(move |f| {
                                     if let Some(element) = element {
                                         f.write_element(element);
                                     }
                                 })
-                            }))
-                            .finish();
+                            },
+                        ));
                     }),
                     ")",
                 ]

--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -45,7 +45,6 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ClassElement<'a>>> {
         while let Some(element) = iter.next() {
             join.entry(element.span(), &(element, iter.peek().copied()));
         }
-        join.finish();
     }
 }
 
@@ -200,9 +199,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        f.join_with(&soft_line_break_or_space())
-            .entries_with_trailing_separator(self.iter(), ",", TrailingSeparator::Disallowed)
-            .finish();
+        f.join_with(&soft_line_break_or_space()).entries_with_trailing_separator(
+            self.iter(),
+            ",",
+            TrailingSeparator::Disallowed,
+        );
     }
 }
 
@@ -228,8 +229,6 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
                 joiner.entry(&heritage);
             }
         }
-
-        joiner.finish();
     }
 }
 

--- a/crates/oxc_formatter/src/write/decorators.rs
+++ b/crates/oxc_formatter/src/write/decorators.rs
@@ -27,7 +27,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
                     f,
                     [group(&format_args!(
                         format_with(|f| {
-                            f.join_nodes_with_soft_line().entries(self.iter()).finish();
+                            f.join_nodes_with_soft_line().entries(self.iter());
                         }),
                         soft_line_break_or_space()
                     ))
@@ -46,7 +46,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
             }
         }
 
-        f.join_with(&soft_line_break_or_space()).entries(self.iter()).finish();
+        f.join_with(&soft_line_break_or_space()).entries(self.iter());
 
         write!(f, [soft_line_break_or_space()]);
     }

--- a/crates/oxc_formatter/src/write/export_declarations.rs
+++ b/crates/oxc_formatter/src/write/export_declarations.rs
@@ -176,26 +176,23 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
-        f.join_with(soft_line_break_or_space())
-            .entries(
-                FormatSeparatedIter::new(self.iter(), ",")
-                    .with_trailing_separator(trailing_separator)
-                    .map(|specifier| {
-                        format_with(move |f| {
-                            // Should add empty line before the specifier if there are comments before it.
-                            let specifier_span = specifier.span();
-                            if f.context().comments().has_comment_before(specifier_span.start)
-                                && f.source_text().get_lines_before(specifier_span, f.comments())
-                                    > 1
-                            {
-                                write!(f, [empty_line()]);
-                            }
+        f.join_with(soft_line_break_or_space()).entries(
+            FormatSeparatedIter::new(self.iter(), ",")
+                .with_trailing_separator(trailing_separator)
+                .map(|specifier| {
+                    format_with(move |f| {
+                        // Should add empty line before the specifier if there are comments before it.
+                        let specifier_span = specifier.span();
+                        if f.context().comments().has_comment_before(specifier_span.start)
+                            && f.source_text().get_lines_before(specifier_span, f.comments()) > 1
+                        {
+                            write!(f, [empty_line()]);
+                        }
 
-                            write!(f, specifier);
-                        })
-                    }),
-            )
-            .finish();
+                        write!(f, specifier);
+                    })
+                }),
+        );
     }
 }
 

--- a/crates/oxc_formatter/src/write/import_declaration.rs
+++ b/crates/oxc_formatter/src/write/import_declaration.rs
@@ -128,7 +128,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                                         write!(f, specifier);
                                     })
                                 });
-                            f.join_with(soft_line_break_or_space()).entries(iter).finish();
+                            f.join_with(soft_line_break_or_space()).entries(iter);
                         }),
                         should_insert_space_around_brackets
                     )),
@@ -209,13 +209,11 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
                             let trailing_separator =
                                 FormatTrailingCommas::ES5.trailing_separator(f.options());
 
-                            f.join_with(soft_line_break())
-                                .entries_with_trailing_separator(
-                                    self.iter(),
-                                    ",",
-                                    trailing_separator,
-                                )
-                                .finish();
+                            f.join_with(soft_line_break()).entries_with_trailing_separator(
+                                self.iter(),
+                                ",",
+                                trailing_separator,
+                            );
                         },),
                         should_insert_space_around_brackets
                     )]
@@ -227,13 +225,11 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
                         let maybe_space = maybe_space(f.options().bracket_spacing.value());
                         write!(f, [maybe_space]);
 
-                        f.join_with(space())
-                            .entries_with_trailing_separator(
-                                self.iter(),
-                                ",",
-                                TrailingSeparator::Disallowed,
-                            )
-                            .finish();
+                        f.join_with(space()).entries_with_trailing_separator(
+                            self.iter(),
+                            ",",
+                            TrailingSeparator::Disallowed,
+                        );
 
                         write!(f, [maybe_space]);
                     })]

--- a/crates/oxc_formatter/src/write/jsx/mod.rs
+++ b/crates/oxc_formatter/src/write/jsx/mod.rs
@@ -301,7 +301,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
             soft_line_break_or_space()
         };
 
-        f.join_with(&line_break).entries(self.iter()).finish();
+        f.join_with(&line_break).entries(self.iter());
     }
 }
 

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -145,9 +145,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
-        f.join_nodes_with_soft_line()
-            .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish();
+        f.join_nodes_with_soft_line().entries_with_trailing_separator(
+            self.iter(),
+            ",",
+            trailing_separator,
+        );
     }
 }
 
@@ -1073,9 +1075,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumBody<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
-        f.join_nodes_with_soft_line()
-            .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish();
+        f.join_nodes_with_soft_line().entries_with_trailing_separator(
+            self.iter(),
+            ",",
+            trailing_separator,
+        );
     }
 }
 
@@ -1502,7 +1506,6 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
                 &FormatTSSignature { signature, next_signature: iter.peek().copied() },
             );
         }
-        joiner.finish();
     }
 }
 
@@ -1522,8 +1525,6 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
                 joiner.entry(&heritage);
             }
         }
-
-        joiner.finish();
     }
 }
 

--- a/crates/oxc_formatter/src/write/parameters.rs
+++ b/crates/oxc_formatter/src/write/parameters.rs
@@ -252,13 +252,11 @@ impl<'a> Format<'a> for ParameterList<'a, '_> {
                 } else {
                     f.join_nodes_with_soft_line()
                 };
-                joiner
-                    .entries_with_trailing_separator(
-                        FormalParametersIter::from(self),
-                        ",",
-                        trailing_separator,
-                    )
-                    .finish();
+                joiner.entries_with_trailing_separator(
+                    FormalParametersIter::from(self),
+                    ",",
+                    trailing_separator,
+                );
             }
             Some(ParameterLayout::Hug) => {
                 let mut join = f.join_with(space());
@@ -267,7 +265,6 @@ impl<'a> Format<'a> for ParameterList<'a, '_> {
                     ",",
                     TrailingSeparator::Omit,
                 );
-                join.finish();
             }
         }
     }

--- a/crates/oxc_formatter/src/write/program.rs
+++ b/crates/oxc_formatter/src/write/program.rs
@@ -90,7 +90,6 @@ impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
 
             join.entry(span, stmt);
         }
-        join.finish();
     }
 }
 
@@ -101,7 +100,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
             return;
         };
 
-        f.join_nodes_with_hardline().entries(self).finish();
+        f.join_nodes_with_hardline().entries(self);
 
         // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
         // JsDirectiveList, for example:

--- a/crates/oxc_formatter/src/write/sequence_expression.rs
+++ b/crates/oxc_formatter/src/write/sequence_expression.rs
@@ -27,7 +27,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
                 write!(f, soft_line_break_or_space());
                 let mut joiner = f.join_with(separator);
                 joiner.entries(expressions);
-                joiner.finish();
             });
 
             if matches!(self.parent, AstNodes::ForStatement(_))

--- a/crates/oxc_formatter/src/write/switch_statement.rs
+++ b/crates/oxc_formatter/src/write/switch_statement.rs
@@ -42,7 +42,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, SwitchCase<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        f.join_nodes_with_hardline().entries(self).finish();
+        f.join_nodes_with_hardline().entries(self);
     }
 }
 

--- a/crates/oxc_formatter/src/write/tuple_type.rs
+++ b/crates/oxc_formatter/src/write/tuple_type.rs
@@ -13,9 +13,11 @@ use super::FormatWrite;
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
-        f.join_nodes_with_soft_line()
-            .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish();
+        f.join_nodes_with_soft_line().entries_with_trailing_separator(
+            self.iter(),
+            ",",
+            trailing_separator,
+        );
     }
 }
 

--- a/crates/oxc_formatter/src/write/type_parameters.rs
+++ b/crates/oxc_formatter/src/write/type_parameters.rs
@@ -84,9 +84,11 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
             FormatTrailingCommas::ES5.trailing_separator(f.options())
         };
 
-        f.join_with(soft_line_break_or_space())
-            .entries_with_trailing_separator(self.iter(), ",", trailing_separator)
-            .finish();
+        f.join_with(soft_line_break_or_space()).entries_with_trailing_separator(
+            self.iter(),
+            ",",
+            trailing_separator,
+        );
     }
 }
 
@@ -121,7 +123,7 @@ impl<'a> Format<'a> for FormatTSTypeParameters<'a, '_> {
                 [group(&format_args!("<", format_with(|f| {
                     if matches!(self.decl.grand_parent(), AstNodes::CallExpression(call) if is_test_call_expression(call))
                     {
-                        f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit).finish();
+                        f.join_nodes_with_space().entries_with_trailing_separator(params, ",", TrailingSeparator::Omit);
                     } else {
                         soft_block_indent(&params).fmt(f);
                     }
@@ -165,9 +167,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
         };
 
         let format_params = format_with(|f| {
-            f.join_with(&soft_line_break_or_space())
-                .entries_with_trailing_separator(params, ",", TrailingSeparator::Disallowed)
-                .finish();
+            f.join_with(&soft_line_break_or_space()).entries_with_trailing_separator(
+                params,
+                ",",
+                TrailingSeparator::Disallowed,
+            );
         });
 
         let should_inline = !is_arrow_function_vars && first_arg_can_be_hugged;

--- a/crates/oxc_formatter/src/write/variable_declaration.rs
+++ b/crates/oxc_formatter/src/write/variable_declaration.rs
@@ -81,7 +81,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
                     write!(f, format_separator);
                 }
 
-                f.join_with(format_separator).entries(declarators).finish();
+                f.join_with(format_separator).entries(declarators);
             }))
         );
     }


### PR DESCRIPTION
No longer needed