### PR TITLE
ci(prettier): Update prettier 3.7.0 -> 3.7.3

### DIFF
--- a/.github/scripts/clone-parallel.sh
+++ b/.github/scripts/clone-parallel.sh
@@ -7,11 +7,11 @@
 set -euo pipefail
 
 # Submodule commit SHAs - updated automatically by .github/workflows/update_submodules.yml
-# NOTE: Prettier version is now pinned to v3.7.0 (not updated by workflow above), Update manually as needed
+# NOTE: Prettier version is now pinned to v3.7.3 (not updated by workflow above), Update manually as needed
 TEST262_SHA="26058a01fdbc8dad9ded0e97133190098ea8c5d8"
 BABEL_SHA="99dcba5e71de3bd81ce14077cfa5b6df58e9b177"
 TYPESCRIPT_SHA="669c25c091ad4d32298d0f33b0e4e681d46de3ea"
-PRETTIER_SHA="8147dddb91ffdb040842be8d13f16ddb99891605"
+PRETTIER_SHA="fdfa6701767f5140a85902ecc9fb6444f5b4e3f8"
 ACORN_TEST262_SHA="21042b087dead16393c4f1d60ec9042d67da6368"
 NODE_COMPAT_TABLE_SHA="499beb6f1daa36f10c26b85a7f3ec3b3448ded23"
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 735/759 (96.84%)
+js compatibility: 737/761 (96.85%)
 
 # Failed
 

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 577/604 (95.53%)
+ts compatibility: 578/605 (95.54%)
 
 # Failed
 


### PR DESCRIPTION
While we're pinning the version, I also think it's OK to update anything that can be update safely.