### PR TITLE
refactor(napi/parser): simplify `raw_transfer_supported`

### DIFF
--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -30,14 +30,12 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 mod raw_transfer;
 mod raw_transfer_types;
 #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
-pub use raw_transfer::{get_buffer_offset, parse_raw, parse_raw_sync, raw_transfer_supported};
+pub use raw_transfer::{get_buffer_offset, parse_raw, parse_raw_sync};
 
-// Fallback for 32-bit or big-endian platforms.
 /// Returns `true` if raw transfer is supported on this platform.
-#[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
 #[napi]
 pub fn raw_transfer_supported() -> bool {
-    false
+    cfg!(all(target_pointer_width = "64", target_endian = "little"))
 }
 
 mod generated {

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -285,12 +285,3 @@ unsafe fn parse_raw_impl(
         buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>().write(metadata);
     }
 }
-
-/// Returns `true` if raw transfer is supported on this platform.
-//
-// This module is only compiled on 64-bit little-endian platforms.
-// Fallback version for unsupported platforms in `lib.rs`.
-#[napi]
-pub fn raw_transfer_supported() -> bool {
-    true
-}


### PR DESCRIPTION
Pure refactor. Instead of having 2 feature-gated implementations of `raw_transfer_supported`, just have one. This makes it clearer on what platforms raw transfer is supported.