### PR TITLE
refactor(linter): store rule options as `Vec`s

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -1077,7 +1077,7 @@ mod test {
         // Base config has external rule with options A, severity warn
         let base_external_rule_id = store.lookup_rule_id("custom", "my-rule").unwrap();
         let base_options_id =
-            store.add_options(ExternalRuleId::DUMMY, serde_json::json!([{ "opt": "A" }]));
+            store.add_options(ExternalRuleId::DUMMY, vec![serde_json::json!({ "opt": "A" })]);
 
         let base = Config::new(
             vec![],
@@ -1096,7 +1096,7 @@ mod test {
                         base_external_rule_id,
                         store.add_options(
                             ExternalRuleId::DUMMY,
-                            serde_json::json!([{ "opt": "B" }]),
+                            vec![serde_json::json!({ "opt": "B" })],
                         ),
                         AllowWarnDeny::Deny,
                     )],

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -145,19 +145,11 @@ impl ExternalPluginStore {
     }
 
     /// Add options to the store and return its [`ExternalOptionsId`].
-    ///
-    /// `options` must be a `serde_json::Value::Array`.
-    ///
-    /// # Panics
-    /// Panics if `options` is not an array.
     pub fn add_options(
         &mut self,
         rule_id: ExternalRuleId,
-        options: serde_json::Value,
+        options: Vec<serde_json::Value>,
     ) -> ExternalOptionsId {
-        let serde_json::Value::Array(options) = options else {
-            panic!("`options` must be an array");
-        };
         debug_assert!(!options.is_empty(), "`options` should never be an empty `Vec`");
         self.options.push((rule_id, options))
     }


### PR DESCRIPTION
Rule options are always an array, so store them as a `Vec<Value>` instead of a single `Value` which is always a `Value::Array`. This gives better type safety.