### PR TITLE
docs(linter/plugins): clarify comments

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -49,7 +49,7 @@ const PARSER_SERVICES_DEFAULT: Record<string, unknown> = Object.freeze({});
  * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent to JS
  * @param ruleIds - IDs of rules to run on this file
  * @param optionsIds - IDs of options to use for rules on this file, in same order as `ruleIds`
- * @param settingsJSON - Settings for file, as JSON
+ * @param settingsJSON - Settings for this file, as JSON string
  * @returns Diagnostics or error serialized to JSON string
  */
 export function lintFile(
@@ -85,7 +85,7 @@ export function lintFile(
  * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent to JS
  * @param ruleIds - IDs of rules to run on this file
  * @param optionsIds - IDs of options to use for rules on this file, in same order as `ruleIds`
- * @param settingsJSON - Stringified settings for this file
+ * @param settingsJSON - Settings for this file, as JSON string
  * @throws {Error} If any parameters are invalid
  * @throws {*} If any rule throws
  */

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -41,7 +41,7 @@ pub type JsLintFileCb = ThreadsafeFunction<
         Option<Uint8Array>, // Buffer (optional)
         Vec<u32>,           // Array of rule IDs
         Vec<u32>,           // Array of options IDs
-        String,             // Stringified settings effective for the file
+        String,             // Settings for the file, as JSON string
     )>,
     // Return value
     String, // `Vec<LintFileResult>`, serialized to JSON


### PR DESCRIPTION
Clarify these comments. "as JSON string" is more specific than "stringified".