### PR TITLE
fix(formatter): JSX text wrapping incorrect

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -393,7 +393,6 @@ pub trait FormatElements {
 
     /// Returns the end tag if:
     /// * the last element is an end tag of `kind`
-    #[expect(unused)]
     fn end_tag(&self, kind: TagKind) -> Option<&Tag>;
 }
 

--- a/crates/oxc_formatter/src/write/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/write/jsx/child_list.rs
@@ -122,7 +122,7 @@ impl FormatJsxChildList {
                     let is_trailing_or_only_whitespace = children_iter.peek().is_none();
 
                     if is_trailing_or_only_whitespace || is_after_line_break {
-                        multiline.write_separator(&JsxRawSpace, f);
+                        multiline.write_separator_in_last_entry(&JsxRawSpace, f);
                     }
                     // Leading whitespace. Only possible if used together with a expression child
                     //
@@ -597,6 +597,20 @@ impl<'a> MultilineBuilder<'a> {
             }
             buffer.into_vec()
         };
+    }
+
+    /// Writes a separator into the last entry if it is an entry.
+    fn write_separator_in_last_entry(
+        &mut self,
+        separator: &dyn Format<'a>,
+        f: &mut Formatter<'_, 'a>,
+    ) {
+        if self.result.last().is_some_and(|element| element.end_tag(TagKind::Entry).is_some()) {
+            let last_index = self.result.len() - 1;
+            self.result.insert(last_index, f.intern(separator).unwrap());
+        } else {
+            self.write_content(separator, f);
+        }
     }
 
     fn finish(self) -> FormatMultilineChildren<'a> {

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 734/759 (96.71%)
+js compatibility: 735/759 (96.84%)
 
 # Failed
 
@@ -28,4 +28,3 @@ js compatibility: 734/759 (96.71%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/text-wrap/test.js | 💥 | 99.56% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 573/604 (94.87%)
+ts compatibility: 574/604 (95.03%)
 
 # Failed
 
@@ -7,7 +7,6 @@ ts compatibility: 573/604 (94.87%)
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/text-wrap/test.js | 💥 | 99.56% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/as-const/as-const.ts | 💥 | 90.91% |


### PR DESCRIPTION
Part of fixing #16199 


IR diff in this change
```diff
fill([
  <interned 4> [
    ["xxxxtextttextttextttextttextttextttextttextttextttextttext"],
    [if_group_breaks(["{" "}", soft_line_break]), if_group_fits_on_line([" "])],
-    [
-      group([
-        "{",
-        indent([
-          soft_line_break,
-          "this",
-          group([indent([soft_line_break, ".props"])]),
-          group([indent([soft_line_break, ".type"])])
-        ]),
-        soft_line_break,
-        line_suffix_boundary,
-        "}"
-      ])
-    ],
-    ["{" "}"]
+    [
+      group([
+        "{",
+        indent([
+          soft_line_break,
+          "this",
+          group([indent([soft_line_break, ".props"])]),
+          group([indent([soft_line_break, ".type"])])
+        ]),
+        soft_line_break,
+        line_suffix_boundary,
+        "}"
+      ]),
+      "{" "}"
+    ],
  ]
])
```

`{ }` should be inserted in the last entry; this change aligns with what [Prettier](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4D4Aeh+8xMJZ5Zcplt1F9VNj5ABMDABaYDOAdAAcAThAH8YATwFwAvq1QB6LHgDcAHSggANCFExM0HslABDISIDuABTMIjKEwBsLJiUZ0AjISbABrODAAyiYAtnAAMphQcMgAZk48cDoQHgBWcGAwAOreAsggwnCJQtgxnt5+AYECPlEA5sgwQgCuSSCJIZiNLW3U0kKYYbBOAPL9JjAQQlYQPJj60PkI6NogfXADQzBOACobUGaYRXEJbXNQdY5wAIrNEPAnjok6qTz4gfVXt-cxSPFPbQAjnd4FYRGJ8iYeABaaJwdDw1ZNEyYRz1ADCEBCIRMkMcjlW50ucAAgmQBh5mqCNpFoo9niBODAQo4stx4DwamA4IE7PMcPMJPkwDx3CBsK0AJJQBGwQJgAYCGAkmWBSRXeltYSzOA5Ex5FCFYqlVbLEaxWm-ECOWKrKLFGBgkx1HGanQ1ITFfKSaQ8BWYJWrYRRbKYdBcZAADgADDohHBgZh406Xbi-qcdNsPFkwxGkAAmHTNRI7Eweez-BlwEIeeEI9DhEwXZrOuAAMSmOLI9UhVIgIBkMiAA) does.
