### PR TITLE
docs(linter): Add config option docs to `jest/consistent-test-it` rule.

### DIFF
--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -37,7 +37,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "eslint/no-warning-comments",
         "eslint/yoda",
         // jest
-        "jest/consistent-test-it",
         "jest/valid-title",
         // react
         "react/forbid-dom-props",


### PR DESCRIPTION
Part of #14743.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### fn

type: `"it" | "test"`

default: `"test"`

Decides whether to use `test` or `it`.

### withinDescribe

type: `"it" | "test"`

default: `"it"`

Decides whether to use `test` or `it` within a `describe` scope.
If only `fn` is provided, this will default to the value of `fn`.

```