### PR TITLE
fix(formatter): should indent variable declarator if there is a trailing comment

### DIFF
--- a/crates/oxc_formatter/src/formatter/separated.rs
+++ b/crates/oxc_formatter/src/formatter/separated.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -19,6 +21,14 @@ pub struct FormatSeparatedElement<E: GetSpan> {
     /// The separator to write if the element has no separator yet.
     separator: &'static str,
     options: FormatSeparatedOptions,
+}
+
+impl<T: GetSpan> Deref for FormatSeparatedElement<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.element
+    }
 }
 
 impl<T: GetSpan> GetSpan for FormatSeparatedElement<T> {

--- a/crates/oxc_formatter/src/write/variable_declaration.rs
+++ b/crates/oxc_formatter/src/write/variable_declaration.rs
@@ -69,7 +69,14 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
         let first_declarator = declarators.next().unwrap();
 
         if length == 1 && !f.comments().has_comment_before(first_declarator.span().start) {
-            return write!(f, first_declarator);
+            return if first_declarator.init.is_none()
+                && f.comments()
+                    .has_comment_in_range(first_declarator.span.end, self.parent.span().end)
+            {
+                write!(f, indent(&first_declarator));
+            } else {
+                write!(f, &first_declarator);
+            };
         }
 
         write!(

--- a/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/issue-16193.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/issue-16193.ts
@@ -1,0 +1,3 @@
+declare const PAGE_PATH: string
+  //<- THIS spaces
+;(()=>{})()

--- a/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/issue-16193.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/issue-16193.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+declare const PAGE_PATH: string
+  //<- THIS spaces
+;(()=>{})()
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+declare const PAGE_PATH: string;
+  //<- THIS spaces
+(() => {})();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+declare const PAGE_PATH: string;
+  //<- THIS spaces
+(() => {})();
+
+===================== End =====================


### PR DESCRIPTION
* close: #16193