### PR TITLE
refactor(formatter, transformer): use `Expression::is_jsx` to simplify JSX checks

### DIFF
--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -628,9 +628,7 @@ fn should_break_after_operator<'a>(
     right: &AstNode<'a, Expression<'a>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
-    let is_jsx = matches!(right.as_ref(), Expression::JSXElement(_) | Expression::JSXFragment(_));
-
-    if is_jsx {
+    if right.is_jsx() {
         return false;
     }
 

--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -512,18 +512,8 @@ impl<'a> Format<'a> for BinaryLeftOrRightSide<'a, '_> {
 impl BinaryLeftOrRightSide<'_, '_> {
     fn is_jsx(&self) -> bool {
         match self {
-            BinaryLeftOrRightSide::Left { parent } => {
-                matches!(
-                    parent.left().as_ref(),
-                    Expression::JSXElement(_) | Expression::JSXFragment(_)
-                )
-            }
-            BinaryLeftOrRightSide::Right { parent, .. } => {
-                matches!(
-                    parent.right().as_ref(),
-                    Expression::JSXElement(_) | Expression::JSXFragment(_)
-                )
-            }
+            BinaryLeftOrRightSide::Left { parent } => parent.left().is_jsx(),
+            BinaryLeftOrRightSide::Right { parent, .. } => parent.right().is_jsx(),
         }
     }
 }

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -88,9 +88,7 @@ impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let argument = self.0;
 
-        if !matches!(argument.as_ref(), Expression::JSXElement(_) | Expression::JSXFragment(_))
-            && has_argument_leading_comments(argument, f)
-        {
+        if !argument.is_jsx() && has_argument_leading_comments(argument, f) {
             write!(f, [token("("), &block_indent(&argument), token(")")]);
         } else if argument.is_binaryish() {
             write!(

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -499,7 +499,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for JsxImpl<'a, '_> {
 
     #[inline]
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if !matches!(expr, Expression::JSXElement(_) | Expression::JSXFragment(_)) {
+        if !expr.is_jsx() {
             return;
         }
         *expr = match expr.take_in(ctx.ast) {


### PR DESCRIPTION
Pure refactor