### PR TITLE
refactor(linter): Refactor more rules to use DefaultRuleConfig

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -3,11 +3,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_type, is_hidden_from_screen_reader, object_has_accessible_child},
 };
 
@@ -19,10 +20,10 @@ fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
     .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct HeadingHasContent(Box<HeadingHasContentConfig>);
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct HeadingHasContentConfig {
     /// Additional custom component names to treat as heading elements.
@@ -74,15 +75,9 @@ const DEFAULT_COMPONENTS: [&str; 6] = ["h1", "h2", "h3", "h4", "h5", "h6"];
 
 impl Rule for HeadingHasContent {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(HeadingHasContentConfig {
-            components: value
-                .get(0)
-                .and_then(|v| v.get("components"))
-                .and_then(serde_json::Value::as_array)
-                .map(|v| {
-                    v.iter().filter_map(serde_json::Value::as_str).map(CompactStr::from).collect()
-                }),
-        }))
+        serde_json::from_value::<DefaultRuleConfig<HeadingHasContent>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -16,6 +16,7 @@ fn role_has_required_aria_props_diagnostic(span: Span, role: &str, props: &str) 
 
 #[derive(Debug, Default, Clone)]
 pub struct RoleHasRequiredAriaProps;
+
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -18,6 +18,9 @@ use crate::{
     },
 };
 
+#[derive(Debug, Default, Clone)]
+pub struct RoleSupportsAriaProps;
+
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -46,9 +49,6 @@ declare_oxc_lint!(
     jsx_a11y,
     correctness
 );
-
-#[derive(Debug, Default, Clone)]
-pub struct RoleSupportsAriaProps;
 
 fn default(span: Span, attr_name: &str, role: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(


### PR DESCRIPTION
And also fix the incorrect capitalization for "IIFEs" in the config docs on explicit-function-return type.

Plus do some refactoring to move a few of these rules closer to a more standard format.