### PR TITLE
docs(linter): Add config docs for `typescript/ban-ts-comment` rule

### DIFF
--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -42,8 +42,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         // react
         "react/forbid-dom-props",
         "react/forbid-elements",
-        // typescript
-        "typescript/ban-ts-comment",
         // unicorn
         "unicorn/filename-case",
     ];


### PR DESCRIPTION
Part of #14743.

Generated docs (with the change to `doc_page.rs` to actually pull the doc comment above each config object, see #16288):

```md
## Configuration

This rule allows you to specify how different TypeScript directive comments should be handled.

For each directive (`@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`, `@ts-check`), you can choose one of the following options:
- `true`: Disallow the directive entirely, preventing its use in the entire codebase.
- `false`: Allow the directive without any restrictions.
- `"allow-with-description"`: Allow the directive only if it is followed by a description explaining its use. The description must meet the minimum length specified by `minimumDescriptionLength`.
- `{ "descriptionFormat": "<regex>" }`: Allow the directive only if the description matches the specified regex pattern.

For example:
\```json
{
"ts-expect-error": "allow-with-description",
"ts-ignore": true,
"ts-nocheck": { "descriptionFormat": "^: TS\\d+ because .+$" },
"ts-check": false,
"minimumDescriptionLength": 3
}
\```

This rule accepts a configuration object with the following properties:

### minimumDescriptionLength

type: `integer`

default: `3`

Minimum description length required when using directives with `allow-with-description`.

### ts-check

How to handle the `@ts-check` directive.

### ts-expect-error

How to handle the `@ts-expect-error` directive.


### ts-ignore

How to handle the `@ts-ignore` directive.


### ts-nocheck

How to handle the `@ts-nocheck` directive.
```