### PR TITLE
fix(formatter): Fix indent for new expression with type cast

### DIFF
--- a/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
@@ -81,6 +81,11 @@ fn is_callee_or_object_context(span: Span, parent: &AstNodes<'_>) -> bool {
         // Static member
         AstNodes::StaticMemberExpression(_) => true,
         AstNodes::ComputedMemberExpression(member) => member.object.span() == span,
-        _ => parent.is_call_like_callee_span(span),
+        // Or CallExpression callee (Not NewExpression, to align with Prettier)
+        // https://github.com/prettier/prettier/blob/fdfa6701767f5140a85902ecc9fb6444f5b4e3f8/src/language-js/print/cast-expression.js#L28-L33
+        // NOTE: We may revert this if resolved: https://github.com/prettier/prettier/issues/18406
+        // _ => parent.is_call_like_callee_span(span),
+        AstNodes::CallExpression(call) => call.callee.span() == span,
+        _ => false,
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/ts/new-expression/issue-16346.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/new-expression/issue-16346.ts
@@ -1,0 +1,8 @@
+new ((
+  require('./webpack/plugins/next-trace-entrypoints-plugin')
+)
+  .TraceEntryPointsPlugin as P)(
+  {
+    rootDir: dir,
+  }
+)

--- a/crates/oxc_formatter/tests/fixtures/ts/new-expression/issue-16346.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/new-expression/issue-16346.ts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+new ((
+  require('./webpack/plugins/next-trace-entrypoints-plugin')
+)
+  .TraceEntryPointsPlugin as P)(
+  {
+    rootDir: dir,
+  }
+)
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+new (require("./webpack/plugins/next-trace-entrypoints-plugin")
+  .TraceEntryPointsPlugin as P)({
+  rootDir: dir,
+});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+new (require("./webpack/plugins/next-trace-entrypoints-plugin").TraceEntryPointsPlugin as P)({
+  rootDir: dir,
+});
+
+===================== End =====================


### PR DESCRIPTION
Fixes #16346
