### PR TITLE
chore(linter): Mark more rules as not-supported in rule support tracker issues

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -110,20 +110,131 @@ const readAllPendingFixRuleNames = async () => {
   return pendingFixRules;
 };
 
+/**
+ * These rules will not be supported/implemented in oxlint.
+ *
+ * oxlint does not intend to cover stylistic lint rules, as oxfmt will handle code formatting.
+ * There are some other rules listed here which are difficult to support due to technical limitations,
+ * or rules that are deprecated in their source plugins and no longer relevant.
+ */
 const NOT_SUPPORTED_RULE_NAMES = new Set([
   "eslint/no-dupe-args", // superseded by strict mode
   "eslint/no-octal", // superseded by strict mode
-  "eslint/no-with", // superseded by strict mode
   "eslint/no-new-symbol", // Deprecated as of ESLint v9, but for a while disable manually
   "eslint/no-undef-init", // #6456 unicorn/no-useless-undefined covers this case
   "import/no-unresolved", // Will always contain false positives due to module resolution complexity,
   "promise/no-native", // handled by eslint/no-undef
-  "react/jsx-equals-spacing", // stylistic rule
-  "react/jsx-curly-spacing", // stylistic rule
-  "react/jsx-indent", // stylistic rule
-  "react/jsx-indent-props", // stylistic rule
-  "react/jsx-props-no-multi-spaces", // stylistic rule
   "unicorn/no-for-loop", // this rule suggest using `Array.prototype.entries` which is slow https://github.com/oxc-project/oxc/issues/11311, furthermore, `typescript/prefer-for-of` covers most cases
+  "eslint/no-negated-in-lhs", // replaced by eslint/no-unsafe-negation, which we support
+  "eslint/no-catch-shadow", // replaced by eslint/no-shadow
+  "eslint/id-blacklist", // replaced by eslint/id-denylist
+  "eslint/no-new-object", // replaced by eslint/no-object-constructor, which we support
+  "eslint/no-native-reassign", // replaced by eslint/no-global-assign, which we support
+  "n/shebang", // replaced by node/hashbang
+  "n/no-hide-core-modules", // this rule is deprecated in eslint-plugin-n for being inherently incorrect, no need for us to implement it
+  "unicorn/no-array-push-push", // replaced by unicorn/prefer-single-call
+  "import/imports-first", // replaced by import/first, which we support
+  "react/jsx-sort-default-props", // replaced by react/sort-default-props
+  "vitest/no-done-callback", // [deprecated in eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/issues/158)
+
+  // ESLint rules that are deprecated in ESLint and replaced by rules in eslint-plugin-n:
+  "eslint/no-process-env", // replaced by node/no-process-env, which we already support
+  "eslint/no-new-require", // replaced by node/no-new-require, which we already support
+  "eslint/no-buffer-constructor", // replaced by node/no-deprecated-api
+  "eslint/no-path-concat", // replaced by node/no-path-concat
+  "eslint/no-sync", // replaced by node/no-sync
+  "eslint/no-process-exit", // replaced by node/no-process-exit
+  "eslint/no-restricted-modules", // replaced by node/no-restricted-require
+  "eslint/no-mixed-requires", // replaced by node/no-mixed-requires
+  "eslint/global-require", // replaced by node/global-require
+  "eslint/handle-callback-err", // replaced by node/handle-callback-err
+
+  // Stylistic rules from eslint-plugin-react:
+  "react/jsx-equals-spacing",
+  "react/jsx-curly-spacing",
+  "react/jsx-indent",
+  "react/jsx-indent-props",
+  "react/jsx-newline",
+  "react/jsx-wrap-multilines",
+  "react/jsx-props-no-multi-spaces",
+  "react/jsx-tag-spacing",
+  "react/jsx-space-before-closing",
+
+  // The following ESLint rules are deprecated in the main package, and are all stylistic:
+  "eslint/array-bracket-newline",
+  "eslint/array-bracket-spacing",
+  "eslint/array-element-newline",
+  "eslint/arrow-parens",
+  "eslint/arrow-spacing",
+  "eslint/block-spacing",
+  "eslint/brace-style",
+  "eslint/comma-dangle",
+  "eslint/comma-spacing",
+  "eslint/comma-style",
+  "eslint/computed-property-spacing",
+  "eslint/dot-location",
+  "eslint/eol-last",
+  "eslint/func-call-spacing",
+  "eslint/function-call-argument-newline",
+  "eslint/function-paren-newline",
+  "eslint/generator-star-spacing",
+  "eslint/implicit-arrow-linebreak",
+  "eslint/indent-legacy",
+  "eslint/indent",
+  "eslint/jsx-quotes",
+  "eslint/key-spacing",
+  "eslint/keyword-spacing",
+  "eslint/line-comment-position",
+  "eslint/linebreak-style",
+  "eslint/lines-around-comment",
+  "eslint/lines-around-directive",
+  "eslint/lines-between-class-members",
+  "eslint/max-len",
+  "eslint/max-statements-per-line",
+  "eslint/multiline-comment-style",
+  "eslint/multiline-ternary",
+  "eslint/new-parens",
+  "eslint/newline-after-var",
+  "eslint/newline-before-return",
+  "eslint/newline-per-chained-call",
+  "eslint/no-confusing-arrow",
+  "eslint/no-extra-parens",
+  "eslint/no-extra-semi",
+  "eslint/no-floating-decimal",
+  "eslint/no-mixed-operators",
+  "eslint/no-mixed-spaces-and-tabs",
+  "eslint/no-multi-spaces",
+  "eslint/no-multiple-empty-lines",
+  "eslint/no-spaced-func",
+  "eslint/no-tabs",
+  "eslint/no-trailing-spaces",
+  "eslint/no-whitespace-before-property",
+  "eslint/nonblock-statement-body-position",
+  "eslint/object-curly-newline",
+  "eslint/object-curly-spacing",
+  "eslint/object-property-newline",
+  "eslint/one-var-declaration-per-line",
+  "eslint/operator-linebreak",
+  "eslint/padded-blocks",
+  "eslint/padding-line-between-statements",
+  "eslint/quote-props",
+  "eslint/quotes",
+  "eslint/rest-spread-spacing",
+  "eslint/semi-spacing",
+  "eslint/semi-style",
+  "eslint/semi",
+  "eslint/space-before-blocks",
+  "eslint/space-before-function-paren",
+  "eslint/space-in-parens",
+  "eslint/space-infix-ops",
+  "eslint/space-unary-ops",
+  "eslint/spaced-comment",
+  "eslint/switch-colon-spacing",
+  "eslint/template-curly-spacing",
+  "eslint/template-tag-spacing",
+  "eslint/wrap-iife",
+  "eslint/wrap-regex",
+  "eslint/yield-star-spacing",
 
   "unicorn/no-named-default", // implemented via import/no-named-default
 


### PR DESCRIPTION
This will update most of the deprecated, stylistic rules in #479 to show they are unsupported.

Other changes:

- Added various deprecated ESLint rules to the not-supported list, mainly those that were deprecated in favor of a rule with a different name, and those that were deprecated in favor of rules in the eslint node plugin.
  - e.g. added `eslint/no-process-env` to the list of rules that are not supported, as it has been implemented via `node/no-process-env` already.
- Added a few more stylistic react rules to the not-supported rule list.
- The `no-with` rule is removed from the not-supported list, as it's [already implemented](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-with.html#eslint-no-with) and that didn't make sense.
- Add various deprecated rules from other plugins to the list of not-planned rules.

-----

This list is based on the upstream rules deprecated as being stylistic in ESLint, sourced from the list of files in [this commit](https://github.com/eslint/eslint/commit/448b57bca3406ee12c4e44e9298fc0c99d3ee10c).

See this comment for where we discussed this briefly: https://github.com/oxc-project/oxc/issues/479#issuecomment-3538409391

Output result for deprecated section in ESLint core issue:

<details >
<summary>
  ✨: 0, 🚫: 90, ⏳: 0 / total: 93
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
| 🚫 | eslint/array-bracket-newline | https://eslint.org/docs/latest/rules/array-bracket-newline |
| 🚫 | eslint/array-bracket-spacing | https://eslint.org/docs/latest/rules/array-bracket-spacing |
| 🚫 | eslint/array-element-newline | https://eslint.org/docs/latest/rules/array-element-newline |
| 🚫 | eslint/arrow-parens | https://eslint.org/docs/latest/rules/arrow-parens |
| 🚫 | eslint/arrow-spacing | https://eslint.org/docs/latest/rules/arrow-spacing |
| 🚫 | eslint/block-spacing | https://eslint.org/docs/latest/rules/block-spacing |
| 🚫 | eslint/brace-style | https://eslint.org/docs/latest/rules/brace-style |
|  | eslint/callback-return | https://eslint.org/docs/latest/rules/callback-return |
| 🚫 | eslint/comma-dangle | https://eslint.org/docs/latest/rules/comma-dangle |
| 🚫 | eslint/comma-spacing | https://eslint.org/docs/latest/rules/comma-spacing |
| 🚫 | eslint/comma-style | https://eslint.org/docs/latest/rules/comma-style |
| 🚫 | eslint/computed-property-spacing | https://eslint.org/docs/latest/rules/computed-property-spacing |
| 🚫 | eslint/dot-location | https://eslint.org/docs/latest/rules/dot-location |
| 🚫 | eslint/eol-last | https://eslint.org/docs/latest/rules/eol-last |
| 🚫 | eslint/func-call-spacing | https://eslint.org/docs/latest/rules/func-call-spacing |
| 🚫 | eslint/function-call-argument-newline | https://eslint.org/docs/latest/rules/function-call-argument-newline |
| 🚫 | eslint/function-paren-newline | https://eslint.org/docs/latest/rules/function-paren-newline |
| 🚫 | eslint/generator-star-spacing | https://eslint.org/docs/latest/rules/generator-star-spacing |
| 🚫 | eslint/global-require | https://eslint.org/docs/latest/rules/global-require |
| 🚫 | eslint/handle-callback-err | https://eslint.org/docs/latest/rules/handle-callback-err |
| 🚫 | eslint/id-blacklist | https://eslint.org/docs/latest/rules/id-blacklist |
| 🚫 | eslint/implicit-arrow-linebreak | https://eslint.org/docs/latest/rules/implicit-arrow-linebreak |
| 🚫 | eslint/indent | https://eslint.org/docs/latest/rules/indent |
| 🚫 | eslint/indent-legacy | https://eslint.org/docs/latest/rules/indent-legacy |
| 🚫 | eslint/jsx-quotes | https://eslint.org/docs/latest/rules/jsx-quotes |
| 🚫 | eslint/key-spacing | https://eslint.org/docs/latest/rules/key-spacing |
| 🚫 | eslint/keyword-spacing | https://eslint.org/docs/latest/rules/keyword-spacing |
| 🚫 | eslint/line-comment-position | https://eslint.org/docs/latest/rules/line-comment-position |
| 🚫 | eslint/linebreak-style | https://eslint.org/docs/latest/rules/linebreak-style |
| 🚫 | eslint/lines-around-comment | https://eslint.org/docs/latest/rules/lines-around-comment |
| 🚫 | eslint/lines-around-directive | https://eslint.org/docs/latest/rules/lines-around-directive |
| 🚫 | eslint/lines-between-class-members | https://eslint.org/docs/latest/rules/lines-between-class-members |
| 🚫 | eslint/max-len | https://eslint.org/docs/latest/rules/max-len |
| 🚫 | eslint/max-statements-per-line | https://eslint.org/docs/latest/rules/max-statements-per-line |
| 🚫 | eslint/multiline-comment-style | https://eslint.org/docs/latest/rules/multiline-comment-style |
| 🚫 | eslint/multiline-ternary | https://eslint.org/docs/latest/rules/multiline-ternary |
| 🚫 | eslint/new-parens | https://eslint.org/docs/latest/rules/new-parens |
| 🚫 | eslint/newline-after-var | https://eslint.org/docs/latest/rules/newline-after-var |
| 🚫 | eslint/newline-before-return | https://eslint.org/docs/latest/rules/newline-before-return |
| 🚫 | eslint/newline-per-chained-call | https://eslint.org/docs/latest/rules/newline-per-chained-call |
| 🚫 | eslint/no-buffer-constructor | https://eslint.org/docs/latest/rules/no-buffer-constructor |
| 🚫 | eslint/no-catch-shadow | https://eslint.org/docs/latest/rules/no-catch-shadow |
| 🚫 | eslint/no-confusing-arrow | https://eslint.org/docs/latest/rules/no-confusing-arrow |
| 🚫 | eslint/no-extra-parens | https://eslint.org/docs/latest/rules/no-extra-parens |
| 🚫 | eslint/no-extra-semi | https://eslint.org/docs/latest/rules/no-extra-semi |
| 🚫 | eslint/no-floating-decimal | https://eslint.org/docs/latest/rules/no-floating-decimal |
| 🚫 | eslint/no-mixed-operators | https://eslint.org/docs/latest/rules/no-mixed-operators |
| 🚫 | eslint/no-mixed-requires | https://eslint.org/docs/latest/rules/no-mixed-requires |
| 🚫 | eslint/no-mixed-spaces-and-tabs | https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs |
| 🚫 | eslint/no-multi-spaces | https://eslint.org/docs/latest/rules/no-multi-spaces |
| 🚫 | eslint/no-multiple-empty-lines | https://eslint.org/docs/latest/rules/no-multiple-empty-lines |
| 🚫 | eslint/no-native-reassign | https://eslint.org/docs/latest/rules/no-native-reassign |
| 🚫 | eslint/no-negated-in-lhs | https://eslint.org/docs/latest/rules/no-negated-in-lhs |
| 🚫 | eslint/no-new-object | https://eslint.org/docs/latest/rules/no-new-object |
| 🚫 | eslint/no-new-require | https://eslint.org/docs/latest/rules/no-new-require |
| 🚫 | eslint/no-new-symbol | https://eslint.org/docs/latest/rules/no-new-symbol |
| 🚫 | eslint/no-path-concat | https://eslint.org/docs/latest/rules/no-path-concat |
| 🚫 | eslint/no-process-env | https://eslint.org/docs/latest/rules/no-process-env |
| 🚫 | eslint/no-process-exit | https://eslint.org/docs/latest/rules/no-process-exit |
| 🚫 | eslint/no-restricted-modules | https://eslint.org/docs/latest/rules/no-restricted-modules |
|  | eslint/no-return-await | https://eslint.org/docs/latest/rules/no-return-await |
| 🚫 | eslint/no-spaced-func | https://eslint.org/docs/latest/rules/no-spaced-func |
| 🚫 | eslint/no-sync | https://eslint.org/docs/latest/rules/no-sync |
| 🚫 | eslint/no-tabs | https://eslint.org/docs/latest/rules/no-tabs |
| 🚫 | eslint/no-trailing-spaces | https://eslint.org/docs/latest/rules/no-trailing-spaces |
| 🚫 | eslint/no-whitespace-before-property | https://eslint.org/docs/latest/rules/no-whitespace-before-property |
| 🚫 | eslint/nonblock-statement-body-position | https://eslint.org/docs/latest/rules/nonblock-statement-body-position |
| 🚫 | eslint/object-curly-newline | https://eslint.org/docs/latest/rules/object-curly-newline |
| 🚫 | eslint/object-curly-spacing | https://eslint.org/docs/latest/rules/object-curly-spacing |
| 🚫 | eslint/object-property-newline | https://eslint.org/docs/latest/rules/object-property-newline |
| 🚫 | eslint/one-var-declaration-per-line | https://eslint.org/docs/latest/rules/one-var-declaration-per-line |
| 🚫 | eslint/operator-linebreak | https://eslint.org/docs/latest/rules/operator-linebreak |
| 🚫 | eslint/padded-blocks | https://eslint.org/docs/latest/rules/padded-blocks |
| 🚫 | eslint/padding-line-between-statements | https://eslint.org/docs/latest/rules/padding-line-between-statements |
|  | eslint/prefer-reflect | https://eslint.org/docs/latest/rules/prefer-reflect |
| 🚫 | eslint/quote-props | https://eslint.org/docs/latest/rules/quote-props |
| 🚫 | eslint/quotes | https://eslint.org/docs/latest/rules/quotes |
| 🚫 | eslint/rest-spread-spacing | https://eslint.org/docs/latest/rules/rest-spread-spacing |
| 🚫 | eslint/semi | https://eslint.org/docs/latest/rules/semi |
| 🚫 | eslint/semi-spacing | https://eslint.org/docs/latest/rules/semi-spacing |
| 🚫 | eslint/semi-style | https://eslint.org/docs/latest/rules/semi-style |
| 🚫 | eslint/space-before-blocks | https://eslint.org/docs/latest/rules/space-before-blocks |
| 🚫 | eslint/space-before-function-paren | https://eslint.org/docs/latest/rules/space-before-function-paren |
| 🚫 | eslint/space-in-parens | https://eslint.org/docs/latest/rules/space-in-parens |
| 🚫 | eslint/space-infix-ops | https://eslint.org/docs/latest/rules/space-infix-ops |
| 🚫 | eslint/space-unary-ops | https://eslint.org/docs/latest/rules/space-unary-ops |
| 🚫 | eslint/spaced-comment | https://eslint.org/docs/latest/rules/spaced-comment |
| 🚫 | eslint/switch-colon-spacing | https://eslint.org/docs/latest/rules/switch-colon-spacing |
| 🚫 | eslint/template-curly-spacing | https://eslint.org/docs/latest/rules/template-curly-spacing |
| 🚫 | eslint/template-tag-spacing | https://eslint.org/docs/latest/rules/template-tag-spacing |
| 🚫 | eslint/wrap-iife | https://eslint.org/docs/latest/rules/wrap-iife |
| 🚫 | eslint/wrap-regex | https://eslint.org/docs/latest/rules/wrap-regex |
| 🚫 | eslint/yield-star-spacing | https://eslint.org/docs/latest/rules/yield-star-spacing |

✨ = Implemented, 🚫 = No need to implement, ⏳ = Fix pending

</details>