### PR TITLE
fix(linter/plugins): reset state after error during AST visitation

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -66,6 +66,7 @@ export function lintFile(
     return JSON.stringify({ Failure: getErrorMessage(err) });
   } finally {
     diagnostics.length = 0;
+    resetFile();
   }
 }
 
@@ -215,8 +216,12 @@ function lintFileImpl(
     // Reset array, ready for next file
     afterHooks.length = 0;
   }
+}
 
-  // Reset file context, source, AST, and settings, to free memory
+/**
+ * Reset file context, source, AST, and settings, to free memory.
+ */
+function resetFile() {
   resetFileContext();
   resetSourceAndAst();
   resetSettings();


### PR DESCRIPTION
If there's an error during AST visitation, ensure state is reset to free memory.

This is only observable if user were to schedule some code in a later tick to access e.g. `sourceCode.text`, and that runs before the next file is linted. I've not added tests, as it'd be hard to write one which isn't flaky.