### PR TITLE
feat(parser): report empty expression in JSX attribute error

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1131,3 +1131,9 @@ pub fn identifier_expected_jsx_no_hyphen(span: Span) -> OxcDiagnostic {
         .with_label(span)
         .with_help("Remove the hyphen from the identifier")
 }
+
+#[cold]
+pub fn jsx_attribute_value_empty_expression(span: Span) -> OxcDiagnostic {
+    ts_error("17000", "JSX attributes must only be assigned a non-empty 'expression'.")
+        .with_label(span)
+}

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -289,6 +289,13 @@ impl<'a> ParserImpl<'a> {
                 self.expect(Kind::RCurly);
             }
             let span = self.end_span(span_start);
+
+            // Empty expression is not allowed in JSX attribute value
+            // e.g. `<C attr={} />`
+            if !in_jsx_child {
+                self.error(diagnostics::jsx_attribute_value_empty_expression(span));
+            }
+
             // Handle comment between curly braces (ex. `{/* comment */}`)
             //                                            ^^^^^^^^^^^^^ span
             let expr = self.ast.jsx_empty_expression(Span::new(span.start + 1, span.end - 1));

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -424,11 +424,6 @@ pub fn check_for_statement_left(left: &ForStatementLeft, is_for_in: bool, ctx: &
     }
 }
 
-fn invalid_jsx_attribute_value(span: Span) -> OxcDiagnostic {
-    ts_error("17000", "JSX attributes must only be assigned a non-empty 'expression'.")
-        .with_label(span)
-}
-
 fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
     ts_error("18007", "JSX expressions may not use the comma operator")
         .with_help("Did you mean to write an array?")
@@ -439,12 +434,6 @@ pub fn check_jsx_expression_container(
     container: &JSXExpressionContainer,
     ctx: &SemanticBuilder<'_>,
 ) {
-    if matches!(container.expression, JSXExpression::EmptyExpression(_))
-        && matches!(ctx.nodes.parent_kind(ctx.current_node_id), AstKind::JSXAttribute(_))
-    {
-        ctx.error(invalid_jsx_attribute_value(container.span()));
-    }
-
     if matches!(container.expression, JSXExpression::SequenceExpression(_)) {
         ctx.error(jsx_expressions_may_not_use_the_comma_operator(container.expression.span()));
     }


### PR DESCRIPTION
Fixes #16371

> TS17000: JSX attributes must only be assigned a non-empty 'expression'.

https://www.typescriptlang.org/dev/bug-workbench/?ignoreDeprecations=6#code/PTAEAEEsHMDsHsBOBTAIsgDigxgQwC6TywDOAXKAGwB0ADAFCQC2GS+oASsrtuwGaJ4TUAHIUPfCMYs2oAMKgBQ0dhEBuevQA8CjAF4A3sABUoACoB5VBdDHgAX1DAAfEA

Coverage results are unchanged:

https://github.com/oxc-project/oxc/blob/d490daa113c582703afef553c6537f592cb02a45/tasks/coverage/snapshots/parser_typescript.snap#L7295-L7317