### PR TITLE
fix(formatter): should not add a hard space before function body

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -1452,6 +1452,7 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
 /// # }
 /// ```
 #[inline]
+#[expect(unused)]
 pub fn soft_line_indent_or_hard_space<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> {
     BlockIndent { content: Argument::new(content), mode: IndentMode::HardSpace }
 }

--- a/crates/oxc_formatter/src/write/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/write/arrow_function_expression.rs
@@ -205,7 +205,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                         [
                             formatted_signature,
                             group(&format_args!(
-                                soft_line_indent_or_hard_space(&format_with(|f| {
+                                soft_line_indent_or_space(&format_with(|f| {
                                     if should_add_parens {
                                         write!(f, if_group_fits_on_line(&"("));
                                     }

--- a/crates/oxc_formatter/tests/fixtures/js/arrow-function/object-method.ts
+++ b/crates/oxc_formatter/tests/fixtures/js/arrow-function/object-method.ts
@@ -1,0 +1,7 @@
+let object = {
+	id: '_files.pickFolderAndOpen',
+	handler: (
+		accessor: ServicesAccessor,
+		options: { forceNewWindow: boolean }
+	) => accessor.get(IFileDialogService).pickFolderAndOpen(options)
+}

--- a/crates/oxc_formatter/tests/fixtures/js/arrow-function/object-method.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/arrow-function/object-method.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+let object = {
+	id: '_files.pickFolderAndOpen',
+	handler: (
+		accessor: ServicesAccessor,
+		options: { forceNewWindow: boolean }
+	) => accessor.get(IFileDialogService).pickFolderAndOpen(options)
+}
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+let object = {
+  id: "_files.pickFolderAndOpen",
+  handler: (accessor: ServicesAccessor, options: { forceNewWindow: boolean }) =>
+    accessor.get(IFileDialogService).pickFolderAndOpen(options),
+};
+
+-------------------
+{ printWidth: 100 }
+-------------------
+let object = {
+  id: "_files.pickFolderAndOpen",
+  handler: (accessor: ServicesAccessor, options: { forceNewWindow: boolean }) =>
+    accessor.get(IFileDialogService).pickFolderAndOpen(options),
+};
+
+===================== End =====================


### PR DESCRIPTION
This is a regression I found in the VSCode repo, caused by #16093. This is a mistake I made, as we should never use a hard space.