### PR TITLE
fix(oxlint/oxfmt/lsp): tell client the real tool name & version

### DIFF
--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -2,5 +2,10 @@ use oxc_language_server::{ServerFormatterBuilder, run_server};
 
 /// Run the language server
 pub async fn run_lsp() {
-    run_server(vec![Box::new(ServerFormatterBuilder)]).await;
+    run_server(
+        "oxfmt".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+        vec![Box::new(ServerFormatterBuilder)],
+    )
+    .await;
 }

--- a/apps/oxlint/src/lsp.rs
+++ b/apps/oxlint/src/lsp.rs
@@ -1,4 +1,9 @@
 /// Run the language server
 pub async fn run_lsp() {
-    oxc_language_server::run_server(vec![Box::new(oxc_language_server::ServerLinterBuilder)]).await;
+    oxc_language_server::run_server(
+        "oxlint".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+        vec![Box::new(oxc_language_server::ServerLinterBuilder)],
+    )
+    .await;
 }

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxBuildHasher;
-use tower_lsp_server::{LspService, Server};
+use tower_lsp_server::{LspService, Server, lsp_types::ServerInfo};
 
 mod backend;
 mod capabilities;
@@ -25,13 +25,20 @@ pub use crate::tool::{Tool, ToolBuilder, ToolRestartChanges, ToolShutdownChanges
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 /// Run the language server
-pub async fn run_server(tools: Vec<Box<dyn ToolBuilder>>) {
+pub async fn run_server(
+    server_name: String,
+    server_version: String,
+    tools: Vec<Box<dyn ToolBuilder>>,
+) {
     env_logger::init();
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::build(|client| Backend::new(client, tools)).finish();
+    let (service, socket) = LspService::build(|client| {
+        Backend::new(client, ServerInfo { name: server_name, version: Some(server_version) }, tools)
+    })
+    .finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -10,5 +10,10 @@ async fn main() {
         v
     };
 
-    oxc_language_server::run_server(tools).await;
+    oxc_language_server::run_server(
+        "oxc".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+        tools,
+    )
+    .await;
 }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -206,7 +206,7 @@ mod test_suite {
     use serde_json::json;
     use tower_lsp_server::{
         jsonrpc::{Id, Response},
-        lsp_types::InitializeResult,
+        lsp_types::{InitializeResult, ServerInfo},
     };
 
     use crate::{
@@ -217,10 +217,13 @@ mod test_suite {
         },
     };
 
+    fn server_info() -> ServerInfo {
+        ServerInfo { name: "oxc".to_owned(), version: Some("1.0.0".to_owned()) }
+    }
+
     #[tokio::test]
     async fn test_basic_start_and_shutdown_flow() {
-        let mut server = TestServer::new(|client| Backend::new(client, vec![]));
-
+        let mut server = TestServer::new(|client| Backend::new(client, server_info(), vec![]));
         // initialize request
         server.send_request(initialize_request(false, false)).await;
         let initialize_result = server.recv_response().await;
@@ -248,7 +251,7 @@ mod test_suite {
 
     #[tokio::test]
     async fn test_workspace_configuration_on_initialized() {
-        let mut server = TestServer::new(|client| Backend::new(client, vec![]));
+        let mut server = TestServer::new(|client| Backend::new(client, server_info(), vec![]));
 
         // initialize request
         server.send_request(initialize_request(true, false)).await;
@@ -290,8 +293,9 @@ mod test_suite {
 
     #[tokio::test]
     async fn test_dynamic_watched_files_registration() {
-        let mut server =
-            TestServer::new(|client| Backend::new(client, vec![Box::new(FakeToolBuilder)]));
+        let mut server = TestServer::new(|client| {
+            Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)])
+        });
 
         // initialize request
         server.send_request(initialize_request(false, true)).await;


### PR DESCRIPTION
for `oxfmt --lsp`:

```
2025-11-27 19:21:51.286 [info] [Trace - 7:21:51 PM] Received response 'initialize - (0)' in 276ms.
2025-11-27 19:21:51.286 [info] Result: {
    "capabilities": {
        "documentFormattingProvider": true,
        "textDocumentSync": {
            "change": 1,
            "openClose": true,
            "save": {
                "includeText": false
            }
        },
        "workspace": {
            "workspaceFolders": {
                "changeNotifications": true,
                "supported": true
            }
        }
    },
    "serverInfo": {
        "name": "oxfmt",
        "version": "0.15.0"
    }
}
```