### PR TITLE
refactor(linter): Fix casing for enum in label-has-associated-control rule.

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -51,7 +51,7 @@ pub struct LabelHasAssociatedControlConfig {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 enum Assert {
     HtmlFor,
     Nesting,


### PR DESCRIPTION
This should be `htmlFor`, not `html-for`.