### PR TITLE
refactor(formatter): Remove unused multiline comment check in ternary

### DIFF
--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -342,13 +342,6 @@ impl<'a> FormatConditionalLike<'a, '_> {
         }
     }
 
-    /// Checks if any part of the conditional has multiline comments
-    #[inline]
-    fn has_multiline_comment(_f: &Formatter<'_, 'a>) -> bool {
-        // TODO: Implement multiline comment detection
-        false
-    }
-
     /// Returns `true` if this is the root conditional expression and the parent is a [`StaticMemberExpression`].
     #[inline]
     fn is_parent_static_member_expression(&self, layout: ConditionalLayout) -> bool {
@@ -502,7 +495,6 @@ impl<'a> Format<'a> for FormatConditionalLike<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let layout = self.layout(f);
         let should_extra_indent = self.should_extra_indent(layout);
-        let has_multiline_comment = Self::has_multiline_comment(f);
         let is_jsx_chain = self.options.jsx_chain || layout.is_jsx_chain();
 
         let format_inner = format_with(|f| {
@@ -580,11 +572,8 @@ impl<'a> Format<'a> for FormatConditionalLike<'a, '_> {
         });
 
         if layout.is_nested_test() || should_extra_indent {
-            write!(f, [group(&soft_block_indent(&grouped)).should_expand(has_multiline_comment)]);
+            write!(f, [group(&soft_block_indent(&grouped))]);
         } else {
-            if has_multiline_comment {
-                write!(f, [expand_parent()]);
-            }
             grouped.fmt(f);
         }
     }


### PR DESCRIPTION
Follow up #16224 

> - Biome
>   - The same logic still exists
>     - https://github.com/biomejs/biome/blob/e7e0f6c14df92d83d08f86b1e57fc82b4df775b7/crates/biome_js_formatter/src/utils/conditional.rs#L197
>   - In either case, the test did not fail
>     - always returning `false`
>     - removing related code like our diff above
> - Prettier
>   - The most relevant lines are here
>     - https://github.com/prettier/prettier/blob/fd69335e513232c9b7aad78c93b42d8d3dd00ae7/src/language-js/print/ternary-old.js#L326-L344
>   - As you expected, if change this to `const shouldBreak = false`, the test did not fail!

From https://github.com/oxc-project/oxc/pull/16224#discussion_r2570513632