### PR TITLE
fix(linter): Fix docs for `consistent-type-specifier-style` and `consistent-type-definitions` rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -16,11 +16,13 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
 
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
 };
 
 fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
@@ -29,7 +31,7 @@ fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct GetterReturn {
     /// When set to `true`, allows getters to implicitly return `undefined` with a `return` statement containing no expression.
@@ -87,6 +89,12 @@ declare_oxc_lint!(
 );
 
 impl Rule for GetterReturn {
+    fn from_configuration(value: Value) -> Self {
+        serde_json::from_value::<DefaultRuleConfig<GetterReturn>>(value)
+            .unwrap_or_default()
+            .into_inner()
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => {
@@ -97,16 +105,6 @@ impl Rule for GetterReturn {
             }
             _ => {}
         }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Self {
-        let allow_implicit = value
-            .get(0)
-            .and_then(|config| config.get("allowImplicit"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-
-        Self { allow_implicit }
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -4,8 +4,13 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn not_string(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
     let mut d =
@@ -24,7 +29,7 @@ fn invalid_value(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
     d
 }
 
-#[derive(Debug, Clone, Default, JsonSchema)]
+#[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ValidTypeof {
     /// The `requireStringLiterals` option when set to `true`, allows the comparison of `typeof`
@@ -154,14 +159,9 @@ impl Rule for ValidTypeof {
     }
 
     fn from_configuration(value: serde_json::Value) -> Self {
-        let require_string_literals = value.get(0).is_some_and(|config| {
-            config
-                .get("requireStringLiterals")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false)
-        });
-
-        Self { require_string_literals }
+        serde_json::from_value::<DefaultRuleConfig<ValidTypeof>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 }
 


### PR DESCRIPTION
Both of these take a string config, and the docs were set up as a configuration object.

Also refactor a few more rules to use the DefaultRuleConfig pattern.