### PR TITLE
fix(linter/plugins): handle zero-token files in `SourceCode#getLastToken()`

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -655,19 +655,17 @@ export function getLastToken(
 
   // Binary search for the last token within `node`'s range
   const nodeTokensLength = nodeTokens.length;
-  let lastTokenIndex = nodeTokensLength;
-  for (let lo = 0, hi = nodeTokensLength; lo < hi; ) {
-    const mid = (lo + hi) >> 1;
+  let lastTokenIndex = 0;
+  for (let hi = nodeTokensLength; lastTokenIndex < hi; ) {
+    const mid = (lastTokenIndex + hi) >> 1;
     if (nodeTokens[mid].range[0] < rangeEnd) {
-      lastTokenIndex = mid;
-      lo = mid + 1;
+      lastTokenIndex = mid + 1;
     } else {
       hi = mid;
     }
   }
 
-  // TODO: this early return feels iffy
-  if (lastTokenIndex === nodeTokensLength) return null;
+  lastTokenIndex--;
 
   if (typeof filter !== "function") {
     if (typeof skip !== "number") return nodeTokens[lastTokenIndex] ?? null;

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -892,7 +892,8 @@ describe("when calling getLastToken", () => {
     resetSourceAndAst();
     sourceText = "foo // comment";
 
-    expect(getLastToken(Program)!.value).toBe("foo");
+    // TODO: this verbatim range should be replaced with `ast`
+    expect(getLastToken({ range: [0, 3] } as Node)!.value).toBe("foo");
     resetSourceAndAst();
   });
 
@@ -901,7 +902,8 @@ describe("when calling getLastToken", () => {
     sourceText = "// comment";
 
     expect(
-      getLastToken({ range: [0, 11] } as Node, {
+      // TODO: this verbatim range should be replaced with `ast`
+      getLastToken({ range: [0, 10] } as Node, {
         filter() {
           expect.fail("Unexpected call to filter callback");
         },


### PR DESCRIPTION
- The root cause of the "iffy" line of code in #16003 was an incorrectly implemented test.
- The corrected test revealed that the code attempted to index the `0` index of an empty array.
- This PR fixes both issues.
- Also took the opportunity to remove a variable declaration in the binary search.