### PR TITLE
refactor(linter/plugins): move placeholder replacement into own function

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -5,7 +5,7 @@ export type { Context, LanguageOptions } from "./plugins/context.ts";
 export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
 export type { Options } from "./plugins/options.ts";
-export type { Diagnostic, Suggestion } from "./plugins/report.ts";
+export type { Diagnostic, DiagnosticData, Suggestion } from "./plugins/report.ts";
 export type {
   Definition,
   DefinitionType,


### PR DESCRIPTION
Pure refactor. Move message placeholder replacement into its own function, so it can also be used by rule tester (#16206).