### PR TITLE
fix(linter): prevent invalid BigInt literal fix for exponential notation

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
@@ -163,6 +163,10 @@ fn trim_leading_zeros(raw: &str) -> &str {
 }
 
 fn bigint_literal_from_numeric(raw: &str, base: NumberBase) -> Option<String> {
+    if raw.contains('e') || raw.contains('E') {
+        return None;
+    }
+
     let literal = match base {
         NumberBase::Binary | NumberBase::Hex => format!("{raw}n"),
         NumberBase::Octal => {
@@ -220,6 +224,8 @@ fn test() {
         r"BigInt(0888)",
         r"BigInt(1.0)",
         r"BigInt(1e2)",
+        r"BigInt(1e6)",
+        r"BigInt(1E6)",
         r"BigInt(/* comment */1)",
         r"BigInt(9007199254740993)",
         r"BigInt(0x20000000000001)",
@@ -248,6 +254,9 @@ fn test() {
             r"BigInt(9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999)",
             "9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999n",
         ),
+        (r"BigInt(1e2)", r"BigInt(1e2)"),
+        (r"BigInt(1e6)", r"BigInt(1e6)"),
+        (r"BigInt(1E6)", r"BigInt(1E6)"),
     ];
 
     Tester::new(PreferBigintLiterals::NAME, PreferBigintLiterals::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_bigint_literals.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_bigint_literals.snap
@@ -100,6 +100,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a bigint literal (e.g. `123n`) instead of calling `BigInt` with a literal argument.
 
   ⚠ eslint-plugin-unicorn(prefer-bigint-literals): Prefer bigint literals over `BigInt(...)`.
+   ╭─[prefer_bigint_literals.tsx:1:8]
+ 1 │ BigInt(1e6)
+   ·        ───
+   ╰────
+  help: Use a bigint literal (e.g. `123n`) instead of calling `BigInt` with a literal argument.
+
+  ⚠ eslint-plugin-unicorn(prefer-bigint-literals): Prefer bigint literals over `BigInt(...)`.
+   ╭─[prefer_bigint_literals.tsx:1:8]
+ 1 │ BigInt(1E6)
+   ·        ───
+   ╰────
+  help: Use a bigint literal (e.g. `123n`) instead of calling `BigInt` with a literal argument.
+
+  ⚠ eslint-plugin-unicorn(prefer-bigint-literals): Prefer bigint literals over `BigInt(...)`.
    ╭─[prefer_bigint_literals.tsx:1:21]
  1 │ BigInt(/* comment */1)
    ·                     ─


### PR DESCRIPTION
The `unicorn/prefer-bigint-literals` rule was incorrectly converting
`BigInt(1e6)` to `1e6n`, which is invalid JavaScript syntax because
BigInt literals do not support exponential notation.

This fix checks for `e` or `E` in the raw numeric text and skips
the auto-fix in those cases, leaving the code unchanged.