### PR TITLE
fix(linter/plugins): handle non-UTF8 file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,7 @@ toml = { version = "0.9.8" }
 tower-lsp-server = "0.22.1" # LSP server framework
 tracing-subscriber = "0.3.20" # Tracing implementation
 ureq = { version = "3.1.4", default-features = false } # HTTP client
+url = { version = "2.5.7" } # URL parsing
 walkdir = "2.5.0" # Directory traversal
 
 [workspace.metadata.cargo-shear]

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -36,12 +36,12 @@ pub fn create_external_linter(
 ///
 /// The returned function will panic if called outside of a Tokio runtime.
 fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
-    Box::new(move |plugin_path, package_name| {
+    Box::new(move |plugin_url, package_name| {
         let cb = &cb;
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
                 let result = cb
-                    .call_async(FnArgs::from((plugin_path, package_name)))
+                    .call_async(FnArgs::from((plugin_url, package_name)))
                     .await?
                     .into_future()
                     .await?;

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -69,6 +69,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -1,4 +1,7 @@
-use std::fmt;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -14,7 +17,7 @@ define_index_type! {
 
 #[derive(Debug)]
 pub struct ExternalPluginStore {
-    registered_plugin_paths: FxHashSet<String>,
+    registered_plugin_paths: FxHashSet<PathBuf>,
 
     plugins: IndexVec<ExternalPluginId, ExternalPlugin>,
     plugin_names: FxHashMap<String, ExternalPluginId>,
@@ -51,7 +54,7 @@ impl ExternalPluginStore {
         self.plugins.is_empty()
     }
 
-    pub fn is_plugin_registered(&self, plugin_path: &str) -> bool {
+    pub fn is_plugin_registered(&self, plugin_path: &Path) -> bool {
         self.registered_plugin_paths.contains(plugin_path)
     }
 
@@ -63,7 +66,7 @@ impl ExternalPluginStore {
     /// - `offset` does not equal the number of registered rules.
     pub fn register_plugin(
         &mut self,
-        plugin_path: String,
+        plugin_path: PathBuf,
         plugin_name: String,
         offset: usize,
         rule_names: Vec<String>,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -462,7 +462,7 @@ impl Linter {
         };
 
         let result = (external_linter.lint_file)(
-            path.to_str().unwrap().to_string(),
+            path.to_string_lossy().into_owned(),
             external_rules.iter().map(|(rule_id, _)| rule_id.raw()).collect(),
             settings_json,
             allocator,


### PR DESCRIPTION
Fix an edge case bug.

Gracefully handle plugins or files being linted that have file paths which are not valid UTF-8. Previously these would cause panics.

* Load plugin: Convert plugin path to a `file://...` URL on Rust side, instead of on JS side. File URLs can encode any path via URL escaping.
* Lint file: Convert path to `String` with `to_string_lossy`.

Avoiding calling `pathToFileURL` on JS side should also be more performant, but that's a very marginal benefit, as loading plugins is a one-time cost in each lint run.

This adds a dependency on `url` crate. It's a very popular and battle-tested crate. 430m downloads. https://crates.io/crates/url

I could not work out how to add tests for this, as it seems it's not possible to create a file on Mac whose path is not valid UTF-8. It *is* possible on Linux and Windows, but no way to check such a file into Git without it malfunctioning on Mac. We could create test files when tests run, dependent on platform, but I didn't want to create complication in the test infra just for this edge case. It *should* work!
