### PR TITLE
fix(linter): Fix the `react/jsx-fragments` rule config to take a string argument

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_fragments.snap
@@ -1,23 +1,30 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred
+  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred.
    ╭─[jsx_fragments.tsx:1:2]
  1 │ <Fragment><Foo /></Fragment>
    ·  ────────
    ╰────
-  help: Use <></> instead of <React.Fragment></React.Fragment>
+  help: Use `<></>` instead of `<React.Fragment></React.Fragment>`.
 
-  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred
+  ⚠ eslint-plugin-react(jsx-fragments): Shorthand form for React fragments is preferred.
    ╭─[jsx_fragments.tsx:1:2]
  1 │ <React.Fragment><Foo /></React.Fragment>
    ·  ──────────────
    ╰────
-  help: Use <></> instead of <React.Fragment></React.Fragment>
+  help: Use `<></>` instead of `<React.Fragment></React.Fragment>`.
 
-  ⚠ eslint-plugin-react(jsx-fragments): Standard form for React fragments is preferred
+  ⚠ eslint-plugin-react(jsx-fragments): Standard form for React fragments is preferred.
    ╭─[jsx_fragments.tsx:1:1]
  1 │ <><Foo /></>
    · ──
    ╰────
-  help: Use <React.Fragment></React.Fragment> instead of <></>
+  help: Use `<React.Fragment></React.Fragment>` instead of `<></>`.
+
+  ⚠ eslint-plugin-react(jsx-fragments): Standard form for React fragments is preferred.
+   ╭─[jsx_fragments.tsx:1:1]
+ 1 │ <><Foo /></>
+   · ──
+   ╰────
+  help: Use `<React.Fragment></React.Fragment>` instead of `<></>`.


### PR DESCRIPTION
The [original rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md) has a config option in the format of `["error", "element"]` or `["error", "syntax"]`. We required a config object like `["error", { "mode": "element" }]`, which is technically incompatible for existing configs that get migrated to oxlint.

This fixes that in the generated docs, and also makes it work correctly in the oxlint config. We retain compatibility with the object syntax in case anyone has set up oxlint with it already, and I've added tests to ensure both formats of the config option work.

Generated docs now:

```md
## Configuration

This rule accepts one of the following string values:

### `"syntax"`

This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.
Keys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.

Examples of **incorrect** code for this rule:
\```jsx
<React.Fragment><Foo /></React.Fragment>
\```

Examples of **correct** code for this rule:
\```jsx
<><Foo /></>
\```

\```jsx
<React.Fragment key="key"><Foo /></React.Fragment>
\```

### `"element"`

This mode enforces the standard form for React fragments.

Examples of **incorrect** code for this rule:
\```jsx
<><Foo /></>
\```

Examples of **correct** code for this rule:
\```jsx
<React.Fragment><Foo /></React.Fragment>
\```

\```jsx
<React.Fragment key="key"><Foo /></React.Fragment>
\```
```