### PR TITLE
fix(formatter): don't wrap parenthesis for yield expression if there is no leading comment

### DIFF
--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -3,7 +3,7 @@ use oxc_span::GetSpan;
 
 use crate::{
     Format,
-    ast_nodes::AstNode,
+    ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{Formatter, prelude::*},
     write,
@@ -122,16 +122,23 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
         let leading_comments = comments.comments_before(start);
 
         if leading_comments.iter().any(|comment| {
-            source_text.contains_newline(comment.span) || comments.is_end_of_line_comment(comment)
+            (comment.is_block() && source_text.contains_newline(comment.span))
+                || comments.is_end_of_line_comment(comment)
         }) {
             return true;
         }
 
         let is_own_line_comment_or_multi_line_comment = |leading_comments: &[Comment]| {
             leading_comments.iter().any(|comment| {
-                comments.is_own_line_comment(comment) || source_text.contains_newline(comment.span)
+                comments.is_own_line_comment(comment)
+                    || (comment.is_block() && source_text.contains_newline(comment.span))
             })
         };
+
+        // Yield expressions only need to check the leading comments on the left side.
+        if matches!(argument.parent, AstNodes::YieldExpression(_)) {
+            continue;
+        }
 
         // This check is based on
         // <https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/handle-comments.js#L335-L349>

--- a/crates/oxc_formatter/tests/fixtures/js/yield/issue-16197.js
+++ b/crates/oxc_formatter/tests/fixtures/js/yield/issue-16197.js
@@ -1,0 +1,5 @@
+function *a() {
+  yield task
+    // No extra parens
+    .run();
+}

--- a/crates/oxc_formatter/tests/fixtures/js/yield/issue-16197.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/yield/issue-16197.js.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+function *a() {
+  yield task
+    // No extra parens
+    .run();
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+function* a() {
+  yield task
+    // No extra parens
+    .run();
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+function* a() {
+  yield task
+    // No extra parens
+    .run();
+}
+
+===================== End =====================


### PR DESCRIPTION
close: #16197