### PR TITLE
fix(formatter): comments in call arguments should be printed as-is

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -230,10 +230,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
                 // Preserve trailing comments of the callee in the following cases:
                 // `call /**/()`
                 // `call /**/<T>()`
-                if self.type_arguments.is_some() || self.arguments.is_empty() {
+                if self.type_arguments.is_some() {
                     write!(f, [callee]);
                 } else {
                     write!(f, [FormatNodeWithoutTrailingComments(callee)]);
+
+                    if self.arguments.is_empty() {
+                        let callee_trailing_comments = f
+                            .context()
+                            .comments()
+                            .comments_before_character(self.callee.span().end, b'(');
+                        write!(f, FormatTrailingComments::Comments(callee_trailing_comments));
+                    }
                 }
                 write!(f, [optional.then_some("?."), type_arguments, arguments]);
             });

--- a/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js
@@ -5,3 +5,11 @@ call // C3
 ()
 call // C4
 ?.()
+
+call(/* argument comment */)
+call?.(/* argument comment */)
+call(
+  // argument line comment
+)
+call?.( // argument line comment
+)

--- a/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js.snap
@@ -10,6 +10,14 @@ call // C3
 call // C4
 ?.()
 
+call(/* argument comment */)
+call?.(/* argument comment */)
+call(
+  // argument line comment
+)
+call?.( // argument line comment
+)
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -20,6 +28,15 @@ call /* C2 */?.();
 call(); // C3
 call?.(); // C4
 
+call(/* argument comment */);
+call?.(/* argument comment */);
+call(
+  // argument line comment
+);
+call?.(
+  // argument line comment
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -28,5 +45,14 @@ call /* C2 */?.();
 
 call(); // C3
 call?.(); // C4
+
+call(/* argument comment */);
+call?.(/* argument comment */);
+call(
+  // argument line comment
+);
+call?.(
+  // argument line comment
+);
 
 ===================== End =====================


### PR DESCRIPTION
fix https://github.com/oxc-project/oxc/issues/16195#issuecomment-3594532824