### PR TITLE
refactor(syntax): add `#[inline]` attribute to `ScopeFlags::is_ts_conditional`

### DIFF
--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -115,6 +115,7 @@ impl ScopeFlags {
         self.contains(Self::CatchClause)
     }
 
+    #[inline]
     pub fn is_ts_conditional(self) -> bool {
         self.contains(Self::TsConditional)
     }


### PR DESCRIPTION
Add `#[inline]` attr to this method, for consistency with all the rest.

This omission was spotted by @aapoalas in #16291.