### PR TITLE
fix(formatter): Fix line comment after `:` inside ternary JSX

### DIFF
--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -6,7 +6,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{
     Format,
     ast_nodes::{AstNode, AstNodes},
-    formatter::{Formatter, prelude::*, trivia::FormatTrailingComments},
+    formatter::{
+        Formatter,
+        prelude::*,
+        trivia::{FormatLeadingComments, FormatTrailingComments},
+    },
     utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
     write,
 };
@@ -377,6 +381,11 @@ impl<'a> FormatConditionalLike<'a, '_> {
         });
 
         if layout.is_nested_alternate() {
+            // The leading comment should not be printed in the the `align`
+            let start = self.conditional.span().start;
+            let comments = f.context().comments().comments_before(start);
+            FormatLeadingComments::Comments(comments).fmt(f);
+
             write!(f, [align(2, &format_inner)]);
         } else {
             write!(f, format_inner);

--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -40,17 +40,15 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
     }
 
     fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        if let AstNodes::ArrowFunctionExpression(arrow) = self.parent().parent().parent()
+        let trailing_comments = if let AstNodes::ArrowFunctionExpression(arrow) =
+            self.parent().parent().parent()
             && arrow.expression
         {
-            let comments = f.context().comments().comments_before(arrow.span.end);
-            FormatTrailingComments::Comments(comments).fmt(f);
+            f.context().comments().comments_before(arrow.span.end)
         } else {
-            match self {
-                Self::Element(element) => element.format_trailing_comments(f),
-                Self::Fragment(fragment) => fragment.format_trailing_comments(f),
-            }
-        }
+            f.context().comments().end_of_line_comments_after(self.span().end)
+        };
+        FormatTrailingComments::Comments(trailing_comments).fmt(f);
     }
 
     /// Checks if a JSX Element should be wrapped in parentheses. Returns a [WrapState] which

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
@@ -37,3 +37,15 @@
     </>
   );
 }
+
+// https://github.com/oxc-project/oxc/issues/16258
+const x = (
+  <>
+    {x ? (
+      <div />
+    ) : // xxx
+    x ? null : (
+      <div />
+    )}
+  </>
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
@@ -42,6 +42,18 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
   );
 }
 
+// https://github.com/oxc-project/oxc/issues/16258
+const x = (
+  <>
+    {x ? (
+      <div />
+    ) : // xxx
+    x ? null : (
+      <div />
+    )}
+  </>
+);
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -88,6 +100,18 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
   );
 }
 
+// https://github.com/oxc-project/oxc/issues/16258
+const x = (
+  <>
+    {x ? (
+      <div />
+    ) : // xxx
+    x ? null : (
+      <div />
+    )}
+  </>
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -132,5 +156,17 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
     </>
   );
 }
+
+// https://github.com/oxc-project/oxc/issues/16258
+const x = (
+  <>
+    {x ? (
+      <div />
+    ) : // xxx
+    x ? null : (
+      <div />
+    )}
+  </>
+);
 
 ===================== End =====================


### PR DESCRIPTION
Fixes #16258