### PR TITLE
feat(formatter/sort-imports): Support `options.internalPattern`

### DIFF
--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -28,6 +28,7 @@ fn main() -> Result<(), String> {
         sort_side_effects,
         ignore_case,
         newlines_between,
+        internal_pattern: None,
         groups: None,
     };
 

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -1004,6 +1004,9 @@ pub struct SortImports {
     ///
     /// NOTE: Cannot be used together with `partition_by_newline: true`.
     pub newlines_between: bool,
+    /// Prefixes for internal imports.
+    /// If `None`, uses the default internal patterns.
+    pub internal_pattern: Option<Vec<String>>,
     /// Groups configuration for organizing imports.
     /// Each inner `Vec` represents a group, and multiple group names in the same `Vec` are treated as one.
     /// If `None`, uses the default groups.
@@ -1019,6 +1022,7 @@ impl Default for SortImports {
             order: SortOrder::default(),
             ignore_case: true,
             newlines_between: true,
+            internal_pattern: None,
             groups: None,
         }
     }

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -150,6 +150,8 @@ pub struct SortImportsConfig {
     pub ignore_case: bool,
     #[serde(default = "default_true")]
     pub newlines_between: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_pattern: Option<Vec<String>>,
     /// Custom groups configuration for organizing imports.
     /// Each array element represents a group, and multiple group names in the same array are treated as one.
     /// Accepts both `string` and `string[]` as group elements.
@@ -378,6 +380,7 @@ impl Oxfmtrc {
                 }),
                 ignore_case: sort_imports_config.ignore_case,
                 newlines_between: sort_imports_config.newlines_between,
+                internal_pattern: sort_imports_config.internal_pattern,
                 groups: sort_imports_config.groups,
             });
         }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -877,6 +877,35 @@ import { z } from "z";
 // ---
 
 #[test]
+fn should_support_internal_pattern_option() {
+    assert_format(
+        r##"
+import type { T } from "a";
+import { a } from "a";
+import type { S } from "#b";
+import c from "#c";
+import { b1, b2 } from "#b";
+import { d } from "../d";
+"##,
+        r##"{ "experimentalSortImports": { "internalPattern": ["#"] } }"##,
+        r##"
+import type { T } from "a";
+
+import { a } from "a";
+
+import type { S } from "#b";
+
+import { b1, b2 } from "#b";
+import c from "#c";
+
+import { d } from "../d";
+"##,
+    );
+}
+
+// ---
+
+#[test]
 fn should_groups_and_sorts_by_type_and_source() {
     assert_format(
         r#"

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -223,6 +223,15 @@ expression: json
           "default": true,
           "type": "boolean"
         },
+        "internalPattern": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "newlinesBetween": {
           "default": true,
           "type": "boolean"

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -168,6 +168,8 @@ export interface OxcSortImportsOptions {
   ignoreCase?: boolean
   /** Add newlines between import groups (default: true) */
   newlinesBetween?: boolean
+  /** Pattern prefixes for internal imports */
+  internalPattern?: Array<string>
   /** Custom groups of imports */
   groups?: Array<Array<string>>
 }

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -510,6 +510,7 @@ impl Oxc {
                 order,
                 ignore_case: sort_imports_config.ignore_case.unwrap_or(true),
                 newlines_between: sort_imports_config.newlines_between.unwrap_or(true),
+                internal_pattern: sort_imports_config.internal_pattern.clone(),
                 groups: sort_imports_config.groups.clone(),
             });
         }

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -163,6 +163,8 @@ pub struct OxcSortImportsOptions {
     pub ignore_case: Option<bool>,
     /// Add newlines between import groups (default: true)
     pub newlines_between: Option<bool>,
+    /// Pattern prefixes for internal imports
+    pub internal_pattern: Option<Vec<String>>,
     /// Custom groups of imports
     pub groups: Option<Vec<Vec<String>>>,
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -219,6 +219,15 @@
           "default": true,
           "type": "boolean"
         },
+        "internalPattern": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "newlinesBetween": {
           "default": true,
           "type": "boolean"


### PR DESCRIPTION
Part of #14253 

The original implementation accepts a `RegExp` string, but based on the actual usage, it seems that checking as prefix is sufficient for now.

https://github.com/search?q=%22internalPattern%3A+%5B%22&type=code