### PR TITLE
perf(linter/no-restricted-types): skip running if config is empty

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
@@ -255,7 +255,7 @@ impl Rule for NoRestrictedTypes {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
+        ctx.source_type().is_typescript() && !self.0.types.is_empty()
     }
 }
 
@@ -330,6 +330,7 @@ fn test() {
         ("let e: namespace.Object;", Some(serde_json::json!([{ "types": { "Object": true } }]))),
         ("let value: _.NS.Banned;", Some(serde_json::json!([{ "types": { "NS.Banned": true } }]))),
         ("let value: NS.Banned._;", Some(serde_json::json!([{ "types": { "NS.Banned": true } }]))),
+        ("let f: any = true", Some(serde_json::json!([{ "types": {} }]))),
     ];
 
     let fail = vec![


### PR DESCRIPTION
@connorshea i thought about doing this, https://github.com/oxc-project/oxc/pull/16276#discussion_r2573090747 But i decided the complexity wasn't worth it.

The only benefit we would get is managing to skip running this rule on some typescript files that have zero type names, however those are so few and far between, the added complexity of adding these custom checks, does not outweigh the perf behifit of implementing those checks.