### PR TITLE
feat(ast): add `Expression::is_jsx` method

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -389,6 +389,11 @@ impl<'a> Expression<'a> {
             false
         }
     }
+
+    /// Returns `true` if this [`Expression`] is a [`JSXElement`] or [`JSXFragment`].
+    pub fn is_jsx(&self) -> bool {
+        matches!(self, Self::JSXElement(_) | Self::JSXFragment(_))
+    }
 }
 
 impl Display for IdentifierName<'_> {


### PR DESCRIPTION
```rs
    /// Returns `true` if this [`Expression`] is a [`JSXElement`] or [`JSXFragment`].
    pub fn is_jsx(&self) -> bool {
        matches!(self, Self::JSXElement(_) | Self::JSXFragment(_))
    }
```