### PR TITLE
refactor(linter/plugins): imports use `.ts` extension

### DIFF
--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -1,5 +1,5 @@
 import { lint } from "./bindings.js";
-import { debugAssertIsNonNull } from "./utils/asserts.js";
+import { debugAssertIsNonNull } from "./utils/asserts.ts";
 
 // Lazy-loaded JS plugin-related functions.
 // Using `typeof wrapper` here makes TS check that the function signatures of `loadPlugin` and `loadPluginWrapper`
@@ -21,7 +21,7 @@ function loadPluginWrapper(path: string, packageName: string | null): Promise<st
   if (loadPlugin === null) {
     // Use promises here instead of making `loadPluginWrapper` an async function,
     // to avoid a micro-tick and extra wrapper `Promise` in all later calls to `loadPluginWrapper`
-    return import("./plugins/index.js").then((mod) => {
+    return import("./plugins/index.ts").then((mod) => {
       ({ loadPlugin, lintFile, setupConfigs } = mod);
       return loadPlugin(path, packageName);
     });

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,6 +1,6 @@
 // Functions and classes
-export { definePlugin, defineRule } from "./package/define.js";
-export { RuleTester } from "./package/rule_tester.js";
+export { definePlugin, defineRule } from "./package/define.ts";
+export { RuleTester } from "./package/rule_tester.ts";
 
 // ESTree types
 export type * as ESTree from "./generated/types.d.ts";

--- a/apps/oxlint/src-js/package/define.ts
+++ b/apps/oxlint/src-js/package/define.ts
@@ -2,7 +2,7 @@
  * `definePlugin` and `defineRule` functions.
  */
 
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Context, FileContext, LanguageOptions } from "../plugins/context.ts";
 import type { CreateOnceRule, Plugin, Rule } from "../plugins/load.ts";

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -3,11 +3,11 @@ import {
   rawTransferSupported as rawTransferSupportedBinding,
   parseRawSync,
 } from "../bindings.js";
-import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.js";
-import { buffers } from "../plugins/lint.js";
-import { BUFFER_SIZE, BUFFER_ALIGN, DATA_POINTER_POS_32 } from "../generated/constants.js";
+import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
+import { buffers } from "../plugins/lint.ts";
+import { BUFFER_SIZE, BUFFER_ALIGN, DATA_POINTER_POS_32 } from "../generated/constants.ts";
 
-import type { BufferWithArrays } from "../plugins/types.js";
+import type { BufferWithArrays } from "../plugins/types.ts";
 
 // Size array buffer for raw transfer
 const ARRAY_BUFFER_SIZE = BUFFER_SIZE + BUFFER_ALIGN;

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -10,18 +10,18 @@
 import { default as assert, AssertionError } from "node:assert";
 import util from "node:util";
 import stringify from "json-stable-stringify-without-jsonify";
-import { registerPlugin, registeredRules } from "../plugins/load.js";
-import { lintFileImpl, resetFile } from "../plugins/lint.js";
-import { getLineColumnFromOffset, getNodeByRangeIndex } from "../plugins/location.js";
+import { registerPlugin, registeredRules } from "../plugins/load.ts";
+import { lintFileImpl, resetFile } from "../plugins/lint.ts";
+import { getLineColumnFromOffset, getNodeByRangeIndex } from "../plugins/location.ts";
 import {
   allOptions,
   initAllOptions,
   mergeOptions,
   DEFAULT_OPTIONS_ID,
-} from "../plugins/options.js";
-import { diagnostics, replacePlaceholders, PLACEHOLDER_REGEX } from "../plugins/report.js";
-import { parse } from "./parse.js";
-import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.js";
+} from "../plugins/options.ts";
+import { diagnostics, replacePlaceholders, PLACEHOLDER_REGEX } from "../plugins/report.ts";
+import { parse } from "./parse.ts";
+import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { RequireAtLeastOne } from "type-fest";
 import type { Plugin, Rule } from "../plugins/load.ts";

--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -2,8 +2,8 @@
  * `SourceCode` methods related to comments.
  */
 
-import { ast, initAst, sourceText } from "./source_code.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+import { ast, initAst, sourceText } from "./source_code.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Comment, Node, NodeOrToken } from "./types.ts";
 

--- a/apps/oxlint/src-js/plugins/config.ts
+++ b/apps/oxlint/src-js/plugins/config.ts
@@ -1,4 +1,4 @@
-import { setOptions } from "./options.js";
+import { setOptions } from "./options.ts";
 
 /**
  * Populates Rust-resolved configuration options on the JS side.

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -26,11 +26,11 @@
  * and global variables (`filePath`, `settings`, `cwd`).
  */
 
-import { ast, initAst, SOURCE_CODE } from "./source_code.js";
-import { report } from "./report.js";
-import { settings, initSettings } from "./settings.js";
-import visitorKeys from "../generated/keys.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+import { ast, initAst, SOURCE_CODE } from "./source_code.ts";
+import { report } from "./report.ts";
+import { settings, initSettings } from "./settings.ts";
+import visitorKeys from "../generated/keys.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { RuleDetails } from "./load.ts";
 import type { Options } from "./options.ts";

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -1,4 +1,4 @@
-import { typeAssertIs } from "../utils/asserts.js";
+import { typeAssertIs } from "../utils/asserts.ts";
 
 import type { RuleDetails } from "./load.ts";
 import type { Range, Ranged } from "./location.ts";

--- a/apps/oxlint/src-js/plugins/index.ts
+++ b/apps/oxlint/src-js/plugins/index.ts
@@ -1,3 +1,3 @@
-export { lintFile } from "./lint.js";
-export { loadPlugin } from "./load.js";
-export { setupConfigs } from "./config.js";
+export { lintFile } from "./lint.ts";
+export { loadPlugin } from "./load.ts";
+export { setupConfigs } from "./config.ts";

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -1,17 +1,17 @@
-import { setupFileContext, resetFileContext } from "./context.js";
-import { registeredRules } from "./load.js";
-import { allOptions, DEFAULT_OPTIONS_ID } from "./options.js";
-import { diagnostics } from "./report.js";
-import { setSettingsForFile, resetSettings } from "./settings.js";
-import { ast, initAst, resetSourceAndAst, setupSourceForFile } from "./source_code.js";
-import { typeAssertIs, debugAssert, debugAssertIsNonNull } from "../utils/asserts.js";
-import { getErrorMessage } from "../utils/utils.js";
+import { setupFileContext, resetFileContext } from "./context.ts";
+import { registeredRules } from "./load.ts";
+import { allOptions, DEFAULT_OPTIONS_ID } from "./options.ts";
+import { diagnostics } from "./report.ts";
+import { setSettingsForFile, resetSettings } from "./settings.ts";
+import { ast, initAst, resetSourceAndAst, setupSourceForFile } from "./source_code.ts";
+import { typeAssertIs, debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
+import { getErrorMessage } from "../utils/utils.ts";
 import {
   addVisitorToCompiled,
   compiledVisitor,
   finalizeCompiledVisitor,
   initCompiledVisitor,
-} from "./visitor.js";
+} from "./visitor.ts";
 
 // Lazy implementation
 /*

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -1,7 +1,7 @@
-import { createContext } from "./context.js";
-import { deepFreezeJsonArray } from "./json.js";
-import { DEFAULT_OPTIONS } from "./options.js";
-import { getErrorMessage } from "../utils/utils.js";
+import { createContext } from "./context.ts";
+import { deepFreezeJsonArray } from "./json.ts";
+import { DEFAULT_OPTIONS } from "./options.ts";
+import { getErrorMessage } from "../utils/utils.ts";
 
 import type { Writable } from "type-fest";
 import type { Context } from "./context.ts";

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -3,9 +3,9 @@
  * Functions for converting between `LineColumn` and offsets, and splitting source text into lines.
  */
 
-import { ast, initAst, initSourceText, sourceText } from "./source_code.js";
-import visitorKeys from "../generated/keys.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+import { ast, initAst, initSourceText, sourceText } from "./source_code.ts";
+import visitorKeys from "../generated/keys.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Node } from "./types.ts";
 import type { Node as ESTreeNode } from "../generated/types.d.ts";

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -3,13 +3,13 @@
  */
 
 import assert from "node:assert";
-import { registeredRules } from "./load.js";
+import { registeredRules } from "./load.ts";
 import {
   deepFreezeJsonValue as deepFreezeValue,
   deepFreezeJsonArray as deepFreezeArray,
   deepFreezeJsonObject as deepFreezeObject,
-} from "./json.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+} from "./json.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { JsonValue } from "./json.ts";
 

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -2,9 +2,9 @@
  * `report` function to report errors + diagnostic types.
  */
 
-import { filePath } from "./context.js";
-import { getFixes } from "./fix.js";
-import { getOffsetFromLineColumn } from "./location.js";
+import { filePath } from "./context.ts";
+import { getFixes } from "./fix.ts";
+import { getOffsetFromLineColumn } from "./location.ts";
 
 import type { RequireAtLeastOne } from "type-fest";
 import type { Fix, FixFn } from "./fix.ts";

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -7,8 +7,8 @@ import {
   type AnalyzeOptions,
   type ScopeManager as TSESLintScopeManager,
 } from "@typescript-eslint/scope-manager";
-import { ast, initAst } from "./source_code.js";
-import { typeAssertIs, debugAssertIsNonNull } from "../utils/asserts.js";
+import { ast, initAst } from "./source_code.ts";
+import { typeAssertIs, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type * as ESTree from "../generated/types.d.ts";
 import type { SetNullable } from "../utils/types.ts";

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -1,6 +1,6 @@
 import esquery from "esquery";
-import visitorKeys from "../generated/keys.js";
-import { FUNCTION_NODE_TYPE_IDS, NODE_TYPE_IDS_MAP } from "../generated/type_ids.js";
+import visitorKeys from "../generated/keys.ts";
+import { FUNCTION_NODE_TYPE_IDS, NODE_TYPE_IDS_MAP } from "../generated/type_ids.ts";
 // @ts-expect-error we need to generate `.d.ts` file for this module
 import { ancestors } from "../generated/walk.js";
 

--- a/apps/oxlint/src-js/plugins/settings.ts
+++ b/apps/oxlint/src-js/plugins/settings.ts
@@ -2,8 +2,8 @@
  * Methods related to settings.
  */
 
-import { deepFreezeJsonValue } from "./json.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+import { deepFreezeJsonValue } from "./json.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { JsonObject } from "./json.ts";
 

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -1,12 +1,12 @@
-import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from "../generated/constants.js";
+import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from "../generated/constants.ts";
 
 // We use the deserializer which removes `ParenthesizedExpression`s from AST,
 // and with `range`, `loc`, and `parent` properties on AST nodes, to match ESLint
 // @ts-expect-error we need to generate `.d.ts` file for this module
 import { deserializeProgramOnly, resetBuffer } from "../generated/deserialize.js";
 
-import visitorKeys from "../generated/keys.js";
-import * as commentMethods from "./comments.js";
+import visitorKeys from "../generated/keys.ts";
+import * as commentMethods from "./comments.ts";
 import {
   getLineColumnFromOffset,
   getNodeByRangeIndex,
@@ -15,12 +15,12 @@ import {
   initLines,
   lines,
   resetLines,
-} from "./location.js";
-import { resetScopeManager, SCOPE_MANAGER } from "./scope.js";
-import * as scopeMethods from "./scope.js";
-import { resetTokens } from "./tokens.js";
-import * as tokenMethods from "./tokens.js";
-import { debugAssertIsNonNull } from "../utils/asserts.js";
+} from "./location.ts";
+import { resetScopeManager, SCOPE_MANAGER } from "./scope.ts";
+import * as scopeMethods from "./scope.ts";
+import { resetTokens } from "./tokens.ts";
+import * as tokenMethods from "./tokens.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Program } from "../generated/types.d.ts";
 import type { Ranged } from "./location.ts";

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -3,8 +3,8 @@
  */
 
 import { createRequire } from "node:module";
-import { sourceText } from "./source_code.js";
-import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.js";
+import { sourceText } from "./source_code.ts";
+import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Comment, Node, NodeOrToken } from "./types.ts";
 import type { Span } from "./location.ts";

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -76,11 +76,11 @@ import {
   LEAF_NODE_TYPES_COUNT,
   NODE_TYPE_IDS_MAP,
   NODE_TYPES_COUNT,
-} from "../generated/type_ids.js";
-import { parseSelector, wrapVisitFnWithSelectorMatch } from "./selector.js";
+} from "../generated/type_ids.ts";
+import { parseSelector, wrapVisitFnWithSelectorMatch } from "./selector.ts";
+import { typeAssertIs, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from "./types.ts";
-import { typeAssertIs, debugAssertIsNonNull } from "../utils/asserts.js";
 
 const ObjectKeys = Object.keys,
   { isArray } = Array;

--- a/apps/oxlint/test/compile_visitor.test.ts
+++ b/apps/oxlint/test/compile_visitor.test.ts
@@ -1,13 +1,13 @@
 // oxlint-disable jest/no-conditional-expect
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP } from "../src-js/generated/type_ids.js";
+import { LEAF_NODE_TYPES_COUNT, NODE_TYPE_IDS_MAP } from "../src-js/generated/type_ids.ts";
 import {
   addVisitorToCompiled,
   compiledVisitor,
   finalizeCompiledVisitor,
   initCompiledVisitor,
-} from "../src-js/plugins/visitor.js";
+} from "../src-js/plugins/visitor.ts";
 
 import type { EnterExit, Node, VisitFn } from "../src-js/plugins/types.ts";
 

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -1,6 +1,6 @@
 import { join as pathJoin } from "node:path";
 import { describe, it } from "vitest";
-import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from "./utils.js";
+import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from "./utils.ts";
 
 import type { Fixture } from "./utils.ts";
 

--- a/apps/oxlint/test/eslint_compat.test.ts
+++ b/apps/oxlint/test/eslint_compat.test.ts
@@ -1,6 +1,6 @@
 import { join as pathJoin } from "node:path";
 import { describe, it } from "vitest";
-import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from "./utils.js";
+import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from "./utils.ts";
 
 import type { Fixture } from "./utils.ts";
 

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, vi, expect, beforeEach } from "vitest";
-import { isSpaceBetween, isSpaceBetweenTokens } from "../src-js/plugins/tokens.js";
-import { resetSourceAndAst } from "../src-js/plugins/source_code";
+import { isSpaceBetween, isSpaceBetweenTokens } from "../src-js/plugins/tokens.ts";
+import { resetSourceAndAst } from "../src-js/plugins/source_code.ts";
 import { parse } from "@typescript-eslint/typescript-estree";
 
-import type { Node } from "../src-js/plugins/types.js";
+import type { Node } from "../src-js/plugins/types.ts";
 
 let sourceText: string | null = null;
 

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { RuleTester } from "../src-js/index.js";
+import { RuleTester } from "../src-js/index.ts";
 
 import type { Rule } from "../src-js/index.ts";
 

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -17,10 +17,10 @@ import {
   getTokensBetween,
   getTokenOrCommentBefore,
   getTokenOrCommentAfter,
-} from "../src-js/plugins/tokens.js";
-import { resetSourceAndAst } from "../src-js/plugins/source_code.js";
-import type { Node } from "../src-js/plugins/types.js";
-import type { BinaryExpression } from "../src-js/generated/types.js";
+} from "../src-js/plugins/tokens.ts";
+import { resetSourceAndAst } from "../src-js/plugins/source_code.ts";
+import type { Node } from "../src-js/plugins/types.ts";
+import type { BinaryExpression } from "../src-js/generated/types.d.ts";
 
 // Source text used for most tests
 const SOURCE_TEXT = "/*A*/var answer/*B*/=/*C*/a/*D*/* b/*E*///F\n    call();\n/*Z*/";

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "target": "ESNext",
+    "allowImportingTsExtensions": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "skipLibCheck": true


### PR DESCRIPTION
Pure refactor. Use `.ts` extension when importing `.ts` files.