### PR TITLE
refactor(linter): Update various rules to use DefaultRuleConfig pattern

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -4,19 +4,25 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use oxc_syntax::operator::BinaryOperator;
 use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_bitwise_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected use of {operator:?}"))
-        .with_help("bitwise operators are not allowed, maybe you mistyped `&&` or `||`")
+    OxcDiagnostic::warn(format!("Unexpected use of `{operator:?}`."))
+        .with_help("bitwise operators are not allowed, maybe you mistyped `&&` or `||`?")
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoBitwise(Box<NoBitwiseConfig>);
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoBitwiseConfig {
     /// The `allow` option permits the given list of bitwise operators to be used
@@ -29,7 +35,7 @@ pub struct NoBitwiseConfig {
     /// ~[1,2,3].indexOf(1) === -1;
     /// ```
     allow: Vec<CompactStr>,
-    /// When set to true the `int32Hint` option allows the use of bitwise OR in |0
+    /// When set to `true` the `int32Hint` option allows the use of bitwise OR in |0
     /// pattern for type casting.
     ///
     /// For example with `{ "int32Hint": true }` the following is permitted:
@@ -92,22 +98,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoBitwise {
-    fn from_configuration(value: serde_json::Value) -> Self {
-        let obj = value.get(0);
-
-        Self(Box::new(NoBitwiseConfig {
-            allow: obj
-                .and_then(|v| v.get("allow"))
-                .and_then(serde_json::Value::as_array)
-                .map(|v| {
-                    v.iter().filter_map(serde_json::Value::as_str).map(CompactStr::from).collect()
-                })
-                .unwrap_or_default(),
-            int32_hint: obj
-                .and_then(|v| v.get("int32Hint"))
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or_default(),
-        }))
+    fn from_configuration(value: Value) -> Self {
+        serde_json::from_value::<DefaultRuleConfig<NoBitwise>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -183,7 +177,7 @@ fn test() {
         ("a < b", None),
         ("~[1, 2, 3].indexOf(1)", Some(json!([ { "allow": ["~"] }]))),
         ("~1<<2 === -8", Some(json!([ { "allow": ["~", "<<"] }]))),
-        ("a|0", Some(json!([ { "int32Hint": true}]))),
+        ("a|0", Some(json!([ { "int32Hint": true }]))),
         ("a|0", Some(json!([ { "int32Hint": false, "allow": ["|"] }]))),
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -13,7 +13,11 @@ use oxc_syntax::operator::AssignmentOperator;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
@@ -100,13 +104,9 @@ declare_oxc_lint!(
 
 impl Rule for NoSelfAssign {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self {
-            props: value
-                .get(0)
-                .and_then(|v| v.get("props"))
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(true),
-        }
+        serde_json::from_value::<DefaultRuleConfig<NoSelfAssign>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -4,8 +4,14 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, fixer::RuleFixer, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::RuleFixer,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -17,7 +23,7 @@ fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
     .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoUnsafeNegation {
     /// The `enforceForOrderingRelations` option determines whether negation is allowed
@@ -64,12 +70,9 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeNegation {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let enforce_for_ordering_relations = value
-            .get(0)
-            .and_then(|config| config.get("enforceForOrderingRelations"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or_default();
-        Self { enforce_for_ordering_relations }
+        serde_json::from_value::<DefaultRuleConfig<NoUnsafeNegation>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_warning_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_warning_comments.rs
@@ -36,7 +36,7 @@ fn no_warning_comments_diagnostic(term: &str, comment: &str, span: Span) -> OxcD
 }
 
 #[derive(Debug, Clone)]
-struct Config {
+struct NoWarningCommentsConfig {
     terms: Vec<String>,
     patterns: Vec<Regex>,
 }
@@ -48,7 +48,16 @@ enum Location {
 }
 
 #[derive(Debug, Clone)]
-pub struct NoWarningComments(Box<Config>);
+pub struct NoWarningComments(Box<NoWarningCommentsConfig>);
+
+impl Default for NoWarningComments {
+    fn default() -> Self {
+        let terms = vec!["todo".to_string(), "fixme".to_string(), "xxx".to_string()];
+        let location = Location::Start;
+        let decoration = FxHashSet::default();
+        Self::new(&terms, &location, &decoration)
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -116,15 +125,6 @@ declare_oxc_lint!(
     pedantic
 );
 
-impl Default for NoWarningComments {
-    fn default() -> Self {
-        let terms = vec!["todo".to_string(), "fixme".to_string(), "xxx".to_string()];
-        let location = Location::Start;
-        let decoration = FxHashSet::default();
-        Self::new(&terms, &location, &decoration)
-    }
-}
-
 impl Rule for NoWarningComments {
     fn from_configuration(value: serde_json::Value) -> Self {
         let config = value.get(0);
@@ -183,7 +183,7 @@ impl Rule for NoWarningComments {
 impl NoWarningComments {
     fn new(terms: &[String], location: &Location, decoration: &FxHashSet<String>) -> Self {
         let patterns = Self::build_patterns(terms, location, decoration);
-        Self(Box::new(Config { terms: terms.to_vec(), patterns }))
+        Self(Box::new(NoWarningCommentsConfig { terms: terms.to_vec(), patterns }))
     }
 
     fn build_patterns(

--- a/crates/oxc_linter/src/snapshots/eslint_no_bitwise.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_bitwise.snap
@@ -1,93 +1,93 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-bitwise): Unexpected use of "^"
+  ⚠ eslint(no-bitwise): Unexpected use of `"^"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a ^ b
    · ─────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "|"
+  ⚠ eslint(no-bitwise): Unexpected use of `"|"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a | b
    · ─────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "&"
+  ⚠ eslint(no-bitwise): Unexpected use of `"&"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a & b
    · ─────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "<<"
+  ⚠ eslint(no-bitwise): Unexpected use of `"<<"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a << b
    · ──────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of ">>"
+  ⚠ eslint(no-bitwise): Unexpected use of `">>"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a >> b
    · ──────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of ">>>"
+  ⚠ eslint(no-bitwise): Unexpected use of `">>>"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a >>> b
    · ───────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "~"
+  ⚠ eslint(no-bitwise): Unexpected use of `"~"`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ ~a
    · ──
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "^="
+  ⚠ eslint(no-bitwise): Unexpected use of `"^="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a ^= b
    · ──────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "|="
+  ⚠ eslint(no-bitwise): Unexpected use of `"|="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a |= b
    · ──────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "&="
+  ⚠ eslint(no-bitwise): Unexpected use of `"&="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a &= b
    · ──────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of "<<="
+  ⚠ eslint(no-bitwise): Unexpected use of `"<<="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a <<= b
    · ───────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of ">>="
+  ⚠ eslint(no-bitwise): Unexpected use of `">>="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a >>= b
    · ───────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?
 
-  ⚠ eslint(no-bitwise): Unexpected use of ">>>="
+  ⚠ eslint(no-bitwise): Unexpected use of `">>>="`.
    ╭─[no_bitwise.tsx:1:1]
  1 │ a >>>= b
    · ────────
    ╰────
-  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`
+  help: bitwise operators are not allowed, maybe you mistyped `&&` or `||`?

--- a/crates/oxc_linter/src/snapshots/eslint_no_console.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_console.snap
@@ -45,6 +45,28 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:1]
+ 1 │ ╭─▶ console
+ 2 │ ╰─▶                .warn(foo)
+   ╰────
+  help: Delete this console statement.
+
+  ⚠ eslint(no-console): Unexpected console statement.
+   ╭─[no_console.tsx:1:1]
+ 1 │ ╭─▶ console
+ 2 │ │                  /* comment */
+ 3 │ ╰─▶                .warn(foo);
+   ╰────
+  help: Delete this console statement.
+
+  ⚠ eslint(no-console): Unexpected console statement.
+   ╭─[no_console.tsx:1:1]
+ 1 │ console.warn(foo)
+   · ────────────
+   ╰────
+  help: Delete this console statement.
+
+  ⚠ eslint(no-console): Unexpected console statement.
+   ╭─[no_console.tsx:1:1]
  1 │ console['log'](foo)
    · ─────────────
    ╰────


### PR DESCRIPTION
Basically just refactoring a bunch of rules to use the `DefaultRuleConfig` pattern, which conveniently also allows us to ensure that the serialization works as-expected with how the docs are rendering these config options.

The only real change here, other than to some diagnostics and a handful of docs, is the fix in `eslint/no-unused-expression` to ensure the docs for the `enforceForJSX` option capitalize it correctly, which I discovered because I updated to use this pattern and that caused the tests to - correctly - fail.

I ran the `just website` command and confirmed that the only docs changes from this branch vs main were the `no-unused-expression` fix and the minor docs update I did on no-bitwise.