### PR TITLE
feat(linter/plugins): support default options

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -156,7 +156,8 @@ function lintFileImpl(
     // Set `options` for rule
     const optionsId = optionsIds[i];
     debugAssert(optionsId < allOptions.length, "Options ID out of bounds");
-    ruleDetails.options = allOptions[optionsId];
+    ruleDetails.options =
+      optionsId === DEFAULT_OPTIONS_ID ? ruleDetails.defaultOptions : allOptions[optionsId];
 
     let { visitor } = ruleDetails;
     if (visitor === null) {

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -10,7 +10,7 @@ import type { JsonValue } from "./json.ts";
 export type Options = JsonValue[];
 
 // Default rule options
-const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
+export const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 
 // All rule options
 export const allOptions: Readonly<Options>[] = [DEFAULT_OPTIONS];

--- a/apps/oxlint/test/fixtures/options/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/options/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "options-plugin/options": "error",
+    "options-plugin/default-options": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/options/files/index.js
+++ b/apps/oxlint/test/fixtures/options/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -1,0 +1,26 @@
+# Exit code
+1
+
+# stdout
+```
+  x options-plugin(default-options): options: ["string",123,true,{"toBe":false,"notToBe":true}]
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^
+   `----
+
+  x options-plugin(options): options: []
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^
+   `----
+
+Found 0 warnings and 2 errors.
+Finished in Xms on 1 file using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -1,0 +1,42 @@
+import type { Node, Plugin } from "#oxlint";
+
+const SPAN: Node = {
+  start: 0,
+  end: 0,
+  range: [0, 0],
+  loc: {
+    start: { line: 0, column: 0 },
+    end: { line: 0, column: 0 },
+  },
+};
+
+const plugin: Plugin = {
+  meta: {
+    name: "options-plugin",
+  },
+  rules: {
+    options: {
+      create(context) {
+        context.report({
+          message: `options: ${JSON.stringify(context.options)}`,
+          node: SPAN,
+        });
+        return {};
+      },
+    },
+    "default-options": {
+      meta: {
+        defaultOptions: ["string", 123, true, { toBe: false, notToBe: true }],
+      },
+      create(context) {
+        context.report({
+          message: `options: ${JSON.stringify(context.options)}`,
+          node: SPAN,
+        });
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
A step towards #15630. Where a rule provides default options, pass them to `create` function as `context.options`.

We don't yet have full options support (#14825), so this is incomplete. Once user can provide options for rules in config, those options need to be merged with default options.

Initially, we should probably do that merging on JS side (borrowing ESLint's code), and then later on port it to Rust.