### PR TITLE
feat(linter/plugins): introduce `RuleTester`

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/esquery": "^1.5.4",
     "@types/estree": "^1.0.8",
+    "@types/json-stable-stringify-without-jsonify": "^1.0.2",
     "@typescript-eslint/scope-manager": "8.46.2",
     "@typescript-eslint/typescript-estree": "^8.47.0",
     "cross-env": "catalog:",
@@ -29,6 +30,7 @@
     "esquery": "^1.6.0",
     "execa": "^9.6.0",
     "jiti": "^2.6.0",
+    "json-stable-stringify-without-jsonify": "^1.0.1",
     "oxc-parser": "^0.99.0",
     "rolldown": "catalog:",
     "tsdown": "catalog:",

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,6 +1,11 @@
+// Functions and classes
 export { definePlugin, defineRule } from "./package/define.js";
+export { RuleTester } from "./package/rule_tester.js";
 
+// ESTree types
 export type * as ESTree from "./generated/types.d.ts";
+
+// Plugin types
 export type { Context, LanguageOptions } from "./plugins/context.ts";
 export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
@@ -57,3 +62,25 @@ export type {
   Visitor,
   VisitorWithHooks,
 } from "./plugins/types.ts";
+
+// Rule tester types.
+// Export as namespace to avoid lengthy type names.
+import type {
+  Config as _Config,
+  DescribeFn as _DescribeFn,
+  ItFn as _ItFn,
+  ValidTestCase as _ValidTestCase,
+  InvalidTestCase as _InvalidTestCase,
+  TestCases as _TestCases,
+  Error as _Error,
+} from "./package/rule_tester.ts";
+
+export namespace RuleTester {
+  export type Config = _Config;
+  export type DescribeFn = _DescribeFn;
+  export type ItFn = _ItFn;
+  export type ValidTestCase = _ValidTestCase;
+  export type InvalidTestCase = _InvalidTestCase;
+  export type TestCases = _TestCases;
+  export type Error = _Error;
+}

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -1,0 +1,915 @@
+/*
+ * `RuleTester` class.
+ *
+ * Heavily based on ESLint's `RuleTester`, but without the complications of configs.
+ * Has the same user-facing API as ESLint's version.
+ * Code: https://github.com/eslint/eslint/blob/0f5a94a84beee19f376025c74f703f275d52c94b/lib/rule-tester/rule-tester.js
+ * License (MIT): https://github.com/eslint/eslint/blob/0f5a94a84beee19f376025c74f703f275d52c94b/LICENSE
+ */
+
+import { default as assert, AssertionError } from "node:assert";
+import util from "node:util";
+import stringify from "json-stable-stringify-without-jsonify";
+import { registerPlugin, registeredRules } from "../plugins/load.js";
+import { lintFileImpl, resetFile } from "../plugins/lint.js";
+import { getLineColumnFromOffset, getNodeByRangeIndex } from "../plugins/location.js";
+import { allOptions, mergeOptions } from "../plugins/options.js";
+import { diagnostics, replacePlaceholders, PLACEHOLDER_REGEX } from "../plugins/report.js";
+import { parse } from "./parse.js";
+
+import type { RequireAtLeastOne } from "type-fest";
+import type { Plugin, Rule } from "../plugins/load.ts";
+import type { Options } from "../plugins/options.ts";
+import type { DiagnosticData, Suggestion } from "../plugins/report.ts";
+
+const { hasOwn } = Object,
+  { isArray } = Array;
+
+// ------------------------------------------------------------------------------
+// `describe` and `it` functions
+// ------------------------------------------------------------------------------
+
+export type DescribeFn = (text: string, fn: () => void) => void;
+export type ItFn = ((text: string, fn: () => void) => void) & { only?: ItFn };
+
+/**
+ * Default `describe` function, if `describe` doesn't exist as a global.
+ * @param text - Description of the test case
+ * @param method - Test case logic
+ * @returns Returned value of `method`
+ */
+function defaultDescribe<R>(text: string, method: () => R): R {
+  return method.call(this);
+}
+
+const globalObj = globalThis as { describe?: DescribeFn; it?: ItFn };
+
+// `describe` function. Can be overwritten via `RuleTester.describe` setter.
+let describe: DescribeFn =
+  typeof globalObj.describe === "function" ? globalObj.describe : defaultDescribe;
+
+/**
+ * Default `it` function, if `it` doesn't exist as a global.
+ * @param text - Description of the test case
+ * @param method - Test case logic
+ * @throws {Error} Any error upon execution of `method`
+ * @returns Returned value of `method`
+ */
+function defaultIt<R>(text: string, method: () => R): R {
+  try {
+    return method.call(this);
+  } catch (err) {
+    if (err instanceof AssertionError) {
+      err.message += ` (${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)})`;
+    }
+    throw err;
+  }
+}
+
+// `it` function. Can be overwritten via `RuleTester.it` setter.
+let it: ItFn = typeof globalObj.it === "function" ? globalObj.it : defaultIt;
+
+// `it.only` function. Can be overwritten via `RuleTester.it` or `RuleTester.itOnly` setters.
+let itOnly: ItFn | null =
+  it !== defaultIt && typeof it.only === "function" ? Function.bind.call(it.only, it) : null;
+
+/**
+ * Get `it` function.
+ * @param only - `true` if `it.only` should be used
+ * @throws {Error} If `it.only` is not available
+ * @returns `it` or `it.only` function
+ */
+function getIt(only?: boolean): ItFn {
+  return only ? getItOnly() : it;
+}
+
+/**
+ * Get `it.only` function.
+ * @throws {Error} If `it.only` is not available
+ * @returns `it.only` function
+ */
+function getItOnly(): ItFn {
+  if (itOnly === null) {
+    throw new Error(
+      "To use `only`, use `RuleTester` with a test framework that provides `it.only()` like Mocha, " +
+        "or provide a custom `it.only` function by assigning it to `RuleTester.itOnly`",
+    );
+  }
+  return itOnly;
+}
+
+// ------------------------------------------------------------------------------
+// Config
+// ------------------------------------------------------------------------------
+
+/**
+ * Configuration for `RuleTester`.
+ */
+export type Config = Record<string, unknown>;
+
+// Default shared config
+const DEFAULT_SHARED_CONFIG: Config = {};
+
+// `RuleTester` uses this config as its default. Can be overwritten via `RuleTester.setDefaultConfig()`.
+let sharedConfig: Config = DEFAULT_SHARED_CONFIG;
+
+// ------------------------------------------------------------------------------
+// Test cases
+// ------------------------------------------------------------------------------
+
+/**
+ * Test case.
+ */
+interface TestCase {
+  code: string;
+  name?: string;
+  only?: boolean;
+  filename?: string;
+  options?: Options;
+  before?: (this: this) => void;
+  after?: (this: this) => void;
+}
+
+/**
+ * Test case for valid code.
+ */
+export interface ValidTestCase extends TestCase {}
+
+/**
+ * Test case for invalid code.
+ */
+export interface InvalidTestCase extends TestCase {
+  output?: string | null;
+  errors: number | ErrorEntry[];
+}
+
+type ErrorEntry = Error | string | RegExp;
+
+/**
+ * Expected error.
+ */
+export type Error = RequireAtLeastOne<ErrorBase, "message" | "messageId">;
+
+interface ErrorBase {
+  message?: string | RegExp;
+  messageId?: string;
+  data?: DiagnosticData;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
+/**
+ * Test cases for a rule.
+ */
+export interface TestCases {
+  valid: (ValidTestCase | string)[];
+  invalid: InvalidTestCase[];
+}
+
+/**
+ * Diagnostic included in assertion errors.
+ *
+ * This matches what ESLint's includes in errors it emits.
+ * `severity` field is pointless, as it's always `1`, but ESLint includes it, so we do too.
+ */
+interface Diagnostic {
+  ruleId: string;
+  message: string;
+  messageId: string | null;
+  severity: 1;
+  nodeType: string | null;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  suggestions: Suggestion[] | null;
+}
+
+// Default path for test cases if not provided
+const DEFAULT_PATH = "file.js";
+
+// ------------------------------------------------------------------------------
+// `RuleTester` class
+// ------------------------------------------------------------------------------
+
+/**
+ * Utility class for testing rules.
+ */
+export class RuleTester {
+  #config: Config | null;
+
+  /**
+   * Creates a new instance of RuleTester.
+   * @param config? - Extra configuration for the tester (optional)
+   */
+  constructor(config?: Config) {
+    this.#config = config === undefined ? null : config;
+  }
+
+  /**
+   * Set the configuration to use for all future tests.
+   * @param config - The configuration to use
+   * @throws {TypeError} If `config` is not an object
+   */
+  static setDefaultConfig(config: Config): void {
+    if (typeof config !== "object" || config === null) {
+      throw new TypeError("`config` must be an object");
+    }
+    sharedConfig = config;
+  }
+
+  /**
+   * Get the current configuration used for all tests.
+   * @returns The current configuration
+   */
+  static getDefaultConfig(): Config {
+    return sharedConfig;
+  }
+
+  /**
+   * Reset the configuration to the initial configuration of the tester removing
+   * any changes made until now.
+   * @returns {void}
+   */
+  static resetDefaultConfig() {
+    sharedConfig = DEFAULT_SHARED_CONFIG;
+  }
+
+  // Getters/setters for `describe` and `it` functions
+
+  static get describe(): DescribeFn {
+    return describe;
+  }
+
+  static set describe(value: DescribeFn) {
+    describe = value;
+  }
+
+  static get it(): ItFn {
+    return it;
+  }
+
+  static set it(value: ItFn) {
+    it = value;
+    if (typeof it.only === "function") {
+      itOnly = Function.bind.call(it.only, it);
+    } else {
+      itOnly = null;
+    }
+  }
+
+  static get itOnly(): ItFn {
+    return getItOnly();
+  }
+
+  static set itOnly(value: ItFn) {
+    itOnly = value;
+  }
+
+  /**
+   * Add the `only` property to a test to run it in isolation.
+   * @param item - A single test to run by itself
+   * @returns The test with `only` set
+   */
+  static only(item: string | TestCase): TestCase {
+    if (typeof item === "string") return { code: item, only: true };
+    return { ...item, only: true };
+  }
+
+  /**
+   * Adds a new rule test to execute.
+   * @param ruleName - Name of the rule to run
+   * @param rule - Rule to test
+   * @param tests - Collection of tests to run
+   * @throws {TypeError|Error} If `rule` is not an object with a `create` method,
+   *   or if non-object `test`, or if a required scenario of the given type is missing
+   */
+  run(ruleName: string, rule: Rule, tests: TestCases): void {
+    // Create plugin for the rule
+    const plugin: Plugin = {
+      meta: { name: "rule-to-test" },
+      rules: { [ruleName]: rule },
+    };
+
+    describe(ruleName, () => {
+      if (tests.valid.length > 0) {
+        describe("valid", () => {
+          const seenTestCases = new Set<string>();
+          for (let test of tests.valid) {
+            if (typeof test === "string") test = { code: test };
+
+            const it = getIt(test.only);
+            it(getTestName(test), () => {
+              runValidTestCase(test, plugin, this.#config, seenTestCases);
+            });
+          }
+        });
+      }
+
+      if (tests.invalid.length > 0) {
+        describe("invalid", () => {
+          const seenTestCases = new Set<string>();
+          for (const test of tests.invalid) {
+            const it = getIt(test.only);
+            it(getTestName(test), () => {
+              runInvalidTestCase(test, plugin, this.#config, seenTestCases);
+            });
+          }
+        });
+      }
+    });
+  }
+}
+
+/**
+ * Run valid test case.
+ * @param test - Valid test case
+ * @param plugin - Plugin containing rule being tested
+ * @param config - Config from `RuleTester` instance
+ * @param seenTestCases - Set of serialized test cases to check for duplicates
+ * @throws {AssertionError} If the test case fails
+ */
+function runValidTestCase(
+  test: ValidTestCase,
+  plugin: Plugin,
+  config: Config | null,
+  seenTestCases: Set<string>,
+): void {
+  try {
+    runBeforeHook(test);
+    assertValidTestCaseIsWellFormed(test, seenTestCases);
+    assertValidTestCasePasses(test, plugin, config);
+  } finally {
+    runAfterHook(test);
+  }
+}
+
+/**
+ * Assert that valid test case passes.
+ * @param test - Valid test case
+ * @param plugin - Plugin containing rule being tested
+ * @param config - Config from `RuleTester` instance
+ * @throws {AssertionError} If the test case fails
+ */
+function assertValidTestCasePasses(
+  test: ValidTestCase,
+  plugin: Plugin,
+  config: Config | null,
+): void {
+  const diagnostics = lint(test, plugin, config);
+  assertErrorCountIsCorrect(diagnostics, 0);
+}
+
+/**
+ * Run invalid test case.
+ * @param test - Invalid test case
+ * @param plugin - Plugin containing rule being tested
+ * @param config - Config from `RuleTester` instance
+ * @param seenTestCases - Set of serialized test cases to check for duplicates
+ * @throws {AssertionError} If the test case fails
+ */
+function runInvalidTestCase(
+  test: InvalidTestCase,
+  plugin: Plugin,
+  config: Config | null,
+  seenTestCases: Set<string>,
+): void {
+  const ruleName = Object.keys(plugin.rules)[0];
+  try {
+    runBeforeHook(test);
+    assertInvalidTestCaseIsWellFormed(test, seenTestCases, ruleName);
+    assertInvalidTestCasePasses(test, plugin, config);
+  } finally {
+    runAfterHook(test);
+  }
+}
+
+/**
+ * Assert that invalid test case passes.
+ * @param test - Invalid test case
+ * @param plugin - Plugin containing rule being tested
+ * @param config - Config from `RuleTester` instance
+ * @throws {AssertionError} If the test case fails
+ */
+function assertInvalidTestCasePasses(
+  test: InvalidTestCase,
+  plugin: Plugin,
+  config: Config | null,
+): void {
+  const diagnostics = lint(test, plugin, config);
+
+  const { errors } = test;
+  if (typeof errors === "number") {
+    // If `errors` is a number, it's expected error count
+    assertErrorCountIsCorrect(diagnostics, errors);
+  } else {
+    // `errors` is an array of error objects
+    assertErrorCountIsCorrect(diagnostics, errors.length);
+
+    const rule = Object.values(plugin.rules)[0],
+      messages = rule.meta?.messages ?? null;
+
+    for (let errorIndex = 0; errorIndex < errors.length; errorIndex++) {
+      const error: ErrorEntry = errors[errorIndex]!,
+        diagnostic = diagnostics[errorIndex]!;
+      if (typeof error === "string" || error instanceof RegExp) {
+        // `error` is a string or `RegExp` - it's expected message
+        assertMessageMatches(diagnostic.message, error);
+        assert(
+          diagnostic.suggestions === null,
+          `Error at index ${errorIndex} has suggestions. Please convert the test error into an object ` +
+            "and specify `suggestions` property on it to test suggestions",
+        );
+      } else {
+        // `error` is an error object
+        assertInvalidTestCaseMessageIsCorrect(diagnostic, error, messages);
+        assertInvalidTestCaseLocationIsCorrect(diagnostic, error);
+
+        // TODO: Test suggestions
+      }
+    }
+  }
+
+  // TODO: Test output after fixes
+}
+
+/**
+ * Assert that message reported by rule under test matches the expected message.
+ * @param diagnostic - Diagnostic emitted by rule under test
+ * @param error - Error object from test case
+ * @param messages - Messages from rule under test
+ * @throws {AssertionError} If `message` / `messageId` is not correct
+ */
+function assertInvalidTestCaseMessageIsCorrect(
+  diagnostic: Diagnostic,
+  error: Error,
+  messages: Record<string, string> | null,
+): void {
+  // Check `message` property
+  if (hasOwn(error, "message")) {
+    // Check `message` property
+    assert(
+      !hasOwn(error, "messageId"),
+      "Error should not specify both `message` and a `messageId`",
+    );
+    assert(!hasOwn(error, "data"), "Error should not specify both `data` and `message`");
+    assertMessageMatches(diagnostic.message, error.message!);
+    return;
+  }
+
+  assert(hasOwn(error, "messageId"), "Test error must specify either a `messageId` or `message`");
+
+  // Check `messageId` property
+  assert(
+    messages !== null,
+    "Error can not use `messageId` if rule under test doesn't define `meta.messages`",
+  );
+
+  const messageId: string = error.messageId!;
+  if (!hasOwn(messages, messageId)) {
+    const legalMessageIds = `[${Object.keys(messages)
+      .map((key) => `'${key}'`)
+      .join(", ")}]`;
+    assert.fail(`Invalid messageId '${messageId}'. Expected one of ${legalMessageIds}`);
+  }
+
+  assert.strictEqual(
+    diagnostic.messageId,
+    messageId,
+    `messageId '${diagnostic.messageId}' does not match expected messageId '${messageId}'`,
+  );
+
+  const reportedMessage = diagnostic.message;
+  const ruleMessage = messages[messageId];
+
+  const unsubstitutedPlaceholders = getUnsubstitutedMessagePlaceholders(
+    reportedMessage,
+    ruleMessage,
+    error.data,
+  );
+  if (unsubstitutedPlaceholders.length !== 0) {
+    assert.fail(
+      "The reported message has " +
+        (unsubstitutedPlaceholders.length > 1
+          ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map((name) => `'${name}'`).join(", ")}`
+          : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`) +
+        `. Please provide the missing ${unsubstitutedPlaceholders.length > 1 ? "values" : "value"} ` +
+        "via the `data` property on the error object.",
+    );
+  }
+
+  if (hasOwn(error, "data")) {
+    // If data was provided, then directly compare the returned message to a synthetic
+    // interpolated message using the same message ID and data provided in the test
+    const rehydratedMessage = replacePlaceholders(ruleMessage, error.data!);
+
+    assert.strictEqual(
+      reportedMessage,
+      rehydratedMessage,
+      `Hydrated message "${rehydratedMessage}" does not match "${reportedMessage}"`,
+    );
+  }
+}
+
+/**
+ * Assert that location reported by rule under test matches the expected location.
+ * @param diagnostic - Diagnostic emitted by rule under test
+ * @param error - Error object from test case
+ * @throws {AssertionError} If diagnostic's location does not match expected location
+ */
+function assertInvalidTestCaseLocationIsCorrect(diagnostic: Diagnostic, error: Error) {
+  interface Location {
+    line?: number;
+    column?: number;
+    endLine?: number;
+    endColumn?: number;
+  }
+
+  const actualLocation: Location = {};
+  const expectedLocation: Location = {};
+
+  if (hasOwn(error, "line")) {
+    actualLocation.line = diagnostic.line;
+    expectedLocation.line = error.line;
+  }
+
+  if (hasOwn(error, "column")) {
+    actualLocation.column = diagnostic.column;
+    expectedLocation.column = error.column;
+  }
+
+  if (hasOwn(error, "endLine")) {
+    actualLocation.endLine = diagnostic.endLine;
+    expectedLocation.endLine = error.endLine;
+  }
+
+  if (hasOwn(error, "endColumn")) {
+    actualLocation.endColumn = diagnostic.endColumn;
+    expectedLocation.endColumn = error.endColumn;
+  }
+
+  if (Object.keys(expectedLocation).length > 0) {
+    assert.deepStrictEqual(
+      actualLocation,
+      expectedLocation,
+      "Actual error location does not match expected error location.",
+    );
+  }
+}
+
+/**
+ * Assert that the number of errors reported for test case is as expected.
+ * @param diagnostics - Diagnostics reported by the rule under test
+ * @param expectedErrorCount - Expected number of diagnistics
+ * @throws {AssertionError} If the number of diagnostics is not as expected
+ */
+function assertErrorCountIsCorrect(diagnostics: Diagnostic[], expectedErrorCount: number): void {
+  if (diagnostics.length === expectedErrorCount) return;
+
+  assert.strictEqual(
+    diagnostics.length,
+    expectedErrorCount,
+    util.format(
+      "Should have %s error%s but had %d: %s",
+      expectedErrorCount === 0 ? "no" : expectedErrorCount,
+      expectedErrorCount === 1 ? "" : "s",
+      diagnostics.length,
+      util.inspect(diagnostics),
+    ),
+  );
+}
+
+/**
+ * Assert that message is matched by matcher.
+ * Matcher can be a string or a regular expression.
+ * @param message - Message
+ * @param matcher - Matcher
+ * @throws {AssertionError} If message does not match
+ */
+function assertMessageMatches(message: string, matcher: string | RegExp) {
+  if (typeof matcher === "string") {
+    assert.strictEqual(message, matcher);
+  } else {
+    assert(matcher.test(message), `Expected '${message}' to match ${matcher}`);
+  }
+}
+
+/**
+ * Get placeholders in the reported messages but only includes the placeholders available in the raw message
+ * and not in the provided data.
+ * @param message - Reported message
+ * @param raw - Raw message specified in the rule's `meta.messages`
+ * @param data - Data from the test case's error object
+ * @returns Missing placeholder names
+ */
+function getUnsubstitutedMessagePlaceholders(
+  message: string,
+  raw: string,
+  data?: DiagnosticData,
+): string[] {
+  const unsubstituted = getMessagePlaceholders(message);
+  if (unsubstituted.length === 0) return [];
+
+  // Remove false positives by only counting placeholders in the raw message,
+  // which were not provided in the data matcher or added with a data property
+  const known = getMessagePlaceholders(raw);
+  const provided = data === undefined ? [] : Object.keys(data);
+  return unsubstituted.filter((name) => known.includes(name) && !provided.includes(name));
+}
+
+/**
+ * Extract names of `{{ name }}` placeholders from a message.
+ * @param message - Message
+ * @returns Array of placeholder names
+ */
+function getMessagePlaceholders(message: string): string[] {
+  return Array.from(message.matchAll(PLACEHOLDER_REGEX), ([, name]) => name.trim());
+}
+
+/**
+ * Lint a test case.
+ * @param test - Test case
+ * @param plugin - Plugin containing rule being tested
+ * @param config - Config from `RuleTester` instance
+ * @returns Array of diagnostics
+ */
+function lint(test: TestCase, plugin: Plugin, config: Config | null): Diagnostic[] {
+  // TODO: Merge `config` and `sharedConfig` into config used for linting
+  let _ = config;
+
+  try {
+    registerPlugin(plugin, null);
+
+    const testOptions = test.options,
+      { defaultOptions } = registeredRules[0];
+    const options =
+      testOptions == null ? defaultOptions : mergeOptions(testOptions, defaultOptions);
+    allOptions.push(options); // Index 1 (0 is empty array default)
+
+    // Parse file into buffer
+    const path = test.filename ?? DEFAULT_PATH;
+    parse(path, test.code);
+
+    // Lint file.
+    // Buffer is stored already, at index 0. No need to pass it.
+    const settingsJSON = "{}"; // TODO
+    lintFileImpl(path, 0, null, [0], [1], settingsJSON);
+
+    // Return diagnostics
+    const ruleId = `${plugin.meta!.name!}/${Object.keys(plugin.rules)[0]}`;
+
+    return diagnostics.map((diagnostic) => {
+      const { line, column } = getLineColumnFromOffset(diagnostic.start),
+        { line: endLine, column: endColumn } = getLineColumnFromOffset(diagnostic.end);
+      const node = getNodeByRangeIndex(diagnostic.start);
+      return {
+        ruleId,
+        message: diagnostic.message,
+        messageId: diagnostic.messageId,
+        severity: 1,
+        nodeType: node === null ? null : node.type,
+        line,
+        column,
+        endLine,
+        endColumn,
+        suggestions: null, // TODO
+      };
+    });
+  } finally {
+    // Reset state
+    registeredRules.length = 0;
+    allOptions.length = 1;
+    diagnostics.length = 0;
+    resetFile();
+  }
+}
+
+/**
+ * Get name of test case.
+ * Control characters in name are replaced with `\u00xx` form.
+ * @param test - Test case
+ * @returns Name of test case
+ */
+function getTestName(test: TestCase): string {
+  const name = test.name || test.code;
+
+  if (typeof name !== "string") return "";
+
+  return name.replace(
+    /[\u0000-\u0009\u000b-\u001a]/gu, // oxlint-disable-line no-control-regex -- Escaping controls
+    (c) => `\\u${c.codePointAt(0)!.toString(16).padStart(4, "0")}`,
+  );
+}
+
+/**
+ * Runs before hook on the given test case.
+ * @param test - Test to run the hook on
+ * @throws {Error} - If the hook is not a function
+ * @throws {*} - Value thrown by the hook function
+ */
+function runBeforeHook(test: TestCase): void {
+  if (hasOwn(test, "before")) runHook(test, test.before, "before");
+}
+
+/**
+ * Runs after hook on the given test case.
+ * @param test - Test to run the hook on
+ * @throws {Error} - If the hook is not a function
+ * @throws {*} - Value thrown by the hook function
+ */
+function runAfterHook(test: TestCase): void {
+  if (hasOwn(test, "after")) runHook(test, test.after, "after");
+}
+
+/**
+ * Runs a hook on the given test case.
+ * @param test - Test to run the hook on
+ * @param hook - Hook function
+ * @param name - Name of the hook
+ * @throws {Error} - If the property is not a function
+ * @throws {*} - Value thrown by the hook function
+ */
+function runHook<T extends TestCase>(
+  test: T,
+  hook: ((this: T) => void) | undefined,
+  name: string,
+): void {
+  assert.strictEqual(
+    typeof hook,
+    "function",
+    `Optional test case property \`${name}\` must be a function`,
+  );
+  hook!.call(test);
+}
+
+/**
+ * Assert that a valid test case object is valid.
+ * A valid test case must specify a string value for `code`.
+ * Optional properties are checked for correct types.
+ *
+ * @param test - Valid test case object to check
+ * @param seenTestCases - Set of serialized test cases to check for duplicates
+ * @throws {AssertionError} If the test case is not valid
+ */
+function assertValidTestCaseIsWellFormed(test: ValidTestCase, seenTestCases: Set<string>): void {
+  assertTestCaseCommonPropertiesAreWellFormed(test);
+
+  // Must not have properties of invalid test cases
+  assert(
+    !("errors" in test) || test.errors === undefined,
+    "Valid test case must not have `errors` property",
+  );
+  assert(
+    !("output" in test) || test.output === undefined,
+    "Valid test case must not have `output` property",
+  );
+
+  assertNotDuplicateTestCase(test, seenTestCases);
+}
+
+/**
+ * Assert that an invalid test case object is valid.
+ * An invalid test case must specify a string value for `code` and must have an `errors` property.
+ * Optional properties are checked for correct types.
+ *
+ * @param test - Invalid test case object to check
+ * @param seenTestCases - Set of serialized test cases to check for duplicates
+ * @param ruleName - Name of the rule being tested
+ * @throws {AssertionError} If the test case is not valid
+ */
+function assertInvalidTestCaseIsWellFormed(
+  test: InvalidTestCase,
+  seenTestCases: Set<string>,
+  ruleName: string,
+): void {
+  assertTestCaseCommonPropertiesAreWellFormed(test);
+
+  // `errors` must be a number greater than 0, or a non-empty array
+  const { errors } = test;
+  if (typeof errors === "number") {
+    assert(errors > 0, "Invalid cases must have `errors` value greater than 0");
+  } else {
+    assert(
+      errors !== undefined,
+      `Did not specify errors for an invalid test of rule \`${ruleName}\``,
+    );
+    assert(
+      isArray(errors),
+      `Invalid 'errors' property for invalid test of rule \`${ruleName}\`:` +
+        `expected a number or an array but got ${errors === null ? "null" : typeof errors}`,
+    );
+    assert(errors.length !== 0, "Invalid cases must have at least one error");
+  }
+
+  // `output` is optional, but if it exists it must be a string or `null`
+  if (hasOwn(test, "output")) {
+    assert(
+      test.output === null || typeof test.output === "string",
+      "Test property `output`, if specified, must be a string or null. " +
+        "If no autofix is expected, then omit the `output` property or set it to null.",
+    );
+  }
+
+  assertNotDuplicateTestCase(test, seenTestCases);
+}
+
+/**
+ * Assert that the common properties of a valid/invalid test case have the correct types.
+ * @param {Object} test - Test case object to check
+ * @throws {AssertionError} If the test case is not valid
+ */
+function assertTestCaseCommonPropertiesAreWellFormed(test: TestCase): void {
+  assert(typeof test.code === "string", "Test case must specify a string value for `code`");
+
+  // optional properties
+  if (test.name) {
+    assert(typeof test.name === "string", "Optional test case property `name` must be a string");
+  }
+  if (hasOwn(test, "only")) {
+    assert(typeof test.only === "boolean", "Optional test case property `only` must be a boolean");
+  }
+  if (hasOwn(test, "filename")) {
+    assert(
+      typeof test.filename === "string",
+      "Optional test case property `filename` must be a string",
+    );
+  }
+  if (hasOwn(test, "options")) {
+    assert(Array.isArray(test.options), "Optional test case property `options` must be an array");
+  }
+}
+
+// Ignored test case properties when checking for test case duplicates
+const DUPLICATION_IGNORED_PROPS = new Set(["name", "errors", "output"]);
+
+/**
+ * Assert that this test case is not a duplicate of one we have seen before.
+ * @param test - Test case object
+ * @param seenTestCases - Set of serialized test cases we have seen so far (managed by this function)
+ * @throws {AssertionError} If the test case is a duplicate
+ */
+function assertNotDuplicateTestCase(test: TestCase, seenTestCases: Set<string>): void {
+  // If we can't serialize a test case (because it contains a function, RegExp, etc), skip the check.
+  // This might happen with properties like: `options`, `plugins`, `settings`, `languageOptions.parser`,
+  // `languageOptions.parserOptions`.
+  if (!isSerializable(test)) return;
+
+  const serializedTestCase = stringify(test, {
+    replacer(key, value) {
+      // `this` is the currently stringified object --> only ignore top-level properties
+      return test !== this || !DUPLICATION_IGNORED_PROPS.has(key) ? value : undefined;
+    },
+  });
+
+  assert(!seenTestCases.has(serializedTestCase), "Detected duplicate test case");
+  seenTestCases.add(serializedTestCase);
+}
+
+/**
+ * Check if a value is serializable.
+ * Functions or objects like RegExp cannot be serialized by JSON.stringify().
+ * Inspired by: https://stackoverflow.com/questions/30579940/reliable-way-to-check-if-objects-is-serializable-in-javascript
+ * @param value - Value
+ * @param seenObjects - Objects already seen in this path from the root object.
+ * @returns {boolean} `true` if the value is serializable
+ */
+function isSerializable(value: unknown, seenObjects: Set<object> = new Set()): boolean {
+  if (!isSerializablePrimitiveOrPlainObject(value)) return false;
+
+  if (value === null || typeof value !== "object") return true;
+
+  // Since this is a depth-first traversal, encountering the same object again means there is a circular reference.
+  // Objects with circular references are not serializable.
+  if (seenObjects.has(value)) return false;
+
+  for (const property in value) {
+    if (!Object.hasOwn(value, property)) continue;
+
+    const prop = (value as { [property]: unknown })[property];
+    if (!isSerializablePrimitiveOrPlainObject(prop)) return false;
+    if (prop === null || typeof prop !== "object") continue;
+
+    // We're creating a new Set of seen objects because we want to ensure that `val` doesn't appear again in this path,
+    // but it can appear in other paths. This allows for reusing objects in the graph, as long as there are no cycles.
+    if (!isSerializable(prop, new Set([...seenObjects, value]))) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if a value is a primitive or plain object created by the `Object` constructor.
+ * @param value - Value to check
+ * @returns `true` if `value` is a primitive or plain object
+ */
+function isSerializablePrimitiveOrPlainObject(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    (typeof value === "object" && (value.constructor === Object || isArray(value)))
+  );
+}

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -90,7 +90,7 @@ export function lintFile(
  * @throws {Error} If any parameters are invalid
  * @throws {*} If any rule throws
  */
-function lintFileImpl(
+export function lintFileImpl(
   filePath: string,
   bufferId: number,
   buffer: Uint8Array | null,
@@ -228,7 +228,7 @@ function lintFileImpl(
 /**
  * Reset file context, source, AST, and settings, to free memory.
  */
-function resetFile() {
+export function resetFile() {
   resetFileContext();
   resetSourceAndAst();
   resetSettings();

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -132,7 +132,7 @@ export async function loadPlugin(url: string, packageName: string | null): Promi
  * @throws {TypeError} If one of plugin's rules is malformed, or its `createOnce` method returns invalid visitor
  * @throws {TypeError} If `plugin.meta.name` is not a string
  */
-function registerPlugin(plugin: Plugin, packageName: string | null): PluginDetails {
+export function registerPlugin(plugin: Plugin, packageName: string | null): PluginDetails {
   // TODO: Use a validation library to assert the shape of the plugin, and of rules
 
   const pluginName = getPluginName(plugin, packageName);

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -71,7 +71,7 @@ export const diagnostics: DiagnosticReport[] = [];
 
 // Regex for message placeholders.
 // https://github.com/eslint/eslint/blob/772c9ee9b65b6ad0be3e46462a7f93c37578cfa8/lib/linter/interpolate.js#L16-L18
-const PLACEHOLDER_REGEX = /\{\{([^{}]+)\}\}/gu;
+export const PLACEHOLDER_REGEX = /\{\{([^{}]+)\}\}/gu;
 
 /**
  * Report error.
@@ -201,7 +201,7 @@ function resolveMessageFromMessageId(messageId: string, ruleDetails: RuleDetails
  * @param data - Data to replace placeholders with
  * @returns Message with placeholders replaced with data values
  */
-function replacePlaceholders(message: string, data: DiagnosticData): string {
+export function replacePlaceholders(message: string, data: DiagnosticData): string {
   return message.replace(PLACEHOLDER_REGEX, (match, key) => {
     key = key.trim();
     const value = data[key];

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1,0 +1,823 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RuleTester } from "../src-js/index.js";
+
+import type { Rule } from "../src-js/index.ts";
+
+/**
+ * Test case.
+ */
+interface Case {
+  path: string[];
+  fn: () => void;
+  only: boolean;
+}
+
+// Current test cases
+const cases: Case[] = [];
+
+// Current test case stack
+const caseStack: string[] = [];
+
+// Set up `RuleTester` to use these `describe` and `it` functions
+function describeHook(name: string, fn: () => void): void {
+  caseStack.push(name);
+  try {
+    return fn();
+  } finally {
+    caseStack.pop();
+  }
+}
+RuleTester.describe = describeHook;
+
+function itHook(name: string, fn: () => void): void {
+  cases.push({ path: caseStack.concat([name]), fn, only: false });
+}
+itHook.only = function itOnlyHook(name: string, fn: () => void): void {
+  cases.push({ path: caseStack.concat([name]), fn, only: true });
+};
+RuleTester.it = itHook;
+
+/**
+ * Run all current test cases.
+ * @returns Array containing errors for each test case
+ */
+function runCases(): (Error | null)[] {
+  const errors = [];
+  for (const testCase of cases) {
+    let error = null;
+    try {
+      testCase.fn();
+    } catch (err) {
+      error = err;
+    }
+    errors.push(error);
+  }
+  return errors;
+}
+
+const simpleRule: Rule = {
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === "foo") context.report({ message: "No foo!", node });
+      },
+    };
+  },
+};
+
+const messageIdsRule: Rule = {
+  meta: {
+    messages: {
+      noFoo: "No foo!",
+      noBar: "No bar! {{name}}",
+      noIdentifiers: "No identifiers! {{name}}",
+    },
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === "foo") {
+          context.report({ messageId: "noFoo", node });
+        } else if (node.name === "bar") {
+          context.report({ messageId: "noBar", node });
+        } else {
+          context.report({ messageId: "noIdentifiers", data: { name: node.name }, node });
+        }
+      },
+    };
+  },
+};
+
+// Tests
+describe("RuleTester", () => {
+  beforeEach(() => {
+    RuleTester.resetDefaultConfig();
+    cases.length = 0;
+    caseStack.length = 0;
+  });
+
+  describe("can be constructed", () => {
+    it("with no config", () => {
+      expect(() => new RuleTester()).not.toThrow();
+    });
+
+    it("with config", () => {
+      expect(() => new RuleTester({})).not.toThrow();
+    });
+  });
+
+  it("generates test cases", () => {
+    const tester = new RuleTester();
+    tester.run("my-rule", simpleRule, {
+      valid: [
+        "valid code string",
+        {
+          code: "valid code from object",
+          options: [],
+        },
+        {
+          name: "valid case name",
+          code: "let x = 1;",
+          options: [],
+        },
+      ],
+      invalid: [
+        {
+          code: "invalid code from object",
+          options: [],
+          errors: 1,
+        },
+        {
+          name: "invalid case name",
+          code: "let x = 1;",
+          options: [],
+          errors: 1,
+        },
+      ],
+    });
+
+    expect(cases).toEqual([
+      { path: ["my-rule", "valid", "valid code string"], fn: expect.any(Function), only: false },
+      {
+        path: ["my-rule", "valid", "valid code from object"],
+        fn: expect.any(Function),
+        only: false,
+      },
+      { path: ["my-rule", "valid", "valid case name"], fn: expect.any(Function), only: false },
+      {
+        path: ["my-rule", "invalid", "invalid code from object"],
+        fn: expect.any(Function),
+        only: false,
+      },
+      { path: ["my-rule", "invalid", "invalid case name"], fn: expect.any(Function), only: false },
+    ]);
+  });
+
+  describe("tests valid cases", () => {
+    it("which are correct", () => {
+      const tester = new RuleTester();
+      tester.run("no-foo", simpleRule, {
+        valid: ["let x;", "let y;"],
+        invalid: [],
+      });
+
+      expect(runCases()).toEqual([null, null]);
+    });
+
+    it("which are incorrect", () => {
+      const tester = new RuleTester();
+      tester.run("no-foo", simpleRule, {
+        valid: ["let foo;", "foo.foo;", "let foo;", "let foo;"],
+        invalid: [],
+      });
+
+      expect(runCases()).toMatchInlineSnapshot(`
+        [
+          [AssertionError: Should have no errors but had 1: [
+          {
+            ruleId: 'rule-to-test/no-foo',
+            message: 'No foo!',
+            messageId: null,
+            severity: 1,
+            nodeType: 'Identifier',
+            line: 1,
+            column: 4,
+            endLine: 1,
+            endColumn: 7,
+            suggestions: null
+          }
+        ]
+
+        1 !== 0
+        ],
+          [AssertionError: Should have no errors but had 2: [
+          {
+            ruleId: 'rule-to-test/no-foo',
+            message: 'No foo!',
+            messageId: null,
+            severity: 1,
+            nodeType: 'Identifier',
+            line: 1,
+            column: 0,
+            endLine: 1,
+            endColumn: 3,
+            suggestions: null
+          },
+          {
+            ruleId: 'rule-to-test/no-foo',
+            message: 'No foo!',
+            messageId: null,
+            severity: 1,
+            nodeType: 'Identifier',
+            line: 1,
+            column: 4,
+            endLine: 1,
+            endColumn: 7,
+            suggestions: null
+          }
+        ]
+
+        2 !== 0
+        ],
+          [AssertionError: Detected duplicate test case],
+          [AssertionError: Detected duplicate test case],
+        ]
+      `);
+    });
+  });
+
+  describe("tests invalid cases", () => {
+    describe("which are correct", () => {
+      it("with error count", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            { code: "let foo;", errors: 1 },
+            { code: "foo.foo;", errors: 2 },
+          ],
+        });
+
+        expect(runCases()).toEqual([null, null]);
+      });
+
+      it("with error messages", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo;",
+              errors: ["No foo!"],
+            },
+            {
+              code: "foo.foo;",
+              errors: ["No foo!", "No foo!"],
+            },
+            {
+              code: "let foo = 1;",
+              errors: ["No foo!"],
+            },
+            {
+              code: "foo.foo = 2;",
+              errors: [/^No foo!$/, /o [fg]o/],
+            },
+            {
+              code: "let foo = 3;",
+              errors: [{ message: "No foo!" }],
+            },
+            {
+              code: "foo.foo = 4;",
+              errors: [{ message: "No foo!" }, { message: "No foo!" }],
+            },
+            {
+              code: "let foo = 5;",
+              errors: [{ message: "No foo!" }],
+            },
+            {
+              code: "foo.foo = 6;",
+              errors: [{ message: /^No foo!$/ }, { message: /o [fg]o/ }],
+            },
+          ],
+        });
+        expect(runCases()).toEqual([null, null, null, null, null, null, null, null]);
+      });
+
+      it("with message IDs and data", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", messageIdsRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo;",
+              errors: [
+                {
+                  messageId: "noFoo",
+                },
+              ],
+            },
+            {
+              code: "qux.bing;",
+              errors: [
+                // Without data
+                {
+                  messageId: "noIdentifiers",
+                },
+                // With data
+                {
+                  messageId: "noIdentifiers",
+                  data: { name: "bing" },
+                },
+              ],
+            },
+          ],
+        });
+        expect(runCases()).toEqual([null, null]);
+      });
+
+      it("with location", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo = 1;\nfoo = 2;",
+              errors: [
+                {
+                  message: "No foo!",
+                  line: 1,
+                },
+                {
+                  message: "No foo!",
+                  line: 2,
+                },
+              ],
+            },
+            {
+              code: "let foo = 1;\nfoo = 3;",
+              errors: [
+                {
+                  message: "No foo!",
+                  column: 4,
+                },
+                {
+                  message: "No foo!",
+                  column: 0,
+                },
+              ],
+            },
+            {
+              code: "let foo = 1;\nfoo = 4;",
+              errors: [
+                {
+                  message: "No foo!",
+                  endLine: 1,
+                },
+                {
+                  message: "No foo!",
+                  endLine: 2,
+                },
+              ],
+            },
+            {
+              code: "let foo = 1;\nfoo = 5;",
+              errors: [
+                {
+                  message: "No foo!",
+                  endColumn: 7,
+                },
+                {
+                  message: "No foo!",
+                  endColumn: 3,
+                },
+              ],
+            },
+            {
+              code: "let foo = 1;\nfoo = 6;",
+              errors: [
+                {
+                  message: "No foo!",
+                  line: 1,
+                  column: 4,
+                  endLine: 1,
+                  endColumn: 7,
+                },
+                {
+                  message: "No foo!",
+                  line: 2,
+                  column: 0,
+                  endLine: 2,
+                  endColumn: 3,
+                },
+              ],
+            },
+          ],
+        });
+        expect(runCases()).toEqual([null, null, null, null, null]);
+      });
+    });
+
+    describe("which are incorrect", () => {
+      it("with error count", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            { code: "let x;", errors: 1 },
+            { code: "let foo;", errors: 2 },
+          ],
+        });
+
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [AssertionError: Should have 1 error but had 0: []
+
+          0 !== 1
+          ],
+            [AssertionError: Should have 2 errors but had 1: [
+            {
+              ruleId: 'rule-to-test/no-foo',
+              message: 'No foo!',
+              messageId: null,
+              severity: 1,
+              nodeType: 'Identifier',
+              line: 1,
+              column: 4,
+              endLine: 1,
+              endColumn: 7,
+              suggestions: null
+            }
+          ]
+
+          1 !== 2
+          ],
+          ]
+        `);
+      });
+
+      it("with error messages", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo;",
+              errors: ["wrong message"],
+            },
+            {
+              code: "foo.foo;",
+              errors: ["again wrong", "so very wrong"],
+            },
+            {
+              code: "let foo = 1;",
+              errors: [/^NO foo!$/],
+            },
+            {
+              code: "foo.foo = 2;",
+              errors: [/wrong/, /so very wrong/],
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [AssertionError: Expected values to be strictly equal:
+          + actual - expected
+
+          + 'No foo!'
+          - 'wrong message'
+          ],
+            [AssertionError: Expected values to be strictly equal:
+          + actual - expected
+
+          + 'No foo!'
+          - 'again wrong'
+          ],
+            [AssertionError: Expected 'No foo!' to match /^NO foo!$/],
+            [AssertionError: Expected 'No foo!' to match /wrong/],
+          ]
+        `);
+      });
+
+      it("with error messages in objects", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo;",
+              errors: [{ message: "wrong message" }],
+            },
+            {
+              code: "foo.foo;",
+              errors: [{ message: "again wrong" }, { message: "so very wrong" }],
+            },
+            {
+              code: "let foo = 1;",
+              errors: [{ message: /^NO foo!$/ }],
+            },
+            {
+              code: "foo.foo = 2;",
+              errors: [{ message: /wrong/ }, { message: /so very wrong/ }],
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [AssertionError: Expected values to be strictly equal:
+          + actual - expected
+
+          + 'No foo!'
+          - 'wrong message'
+          ],
+            [AssertionError: Expected values to be strictly equal:
+          + actual - expected
+
+          + 'No foo!'
+          - 'again wrong'
+          ],
+            [AssertionError: Expected 'No foo!' to match /^NO foo!$/],
+            [AssertionError: Expected 'No foo!' to match /wrong/],
+          ]
+        `);
+      });
+
+      it("with message IDs and data", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", messageIdsRule, {
+          valid: [],
+          invalid: [
+            // Wrong message ID
+            {
+              code: "foo",
+              errors: [
+                {
+                  messageId: "noIdentifiers",
+                },
+              ],
+            },
+            {
+              code: "bar",
+              errors: [
+                {
+                  messageId: "noFoo",
+                },
+              ],
+            },
+            // Wrong data
+            {
+              code: "qux",
+              errors: [
+                {
+                  messageId: "noIdentifiers",
+                  data: { name: "not qux" },
+                },
+              ],
+            },
+            // Missing data
+            {
+              code: "whoosh",
+              errors: [
+                {
+                  messageId: "noIdentifiers",
+                  data: { x: "whoosh" },
+                },
+              ],
+            },
+            // Missing placeholder
+            {
+              code: "let bar",
+              errors: [
+                {
+                  messageId: "noBar",
+                },
+              ],
+            },
+            {
+              code: "bar = 1",
+              errors: [
+                {
+                  messageId: "noBar",
+                  data: { name: "bar" },
+                },
+              ],
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [AssertionError: messageId 'noFoo' does not match expected messageId 'noIdentifiers'
+          + actual - expected
+
+          + 'noFoo'
+          - 'noIdentifiers'
+               ^
+          ],
+            [AssertionError: messageId 'noBar' does not match expected messageId 'noFoo'
+
+          'noBar' !== 'noFoo'
+          ],
+            [AssertionError: Hydrated message "No identifiers! not qux" does not match "No identifiers! qux"
+          + actual - expected
+
+          + 'No identifiers! qux'
+          - 'No identifiers! not qux'
+                             ^
+          ],
+            [AssertionError: Hydrated message "No identifiers! {{name}}" does not match "No identifiers! whoosh"
+          + actual - expected
+
+          + 'No identifiers! whoosh'
+          - 'No identifiers! {{name}}'
+                             ^
+          ],
+            [AssertionError: The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the \`data\` property on the error object.],
+            [AssertionError: Hydrated message "No bar! bar" does not match "No bar! {{name}}"
+          + actual - expected
+
+          + 'No bar! {{name}}'
+          - 'No bar! bar'
+                     ^
+          ],
+          ]
+        `);
+      });
+
+      it("with location", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo = 1;",
+              errors: [
+                {
+                  message: "No foo!",
+                  line: 2,
+                },
+              ],
+            },
+            {
+              code: "let foo = 2;",
+              errors: [
+                {
+                  message: "No foo!",
+                  column: 2,
+                },
+              ],
+            },
+            {
+              code: "let foo = 3;",
+              errors: [
+                {
+                  message: "No foo!",
+                  endLine: 2,
+                },
+              ],
+            },
+            {
+              code: "let foo = 4;",
+              errors: [
+                {
+                  message: "No foo!",
+                  endColumn: 4,
+                },
+              ],
+            },
+            {
+              code: "let foo = 5;",
+              errors: [
+                {
+                  message: "No foo!",
+                  line: 2,
+                  column: 2,
+                  endLine: 3,
+                  endColumn: 4,
+                },
+              ],
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [AssertionError: Actual error location does not match expected error location.
+          + actual - expected
+
+            {
+          +   line: 1
+          -   line: 2
+            }
+          ],
+            [AssertionError: Actual error location does not match expected error location.
+          + actual - expected
+
+            {
+          +   column: 4
+          -   column: 2
+            }
+          ],
+            [AssertionError: Actual error location does not match expected error location.
+          + actual - expected
+
+            {
+          +   endLine: 1
+          -   endLine: 2
+            }
+          ],
+            [AssertionError: Actual error location does not match expected error location.
+          + actual - expected
+
+            {
+          +   endColumn: 7
+          -   endColumn: 4
+            }
+          ],
+            [AssertionError: Actual error location does not match expected error location.
+          + actual - expected
+
+            {
+          +   column: 4,
+          +   endColumn: 7,
+          +   endLine: 1,
+          +   line: 1
+          -   column: 2,
+          -   endColumn: 4,
+          -   endLine: 3,
+          -   line: 2
+            }
+          ],
+          ]
+        `);
+      });
+
+      it("duplicate code", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [],
+          invalid: [
+            {
+              code: "let foo;",
+              errors: 1,
+            },
+            {
+              code: "let foo;",
+              errors: 1,
+            },
+            {
+              code: "let foo;",
+              errors: 1,
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            null,
+            [AssertionError: Detected duplicate test case],
+            [AssertionError: Detected duplicate test case],
+          ]
+        `);
+      });
+    });
+  });
+
+  it("errors when parsing failure", () => {
+    const tester = new RuleTester();
+    tester.run("no-foo", simpleRule, {
+      valid: ["let"],
+      invalid: [{ code: "let", errors: 1 }],
+    });
+    expect(runCases()).toMatchInlineSnapshot(`
+      [
+        [Error: Parsing failed],
+        [Error: Parsing failed],
+      ]
+    `);
+  });
+
+  it("runs `before` and `after` hooks", () => {
+    const validTests = [
+      // Passes
+      {
+        code: "let x;",
+        before: vi.fn(),
+        after: vi.fn(),
+      },
+      // Fails
+      {
+        code: "let foo;",
+        before: vi.fn(),
+        after: vi.fn(),
+      },
+    ];
+
+    const invalidTests = [
+      // Passes
+      {
+        code: "let foo;",
+        before: vi.fn(),
+        after: vi.fn(),
+        errors: 1,
+      },
+      // Fails
+      {
+        code: "let x;",
+        before: vi.fn(),
+        after: vi.fn(),
+        errors: 2,
+      },
+    ];
+
+    const tester = new RuleTester();
+    tester.run("no-foo", simpleRule, {
+      valid: validTests,
+      invalid: invalidTests,
+    });
+    runCases();
+
+    for (const test of [...validTests, ...invalidTests]) {
+      expect(test.before).toHaveBeenCalledExactlyOnceWith();
+      expect(test.before.mock.contexts[0]).toBe(test);
+      expect(test.after).toHaveBeenCalledExactlyOnceWith();
+      expect(test.after.mock.contexts[0]).toBe(test);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@types/estree':
         specifier: ^1.0.8
         version: 1.0.8
+      '@types/json-stable-stringify-without-jsonify':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@typescript-eslint/scope-manager':
         specifier: 8.46.2
         version: 8.46.2(patch_hash=08ab34b5f27480602bc518186b717a8915aa4d6b2b5df1adc747320ba25b1f8b)
@@ -122,6 +125,9 @@ importers:
       jiti:
         specifier: ^2.6.0
         version: 2.6.1
+      json-stable-stringify-without-jsonify:
+        specifier: ^1.0.1
+        version: 1.0.1
       oxc-parser:
         specifier: ^0.99.0
         version: 0.99.0
@@ -1983,6 +1989,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json-stable-stringify-without-jsonify@1.0.2':
+    resolution: {integrity: sha512-X/Kn5f5fv1KBGqGDaegrj72Dlh+qEKN3ELwMAB6RdVlVzkf6NTeEnJpgR/Hr0AlpgTlYq/Vd0U3f79lavn6aDA==}
 
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
@@ -5741,6 +5750,8 @@ snapshots:
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/json-stable-stringify-without-jsonify@1.0.2': {}
 
   '@types/mocha@10.0.10': {}
 


### PR DESCRIPTION
Part of #16018.

Implement `RuleTester` class for testing rules. Has same API as ESLint's `RuleTester`.

A few features not implemented yet:

* Fixes are not executed, or checked against provided `output`.
* Suggestions are not checked (we don't yet have support for suggestions in JS plugins).
* No use of config provided through `RuleTester` class constructor or via `RuleTester.setDefaultConfig`.