### PR TITLE
style(editors): prefer `const` to `let`

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -74,7 +74,7 @@ export class ConfigService implements IDisposable {
 
     if (!path.isAbsolute(bin)) {
       // if the path is not absolute, resolve it to the first workspace folder
-      let cwd = this.workspaceConfigs.keys().next().value;
+      const cwd = this.workspaceConfigs.keys().next().value;
       if (!cwd) {
         return;
       }

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -139,7 +139,7 @@ export default class LinterTool implements ToolInterface {
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     // Options to control the language client
-    let clientOptions: LanguageClientOptions = {
+    const clientOptions: LanguageClientOptions = {
       // Register the server for plain text documents
       documentSelector: [
         {

--- a/editors/vscode/tests/ConfigService.spec.ts
+++ b/editors/vscode/tests/ConfigService.spec.ts
@@ -44,7 +44,7 @@ suite('ConfigService', () => {
       await conf.update('path.server', './relative/oxc_language_server');
       const relativeServerPath = service.getUserServerBinPath();
 
-      let workspace_path = getWorkspaceFolderPlatformSafe();
+      const workspace_path = getWorkspaceFolderPlatformSafe();
       strictEqual(relativeServerPath, `${workspace_path}/relative/oxc_language_server`);
     });
 
@@ -63,7 +63,7 @@ suite('ConfigService', () => {
       const service = new ConfigService();
       await conf.update('path.server', './relative/oxc_language_server');
       const relativeServerPath = service.getUserServerBinPath();
-      let workspace_path = getWorkspaceFolderPlatformSafe();
+      const workspace_path = getWorkspaceFolderPlatformSafe();
 
       strictEqual(workspace_path[1], ':', 'The test workspace folder must be an absolute path with a drive letter on Windows');
       strictEqual(relativeServerPath, `${workspace_path}\\relative\\oxc_language_server`);

--- a/editors/vscode/tests/code_actions.spec.ts
+++ b/editors/vscode/tests/code_actions.spec.ts
@@ -83,8 +83,8 @@ suite('code actions', () => {
 
   // https://github.com/oxc-project/oxc/issues/10422
   test('code action `source.fixAll.oxc` on editor.codeActionsOnSave', async () => {
-    let file = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'file.js');
-    let expectedFile = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'expected.txt');
+    const file = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'file.js');
+    const expectedFile = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'expected.txt');
 
     await workspace.getConfiguration('editor').update('codeActionsOnSave', {
       'source.fixAll.oxc': 'always',
@@ -112,8 +112,8 @@ suite('code actions', () => {
 
   // https://discord.com/channels/1079625926024900739/1080723403595591700/1422191300395929620
    test('code action `source.fixAll.oxc` ignores "ignore this rule for this line/file"', async () => {
-    let file = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'file2.js');
-    let expectedFile = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'expected.txt');
+    const file = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'file2.js');
+    const expectedFile = Uri.joinPath(fixturesWorkspaceUri(), 'fixtures', 'expected.txt');
 
     await workspace.getConfiguration('editor').update('codeActionsOnSave', {
       'source.fixAll.oxc': 'always',


### PR DESCRIPTION
Use `const` where variables are not reassigned instead of `let`. Preparation for enabling ESLint's `prefer-const` rule (running as an Oxlint JS plugin) in our linting setup.