### PR TITLE
refactor(linter): Remove unnecessary Default impl

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -18,19 +18,16 @@ fn no_obj_calls_diagnostic(obj_name: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct NoObjCalls;
-
-impl Default for NoObjCalls {
-    fn default() -> Self {
-        Self
-    }
-}
 
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow calling some global objects as functions
+    /// Disallow calling some global objects as functions.
+    ///
+    /// It is safe to disable this rule when using TypeScript, because
+    /// TypeScript's compiler enforces this check.
     ///
     /// ### Why is this bad?
     ///


### PR DESCRIPTION
Also add a note that this rule can be disabled when using TypeScript, as is noted for the rule in the ESLint docs.