### PR TITLE
build(linter/plugins): fully remove debug assertions

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -29,6 +29,7 @@
     "esquery": "^1.6.0",
     "execa": "^9.6.0",
     "jiti": "^2.6.0",
+    "oxc-parser": "^0.99.0",
     "rolldown": "catalog:",
     "tsdown": "catalog:",
     "type-fest": "^5.2.0",

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { defineConfig } from "tsdown";
+import { parseSync, Visitor } from "oxc-parser";
 
 import type { Plugin } from "rolldown";
 
@@ -58,17 +59,22 @@ export default defineConfig([
 ]);
 
 /**
- * Create a plugin to remove imports of `assert*` functions from `src-js/utils/asserts.ts`,
- * and replace those imports with empty function declarations.
+ * Create a plugin to remove imports of `debugAssert*` / `typeAssert*` functions from `src-js/utils/asserts.ts`,
+ * and all their call sites.
  *
  * ```ts
  * // Original code
- * import { assertIs, assertIsNonNull } from '../utils/asserts.ts';
+ * import { debugAssertIsNonNull } from '../utils/asserts.ts';
+ * const foo = getFoo();
+ * debugAssertIsNonNull(foo.bar);
  *
  * // After transform
- * function assertIs() {}
- * function assertIsNonNull() {}
+ * const foo = getFoo();
  * ```
+ *
+ * This solves 2 problems:
+ *
+ * # 1. Minifier works chunk-by-chunk
  *
  * Minifier can already remove all calls to these functions as dead code, but only if the functions are defined
  * in the same file as the call sites.
@@ -77,7 +83,23 @@ export default defineConfig([
  * So without this transform, TSDown creates a shared chunk for `asserts.ts`. Minifier works chunk-by-chunk,
  * so can't see that these functions are no-ops, and doesn't remove the function calls.
  *
- * Inlining these functions in each file solves the problem, and minifier removes all trace of them.
+ * # 2. Not entirely removed
+ *
+ * Even if minifier does remove all calls to these functions, it can't prove that expressions *inside* the calls
+ * don't have side effects.
+ *
+ * In example above, it can't know if `foo` has a getter for `bar` property.
+ * So it removes the call to `debugAssertIsNonNull`, but leaves behind the `foo.bar` expression.
+ *
+ * ```ts
+ * const foo = getFoo();
+ * foo.bar;
+ * ```
+ *
+ * This plugin visits AST and removes all calls to `debugAssert*` / `typeAssert*` functions entirely,
+ * *including* the expressions inside the calls.
+ *
+ * This makes these debug assertion functions act like `debug_assert!` in Rust.
  *
  * @returns Plugin
  */
@@ -90,11 +112,16 @@ function createReplaceAssertsPlugin(): Plugin {
       // Only process TS files in `src-js` directory
       filter: { id: /\/src-js\/.+\.ts$/ },
 
-      async handler(code, id, meta) {
+      async handler(code, path, meta) {
         const magicString = meta.magicString!;
-        const program = this.parse(code, { lang: "ts" });
+        const { program, errors } = parseSync(path, code);
+        if (errors.length !== 0) throw new Error(`Failed to parse ${path}: ${errors[0].message}`);
 
-        stmts: for (const stmt of program.body) {
+        // Gather names of assertion functions imported from `asserts.ts`.
+        // Also gather all identifiers used in the `import` statements, so can avoid erroring on them in visitor below.
+        const assertFnNames: Set<string> = new Set(),
+          idents = new Set();
+        for (const stmt of program.body) {
           if (stmt.type !== "ImportDeclaration") continue;
 
           // Check if import is from `utils/asserts.ts`.
@@ -102,18 +129,45 @@ function createReplaceAssertsPlugin(): Plugin {
           const source = stmt.source.value;
           if (!source.endsWith("/asserts.ts") && !source.endsWith("/asserts.js")) continue;
           // oxlint-disable-next-line no-await-in-loop
-          const importedId = await this.resolve(source, id);
+          const importedId = await this.resolve(source, path);
           if (importedId === null || importedId.id !== ASSERTS_PATH) continue;
 
-          // Replace `import` statement with empty function declarations
-          let functionsCode = "";
+          // Remove `import` statement
           for (const specifier of stmt.specifiers) {
-            // Skip this `import` statement if it's a default or namespace import - can't handle those
-            if (specifier.type !== "ImportSpecifier") continue stmts;
-            functionsCode += `function ${specifier.local.name}() {}\n`;
+            if (specifier.type !== "ImportSpecifier") {
+              throw new Error(`Only use named imports when importing from \`asserts.ts\`: ${path}`);
+            }
+            idents.add(specifier.local);
+            if (specifier.imported.type === "Identifier") idents.add(specifier.imported);
+            assertFnNames.add(specifier.local.name);
           }
-          magicString.overwrite(stmt.start, stmt.end, functionsCode);
+          magicString.remove(stmt.start, stmt.end);
         }
+
+        if (assertFnNames.size === 0) return;
+
+        // Visit AST and remove all calls to assertion functions
+        const visitor = new Visitor({
+          // Replace `debugAssert(...)` calls with `null`. Minifier will remove the `null`.
+          CallExpression(node) {
+            const { callee } = node;
+            if (callee.type !== "Identifier") return;
+            if (assertFnNames.has(callee.name)) {
+              idents.add(callee);
+              magicString.overwrite(node.start, node.end, "null");
+            }
+          },
+          // Error if assertion functions are used in any other way. We lack logic to deal with that.
+          Identifier(node) {
+            const { name } = node;
+            if (assertFnNames.has(name) && !idents.has(node)) {
+              throw new Error(
+                `Do not use \`${name}\` imported from \`asserts.ts\` except in function calls: ${path}`,
+              );
+            }
+          },
+        });
+        visitor.visit(program);
 
         return { code: magicString };
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       jiti:
         specifier: ^2.6.0
         version: 2.6.1
+      oxc-parser:
+        specifier: ^0.99.0
+        version: 0.99.0
       rolldown:
         specifier: 'catalog:'
         version: 1.0.0-beta.52
@@ -1469,6 +1472,95 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@oxc-parser/binding-android-arm64@0.99.0':
+    resolution: {integrity: sha512-V4jhmKXgQQdRnm73F+r3ZY4pUEsijQeSraFeaCGng7abSNJGs76X6l82wHnmjLGFAeY00LWtjcELs7ZmbJ9+lA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.99.0':
+    resolution: {integrity: sha512-Rp41nf9zD5FyLZciS9l1GfK8PhYqrD5kEGxyTOA2esTLeAy37rZxetG2E3xteEolAkeb2WDkVrlxPtibeAncMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.99.0':
+    resolution: {integrity: sha512-WVonp40fPPxo5Gs0POTI57iEFv485TvNKOHMwZRhigwZRhZY2accEAkYIhei9eswF4HN5B44Wybkz7Gd1Qr/5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.99.0':
+    resolution: {integrity: sha512-H30bjOOttPmG54gAqu6+HzbLEzuNOYO2jZYrIq4At+NtLJwvNhXz28Hf5iEAFZIH/4hMpLkM4VN7uc+5UlNW3Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.99.0':
+    resolution: {integrity: sha512-0Z/Th0SYqzSRDPs6tk5lQdW0i73UCupnim3dgq2oW0//UdLonV/5wIZCArfKGC7w9y4h8TxgXpgtIyD1kKzzlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.99.0':
+    resolution: {integrity: sha512-xo0wqNd5bpbzQVNpAIFbHk1xa+SaS/FGBABCd942SRTnrpxl6GeDj/s1BFaGcTl8MlwlKVMwOcyKrw/2Kdfquw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.99.0':
+    resolution: {integrity: sha512-u26I6LKoLTPTd4Fcpr0aoAtjnGf5/ulMllo+QUiBhupgbVCAlaj4RyXH/mvcjcsl2bVBv9E/gYJZz2JjxQWXBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.99.0':
+    resolution: {integrity: sha512-qhftDo2D37SqCEl3ZTa367NqWSZNb1Ddp34CTmShLKFrnKdNiUn55RdokLnHtf1AL5ssaQlYDwBECX7XiBWOhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.99.0':
+    resolution: {integrity: sha512-zxn/xkf519f12FKkpL5XwJipsylfSSnm36h6c1zBDTz4fbIDMGyIhHfWfwM7uUmHo9Aqw1pLxFpY39Etv398+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.99.0':
+    resolution: {integrity: sha512-Y1eSDKDS5E4IVC7Oxw+NbYAKRmJPMJTIjW+9xOWwteDHkFqpocKe0USxog+Q1uhzalD9M0p9eXWEWdGQCMDBMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.99.0':
+    resolution: {integrity: sha512-YVJMfk5cFWB8i2/nIrbk6n15bFkMHqWnMIWkVx7r2KwpTxHyFMfu2IpeVKo1ITDSmt5nBrGdLHD36QRlu2nDLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.99.0':
+    resolution: {integrity: sha512-2+SDPrie5f90A1b9EirtVggOgsqtsYU5raZwkDYKyS1uvJzjqHCDhG/f4TwQxHmIc5YkczdQfwvN91lwmjsKYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-wasm32-wasi@0.99.0':
+    resolution: {integrity: sha512-DKA4j0QerUWSMADziLM5sAyM7V53Fj95CV9SjP77bPfEfT7MnvFKnneaRMqPK1cpzjAGiQF52OBUIKyk0dwOQA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.99.0':
+    resolution: {integrity: sha512-EaB3AvsxqdNUhh9FOoAxRZ2L4PCRwDlDb//QXItwyOJrX7XS+uGK9B1KEUV4FZ/7rDhHsWieLt5e07wl2Ti5AQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.99.0':
+    resolution: {integrity: sha512-sJN1Q8h7ggFOyDn0zsHaXbP/MklAVUvhrbq0LA46Qum686P3SZQHjbATqJn9yaVEvaSKXCshgl0vQ1gWkGgpcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-project/runtime@0.96.0':
     resolution: {integrity: sha512-34lh4o9CcSw09Hx6fKihPu85+m+4pmDlkXwJrLvN5nMq5JrcGhhihVM415zDqT8j8IixO1PYYdQZRN4SwQCncg==}
@@ -3362,6 +3454,10 @@ packages:
     resolution: {integrity: sha512-MZ7pgQ+IS5kumAfZGnhEjmdOUwW0UlmlekMwuA5DeUJeft7jFu9fTIEhH71ypjdUSpdqchodoKgb5y/ilh7b5g==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  oxc-parser@0.99.0:
+    resolution: {integrity: sha512-MpS1lbd2vR0NZn1v0drpgu7RUFu3x9Rd0kxExObZc2+F+DIrV0BOMval/RO3BYGwssIOerII6iS8EbbpCCZQpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.15.0:
     resolution: {integrity: sha512-WOPBsZteu/H7t+3UGuEDyYi87+v2H96zyBwrEIwq4SEAt8P3bL6velrvs71V6aOpxjLcIPAnKjXeHScvFImI4w==}
@@ -5360,6 +5456,53 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@oxc-parser/binding-android-arm64@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.99.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.99.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.99.0':
+    optional: true
+
   '@oxc-project/runtime@0.96.0': {}
 
   '@oxc-project/types@0.98.0': {}
@@ -7220,6 +7363,26 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  oxc-parser@0.99.0:
+    dependencies:
+      '@oxc-project/types': 0.99.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm64': 0.99.0
+      '@oxc-parser/binding-darwin-arm64': 0.99.0
+      '@oxc-parser/binding-darwin-x64': 0.99.0
+      '@oxc-parser/binding-freebsd-x64': 0.99.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.99.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.99.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.99.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.99.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.99.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.99.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.99.0
+      '@oxc-parser/binding-linux-x64-musl': 0.99.0
+      '@oxc-parser/binding-wasm32-wasi': 0.99.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.99.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.99.0
 
   oxfmt@0.15.0:
     optionalDependencies:


### PR DESCRIPTION
`debugAssert` and friends are meant to be completely removed in release build (like `debug_assert!` in Rust). Turns out they weren't.

Minifier does remove all calls to these functions, but it can't always prove that the expressions *inside* the function calls don't have side effects, so was leaving them in place in some cases.

Fix that by visiting the AST in TSDown plugin, and removing all calls to debug assert functions entirely.

Source code:

```ts
if (visitor === null) {
    debugAssertIsNonNull(ruleDetails.rule.create);
    visitor = ruleDetails.rule.create(ruleDetails.context);
}
```

Release build, before this PR:

```ts
if (visitor === null) ruleDetails.rule.create, visitor = ruleDetails.rule.create(ruleDetails.context);
```

After this PR:

```ts
if (visitor === null) visitor = ruleDetails.rule.create(ruleDetails.context);
```
