### PR TITLE
fix(linter): Fix rule option docs for no-extra-boolean-cast, prefer-number-properties, and prefer-structured-clone

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
@@ -555,6 +555,62 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the double negation as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!foo || bar) {}
+   ·     ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!foo && bar) {}
+   ·     ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:6]
+ 1 │ if ((!!foo || bar) && bat) {}
+   ·      ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:12]
+ 1 │ if (foo && !!bar) {}
+   ·            ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:14]
+ 1 │ do {} while (!!foo || bar)
+   ·              ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:8]
+ 1 │ while (!!foo || bar) {}
+   ·        ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:1]
+ 1 │ !!foo && bat ? bar : baz
+   · ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:8]
+ 1 │ for (; !!foo || bar;) {}
+   ·        ─────
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
    ╭─[no_extra_boolean_cast.tsx:1:2]
  1 │ !!!foo || bar
    ·  ─────


### PR DESCRIPTION
- Set up the alias properly in `no-extra-boolean-cast` and add tests for the rule to ensure both option names work.
- Fix the docs for `prefer-number-properties`, as the config option name was mistaken in the docs.
- Fix the `unicorn/prefer-structured-clone` config option docs as they were using the wrong name for an option.

Split this out from #16284 for simplicity.