### PR TITLE
fix(formatter): Print comment in ternary jsx

### DIFF
--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -647,7 +647,7 @@ impl<'a> Format<'a> for FormatJsxChainExpression<'a, '_> {
                 }
                 .fmt(f);
             } else {
-                FormatNodeWithoutTrailingComments(self.expression).fmt(f);
+                self.expression.fmt(f);
             }
         });
 

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
@@ -1,0 +1,13 @@
+{isVideo ? (
+  <Video {...props} />
+) : (
+  <Image {...props} /> // eslint-disable-line
+)}
+
+<>
+{isVideo ? (
+  <Video {...props} />
+) : (
+  <Image {...props} /> // eslint-disable-line
+)}
+</>

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
@@ -1,0 +1,58 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+{isVideo ? (
+  <Video {...props} />
+) : (
+  <Image {...props} /> // eslint-disable-line
+)}
+
+<>
+{isVideo ? (
+  <Video {...props} />
+) : (
+  <Image {...props} /> // eslint-disable-line
+)}
+</>
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+{
+  isVideo ? (
+    <Video {...props} />
+  ) : (
+    <Image {...props} /> // eslint-disable-line
+  );
+}
+
+<>
+  {isVideo ? (
+    <Video {...props} />
+  ) : (
+    <Image {...props} /> // eslint-disable-line
+  )}
+</>;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+{
+  isVideo ? (
+    <Video {...props} />
+  ) : (
+    <Image {...props} /> // eslint-disable-line
+  );
+}
+
+<>
+  {isVideo ? (
+    <Video {...props} />
+  ) : (
+    <Image {...props} /> // eslint-disable-line
+  )}
+</>;
+
+===================== End =====================


### PR DESCRIPTION
Fixes #16194

Just prints `self.expression`, instead of `FormatNodeWithoutTrailingComments`.

Aligned with Prettier 3.7.1 outputs:

```tsx
{
  isVideo ? (
    <Video {...props} />
  ) : (
    <Image {...props} /> // eslint-disable-line
  );
}

<>
  {isVideo ? (
    <Video {...props} />
  ) : (
    <Image {...props} /> // eslint-disable-line
  )}
</>;
```

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEwCWBnAamgJnCAAgH5CAKAHSkMIB4d8jgA6VgBwCcI2MBfQgPQA+KgEpCSclRq0AkgFsAhgHM4hFuy49+wwQMJwMAGzSwAtLkyKARkbhmTUOGN5UqtEVHTY8BElOo6Bj8NZk5uPkFPcUlKQLklVXVWMK1I3QF9Q0cYCytbe0dnKFFXKFphEAAaEG4YNGgMZFBFDi4AdwAFVoQmlEUjdsUATyaa6w5FMABrOBgAZUV5OAAZUzhkADMBjDgaiGsAKzgwGAB1SbZkEE5DOA4ANw3xyZm5+bYp02VkGA4AVz2IF28jQvwBQLgAA82Pc0MtYAMAPKwyYwCAcToQDBoerQa4IXDVEDQ1HwhAwAYAFXuUFaaEMWx2QJxUGUdgAiv8IPAmUZdjVDhgofNvpzubykNt+UCAI4SuCdNLXRQYMxOOD4Ik1P6KNCOZQAYQg8iUKqMRmJrPZcAAgjA-mhrP94J17msnHyBSAABYweRGM4+3GGT5gODzXq4tAPXHDa5gDBjEAPQGyKD4WDzMAcNBsGC2jPzGDDOxeoHhXYXRRXFC3XaPZ4gUwNmBKlRmqXMmqfDgN67WGxwS093OwM54GA+5AADgADDUOHB5Wgl+3lJ3pd7KdYJ7gp8gAEw1f67Kk2PpbyHyayarUrRRs-4qOAAMQxSgd3xVLogIF4vBAA