### PR TITLE
fix(formatter): template literal element should not be indented

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/template-literal-type/issue-16136.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/template-literal-type/issue-16136.ts
@@ -1,0 +1,12 @@
+type templateLiteralType = `${
+  TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+    ? '_'
+    : ''
+}`;
+
+type CamelToSnakeCase<TCamelCaseString extends string> =
+  TCamelCaseString extends `${infer TStringConvertedSoFar}${infer TStringYetToConvert}`
+    ? `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+        ? '_'
+        : ''}${Lowercase<TStringConvertedSoFar>}${CamelToSnakeCase<TStringYetToConvert>}`
+    : TCamelCaseString;

--- a/crates/oxc_formatter/tests/fixtures/ts/template-literal-type/issue-16136.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/template-literal-type/issue-16136.ts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+type templateLiteralType = `${
+  TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+    ? '_'
+    : ''
+}`;
+
+type CamelToSnakeCase<TCamelCaseString extends string> =
+  TCamelCaseString extends `${infer TStringConvertedSoFar}${infer TStringYetToConvert}`
+    ? `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+        ? '_'
+        : ''}${Lowercase<TStringConvertedSoFar>}${CamelToSnakeCase<TStringYetToConvert>}`
+    : TCamelCaseString;
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+type templateLiteralType =
+  `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+    ? "_"
+    : ""}`;
+
+type CamelToSnakeCase<TCamelCaseString extends string> =
+  TCamelCaseString extends `${infer TStringConvertedSoFar}${infer TStringYetToConvert}`
+    ? `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+        ? "_"
+        : ""}${Lowercase<TStringConvertedSoFar>}${CamelToSnakeCase<TStringYetToConvert>}`
+    : TCamelCaseString;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+type templateLiteralType = `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+  ? "_"
+  : ""}`;
+
+type CamelToSnakeCase<TCamelCaseString extends string> =
+  TCamelCaseString extends `${infer TStringConvertedSoFar}${infer TStringYetToConvert}`
+    ? `${TStringConvertedSoFar extends Capitalize<TStringConvertedSoFar>
+        ? "_"
+        : ""}${Lowercase<TStringConvertedSoFar>}${CamelToSnakeCase<TStringYetToConvert>}`
+    : TCamelCaseString;
+
+===================== End =====================


### PR DESCRIPTION
* close: https://github.com/oxc-project/oxc/issues/16136