### PR TITLE
ci(lint): enable `typescript/consistent-indexed-object-style` rule

### DIFF
--- a/apps/oxlint/src-js/plugins/json.ts
+++ b/apps/oxlint/src-js/plugins/json.ts
@@ -13,6 +13,8 @@ export type JsonValue = JsonObject | JsonValue[] | string | number | boolean | n
 /**
  * A JSON object.
  */
+// Can't use `Record<string, JsonValue>` here, because of circular reference between `JsonObject` and `JsonValue`
+// oxlint-disable-next-line typescript/consistent-indexed-object-style
 export type JsonObject = { [key: string]: JsonValue };
 
 /**

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -17,7 +17,8 @@
     "perf": "error"
   },
   "rules": {
-    "no-console": "error"
+    "no-console": "error",
+    "typescript/consistent-indexed-object-style": ["error", "record"]
   },
   "overrides": [
     {


### PR DESCRIPTION
Enable `typescript/consistent-indexed-object-style` Oxlint rule to enforce consistent style in our TS code.