### PR TITLE
style(linter/plugins): prefer `const` to `let`

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -643,7 +643,7 @@ function getMessagePlaceholders(message: string): string[] {
  */
 function lint(test: TestCase, plugin: Plugin, config: Config | null): Diagnostic[] {
   // TODO: Merge `config` and `sharedConfig` into config used for linting
-  let _ = config;
+  const _ = config;
 
   // Initialize `allOptions` if not already initialized
   if (allOptions === null) initAllOptions();

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -167,7 +167,7 @@ export function getFixes(diagnostic: Diagnostic, ruleDetails: RuleDetails): Fix[
  */
 function validateAndConformFix(fix: unknown): Fix {
   typeAssertIs<Fix>(fix);
-  let { range, text } = fix;
+  const { range, text } = fix;
 
   // These checks follow ESLint, which throws if `range` is missing or invalid
   if (!range || typeof range[0] !== "number" || typeof range[1] !== "number") {

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -201,7 +201,7 @@ export function registerPlugin(plugin: Plugin, packageName: string | null): Plug
 
     if ("createOnce" in rule) {
       // TODO: Compile visitor object to array here, instead of repeating compilation on each file
-      let visitorWithHooks = rule.createOnce(context) as SetNullable<
+      const visitorWithHooks = rule.createOnce(context) as SetNullable<
         VisitorWithHooks,
         "before" | "after"
       >;

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -203,7 +203,7 @@ function normalizeStdout(stdout: string, fixtureName: string, isESLint: boolean)
     // Handle stack trace lines.
     // e.g. ` | at file:///path/to/oxc/apps/oxlint/test/fixtures/foo/bar.js:1:1`
     // e.g. ` | at whatever (file:///path/to/oxc/apps/oxlint/test/fixtures/foo/bar.js:1:1)`
-    let match = line.match(/^(\s*\|\s+at (?:.+?\()?)(.+)$/);
+    const match = line.match(/^(\s*\|\s+at (?:.+?\()?)(.+)$/);
     if (match) {
       let [, preamble, at] = match;
       if (!at.startsWith(FIXTURES_URL)) return [];


### PR DESCRIPTION
Use `const` where variables are not reassigned instead of `let`. Preparation for enabling ESLint's `prefer-const` rule (running as an Oxlint JS plugin) in our linting setup.