### PR TITLE
fix(formatter): correct printing of AsExpression and SatisfiesExpression

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -209,7 +209,7 @@ impl<'a> Comments<'a> {
     /// Returns comments that fall between the given start and end positions.
     pub fn comments_in_range(&self, start: u32, end: u32) -> &'a [Comment] {
         let comments = self.comments_after(start);
-        let end_index = comments.iter().take_while(|c| c.span.end < end).count();
+        let end_index = comments.iter().take_while(|c| c.span.end <= end).count();
         &comments[..end_index]
     }
 

--- a/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
@@ -3,9 +3,9 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    formatter::{Formatter, prelude::*},
+    formatter::{Formatter, prelude::*, trivia::FormatTrailingComments},
     write,
-    write::FormatWrite,
+    write::{FormatNodeWithoutTrailingComments, FormatWrite},
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
@@ -42,8 +42,31 @@ fn format_as_or_satisfies_expression<'a>(
     f: &mut Formatter<'_, 'a>,
 ) {
     let format_inner = format_with(|f| {
-        write!(f, [expression, space(), token(operation)]);
-        write!(f, [space(), type_annotation]);
+        let type_start = type_annotation.span().start;
+
+        // Check for block comments between expression and type.
+        // Prettier's `handleBinaryCastExpressionComment()` handles these specially.
+        // https://github.com/prettier/prettier/blob/fdfa6701767f5140a85902ecc9fb6444f5b4e3f8/src/language-js/comments/handle-comments.js#L1131
+        // See also https://github.com/prettier/prettier/blob/3.7.3/tests/format/typescript/as/comments/18160.ts
+        let comments = f.context().comments().comments_in_range(expression.span().end, type_start);
+        let multiline_comment_position =
+            comments.iter().position(|c| c.is_block() && f.source_text().contains_newline(c.span));
+        let block_comments =
+            if let Some(pos) = multiline_comment_position { &comments[..pos] } else { comments };
+
+        if !comments.is_empty()
+            && let AstNodes::TSTypeReference(reference) = type_annotation.as_ast_nodes()
+            && reference.type_name.is_const()
+        {
+            write!(f, [FormatNodeWithoutTrailingComments(expression)]);
+            write!(f, [FormatTrailingComments::Comments(block_comments)]);
+            write!(f, [space(), token(operation), space(), token("const")]);
+        } else if block_comments.is_empty() {
+            write!(f, [FormatNodeWithoutTrailingComments(expression)]);
+            write!(f, [space(), token(operation), space(), type_annotation]);
+        } else {
+            write!(f, [expression, space(), token(operation), space(), type_annotation]);
+        }
     });
 
     if is_callee_or_object {

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 575/604 (95.20%)
+ts compatibility: 577/604 (95.53%)
 
 # Failed
 
@@ -9,9 +9,7 @@ ts compatibility: 575/604 (95.20%)
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
-| typescript/as/as-const/as-const.ts | 💥 | 90.91% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 82.22% |
-| typescript/as/comments/18160.ts | 💥 | 71.58% |
 | typescript/chain-expression/call-expression.ts | 💥 | 68.75% |
 | typescript/chain-expression/member-expression.ts | 💥 | 65.67% |
 | typescript/chain-expression/test.ts | 💥 | 0.00% |


### PR DESCRIPTION
Address https://github.com/prettier/prettier/tree/3.7.0/tests/format/typescript/as/comments/18160.ts

As you may have guessed, this is a collaboration with Claude...
I'll assign for review it after I understand, simplify the code a bit more and add some comments.