### PR TITLE
refactor(linter/plugins): split JSON deep freeze into multiple functions

### DIFF
--- a/apps/oxlint/src-js/plugins/json.ts
+++ b/apps/oxlint/src-js/plugins/json.ts
@@ -27,18 +27,41 @@ export type JsonObject = { [key: string]: JsonValue };
 export function deepFreezeJsonValue(value: JsonValue): undefined {
   if (value === null || typeof value !== "object") return;
 
-  // Circular references are not possible in JSON, so no need to handle them here
   if (isArray(value)) {
-    for (let i = 0, len = value.length; i !== len; i++) {
-      deepFreezeJsonValue(value[i]);
-    }
+    deepFreezeJsonArray(value);
   } else {
-    // Symbol properties are not possible in JSON, so no need to handle them here.
-    // All properties are enumerable own properties, so can use simple `for..in` loop.
-    for (const key in value) {
-      deepFreezeJsonValue(value[key]);
-    }
+    deepFreezeJsonObject(value);
   }
+}
 
-  freeze(value);
+/**
+ * Deep freeze a JSON object, recursively freezing all nested objects and arrays.
+ *
+ * Freezes the object in place, and returns `undefined`.
+ *
+ * @param obj - The value to deep freeze
+ */
+export function deepFreezeJsonObject(obj: JsonObject): undefined {
+  // Circular references are not possible in JSON, so no need to handle them here.
+  // Symbol properties are not possible in JSON, so no need to handle them here.
+  // All properties are enumerable own properties, so can use simple `for..in` loop.
+  for (const key in obj) {
+    deepFreezeJsonValue(obj[key]);
+  }
+  freeze(obj);
+}
+
+/**
+ * Deep freeze a JSON array, recursively freezing all nested objects and arrays.
+ *
+ * Freezes the array in place, and returns `undefined`.
+ *
+ * @param arr - The value to deep freeze
+ */
+export function deepFreezeJsonArray(arr: JsonValue[]): undefined {
+  // Circular references are not possible in JSON, so no need to handle them here
+  for (let i = 0, len = arr.length; i !== len; i++) {
+    deepFreezeJsonValue(arr[i]);
+  }
+  freeze(arr);
 }


### PR DESCRIPTION
Pure refactor. Split JSON merging into multiple functions, exposing `deepFreezeJsonObject` and `deepFreezeJsonArray` methods. These are needed for merging rule options (#16217).