### PR TITLE
fix(formatter): inconsistent union type output between two runs

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts
@@ -1,3 +1,25 @@
 interface _KeywordDef {
   type?: JSONType | JSONType[] // data types that keyword applies to
 }
+
+type C1 = | (
+  /* 1 */ /*1*/ | (
+    | (
+          | A
+          // A comment to force break
+          | B
+        )
+  )
+  );
+
+
+type C2 = | (
+  /* 1 */ /*1*/ 
+  /* 1 */ | (
+    | (
+          | A
+          // A comment to force break
+          | B
+        )
+  )
+  );

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts.snap
@@ -6,6 +6,28 @@ interface _KeywordDef {
   type?: JSONType | JSONType[] // data types that keyword applies to
 }
 
+type C1 = | (
+  /* 1 */ /*1*/ | (
+    | (
+          | A
+          // A comment to force break
+          | B
+        )
+  )
+  );
+
+
+type C2 = | (
+  /* 1 */ /*1*/ 
+  /* 1 */ | (
+    | (
+          | A
+          // A comment to force break
+          | B
+        )
+  )
+  );
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -14,11 +36,33 @@ interface _KeywordDef {
   type?: JSONType | JSONType[]; // data types that keyword applies to
 }
 
+type C1 = /* 1 */ /*1*/
+  | A
+  // A comment to force break
+  | B;
+
+type C2 =
+  /* 1 */ /*1*/
+  /* 1 */ | A
+  // A comment to force break
+  | B;
+
 -------------------
 { printWidth: 100 }
 -------------------
 interface _KeywordDef {
   type?: JSONType | JSONType[]; // data types that keyword applies to
 }
+
+type C1 = /* 1 */ /*1*/
+  | A
+  // A comment to force break
+  | B;
+
+type C2 =
+  /* 1 */ /*1*/
+  /* 1 */ | A
+  // A comment to force break
+  | B;
 
 ===================== End =====================

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,15 +2,13 @@ commit: 669c25c0
 
 formatter_typescript Summary:
 AST Parsed     : 9822/9822 (100.00%)
-Positive Passed: 9814/9822 (99.92%)
+Positive Passed: 9815/9822 (99.93%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
-
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/letIdentifierInElementAccess01.ts


### PR DESCRIPTION
This PR is to fix a union type issue that didn't pass idempotency testing, which was regressed by #16205.