### PR TITLE
fix(linter): add considerDefaultExhaustiveForUnions option to switch-exhaustiveness-check

### DIFF
--- a/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
@@ -1,0 +1,13 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "typescript/switch-exhaustiveness-check": [
+      "error",
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ]
+  }
+}

--- a/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
@@ -1,0 +1,17 @@
+type Day = 'Monday' | 'Tuesday';
+
+declare const day: Day;
+let result = 0;
+
+// This should NOT error when considerDefaultExhaustiveForUnions is true
+// because the default case makes it exhaustive
+switch (day) {
+  case 'Monday':
+    result = 1;
+    break;
+  default:
+    result = 3;
+    break;
+}
+
+export { result };

--- a/apps/oxlint/fixtures/tsgolint_rule_options/tsconfig.json
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node"
+  },
+  "include": ["*.ts"]
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1412,4 +1412,13 @@ mod test {
             .with_cwd("fixtures/tsgolint_tsconfig_extends_config_err".into())
             .test_and_snapshot(args);
     }
+
+    #[test]
+    #[cfg(all(not(target_os = "windows"), not(target_endian = "big")))]
+    fn test_tsgolint_rule_options() {
+        // Test that rule options are correctly passed to tsgolint
+        // See: https://github.com/oxc-project/oxc/issues/16182
+        let args = &["--type-aware"];
+        Tester::new().with_cwd("fixtures/tsgolint_rule_options".into()).test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --type-aware
+working directory: fixtures/tsgolint_rule_options
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -13,9 +13,10 @@ pub struct SwitchExhaustivenessCheckConfig {
     /// Whether to allow default cases on switches that are not exhaustive.
     /// When false, requires exhaustive switch statements without default cases.
     pub allow_default_case_for_exhaustive_switch: bool,
-    /// Whether to allow this rule to run without `strictNullChecks` enabled.
-    /// This is not recommended as the rule may produce incorrect results.
-    pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
+    /// Whether to consider `default` cases exhaustive for union types.
+    /// When true, a switch statement with a `default` case is considered exhaustive
+    /// even if not all union members are handled explicitly.
+    pub consider_default_exhaustive_for_unions: bool,
     /// Regular expression pattern that when matched in a default case comment,
     /// will suppress the exhaustiveness check.
     /// Example: `"@skip-exhaustive-check"` to allow `default: // @skip-exhaustive-check`


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/16182