### PR TITLE
fix(napi/parser): reorder fields of `ExportEntry` on JS side

### DIFF
--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -46,11 +46,11 @@ impl ESTree for ImportImportName<'_> {
 impl ESTree for ExportEntry<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_field("importName", &self.import_name);
         state.serialize_field("exportName", &self.export_name);
         state.serialize_field("localName", &self.local_name);
         state.serialize_field("isType", &self.is_type);
+        state.serialize_field("moduleRequest", &self.module_request);
         state.serialize_span(self.span);
         state.end();
     }

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -231,7 +231,11 @@ impl ImportImportName<'_> {
 #[ast]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[generate_derive(ESTree)]
-#[estree(no_type, no_ts_def)]
+#[estree(
+    no_type,
+    no_ts_def,
+    field_order(import_name, export_name, local_name, is_type, module_request, span)
+)]
 pub struct ExportEntry<'a> {
     /// Span of the import statement.
     #[estree(skip)]

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4279,11 +4279,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
   };

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -5012,11 +5012,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
   };

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -4730,11 +4730,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
     range: [start, end],

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -5264,11 +5264,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
     range: [start, end],

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4532,11 +4532,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
   };

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -5273,11 +5273,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
   };

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -4982,11 +4982,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
     range: [start, end],

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -5532,11 +5532,11 @@ function deserializeExportEntry(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4);
   return {
-    moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
+    moduleRequest: deserializeOptionNameSpan(pos + 16),
     start,
     end,
     range: [start, end],

--- a/napi/parser/src-js/index.d.ts
+++ b/napi/parser/src-js/index.d.ts
@@ -209,7 +209,6 @@ export interface StaticExport {
 export interface StaticExportEntry {
   start: number
   end: number
-  moduleRequest?: ValueSpan
   /** The name under which the desired binding is exported by the module`. */
   importName: ExportImportName
   /** The name used to export this binding by this module. */
@@ -230,6 +229,7 @@ export interface StaticExportEntry {
    * ```
    */
   isType: boolean
+  moduleRequest?: ValueSpan
 }
 
 export interface StaticImport {

--- a/napi/parser/src/types.rs
+++ b/napi/parser/src/types.rs
@@ -182,7 +182,6 @@ pub struct ImportName {
 pub struct StaticExportEntry {
     pub start: u32,
     pub end: u32,
-    pub module_request: Option<ValueSpan>,
     /// The name under which the desired binding is exported by the module`.
     pub import_name: ExportImportName,
     /// The name used to export this binding by this module.
@@ -201,6 +200,7 @@ pub struct StaticExportEntry {
     /// export type { foo } from 'mod';
     /// ```
     pub is_type: bool,
+    pub module_request: Option<ValueSpan>,
 }
 
 #[napi(object)]

--- a/napi/parser/test/__snapshots__/esm.test.ts.snap
+++ b/napi/parser/test/__snapshots__/esm.test.ts.snap
@@ -12,11 +12,6 @@ exports[`esm > export * as name1 from "module-name"; 1`] = `
         {
           "start": 0,
           "end": 37,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 23,
-            "end": 36
-          },
           "importName": {
             "kind": "All"
           },
@@ -29,7 +24,12 @@ exports[`esm > export * as name1 from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 23,
+            "end": 36
+          }
         }
       ]
     }
@@ -51,11 +51,6 @@ exports[`esm > export * from "module-name"; 1`] = `
         {
           "start": 0,
           "end": 28,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 14,
-            "end": 27
-          },
           "importName": {
             "kind": "AllButDefault"
           },
@@ -65,7 +60,12 @@ exports[`esm > export * from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 14,
+            "end": 27
+          }
         }
       ]
     }
@@ -87,11 +87,6 @@ exports[`esm > export { default as name1 } from "module-name"; 1`] = `
         {
           "start": 9,
           "end": 25,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 33,
-            "end": 46
-          },
           "importName": {
             "kind": "Name",
             "name": "default",
@@ -107,7 +102,12 @@ exports[`esm > export { default as name1 } from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 33,
+            "end": 46
+          }
         }
       ]
     }
@@ -129,11 +129,6 @@ exports[`esm > export { default, /* …, */ } from "module-name"; 1`] = `
         {
           "start": 9,
           "end": 16,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 34,
-            "end": 47
-          },
           "importName": {
             "kind": "Name",
             "name": "default",
@@ -149,7 +144,12 @@ exports[`esm > export { default, /* …, */ } from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 34,
+            "end": 47
+          }
         }
       ]
     }
@@ -171,11 +171,6 @@ exports[`esm > export { import1 as name1, import2 as name2, /* …, */ nameN } f
         {
           "start": 9,
           "end": 25,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 67,
-            "end": 80
-          },
           "importName": {
             "kind": "Name",
             "name": "import1",
@@ -191,16 +186,16 @@ exports[`esm > export { import1 as name1, import2 as name2, /* …, */ nameN } f
           "localName": {
             "kind": "None"
           },
-          "isType": false
-        },
-        {
-          "start": 27,
-          "end": 43,
+          "isType": false,
           "moduleRequest": {
             "value": "module-name",
             "start": 67,
             "end": 80
-          },
+          }
+        },
+        {
+          "start": 27,
+          "end": 43,
           "importName": {
             "kind": "Name",
             "name": "import2",
@@ -216,16 +211,16 @@ exports[`esm > export { import1 as name1, import2 as name2, /* …, */ nameN } f
           "localName": {
             "kind": "None"
           },
-          "isType": false
-        },
-        {
-          "start": 54,
-          "end": 59,
+          "isType": false,
           "moduleRequest": {
             "value": "module-name",
             "start": 67,
             "end": 80
-          },
+          }
+        },
+        {
+          "start": 54,
+          "end": 59,
           "importName": {
             "kind": "Name",
             "name": "nameN",
@@ -241,7 +236,12 @@ exports[`esm > export { import1 as name1, import2 as name2, /* …, */ nameN } f
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 67,
+            "end": 80
+          }
         }
       ]
     }
@@ -300,11 +300,6 @@ exports[`esm > export { name1, /* …, */ nameN } from "module-name"; 1`] = `
         {
           "start": 9,
           "end": 14,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 38,
-            "end": 51
-          },
           "importName": {
             "kind": "Name",
             "name": "name1",
@@ -320,16 +315,16 @@ exports[`esm > export { name1, /* …, */ nameN } from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 38,
+            "end": 51
+          }
         },
         {
           "start": 25,
           "end": 30,
-          "moduleRequest": {
-            "value": "module-name",
-            "start": 38,
-            "end": 51
-          },
           "importName": {
             "kind": "Name",
             "name": "nameN",
@@ -345,7 +340,12 @@ exports[`esm > export { name1, /* …, */ nameN } from "module-name"; 1`] = `
           "localName": {
             "kind": "None"
           },
-          "isType": false
+          "isType": false,
+          "moduleRequest": {
+            "value": "module-name",
+            "start": 38,
+            "end": 51
+          }
         }
       ]
     }


### PR DESCRIPTION
NAPI-RS 3.6.0 makes a change to the ordering of objects. It now puts optional fields last.

This made tests in `napi/parser` for module record fail when we tried to update (#16383) because the `module_request` field of `ExportEntry` moves to last which breaks the snapshots.

The change in NAPI-RS is unlikely to be reverted, because it's a sizeable perf optimization: https://github.com/napi-rs/napi-rs/pull/2990

To work around this problem:

1. Move the field in the `ExportEntry` intermediate struct in `napi/parser` to last, so NAPI's output matches what you'd expect from the struct definition.
2. Alter the `#[estree]` attr on `ExportEntry` struct in `oxc_syntax` crate to match.

Note: The `ExportEntry` struct in `napi/parser` is just an intermediate structure used for serialization. So I think it's fine to fiddle with its field order. The actual `ExportEntry` struct used in the module record is in `oxc_syntax` crate, and it remains unaltered.
