### PR TITLE
fix(tsgolint): use `expect` when sending diagnostics

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -203,10 +203,9 @@ impl TsGoLintState {
                                         vec![oxc_diagnostic],
                                     );
 
-                                    if error_sender.send(diagnostics).is_err() {
-                                        // Receiver has been dropped, stop processing
-                                        return Ok(());
-                                    }
+                                    error_sender
+                                        .send(diagnostics)
+                                        .expect("Failed to send diagnostics");
                                 }
                                 TsGoLintDiagnostic::Internal(e) => {
                                     let oxc_diagnostic: OxcDiagnostic = e.clone().into();
@@ -237,7 +236,9 @@ impl TsGoLintState {
                                         vec![oxc_diagnostic.into()]
                                     };
 
-                                    error_sender.send(diagnostics).unwrap();
+                                    error_sender
+                                        .send(diagnostics)
+                                        .expect("Failed to send diagnostics");
                                 }
                             }
                         }


### PR DESCRIPTION
these should never fail, if they do, it's a bug in our code, so lets not fail silently so that can know that it's broken and fix it