### PR TITLE
fix(oxlint/lsp): run diagnostics after delayed worker initialization

### DIFF
--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -23,4 +23,8 @@ impl LSPFileSystem {
     pub fn remove(&self, uri: &Uri) {
         self.files.pin().remove(uri);
     }
+
+    pub fn keys(&self) -> Vec<Uri> {
+        self.files.pin().keys().cloned().collect()
+    }
 }


### PR DESCRIPTION
When the Client does not a configuration object in the `initialize` request, we delay the workspace worker start until we request later the configuration inside the `initialized` notification.

In the time, the client could already send `document/didOpen` notification, we should check here if we have already something in the file system.

- close https://github.com/oxc-project/oxc-zed/issues/31 
- close https://github.com/oxc-project/oxc/issues/15374