### PR TITLE
refactor(linter): rename `RuleEnum::read_json` to `from_configuration`

### DIFF
--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -96,7 +96,7 @@ impl OxlintRules {
                             .find(|r| r.name() == rule_name && r.plugin_name() == plugin_name)
                     });
                     if let Some(rule) = rule {
-                        rules_to_replace.push((rule.read_json(config), severity));
+                        rules_to_replace.push((rule.from_configuration(config), severity));
                     }
                 } else {
                     // If JS plugins are disabled (language server), assume plugin name refers to a JS plugin,

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -482,7 +482,7 @@ impl Tester {
         fix_kind: ExpectFixKind,
         fix_index: u8,
     ) -> TestResult {
-        let rule = self.find_rule().read_json(rule_config.unwrap_or_default());
+        let rule = self.find_rule().from_configuration(rule_config.unwrap_or_default());
         let mut external_plugin_store = ExternalPluginStore::default();
         let linter = Linter::new(
             self.lint_options,

--- a/crates/oxc_linter/tests/rule_configuration_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_test.rs
@@ -40,7 +40,7 @@ fn test_rule_default_matches_from_configuration_null() {
         let default_rule = rule.clone();
 
         // Get the configuration using rule::from_configuration(null)
-        let null_configured_rule = rule.read_json(Value::Null);
+        let null_configured_rule = rule.from_configuration(Value::Null);
 
         // Compare the two configurations
         // Since RuleEnum doesn't implement PartialEq for the inner rule types,

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -136,7 +136,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn read_json(&self, value: serde_json::Value) -> Self {
+            pub fn from_configuration(&self, value: serde_json::Value) -> Self {
                 match self {
                     #(Self::#struct_names(_) => Self::#struct_names(
                         #struct_names::from_configuration(value),


### PR DESCRIPTION
Pure refactor. `RuleEnum::read_json` delegates to the rule's `from_configuration` method. So it makes more sense IMO for this method to be called `from_configuration` too. This follows the same pattern as the rest of `RuleEnum`'s methods.