### PR TITLE
style(traverse, tasks): prefer `const` to `let`

### DIFF
--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -134,7 +134,7 @@ function generateWalkForStruct(type, types) {
 
     // const Var = Self::Top.bits() | Self::Function.bits() | Self::ClassStaticBlock.bits() | Self::TsModuleBlock.bits();
     // `Function` type is a special case as its flags are set dynamically depending on the parent.
-    let isVarHoistingScope =
+    const isVarHoistingScope =
       type.name == "Function" ||
       ["Top", "Function", "ClassStaticBlock", "TsModuleBlock"].some((flag) =>
         scopeArgs.flags.includes(flag),
@@ -148,7 +148,7 @@ function generateWalkForStruct(type, types) {
     }
 
     // TODO: Type names shouldn't be hard-coded here. Block scopes should be signalled by attrs in AST.
-    let isBlockScope = [
+    const isBlockScope = [
       "Program",
       "BlockStatement",
       "Function",
@@ -227,8 +227,8 @@ function generateWalkForStruct(type, types) {
         // Special case for `Vec<Statement>`
         walkVecCode = `walk_statements(traverser, ${fieldCode}, ctx);`;
       } else {
-        let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
-          iteratorCode = "";
+        const walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`;
+        let iteratorCode;
         if (field.wrappers.length === 2 && field.wrappers[1] === "Option") {
           iteratorCode = `(*(${fieldCode})).iter_mut().flatten()`;
         } else {

--- a/tasks/transform_conformance/update_fixtures.mjs
+++ b/tasks/transform_conformance/update_fixtures.mjs
@@ -147,13 +147,13 @@ function updateOptions(options) {
 
 // Ensure all class plugins are enabled if any of class related plugins are enabled
 function ensureAllClassPluginsEnabled(options) {
-  let plugins = options.plugins;
+  const { plugins } = options;
   if (!plugins) return false;
 
-  let already_enabled = [];
+  const already_enabled = [];
   let pluginOptions;
   plugins.forEach((plugin) => {
-    let pluginName = getName(plugin);
+    const pluginName = getName(plugin);
     if (CLASS_PLUGINS.includes(pluginName)) {
       if (Array.isArray(plugin) && plugin[1]) {
         // Store options for the plugin, so that we can ensure all plugins are


### PR DESCRIPTION
Use `const` where variables are not reassigned instead of `let`. Preparation for enabling ESLint's `prefer-const` rule (running as an Oxlint JS plugin) in our linting setup.