### PR TITLE
fix(linter): Fix `typescript/no-empty-interface` config option casing.

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
@@ -41,6 +41,14 @@ source: crates/oxc_linter/src/tester.rs
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
+ 7 │ 
+   ╰────
+
+  ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
+   ╭─[no_empty_interface.tsx:6:4]
+ 5 │ 
+ 6 │             interface Bar extends Foo {}
+   ·             ────────────────────────────
  7 │                   
    ╰────
 


### PR DESCRIPTION
See the original rule's docs: https://typescript-eslint.io/rules/no-empty-interface/

This config option was incorrectly set up as using snake case, when it should've always been camelCase.

I added an alias so that `allow_single_extends` still works, in case anyone set it up like that in their linter config. But the docs have never mentioned it under that name.