### PR TITLE
refactor(linter): Use DefaultRuleConfig for more rules.

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -3,8 +3,13 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_dnyamic_require_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a literal string or immutable template literal")
@@ -12,7 +17,7 @@ fn no_dnyamic_require_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoDynamicRequire {
     /// When `true`, also check `import()` expressions for dynamic module specifiers.
@@ -53,13 +58,9 @@ declare_oxc_lint!(
 
 impl Rule for NoDynamicRequire {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let esmodule = value
-            .get(0)
-            .and_then(|config| config.get("esmodule"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-
-        Self { esmodule }
+        serde_json::from_value::<DefaultRuleConfig<NoDynamicRequire>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
@@ -8,8 +8,13 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_unassigned_import_diagnostic(span: Span, msg: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(msg.to_string())
@@ -17,10 +22,10 @@ fn no_unassigned_import_diagnostic(span: Span, msg: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoUnassignedImport(Box<NoUnassignedImportConfig>);
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 pub struct NoUnassignedImportConfig {
     /// A list of glob patterns to allow unassigned imports for specific modules.
     /// For example:
@@ -79,14 +84,11 @@ declare_oxc_lint!(
 
 impl Rule for NoUnassignedImport {
     fn from_configuration(value: Value) -> Self {
-        let obj = value.get(0);
-        let globs = obj
-            .and_then(|v| v.get("allow"))
-            .and_then(Value::as_array)
-            .map(|v| v.iter().filter_map(Value::as_str).map(CompactStr::from).collect())
-            .unwrap_or_default();
-        Self(Box::new(NoUnassignedImportConfig { globs }))
+        serde_json::from_value::<DefaultRuleConfig<NoUnassignedImport>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ImportDeclaration(import_decl) => {

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -7,12 +7,14 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
+use serde::Deserialize;
 use serde_json::Value;
+use std::ops::Deref;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_type, has_jsx_prop_ignore_case},
 };
 
@@ -22,8 +24,29 @@ fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnosti
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct AutocompleteValid(Box<AutocompleteValidConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AutocompleteValidConfig {
+    /// List of custom component names that should be treated as input elements.
+    input_components: FxHashSet<CompactStr>,
+}
+
+impl Deref for AutocompleteValid {
+    type Target = AutocompleteValidConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for AutocompleteValidConfig {
+    fn default() -> Self {
+        Self { input_components: FxHashSet::from_iter([CompactStr::new("input")]) }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -50,27 +73,6 @@ declare_oxc_lint!(
     correctness,
     config = AutocompleteValidConfig
 );
-
-#[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-pub struct AutocompleteValidConfig {
-    /// List of custom component names that should be treated as input elements.
-    input_components: FxHashSet<CompactStr>,
-}
-
-impl std::ops::Deref for AutocompleteValid {
-    type Target = AutocompleteValidConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::default::Default for AutocompleteValidConfig {
-    fn default() -> Self {
-        Self { input_components: FxHashSet::from_iter([CompactStr::new("input")]) }
-    }
-}
 
 static VALID_AUTOCOMPLETE_VALUES: phf::Set<&'static str> = phf::phf_set![
     "address-level1",
@@ -152,20 +154,9 @@ fn is_valid_autocomplete_value(value: &str) -> bool {
 
 impl Rule for AutocompleteValid {
     fn from_configuration(config: Value) -> Self {
-        config
-            .get(0)
-            .and_then(|c| c.get("inputComponents"))
-            .and_then(Value::as_array)
-            .map(|components| {
-                components
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(CompactStr::from)
-                    .chain(Some("input".into()))
-                    .collect()
-            })
-            .map(|input_components| Self(Box::new(AutocompleteValidConfig { input_components })))
+        serde_json::from_value::<DefaultRuleConfig<AutocompleteValid>>(config)
             .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -7,11 +7,15 @@ use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_process_env_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `process.env`")
-        .with_help("Remove usage of `process.env`")
+    OxcDiagnostic::warn("Disallowed usage of `process.env`.")
+        .with_help("Remove usage of `process.env`.")
         .with_label(span)
 }
 
@@ -67,20 +71,9 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
 
 impl Rule for NoProcessEnv {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let allowed_variables: FxHashSet<CompactStr> = value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.get("allowedVariables"))
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str())
-                    .map(CompactStr::from)
-                    .collect::<FxHashSet<CompactStr>>()
-            })
-            .unwrap_or_default();
-
-        Self(Box::new(NoProcessEnvConfig { allowed_variables }))
+        serde_json::from_value::<DefaultRuleConfig<NoProcessEnv>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -163,6 +156,8 @@ fn test() {
         ("process['env']", None),
         ("process.env.ENV", None),
         ("f(process.env)", None),
+        ("process.env.ENV", Some(serde_json::json!([{ "allowedVariables": [] }]))),
+        ("f(process.env.NODE_ENV)", None),
         (
             "process.env['OTHER_VARIABLE']",
             Some(serde_json::json!([{ "allowedVariables": ["NODE_ENV"] }])),

--- a/crates/oxc_linter/src/snapshots/node_no_process_env.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_process_env.snap
@@ -1,72 +1,86 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process.env
    · ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process['env']
    · ──────────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process.env.ENV
    · ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:3]
  1 │ f(process.env)
    ·   ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
+   ╭─[no_process_env.tsx:1:1]
+ 1 │ process.env.ENV
+   · ───────────
+   ╰────
+  help: Remove usage of `process.env`.
+
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
+   ╭─[no_process_env.tsx:1:3]
+ 1 │ f(process.env.NODE_ENV)
+   ·   ───────────
+   ╰────
+  help: Remove usage of `process.env`.
+
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process.env['OTHER_VARIABLE']
    · ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process.env.OTHER_VARIABLE
    · ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process['env']['OTHER_VARIABLE']
    · ──────────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process['env'].OTHER_VARIABLE
    · ──────────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process.env[NODE_ENV]
    · ───────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.
 
-  ⚠ eslint-plugin-node(no-process-env): Unexpected use of `process.env`
+  ⚠ eslint-plugin-node(no-process-env): Disallowed usage of `process.env`.
    ╭─[no_process_env.tsx:1:1]
  1 │ process['env'][NODE_ENV]
    · ──────────────
    ╰────
-  help: Remove usage of `process.env`
+  help: Remove usage of `process.env`.

--- a/crates/oxc_linter/src/snapshots/promise_spec_only.snap
+++ b/crates/oxc_linter/src/snapshots/promise_spec_only.snap
@@ -1,25 +1,31 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done`
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.done()
    · ────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.something`
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
+   ╭─[spec_only.tsx:1:1]
+ 1 │ Promise.done()
+   · ────────────
+   ╰────
+
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.something` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.something()
    · ─────────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done`
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:5]
  1 │ new Promise.done()
    ·     ────────────
    ╰────
 
-  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done`
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:4:22]
  3 │               var a = getA()
  4 │               return Promise.done(a)
@@ -27,10 +33,22 @@ source: crates/oxc_linter/src/tester.rs
  5 │             }
    ╰────
 
-  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done`
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:3:20]
  2 │             function foo() {
  3 │               getA(Promise.done)
    ·                    ────────────
  4 │             }
+   ╰────
+
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.notPermittedMethod` method.
+   ╭─[spec_only.tsx:1:1]
+ 1 │ Promise.notPermittedMethod()
+   · ──────────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.differingCase` method.
+   ╭─[spec_only.tsx:1:1]
+ 1 │ Promise.differingCase()
+   · ─────────────────────
    ╰────


### PR DESCRIPTION
This allows us to simplify the code a decent amount in a lot of rules, and rely on the config schema defined for the config docs.