### PR TITLE
docs(linter): Pull configuration struct doc comment when rendering config docs

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -5,7 +5,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use schemars::JsonSchema;
 use serde_json::Value;
 
-/// See [ESLint - no-unused-vars config schema](https://github.com/eslint/eslint/blob/53b1ff047948e36682fade502c949f4e371e53cd/lib/rules/no-unused-vars.js#L61)
+// See [ESLint - no-unused-vars config schema](https://github.com/eslint/eslint/blob/53b1ff047948e36682fade502c949f4e371e53cd/lib/rules/no-unused-vars.js#L61)
 #[derive(Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[must_use]

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -17,7 +17,7 @@ fn max_dependencies_diagnostic<S: Into<Cow<'static, str>>>(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/max-dependencies.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/max-dependencies.md>
 #[derive(Debug, Default, Clone)]
 pub struct MaxDependencies(Box<MaxDependenciesConfig>);
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -14,7 +14,7 @@ fn named_diagnostic(imported_name: &str, module_name: &str, span: Span) -> OxcDi
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/named.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/named.md>
 #[derive(Debug, Default, Clone)]
 pub struct Named;
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -47,7 +47,7 @@ fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/namespace.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Namespace {

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -22,7 +22,7 @@ fn no_absolute_path_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not import modules using an absolute path").with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoAbsolutePath {

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -126,6 +126,7 @@ fn is_conditional(parent_node: &AstNode, ctx: &LintContext) -> bool {
         }
     }
 }
+
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-commonjs.md>
 impl Rule for NoCommonjs {
     fn from_configuration(value: serde_json::Value) -> Self {

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -20,7 +20,7 @@ fn no_cycle_diagnostic(span: Span, paths: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-cycle.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-cycle.md>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoCycle {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -37,7 +37,7 @@ where
         .with_help("Merge these imports into a single import statement")
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-duplicates.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-duplicates.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoDuplicates {

--- a/crates/oxc_linter/src/rules/import/no_mutable_exports.rs
+++ b/crates/oxc_linter/src/rules/import/no_mutable_exports.rs
@@ -17,7 +17,7 @@ fn no_mutable_exports_diagnostic(span: Span, kind: VariableDeclarationKind) -> O
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-mutable-exports.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-mutable-exports.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoMutableExports;
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -14,7 +14,7 @@ fn no_named_as_default_diagnostic(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoNamedAsDefault;
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -21,7 +21,7 @@ fn no_named_as_default_member_diagnostic(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
+// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoNamedAsDefaultMember;
 

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -20,7 +20,7 @@ fn no_jasmine_globals_diagnostic(
         .with_label(span)
 }
 
-/// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-jasmine-globals.md>
+// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-jasmine-globals.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoJasmineGlobals;
 

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -13,7 +13,7 @@ fn no_mocks_import_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-mocks-import.md>
+// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-mocks-import.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoMocksImport;
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -49,7 +49,7 @@ impl Deref for ConsistentTypeImports {
     }
 }
 
-/// <https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
+// <https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ConsistentTypeImportsConfig {

--- a/tasks/website_linter/src/rules/doc_page.rs
+++ b/tasks/website_linter/src/rules/doc_page.rs
@@ -117,8 +117,18 @@ const source = `{}`;{}
         // rule configuration
         if let Some(Schema::Object(schema)) = resolved {
             let config_section = self.rule_config(schema);
+            // Pull rule configuration description from the schema metadata, if present.
+            // The schemars `SchemaObject` may contain a `metadata` block with an
+            // optional `description` field. If present, include it above the
+            // configuration listing so readers see the intent for the config.
+            let section_description = schema
+                .metadata
+                .as_ref()
+                .and_then(|m| m.description.as_ref())
+                .map(|desc| format!("\n{desc}\n"))
+                .unwrap_or_default();
             if !config_section.trim().is_empty() {
-                writeln!(self.page, "\n## Configuration\n{config_section}")?;
+                writeln!(self.page, "\n## Configuration\n{section_description}{config_section}")?;
             }
         }
 


### PR DESCRIPTION
This is necessary for a proper config object explanation to be provided on some complex rules, and is just generally useful. I'm assuming we do not want this to show up on rules that only have the link to the original source, so I updated various rules accordingly. 

For example, from #16287:

```md
## Configuration

This rule allows you to specify how different TypeScript directive comments should be handled.

For each directive (`@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`, `@ts-check`), you can choose one of the following options:
- `true`: Disallow the directive entirely, preventing its use in the entire codebase.
- `false`: Allow the directive without any restrictions.
- `"allow-with-description"`: Allow the directive only if it is followed by a description explaining its use. The description must meet the minimum length specified by `minimumDescriptionLength`.
- `{ "descriptionFormat": "<regex>" }`: Allow the directive only if the description matches the specified regex pattern.

For example:
\```json
{
"ts-expect-error": "allow-with-description",
"ts-ignore": true,
"ts-nocheck": { "descriptionFormat": "^: TS\\d+ because .+$" },
"ts-check": false,
"minimumDescriptionLength": 3
}
\```

This rule accepts a configuration object with the following properties:

### minimumDescriptionLength

type: `integer`

default: `3`

Minimum description length required when using directives with `allow-with-description`.

### ts-check

How to handle the `@ts-check` directive.

### ts-expect-error

How to handle the `@ts-expect-error` directive.


### ts-ignore

How to handle the `@ts-ignore` directive.


### ts-nocheck

How to handle the `@ts-nocheck` directive.
```