### PR TITLE
perf(span): add `#[repr(transparent)]` to `Atom`

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -16,6 +16,7 @@ use crate::{CompactStr, ContentEq};
 ///
 /// Use [CompactStr] with [Atom::to_compact_str] or [Atom::into_compact_str] for
 /// the lifetimeless form.
+#[repr(transparent)]
 #[derive(Clone, Copy, Eq)]
 pub struct Atom<'a>(&'a str);
 


### PR DESCRIPTION
`Atom` is just a wrapper around a `&str`, so make it `#[repr(transparent)]`. This *may* help perf in some circumstances.