### PR TITLE
refactor(linter/plugins): store `messageId` in diagnostics

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -22,6 +22,8 @@ import { walkProgram } from '../generated/walk.js';
 // @ts-expect-error we need to generate `.d.ts` file for this module
 import { walkProgram } from "../generated/walk.js";
 
+import type { SetOptional } from "type-fest";
+import type { DiagnosticReport } from "../plugins/report.ts";
 import type { AfterHook, BufferWithArrays } from "./types.ts";
 
 // Buffers cache.
@@ -61,6 +63,12 @@ export function lintFile(
 
   try {
     lintFileImpl(filePath, bufferId, buffer, ruleIds, optionsIds, settingsJSON);
+
+    // Remove `messageId` field from diagnostics. It's not needed on Rust side.
+    for (let i = 0, len = diagnostics.length; i < len; i++) {
+      (diagnostics[i] as SetOptional<DiagnosticReport, "messageId">).messageId = undefined;
+    }
+
     return JSON.stringify({ Success: diagnostics });
   } catch (err) {
     return JSON.stringify({ Failure: getErrorMessage(err) });


### PR DESCRIPTION
Store `messageId` in `DiagnosticReport` objects. It's not required for sending to Rust, but it is needed for rule tester (#16206).

I think it's fine to add a little code that's redundant in the main runtime, because it only has an overhead when a rule produces diagnostics, which should be an uncommon path.