### PR TITLE
refactor(linter/plugins): prepare for rule options

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -10,7 +10,8 @@ import type { SetNullable } from "./utils/types.ts";
 export type * as ESTree from "./generated/types.d.ts";
 export type { Context, LanguageOptions } from "./plugins/context.ts";
 export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
-export type { CreateOnceRule, CreateRule, Options, Plugin, Rule } from "./plugins/load.ts";
+export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
+export type { Options } from "./plugins/options.ts";
 export type { Diagnostic, Suggestion } from "./plugins/report.ts";
 export type {
   Definition,

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -31,7 +31,8 @@ import { report } from "./report.js";
 import { settings, initSettings } from "./settings.js";
 import { debugAssertIsNonNull } from "../utils/asserts.js";
 
-import type { Options, RuleDetails } from "./load.ts";
+import type { RuleDetails } from "./load.ts";
+import type { Options } from "./options.ts";
 import type { Diagnostic } from "./report.ts";
 import type { Settings } from "./settings.ts";
 import type { SourceCode } from "./source_code.ts";
@@ -363,6 +364,7 @@ export function createContext(fullRuleName: string, ruleDetails: RuleDetails): R
     // Getter for rule options for this rule on this file
     get options(): Readonly<Options> {
       if (filePath === null) throw new Error("Cannot access `context.options` in `createOnce`");
+      debugAssertIsNonNull(ruleDetails.options);
       return ruleDetails.options;
     },
     /**

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -5,7 +5,7 @@ import { getErrorMessage } from "../utils/utils.js";
 
 import type { Writable } from "type-fest";
 import type { Context } from "./context.ts";
-import type { JsonValue } from "./json.ts";
+import type { Options } from "./options.ts";
 import type { RuleMeta } from "./rule_meta.ts";
 import type { AfterHook, BeforeHook, Visitor, VisitorWithHooks } from "./types.ts";
 import type { SetNullable } from "../utils/types.ts";
@@ -47,11 +47,6 @@ export interface CreateOnceRule {
 }
 
 /**
- * Options for a rule on a file.
- */
-export type Options = JsonValue[];
-
-/**
  * Linter rule, context object, and other details of rule.
  * If `rule` has a `createOnce` method, the visitor it returns is stored in `visitor` property.
  */
@@ -64,7 +59,7 @@ interface RuleDetailsBase {
   readonly messages: Readonly<Record<string, string>> | null;
   // Updated for each file
   ruleIndex: number;
-  options: Readonly<Options>;
+  options: Readonly<Options> | null; // Initially `null`, set to options object before linting a file
 }
 
 interface CreateRuleDetails extends RuleDetailsBase {
@@ -90,9 +85,6 @@ export const registeredRules: RuleDetails[] = [];
 
 // `before` hook which makes rule never run.
 const neverRunBeforeHook: BeforeHook = () => false;
-
-// Default rule options
-const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 
 // Plugin details returned to Rust
 interface PluginDetails {
@@ -186,7 +178,7 @@ async function loadPluginImpl(path: string, packageName: string | null): Promise
       isFixable,
       messages,
       ruleIndex: 0,
-      options: DEFAULT_OPTIONS,
+      options: null,
       visitor: null,
       beforeHook: null,
       afterHook: null,

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -1,0 +1,19 @@
+/*
+ * Options for rules.
+ */
+
+import type { JsonValue } from "./json.ts";
+
+/**
+ * Options for a rule on a file.
+ */
+export type Options = JsonValue[];
+
+// Default rule options
+const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
+
+// All rule options
+export const allOptions: Readonly<Options>[] = [DEFAULT_OPTIONS];
+
+// Index into `allOptions` for default options
+export const DEFAULT_OPTIONS_ID = 0;


### PR DESCRIPTION
Preparatory work for supporting rule options.

Store options for all rules in an `allOptions` array. Currently this array only contains a single value for empty options, but in future we'll populate it with options extracted from configs, sent over from Rust side.

Am adding this now, before full implementation (#14825), as it's required for rule tester.
