### PR TITLE
refactor(linter): Adopt DefaultRuleConfig in a lot of files

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -6,14 +6,14 @@ arguments: overrides
 working directory: fixtures/extends_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected any. Specify a different type.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected `any`. Specify a different type.
    ,-[overrides/test.ts:1:10]
  1 | const x: any = 3;
    :          ^^^
    `----
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected any. Specify a different type.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected `any`. Specify a different type.
    ,-[overrides/test.tsx:1:23]
  1 | function component(): any {
    :                       ^^^

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -4,8 +4,13 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeId;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary `else` after `return`.")
@@ -16,7 +21,7 @@ fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagno
         .with_help("Remove the `else` block, moving its contents outside of the `if` statement.")
 }
 
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoElseReturn {
     /// Whether to allow `else if` blocks after a return statement.
@@ -334,13 +339,9 @@ fn check_if_without_else(ctx: &LintContext, node: &AstNode) {
 
 impl Rule for NoElseReturn {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let Some(value) = value.get(0) else { return Self::default() };
-        Self {
-            allow_else_if: value
-                .get("allowElseIf")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(true),
-        }
+        serde_json::from_value::<DefaultRuleConfig<NoElseReturn>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -3,20 +3,21 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     ast_util::{self},
     config::GlobalValue,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
 };
 
 fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eval can be harmful.").with_label(span)
 }
 
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoEval {
     /// This `allowIndirect` option allows indirect `eval()` calls.
@@ -93,12 +94,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEval {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let allow_indirect = value
-            .get(0)
-            .and_then(|config| config.get("allowIndirect").and_then(serde_json::Value::as_bool))
-            .unwrap_or(true);
-
-        Self { allow_indirect }
+        serde_json::from_value::<DefaultRuleConfig<NoEval>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -11,7 +11,11 @@ use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 const ADD_CAUSE_PROPERTY: &str = "Add cause property to the thrown error";
 const REPLACE_CAUSE_PROPERTY: &str = "Replace cause property value with the caught error";
@@ -301,19 +305,9 @@ impl PreserveCaughtError {
 
 impl Rule for PreserveCaughtError {
     fn from_configuration(value: serde_json::Value) -> Self {
-        if value.is_null() {
-            return Self::default();
-        }
-
-        let Some(config_array) = value.as_array() else {
-            return serde_json::from_value(value).unwrap_or_default();
-        };
-
-        let Some(config_obj) = config_array.first() else {
-            return Self::default();
-        };
-
-        serde_json::from_value(config_obj.clone()).unwrap_or_default()
+        serde_json::from_value::<DefaultRuleConfig<PreserveCaughtError>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use crate::{
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
@@ -14,7 +14,7 @@ fn check_tag_names_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid tag name found.").with_help(x1.to_string()).with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct CheckTagNames(Box<CheckTagNamesConfig>);
 
 declare_oxc_lint!(
@@ -232,11 +232,9 @@ const OUTSIDE_AMBIENT_INVALID_TAGS_IF_TYPED: [&str; 27] = [
 
 impl Rule for CheckTagNames {
     fn from_configuration(value: serde_json::Value) -> Self {
-        value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
-            .map_or_else(Self::default, |value| Self(Box::new(value)))
+        serde_json::from_value::<DefaultRuleConfig<CheckTagNames>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::{
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{
         get_function_nearest_jsdoc_node, is_duplicated_special_tag, is_missing_special_tag,
         should_ignore_as_avoid, should_ignore_as_custom_skip, should_ignore_as_internal,
@@ -32,7 +32,7 @@ fn duplicate_returns_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct RequireReturns(Box<RequireReturnsConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -99,11 +99,9 @@ declare_oxc_lint!(
 
 impl Rule for RequireReturns {
     fn from_configuration(value: serde_json::Value) -> Self {
-        value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
-            .map_or_else(Self::default, |value| Self(Box::new(value)))
+        serde_json::from_value::<DefaultRuleConfig<RequireReturns>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -1,14 +1,14 @@
-use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
-use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
-use schemars::JsonSchema;
-
 use crate::{
     ModuleRecord,
     context::LintContext,
     module_graph_visitor::{ModuleGraphVisitorBuilder, VisitFoldWhile},
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
 };
+use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -18,7 +18,7 @@ fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> O
     .with_labels(labels)
 }
 
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoBarrelFile {
     /// The maximum number of modules that can be re-exported via `export *`
@@ -74,15 +74,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoBarrelFile {
-    #[expect(clippy::cast_possible_truncation)]
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self {
-            threshold: value
-                .get(0)
-                .and_then(|config| config.get("threshold"))
-                .and_then(serde_json::Value::as_u64)
-                .map_or(NoBarrelFile::default().threshold, |n| n as usize),
-        }
+        serde_json::from_value::<DefaultRuleConfig<NoBarrelFile>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -18,7 +18,7 @@ use crate::{
     AstNode,
     context::{ContextHost, LintContext},
     globals::is_valid_aria_property,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::get_jsx_attribute_name,
 };
 
@@ -48,7 +48,7 @@ fn unknown_prop(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoUnknownProperty(Box<NoUnknownPropertyConfig>);
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
@@ -474,11 +474,9 @@ fn has_uppercase(name: &str) -> bool {
 
 impl Rule for NoUnknownProperty {
     fn from_configuration(value: serde_json::Value) -> Self {
-        value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
-            .map_or_else(Self::default, |value| Self(Box::new(value)))
+        serde_json::from_value::<DefaultRuleConfig<NoUnknownProperty>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -4,12 +4,13 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     ast_util::get_outer_member_expression,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{is_es6_component, is_state_member_expression},
 };
 
@@ -22,7 +23,7 @@ fn state_in_constructor_diagnostic(span: Span, is_state_init_constructor: bool) 
     OxcDiagnostic::warn(message).with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum StateInConstructorConfig {
     /// Enforce state initialization in the constructor.
@@ -42,7 +43,7 @@ impl StateInConstructorConfig {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct StateInConstructor(Box<StateInConstructorConfig>);
 
 impl std::ops::Deref for StateInConstructor {
@@ -128,16 +129,9 @@ declare_oxc_lint!(
 
 impl Rule for StateInConstructor {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = value
-            .get(0)
-            .and_then(serde_json::Value::as_str)
-            .map(|mode| match mode {
-                "never" => StateInConstructorConfig::Never,
-                _ => StateInConstructorConfig::Always,
-            })
-            .unwrap_or_default();
-
-        Self(Box::new(config))
+        serde_json::from_value::<DefaultRuleConfig<StateInConstructor>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -18,8 +18,35 @@ use crate::{
     rule::Rule,
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct ArrayType(Box<ArrayTypeConfig>);
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ArrayTypeConfig {
+    /// The array type expected for mutable cases.
+    default: ArrayOption,
+    /// The array type expected for readonly cases. If omitted, the value for `default` will be used.
+    #[schemars(with = "ArrayOption")]
+    readonly: Option<ArrayOption>,
+}
+
+impl std::ops::Deref for ArrayType {
+    type Target = ArrayTypeConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArrayOption {
+    #[default]
+    Array,
+    ArraySimple,
+    Generic,
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -107,33 +134,6 @@ fn array_simple(
         "Array type using '{type_name}<{generic_name}>' is forbidden for simple types. Use '{readonly_prefix}{generic_name}[]' instead."
     ))
     .with_label(span)
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct ArrayTypeConfig {
-    /// The array type expected for mutable cases.
-    default: ArrayOption,
-    /// The array type expected for readonly cases. If omitted, the value for `default` will be used.
-    #[schemars(with = "ArrayOption")]
-    readonly: Option<ArrayOption>,
-}
-
-impl std::ops::Deref for ArrayType {
-    type Target = ArrayTypeConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum ArrayOption {
-    #[default]
-    Array,
-    ArraySimple,
-    Generic,
 }
 
 impl Rule for ArrayType {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -27,7 +27,7 @@ fn no_empty_object_type_diagnostic<S: Into<Cow<'static, str>>>(
 pub struct NoEmptyObjectType(Box<NoEmptyObjectTypeConfig>);
 
 #[expect(clippy::struct_field_names)]
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoEmptyObjectTypeConfig {
     /// Whether to allow empty interfaces.
@@ -66,8 +66,43 @@ pub struct NoEmptyObjectTypeConfig {
     /// interface InterfaceProps {}
     /// type TypeProps = {};
     /// ```
-    #[serde(skip)] // TODO: Serialize this so it can be documented properly.
     allow_with_name: Option<Regex>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum AllowInterfaces {
+    #[default]
+    Never,
+    Always,
+    WithSingleExtends,
+}
+
+impl From<&str> for AllowInterfaces {
+    fn from(raw: &str) -> Self {
+        match raw {
+            "always" => Self::Always,
+            "with-single-extends" => Self::WithSingleExtends,
+            _ => Self::Never,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum AllowObjectTypes {
+    #[default]
+    Never,
+    Always,
+}
+
+impl From<&str> for AllowObjectTypes {
+    fn from(raw: &str) -> Self {
+        match raw {
+            "always" => Self::Always,
+            _ => Self::Never,
+        }
+    }
 }
 
 impl std::ops::Deref for NoEmptyObjectType {
@@ -234,42 +269,6 @@ fn check_type_literal(
         type_literal.span,
         "Do not use the empty object type literal.",
     ));
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-enum AllowInterfaces {
-    #[default]
-    Never,
-    Always,
-    WithSingleExtends,
-}
-
-impl From<&str> for AllowInterfaces {
-    fn from(raw: &str) -> Self {
-        match raw {
-            "always" => Self::Always,
-            "with-single-extends" => Self::WithSingleExtends,
-            _ => Self::Never,
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum AllowObjectTypes {
-    #[default]
-    Never,
-    Always,
-}
-
-impl From<&str> for AllowObjectTypes {
-    fn from(raw: &str) -> Self {
-        match raw {
-            "always" => Self::Always,
-            _ => Self::Never,
-        }
-    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/typescript_no_explicit_any.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_explicit_any.snap
@@ -1,112 +1,112 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:15]
  1 │ const number: any = 1
    ·               ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:21]
  1 │ function generic(): any {}
    ·                     ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:27]
  1 │ function generic(): Array<any>
    ·                           ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:21]
  1 │ function generic(): any[] {}
    ·                     ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:31]
  1 │ function generic(param: Array<any>): number { return 1 }
    ·                               ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:25]
  1 │ function generic(param: any[]): number { return 1 }
    ·                         ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:31]
  1 │ function generic(param: Array<any>): Array<any>
    ·                               ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:44]
  1 │ function generic(param: Array<any>): Array<any>
    ·                                            ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:33]
  1 │ function generic(): Array<Array<any>>
    ·                                 ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:31]
  1 │ function generic(param: Array<any[]>): Array<any>
    ·                               ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:46]
  1 │ function generic(param: Array<any[]>): Array<any>
    ·                                              ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:42]
  1 │ class Greeter { constructor(param: Array<any>) {} }
    ·                                          ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:26]
  1 │ class Greeter { message: any }
    ·                          ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:32]
  1 │ class Greeter { message: Array<any> }
    ·                                ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:26]
  1 │ class Greeter { message: any[] }
    ·                          ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:38]
  1 │ class Greeter { message: Array<Array<any>> }
    ·                                      ───
@@ -119,28 +119,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                    ─
    ╰────
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:30]
  1 │ interface Greeter { message: any }
    ·                              ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:36]
  1 │ interface Greeter { message: Array<any> }
    ·                                    ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:30]
  1 │ interface Greeter { message: any[] }
    ·                              ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:42]
  1 │ interface Greeter { message: Array<Array<any>> }
    ·                                          ───
@@ -153,147 +153,147 @@ source: crates/oxc_linter/src/tester.rs
    ·                                             ─
    ╰────
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:23]
  1 │ type obj = { message: any }
    ·                       ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:29]
  1 │ type obj = { message: Array<any> }
    ·                             ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:23]
  1 │ type obj = { message: any[] }
    ·                       ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:35]
  1 │ type obj = { message: Array<Array<any>> }
    ·                                   ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:32]
  1 │ type obj = { message: string | any }
    ·                                ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:38]
  1 │ type obj = { message: string | Array<any> }
    ·                                      ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:38]
  1 │ type obj = { message: string | Array<any[]> }
    ·                                      ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:44]
  1 │ type obj = { message: string | Array<Array<any>> }
    ·                                            ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:32]
  1 │ type obj = { message: string & any }
    ·                                ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:32]
  1 │ type obj = { message: string & any[] }
    ·                                ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:38]
  1 │ type obj = { message: string & Array<any> }
    ·                                      ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:44]
  1 │ type obj = { message: string & Array<Array<any>> }
    ·                                            ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:38]
  1 │ type obj = { message: string & Array<any[]> }
    ·                                      ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:15]
  1 │ class Foo<T = any> extends Bar<any> {}
    ·               ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:32]
  1 │ class Foo<T = any> extends Bar<any> {}
    ·                                ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:24]
  1 │ abstract class Foo<T = any> extends Bar<any> {}
    ·                        ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:41]
  1 │ abstract class Foo<T = any> extends Bar<any> {}
    ·                                         ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:33]
  1 │ function test<T extends Partial<any>>() {}
    ·                                 ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:33]
  1 │ const test = <T extends Partial<any>>() => {};
    ·                                 ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:34]
  1 │ function foo(a: number, ...rest: any[]): void { return; }
    ·                                  ───
    ╰────
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ⚠ typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.
+  ⚠ typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ╭─[no_explicit_any.tsx:1:12]
  1 │ type Any = any;
    ·            ───


### PR DESCRIPTION
- Update a _lot_ of rules to use the DefaultRuleConfig pattern.- Move code around in a few files to ensure the rule files have similar patterns in terms of order-of-methods in each rule. (e.g. `numeric_separators_style.rs`)
- Fix the docs for `no-extraneous-class` so they have correct casing, previously it was using `serde(renameAll = "camelCase")`, which does not exist.

See also #16285 for a few fixes that were split from this PR.