### PR TITLE
refactor(linter): Use DefaultRuleConfig for four more rules.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -9,7 +9,11 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_array_sort_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Array#toSorted()` instead of `Array#sort()`.")
@@ -66,13 +70,9 @@ declare_oxc_lint!(
 
 impl Rule for NoArraySort {
     fn from_configuration(value: Value) -> Self {
-        Self {
-            allow_expression_statement: value
-                .get(0)
-                .and_then(|v| v.get("allowExpressionStatement"))
-                .and_then(Value::as_bool)
-                .unwrap_or(true),
-        }
+        serde_json::from_value::<DefaultRuleConfig<NoArraySort>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
Also fix the tests for no-array-reduce. Apparently these were not working correctly before, due to passing something other than an array into the tester. (and/or the original implementation was just incorrect, and allowed the tests to pass when they should not have done so)