### PR TITLE
test(napi/parser): patch types for hidden parser options

### DIFF
--- a/napi/parser/test/parse-raw-worker.ts
+++ b/napi/parser/test/parse-raw-worker.ts
@@ -3,7 +3,7 @@
 import { readFile } from "node:fs/promises";
 import { basename, join as pathJoin } from "node:path";
 
-import { parseSync } from "../src-js/index.js";
+import { parseSync } from "./parser.ts";
 import {
   ACORN_TEST262_DIR_PATH,
   JSX_DIR_PATH,
@@ -22,16 +22,11 @@ import {
   TS_ESTREE_DIR_PATH,
 } from "./parse-raw-common.ts";
 import { makeUnitsFromTest } from "./typescript-make-units-from-test.ts";
-import type { Node, ParserOptions } from "../src-js/index.js";
+
+import type { Node, ParserOptions } from "./parser.ts";
 
 const { hasOwn } = Object,
   { isArray } = Array;
-
-interface ExtendedParserOptions extends ParserOptions {
-  experimentalRawTransfer?: boolean;
-  experimentalParent?: boolean;
-  experimentalLazy?: boolean;
-}
 
 type TestCaseProps = string | { filename: string; sourceText: string };
 
@@ -111,7 +106,6 @@ async function runTest262Case(
 
   const { program } = parseSync(filename, sourceText, {
     sourceType,
-    // @ts-expect-error
     experimentalRawTransfer: true,
   });
   const json = stringifyAcornTest262Style(program);
@@ -145,7 +139,6 @@ async function runJsxCase(
 
   const { program } = parseSync(filename, sourceText, {
     sourceType,
-    // @ts-expect-error
     experimentalRawTransfer: true,
   });
   const json = stringifyAcornTest262Style(program);
@@ -182,7 +175,7 @@ async function runTsCase(
   for (let i = 0; i < tests.length; i++) {
     const { name: filename, content: code, sourceType } = tests[i];
 
-    const options: ExtendedParserOptions = {
+    const options: ParserOptions = {
       sourceType: sourceType.module ? "module" : "unambiguous",
       astType: "ts",
       preserveParens: false,
@@ -198,7 +191,7 @@ async function runTsCase(
       continue;
     }
 
-    const { program, errors } = parseSync(filename, code, options as ParserOptions);
+    const { program, errors } = parseSync(filename, code, options);
     const oxcJson = stringifyAcornTest262Style(program);
 
     const estreeJson = estreeJsons[i];
@@ -212,7 +205,7 @@ async function runTsCase(
       const standard = parseSync(filename, code, {
         ...options,
         experimentalRawTransfer: false,
-      } as ParserOptions);
+      });
       const standardJson = stringifyAcornTest262Style(standard.program);
       const errorsStandard = standard.errors;
 
@@ -266,7 +259,7 @@ async function runInlineFixture(
 function testRangeParent(
   filename: string,
   sourceText: string,
-  options: ExtendedParserOptions | null,
+  options: ParserOptions | null,
   expect: ExpectFunction,
 ): void {
   const ret = parseSync(filename, sourceText, {
@@ -274,7 +267,7 @@ function testRangeParent(
     range: true,
     experimentalRawTransfer: true,
     experimentalParent: true,
-  } as ParserOptions);
+  });
 
   let parent: any = null;
   function walk(node: null | Node[] | Node): void {
@@ -320,16 +313,12 @@ function testRangeParent(
 
 // Test lazy deserialization does not throw an error.
 // We don't test the correctness of the output.
-function testLazy(
-  filename: string,
-  sourceText: string,
-  options: ExtendedParserOptions | null,
-): void {
+function testLazy(filename: string, sourceText: string, options: ParserOptions | null): void {
   const ret = parseSync(filename, sourceText, {
     ...options,
     experimentalRawTransfer: false,
     experimentalLazy: true,
-  } as ParserOptions);
+  });
   JSON.stringify(ret.program);
   JSON.stringify(ret.comments);
   JSON.stringify(ret.errors);
@@ -360,7 +349,7 @@ function assertRawAndStandardMatch(
 
   const retRaw = parseSync(filename, sourceText, {
     experimentalRawTransfer: true,
-  } as ParserOptions);
+  });
   const { program: programRaw, comments: commentsRaw } = retRaw;
   // Remove `null` values, to match what NAPI-RS does
   const moduleRaw = removeNullProperties(retRaw.module);

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -5,13 +5,7 @@ import { basename, join as pathJoin } from "node:path";
 import Tinypool from "tinypool";
 import { describe, expect, it } from "vitest";
 
-import {
-  parse,
-  parseSync,
-  type TSTypeAliasDeclaration,
-  type VariableDeclaration,
-} from "../src-js/index.js";
-
+import { parse, parseSync } from "./parser.ts";
 import {
   ACORN_TEST262_DIR_PATH,
   JSX_DIR_PATH,
@@ -32,8 +26,11 @@ import {
   TS_ESTREE_DIR_PATH,
   TS_SHORT_DIR_PATH,
   TS_SNAPSHOT_PATH,
-} from "./parse-raw-common";
+} from "./parse-raw-common.ts";
 
+import type { TSTypeAliasDeclaration, VariableDeclaration } from "./parser.ts";
+
+// Define `describe` and `it` variants which run/skip tests based on environment variables
 const { env } = process;
 const isEnabled = (envValue) => envValue === "true" || envValue === "1";
 
@@ -292,7 +289,6 @@ describe.concurrent("`parse`", () => {
       filename = basename(path),
       sourceText = await readFile(pathJoin(ROOT_DIR_PATH, path), "utf8");
     const programStandard = parseSync(filename, sourceText).program;
-    // @ts-ignore
     const programRaw = (await parse(filename, sourceText, { experimentalRawTransfer: true }))
       .program;
     expect(programRaw).toEqual(programStandard);
@@ -315,7 +311,6 @@ describe.concurrent("`parse`", () => {
     const promises = [];
     for (let i = 0; i < iterations; i++) {
       const code = `let x = ${i}`;
-      // @ts-ignore
       promises.push(parse("test.js", code, { experimentalRawTransfer: true }));
     }
     const results = await Promise.all(promises);
@@ -331,11 +326,9 @@ describe.concurrent("`parse`", () => {
 it.concurrent("checks semantic", async () => {
   const code = "let x; let x;";
 
-  // @ts-ignore
   let ret = parseSync("test.js", code, { experimentalRawTransfer: true });
   expect(ret.errors.length).toBe(0);
 
-  // @ts-ignore
   ret = parseSync("test.js", code, { experimentalRawTransfer: true, showSemanticErrors: true });
   expect(ret.errors.length).toBe(1);
 });
@@ -346,7 +339,6 @@ describe.concurrent("`preserveParens` option", () => {
       const code = "let x = (1 + 2);";
 
       const ret = parseSync("test.js", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         preserveParens: false,
       });
@@ -359,7 +351,6 @@ describe.concurrent("`preserveParens` option", () => {
       const code = "let x = (1 + 2); type T = (string);";
 
       const ret = parseSync("test.ts", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         preserveParens: false,
       });
@@ -376,7 +367,6 @@ describe.concurrent("`preserveParens` option", () => {
       const code = "let x = (1 + 2);";
 
       const ret = parseSync("test.js", code, {
-        // @ts-ignore
         experimentalRawTransfer: true,
         preserveParens: true,
       });
@@ -389,7 +379,6 @@ describe.concurrent("`preserveParens` option", () => {
       const code = "let x = (1 + 2); type T = (string);";
 
       const ret = parseSync("test.ts", code, {
-        // @ts-ignore
         experimentalRawTransfer: true,
         preserveParens: true,
       });
@@ -407,7 +396,6 @@ describe.concurrent("`range` option", () => {
     it.concurrent("JS", async () => {
       const code = "let x = 1;";
 
-      // @ts-ignore
       const ret = parseSync("test.js", code, { experimentalRawTransfer: true, range: false });
       expect(ret.errors.length).toBe(0);
       const { program } = ret;
@@ -423,7 +411,6 @@ describe.concurrent("`range` option", () => {
     it.concurrent("TS", async () => {
       const code = "let x = 1;";
 
-      // @ts-ignore
       const ret = parseSync("test.ts", code, { experimentalRawTransfer: true, range: false });
       expect(ret.errors.length).toBe(0);
       const { program } = ret;
@@ -441,7 +428,6 @@ describe.concurrent("`range` option", () => {
     it.concurrent("JS", async () => {
       const code = "let x = 1;";
 
-      // @ts-ignore
       const ret = parseSync("test.js", code, { experimentalRawTransfer: true, range: true });
       expect(ret.errors.length).toBe(0);
       const { program } = ret;
@@ -457,7 +443,6 @@ describe.concurrent("`range` option", () => {
     it.concurrent("TS", async () => {
       const code = "let x = 1;";
 
-      // @ts-ignore
       const ret = parseSync("test.ts", code, { experimentalRawTransfer: true, range: true });
       expect(ret.errors.length).toBe(0);
       const { program } = ret;
@@ -478,7 +463,6 @@ describe.concurrent("`experimentalParent` option", () => {
       const code = "let x = 1;";
 
       const ret = parseSync("test.js", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         experimentalParent: false,
       });
@@ -497,7 +481,6 @@ describe.concurrent("`experimentalParent` option", () => {
       const code = "let x = 1;";
 
       const ret = parseSync("test.ts", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         experimentalParent: false,
       });
@@ -518,7 +501,6 @@ describe.concurrent("`experimentalParent` option", () => {
       const code = "let x = 1;";
 
       const ret = parseSync("test.js", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         experimentalParent: true,
       });
@@ -537,7 +519,6 @@ describe.concurrent("`experimentalParent` option", () => {
       const code = "let x = 1;";
 
       const ret = parseSync("test.ts", code, {
-        // @ts-expect-error
         experimentalRawTransfer: true,
         experimentalParent: true,
       });

--- a/napi/parser/test/parser.ts
+++ b/napi/parser/test/parser.ts
@@ -1,0 +1,29 @@
+/*
+ * Re-export `parse` and `parseSync` functions with type definitions patched
+ * to expose hidden `experimentalRawTransfer`, `experimentalLazy`, and `experimentalParent` options.
+ */
+
+import * as parser from "../src-js/index.js";
+
+import type { ParserOptions as OriginalParserOptions } from "../src-js/index.js";
+
+export type * from "../src-js/index.js";
+
+interface ExperimentalParserOptions {
+  experimentalRawTransfer?: boolean;
+  experimentalParent?: boolean;
+  experimentalLazy?: boolean;
+}
+
+export type ParserOptions = OriginalParserOptions & ExperimentalParserOptions;
+
+type OverrideOptions<F extends (...args: any[]) => any> = F extends (
+  filename: infer A,
+  sourceText: infer B,
+  options?: infer C,
+) => infer R
+  ? (filename: A, sourceText: B, options?: C & ExperimentalParserOptions) => R
+  : never;
+
+export const parse: OverrideOptions<typeof parser.parse> = parser.parse;
+export const parseSync: OverrideOptions<typeof parser.parseSync> = parser.parseSync;


### PR DESCRIPTION
`napi/parser` tests utilize hidden `experimentalRawTransfer` and `experimentalParent` options. Patch the types of `parse` and `parseSync` in the tests so using these options is not a type error. This replaces a bunch of `// @ts-ignore` and `// @ts-expect-error` comments.