### PR TITLE
fix(linter): Correct the default config options for the switch-exhaustiveness-check rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -2,7 +2,10 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::rule::{DefaultRuleConfig, Rule};
+use crate::{
+    rule::{DefaultRuleConfig, Rule},
+    utils::default_true,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct SwitchExhaustivenessCheck(Box<SwitchExhaustivenessCheckConfig>);
@@ -12,6 +15,7 @@ pub struct SwitchExhaustivenessCheck(Box<SwitchExhaustivenessCheckConfig>);
 pub struct SwitchExhaustivenessCheckConfig {
     /// Whether to allow default cases on switches that are not exhaustive.
     /// When false, requires exhaustive switch statements without default cases.
+    #[serde(default = "default_true")]
     pub allow_default_case_for_exhaustive_switch: bool,
     /// Whether to consider `default` cases exhaustive for union types.
     /// When true, a switch statement with a `default` case is considered exhaustive


### PR DESCRIPTION
[The original ESLint rule](https://typescript-eslint.io/rules/switch-exhaustiveness-check/) has `allowDefaultCaseForExhaustiveSwitch: true` by default.

Fixes #16263.

I don't think this was an intentional decision, as the rule def on the tsgolint side is set to true by default, it's only because of the oxlint rule's defaults that it isn't actually `true` by default.