### PR TITLE
chore(deps): apply the fix from latest cargo-shear

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -28,7 +28,6 @@ oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["assert_unchecked", "inline_string", "rope", "slice_iter", "stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
-oxc_parser = { workspace = true }
 oxc_regular_expression = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -76,8 +76,6 @@ oxc_transformer = { workspace = true, optional = true }
 
 criterion2 = { workspace = true }
 
-rustc-hash = { workspace = true }
-
 # Only for lexer benchmark
 cow-utils = { workspace = true, optional = true }
 
@@ -118,3 +116,6 @@ linter = [
   "dep:oxc_tasks_common",
   "oxc_semantic/cfg",
 ]
+
+[dev-dependencies]
+rustc-hash = { workspace = true }


### PR DESCRIPTION
Since the update of [cargo-shear](https://github.com/Boshen/cargo-shear/releases/tag/v1.6.6), there are more unused dependencies be found in latest version of it, it prevents the git commits and this PR applies the fix from latest cargo shear to fix it