### PR TITLE
docs(linter): Add config option docs for `unicorn/filename-case` rule.

### DIFF
--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_14565@foo-bar.astro.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_14565@foo-bar.astro.snap
@@ -8,7 +8,7 @@ file: fixtures/linter/issue_14565/foo-bar.astro
 
 code: "eslint-plugin-unicorn(filename-case)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/filename-case.html"
-message: "Filename should be in snake case, or pascal case\nhelp: Rename the file to 'foo_bar.astro', or 'FooBar.astro'"
+message: "Filename should be in snake_case, or PascalCase\nhelp: Rename the file to 'foo_bar.astro', or 'FooBar.astro'"
 range: Range { start: Position { line: 0, character: 3 }, end: Position { line: 0, character: 3 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/issue_14565/foo-bar.astro"

--- a/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
@@ -1,167 +1,177 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo-bar.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'fooBar.test.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'fooBar.test_utils.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo_bar.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo_bar.test.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo_bar.testUtils.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'foo-bar.test.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'foo-bar.testUtils.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'FooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'FooBar.test.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'FooBar.test-utils.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_fooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '___fooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_foo_bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '___foo_bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '___foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_FooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '___FooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case, or pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'fooBar.js', or 'FooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case, kebab case, or pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_fooBar.js', '_foo-bar.js', or '_FooBar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '_foo_bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '[foo-bar].js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '$foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '$foo-bar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case, kebab case, or pascal case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to '{fooBar}.js', '{foo-bar}.js', or '{fooBar}.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'foobar.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camel case
-   ╭─[filename_case.tsx:1:1]
-   ╰────
-  help: Rename the file to 'fooBar.testUtils.js'
-
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo_bar.test_utils.js'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo_bar.test_utils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.test.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.testUtils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'FooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'FooBar.test.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'FooBar.test-utils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_fooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '___fooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_foo_bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '___foo_bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '___foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_FooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '___FooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase, or PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'fooBar.js', or 'FooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase, kebab-case, or PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_fooBar.js', '_foo-bar.js', or '_FooBar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '_foo_bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '[foo-bar].js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '$foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '$foo-bar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase, kebab-case, or PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to '{fooBar}.js', '{foo-bar}.js', or '{fooBar}.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foobar.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in camelCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'fooBar.testUtils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in snake_case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo_bar.test_utils.js'
+
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
    ╭─[filename_case.tsx:1:1]
    ╰────
   help: Rename the file to 'foo-bar.tsx'
 
-  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab case
+  ⚠ eslint-plugin-unicorn(filename-case): Filename should be in kebab-case
    ╭─[filename_case.tsx:1:9]
  1 │ <script></script><script setup></script>
    ·         ▲

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -41,8 +41,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         // react
         "react/forbid-dom-props",
         "react/forbid-elements",
-        // unicorn
-        "unicorn/filename-case",
     ];
 
     let exception_set: FxHashSet<&str> = exceptions.iter().copied().collect();


### PR DESCRIPTION
Part of #14743.

- Refactors the FilenameCase rule code
- Adds some additional tests for the rule.
- Matches the original rule by ignoring `index.js`, `index.ts`, etc automatically, to avoid problems with the rule causing invalid filenames in various frameworks.
- Adds schema-specific structs to match the actual config object an end-user will set up. I didn't want to refactor the entire rule to match the end-user config object for now, as that seemed like it'd be really difficult to get working.

To review the changeset it'd be best to go through it commit-by-commit.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### case

type: `"kebabCase" | "camelCase" | "snakeCase" | "pascalCase"`

default: `"kebabCase"`

The case style to enforce for filenames.

You can set the `case` option like this:
\```json
"unicorn/filename-case": [
"error",
{
"case": "kebabCase"
}
]
\```


### cases

type: `object`

default: `{"kebabCase":true, "camelCase":false, "snakeCase":false, "pascalCase":false}`

The case style(s) to allow/enforce for filenames. `true` means the case style is allowed, `false` means it is banned.

You can set the `cases` option like this:
\```json
"unicorn/filename-case": [
"error",
{
"cases": {
"camelCase": true,
"pascalCase": true
}
}
]
\```

#### cases.camelCase

type: `boolean`

default: `false`

Whether camel case is allowed, e.g. `someFileName.js`.


#### cases.kebabCase

type: `boolean`

default: `true`

Whether kebab case is allowed, e.g. `some-file-name.js`.


#### cases.pascalCase

type: `boolean`

default: `false`

Whether pascal case is allowed, e.g. `SomeFileName.js`.


#### cases.snakeCase

type: `boolean`

default: `false`

Whether snake case is allowed, e.g. `some_file_name.js`.


### ignore

type: `[
  string,
  null
]`


A regular expression pattern for filenames to ignore.

You can set the `ignore` option like this:
\```json
"unicorn/filename-case": [
"error",
{
"ignore": "^foo.*$"
}
]
\```

### multipleFileExtensions

type: `boolean`

default: `true`

Whether to treat additional, `.`-separated parts of a filename as
parts of the extension rather than parts of the filename.
```