### PR TITLE
chore(github): Update issue template labels for formatter diff report

### DIFF
--- a/.github/ISSUE_TEMPLATE/formatter_diff_report.yaml
+++ b/.github/ISSUE_TEMPLATE/formatter_diff_report.yaml
@@ -1,7 +1,7 @@
 name: Formatter diff report
 description: Report Oxfmt differences with Prettier
 title: "formatter: Diff with Prettier on ..."
-labels: ["A-formatter"]
+labels: ["A-formatter-prettier-diff"]
 type: Bug
 
 body:


### PR DESCRIPTION
Changed label `A-formatter` > `A-formatter-prettier-diff`.