### PR TITLE
feat(formatter): support custom internal import patterns

### DIFF
--- a/apps/oxfmt/test/__snapshots__/sort_imports_internal_pattern.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/sort_imports_internal_pattern.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`sort_imports_internal_pattern > respects configured internal prefixes 1`] = `
+"--- FILE -----------
+monorepo.js
+--- BEFORE ---------
+import utils from "@company/core/utils";
+import other from "pkg-tools";
+import relative from "./relative";
+import vendor from "react";
+import feature from "@company/feature";
+
+--- AFTER ----------
+import utils from "@company/core/utils";
+import feature from "@company/feature";
+import other from "pkg-tools";
+
+import vendor from "react";
+
+import relative from "./relative";
+
+--------------------"
+`;
+
+exports[`sort_imports_internal_pattern > treats literal asterisks as literal prefixes 1`] = `
+"--- FILE -----------
+literal.js
+--- BEFORE ---------
+import literal from "pkg-*";
+import actual from "pkg-core";
+import sibling from "./sibling";
+
+--- AFTER ----------
+import literal from "pkg-*";
+
+import actual from "pkg-core";
+
+import sibling from "./sibling";
+
+--------------------"
+`;

--- a/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/.oxfmtrc.jsonc
+++ b/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/.oxfmtrc.jsonc
@@ -1,0 +1,7 @@
+{
+  "experimentalSortImports": {
+    "groups": ["internal", "external", "sibling"],
+    "internalPattern": ["@company/", "pkg-"],
+    "newlinesBetween": true
+  }
+}

--- a/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/literal.js
+++ b/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/literal.js
@@ -1,0 +1,3 @@
+import literal from "pkg-*";
+import actual from "pkg-core";
+import sibling from "./sibling";

--- a/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/literal.jsonc
+++ b/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/literal.jsonc
@@ -1,0 +1,7 @@
+{
+  "experimentalSortImports": {
+    "groups": ["internal", "external", "sibling"],
+    "internalPattern": "pkg-**",
+    "newlinesBetween": true
+  }
+}

--- a/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/monorepo.js
+++ b/apps/oxfmt/test/fixtures/sort_imports_internal_pattern/monorepo.js
@@ -1,0 +1,5 @@
+import utils from "@company/core/utils";
+import other from "pkg-tools";
+import relative from "./relative";
+import vendor from "react";
+import feature from "@company/feature";

--- a/apps/oxfmt/test/sort_imports_internal_pattern.test.ts
+++ b/apps/oxfmt/test/sort_imports_internal_pattern.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { runWriteModeAndSnapshot } from "./utils";
+
+const fixturesDir = join(__dirname, "fixtures");
+const fixtureDir = join(fixturesDir, "sort_imports_internal_pattern");
+
+describe("sort_imports_internal_pattern", () => {
+  it("respects configured internal prefixes", async () => {
+    const snapshot = await runWriteModeAndSnapshot(fixtureDir, ["monorepo.js"]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it("treats literal asterisks as literal prefixes", async () => {
+    const snapshot = await runWriteModeAndSnapshot(
+      fixtureDir,
+      ["literal.js"],
+      ["--config", "./literal.jsonc"],
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+});

--- a/apps/oxfmt/test/utils.ts
+++ b/apps/oxfmt/test/utils.ts
@@ -11,6 +11,12 @@ declare global {
   }
 }
 
+const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g;
+
+if (typeof RegExp.escape !== "function") {
+  RegExp.escape = (str: string): string => str.replace(ESCAPE_REGEXP, "\\$&");
+}
+
 // Test function for running the CLI with various arguments
 export async function runAndSnapshot(cwd: string, testCases: string[][]): Promise<string> {
   const snapshot = [];

--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), String> {
         ignore_case,
         newlines_between,
         groups: None,
+        internal_patterns: Vec::new(),
     };
 
     // Read source file

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
@@ -36,7 +36,7 @@ pub fn compute_import_metadata<'a>(
         is_side_effect: *is_side_effect,
         is_type_import: *is_type_import,
         is_style_import,
-        path_kind: to_path_kind(source),
+        path_kind: to_path_kind(source, options),
         is_subpath: is_subpath(source),
         has_default_specifier: *has_default_specifier,
         has_namespace_specifier: *has_namespace_specifier,
@@ -346,9 +346,13 @@ enum ImportPathKind {
 }
 
 /// Determine the path kind for an import source.
-fn to_path_kind(source: &str) -> ImportPathKind {
+fn to_path_kind(source: &str, options: &options::SortImports) -> ImportPathKind {
     if is_builtin(source) {
         return ImportPathKind::Builtin;
+    }
+
+    if options.is_internal_path(source) {
+        return ImportPathKind::Internal;
     }
 
     if source.starts_with('.') {
@@ -364,7 +368,6 @@ fn to_path_kind(source: &str) -> ImportPathKind {
         return ImportPathKind::Sibling;
     }
 
-    // TODO: This can be changed via `options.internalPattern`
     if source.starts_with("~/") || source.starts_with("@/") {
         return ImportPathKind::Internal;
     }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -17,7 +17,10 @@ use oxc_ast::ast::*;
 
 pub use crate::embedded_formatter::{EmbeddedFormatter, EmbeddedFormatterCallback};
 pub use crate::options::*;
-pub use crate::service::{oxfmtrc::Oxfmtrc, parse_utils::*};
+pub use crate::service::{
+    oxfmtrc::{normalize_internal_pattern_value, Oxfmtrc},
+    parse_utils::*,
+};
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{FormatContext, Formatted},

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_formatter/tests/schema.rs
+assertion_line: 26
 expression: json
 ---
 {
@@ -223,6 +224,17 @@ expression: json
           "default": true,
           "type": "boolean"
         },
+        "internalPattern": {
+          "description": "Patterns treated as internal modules when sorting imports.\nMatches operate on prefixes (a trailing `*` is optional) and accept either a single string or an array of strings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrStringArray"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "newlinesBetween": {
           "default": true,
           "type": "boolean"
@@ -256,6 +268,19 @@ expression: json
       "enum": [
         "asc",
         "desc"
+      ]
+    },
+    "StringOrStringArray": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       ]
     },
     "TrailingCommaConfig": {

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -170,6 +170,8 @@ export interface OxcSortImportsOptions {
   newlinesBetween?: boolean
   /** Custom groups of imports */
   groups?: Array<Array<string>>
+  /** Patterns treated as internal modules */
+  internalPattern?: string | string[]
 }
 
 export interface OxcTransformerOptions {

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -165,4 +165,7 @@ pub struct OxcSortImportsOptions {
     pub newlines_between: Option<bool>,
     /// Custom groups of imports
     pub groups: Option<Vec<Vec<String>>>,
+    /// Patterns that should be treated as "internal" modules when sorting.
+    #[napi(ts_type = "string | string[]")]
+    pub internal_pattern: Option<Either<String, Vec<String>>>,
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -219,6 +219,17 @@
           "default": true,
           "type": "boolean"
         },
+        "internalPattern": {
+          "description": "Patterns treated as internal modules when sorting imports.\nMatches operate on prefixes (a trailing `*` is optional) and accept either a single string or an array of strings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrStringArray"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "newlinesBetween": {
           "default": true,
           "type": "boolean"
@@ -252,6 +263,19 @@
       "enum": [
         "asc",
         "desc"
+      ]
+    },
+    "StringOrStringArray": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       ]
     },
     "TrailingCommaConfig": {


### PR DESCRIPTION
## Summary
- honor `.oxfmtrc` `experimentalSortImports.internalPattern` by parsing prefixes once in the formatter core, validating config input, and surfacing the option through the NAPI playground + schema docs
- add Vitest write-mode coverage (with a RegExp.escape polyfill) so the CLI path stays exercised end to end when internal prefixes or literal asterisks are configured

## Testing
- pnpm --filter oxfmt-app run build-test
- pnpm --filter oxfmt-app test