### PR TITLE
feat(linter/plugins): merge default options into options

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -162,6 +162,7 @@ export function lintFileImpl(
 
     // Set `options` for rule
     const optionsId = optionsIds[i];
+    debugAssertIsNonNull(allOptions);
     debugAssert(optionsId < allOptions.length, "Options ID out of bounds");
 
     // If the rule has no user-provided options, use the plugin-provided default

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -2,11 +2,14 @@
  * Options for rules.
  */
 
+import assert from "node:assert";
+import { registeredRules } from "./load.js";
 import {
   deepFreezeJsonValue as deepFreezeValue,
   deepFreezeJsonArray as deepFreezeArray,
   deepFreezeJsonObject as deepFreezeObject,
 } from "./json.js";
+import { debugAssertIsNonNull } from "../utils/asserts.js";
 
 import type { JsonValue } from "./json.ts";
 
@@ -23,12 +26,68 @@ export type Options = JsonValue[];
 export const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 
 // All rule options.
-// Indexed by options ID sent alongside rule ID for each file.
-// Element 0 is always the default options (empty array).
-export let allOptions: Readonly<Options>[] = [DEFAULT_OPTIONS];
+// `lintFile` is called with an array of options IDs, which are indices into this array.
+// First element is irrelevant - never accessed - because 0 index is a sentinel meaning default options.
+export let allOptions: Readonly<Options>[] | null = null;
 
 // Index into `allOptions` for default options
 export const DEFAULT_OPTIONS_ID = 0;
+
+/**
+ * Set all external rule options.
+ * Called once from Rust after config building, before any linting occurs.
+ * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
+ */
+export function setOptions(optionsJson: string): void {
+  const details = JSON.parse(optionsJson);
+  allOptions = details.options;
+  debugAssertIsNonNull(allOptions);
+
+  const { ruleIds } = details;
+
+  // Validate
+  if (DEBUG) {
+    assert(isArray(allOptions), `options must be an array, got ${typeof allOptions}`);
+    assert(isArray(ruleIds), `ruleIds must be an array, got ${typeof allOptions}`);
+    assert.strictEqual(
+      allOptions.length,
+      ruleIds.length,
+      "ruleIds and options arrays must be the same length",
+    );
+
+    for (const options of allOptions) {
+      assert(isArray(options), `Elements of options must be arrays, got ${typeof options}`);
+    }
+
+    for (const ruleId of ruleIds) {
+      assert(
+        typeof ruleId === "number" && ruleId >= 0 && ruleId === Math.floor(ruleId),
+        `Elements of ruleIds must be non-negative integers, got ${ruleId}`,
+      );
+    }
+  }
+
+  // Merge each options array with default options for their corresponding rule.
+  // Skip the first, as index 0 is a sentinel value meaning default options. First element is never accessed.
+  // `mergeOptions` also deep-freezes the options.
+  for (let i = 1, len = allOptions.length; i < len; i++) {
+    allOptions[i] = mergeOptions(
+      allOptions[i] as Options, // `allOptions`' type is `Readonly`, but the array is mutable at present
+      registeredRules[ruleIds[i]].defaultOptions,
+    );
+  }
+}
+
+/**
+ * Initialize `allOptions` to 1-element array.
+ * The first element is irrelevant and never accessed.
+ *
+ * This function is only used in `RuleTester`.
+ * Main linter process uses `setOptions` instead.
+ */
+export function initAllOptions(): void {
+  allOptions = [DEFAULT_OPTIONS];
+}
 
 /**
  * Merge user-provided options from config with rule's default options.
@@ -53,14 +112,10 @@ export const DEFAULT_OPTIONS_ID = 0;
  * @returns Merged options
  */
 export function mergeOptions(
-  configOptions: Options | null,
-  defaultOptions: Readonly<Options> | null,
+  configOptions: Options,
+  defaultOptions: Readonly<Options>,
 ): Readonly<Options> {
-  if (configOptions === null) {
-    return defaultOptions === null ? DEFAULT_OPTIONS : defaultOptions;
-  }
-
-  if (defaultOptions === null) {
+  if (defaultOptions === DEFAULT_OPTIONS) {
     deepFreezeArray(configOptions);
     return configOptions;
   }
@@ -129,28 +184,4 @@ function mergeValues(configValue: JsonValue, defaultValue: JsonValue): JsonValue
   }
 
   return freeze(merged);
-}
-
-/**
- * Set all external rule options.
- * Called once from Rust after config building, before any linting occurs.
- * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
- */
-export function setOptions(optionsJson: string): void {
-  allOptions = JSON.parse(optionsJson);
-
-  // Validate that `allOptions` is an array of arrays
-  if (DEBUG) {
-    if (!isArray(allOptions)) {
-      throw new TypeError(`Expected optionsJson to decode to an array, got ${typeof allOptions}`);
-    }
-    for (const options of allOptions) {
-      if (!isArray(options)) {
-        throw new TypeError(`Each options entry must be an array, got ${typeof options}`);
-      }
-    }
-  }
-
-  // `allOptions`' type is `Readonly`, but the array is mutable until after this call
-  deepFreezeArray(allOptions as JsonValue[]);
 }

--- a/apps/oxlint/test/fixtures/options/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/options/.oxlintrc.json
@@ -10,13 +10,28 @@
       false,
       {
         "array": [
-          {"deep": true, "str": "hello"},
+          { "deep": true, "str": "hello" },
           456
         ],
         "not": null
       }
     ],
-    "options-plugin/default-options": "error"
+    "options-plugin/default-options": "error",
+    "options-plugin/merge-options": [
+      "error",
+      {
+        "fromConfig": 11,
+        "overrideDefault": 12,
+        "nested": {
+          "fromConfig": 13,
+          "overrideDefault": 14
+        }
+      },
+      15,
+      true,
+      [],
+      16
+    ]
   },
   "overrides": [
     {
@@ -24,7 +39,12 @@
       "rules": {
         "options-plugin/options": [
           "error",
-          {"somethingElse": true}
+          { "somethingElse": true }
+        ],
+        "options-plugin/merge-options": [
+          "error",
+          { "fromConfig": 21 },
+          { "fromConfig": 22 },
         ]
       }
     }

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -34,6 +34,29 @@
    : ^
    `----
 
+  x options-plugin(merge-options):
+  | options: [
+  |   {
+  |     "fromDefault": 1,
+  |     "overrideDefault": 12,
+  |     "nested": {
+  |       "fromDefault": 3,
+  |       "overrideDefault": 14,
+  |       "fromConfig": 13
+  |     },
+  |     "fromConfig": 11
+  |   },
+  |   15,
+  |   true,
+  |   [],
+  |   16
+  | ]
+  | isDeepFrozen: true
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^
+   `----
+
   x options-plugin(no-options):
   | options: []
   | isDeepFrozen: true
@@ -93,6 +116,32 @@
    : ^
    `----
 
+  x options-plugin(merge-options):
+  | options: [
+  |   {
+  |     "fromDefault": 1,
+  |     "overrideDefault": 2,
+  |     "nested": {
+  |       "fromDefault": 3,
+  |       "overrideDefault": 4
+  |     },
+  |     "fromConfig": 21
+  |   },
+  |   {
+  |     "fromDefault": 5,
+  |     "fromConfig": 22
+  |   },
+  |   {
+  |     "fromDefault": 6
+  |   },
+  |   7
+  | ]
+  | isDeepFrozen: true
+   ,-[files/nested/index.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x options-plugin(no-options):
   | options: []
   | isDeepFrozen: true
@@ -113,7 +162,7 @@
    : ^
    `----
 
-Found 0 warnings and 6 errors.
+Found 0 warnings and 8 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -57,6 +57,25 @@ const plugin: Plugin = {
         return {};
       },
     },
+    "merge-options": {
+      meta: {
+        defaultOptions: [
+          { fromDefault: 1, overrideDefault: 2, nested: { fromDefault: 3, overrideDefault: 4 } },
+          { fromDefault: 5 },
+          { fromDefault: 6 },
+          7,
+        ],
+      },
+      create(context) {
+        context.report({
+          message:
+            `\noptions: ${JSON.stringify(context.options, null, 2)}\n` +
+            `isDeepFrozen: ${isDeepFrozen(context.options)}`,
+          node: SPAN,
+        });
+        return {};
+      },
+    },
   },
 };
 

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -364,7 +364,7 @@ mod test {
     use rustc_hash::FxHashMap;
     use serde_json::Value;
 
-    use super::{ConfigStore, ResolvedOxlintOverrides};
+    use super::{ConfigStore, ExternalRuleId, ResolvedOxlintOverrides};
     use crate::{
         AllowWarnDeny, ExternalOptionsId, ExternalPluginStore, LintPlugins, RuleCategory, RuleEnum,
         config::{
@@ -1076,7 +1076,8 @@ mod test {
 
         // Base config has external rule with options A, severity warn
         let base_external_rule_id = store.lookup_rule_id("custom", "my-rule").unwrap();
-        let base_options_id = store.add_options(serde_json::json!([{ "opt": "A" }]));
+        let base_options_id =
+            store.add_options(ExternalRuleId::DUMMY, serde_json::json!([{ "opt": "A" }]));
 
         let base = Config::new(
             vec![],
@@ -1093,7 +1094,10 @@ mod test {
                     builtin_rules: vec![],
                     external_rules: vec![(
                         base_external_rule_id,
-                        store.add_options(serde_json::json!([{ "opt": "B" }])),
+                        store.add_options(
+                            ExternalRuleId::DUMMY,
+                            serde_json::json!([{ "opt": "B" }]),
+                        ),
                         AllowWarnDeny::Deny,
                     )],
                 },

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -112,7 +112,7 @@ impl OxlintRules {
 
                         // Add options to store and get options ID
                         let options_id = if let Some(config) = &rule_config.config {
-                            external_plugin_store.add_options(config.clone())
+                            external_plugin_store.add_options(external_rule_id, config.clone())
                         } else {
                             // No options - use reserved index 0
                             ExternalOptionsId::NONE


### PR DESCRIPTION
Closes #15630.

* #16170 added support for default options defined in the rule.
* #16215 added support for options defined in configs.
* #16217 implemented the logic for merging the 2 but only applied it in `RuleTester`.

Bring these elements together, and support merging default options from rule into options provided in config.