### PR TITLE
fix(oxlint/lsp): revalidate all known files after internal restart

### DIFF
--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -183,18 +183,13 @@ impl Tool for ServerFormatter {
         };
 
         if old_option == new_option {
-            return ToolRestartChanges {
-                tool: None,
-                diagnostic_reports: None,
-                watch_patterns: None,
-            };
+            return ToolRestartChanges { tool: None, watch_patterns: None };
         }
 
         let new_formatter = ServerFormatterBuilder::build(root_uri, new_options_json.clone());
         let watch_patterns = new_formatter.get_watcher_patterns(new_options_json);
         ToolRestartChanges {
             tool: Some(Box::new(new_formatter)),
-            diagnostic_reports: None,
             watch_patterns: Some(watch_patterns),
         }
     }
@@ -228,11 +223,7 @@ impl Tool for ServerFormatter {
         options: serde_json::Value,
     ) -> ToolRestartChanges {
         if !self.should_run {
-            return ToolRestartChanges {
-                tool: None,
-                diagnostic_reports: None,
-                watch_patterns: None,
-            };
+            return ToolRestartChanges { tool: None, watch_patterns: None };
         }
 
         // TODO: Check if the changed file is actually a config file
@@ -241,7 +232,6 @@ impl Tool for ServerFormatter {
 
         ToolRestartChanges {
             tool: Some(Box::new(new_formatter)),
-            diagnostic_reports: None,
             // TODO: update watch patterns if config_path changed
             watch_patterns: None,
         }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -55,34 +55,19 @@ impl Tool for FakeTool {
         _old_options_json: &serde_json::Value,
         new_options_json: serde_json::Value,
     ) -> ToolRestartChanges {
-        if new_options_json.as_u64() == Some(1) {
+        if new_options_json.as_u64() == Some(1) || new_options_json.as_u64() == Some(3) {
             return ToolRestartChanges {
                 tool: Some(FakeToolBuilder.build_boxed(root_uri, new_options_json)),
-                diagnostic_reports: None,
                 watch_patterns: None,
             };
         }
         if new_options_json.as_u64() == Some(2) {
             return ToolRestartChanges {
                 tool: None,
-                diagnostic_reports: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
             };
         }
-        if new_options_json.as_u64() == Some(3) {
-            return ToolRestartChanges {
-                tool: None,
-                diagnostic_reports: Some(vec![(
-                    root_uri.to_string(),
-                    vec![Diagnostic {
-                        message: "Fake diagnostic".to_string(),
-                        ..Default::default()
-                    }],
-                )]),
-                watch_patterns: None,
-            };
-        }
-        ToolRestartChanges { tool: None, diagnostic_reports: None, watch_patterns: None }
+        ToolRestartChanges { tool: None, watch_patterns: None }
     }
 
     fn get_watcher_patterns(
@@ -101,34 +86,22 @@ impl Tool for FakeTool {
         root_uri: &Uri,
         options: serde_json::Value,
     ) -> ToolRestartChanges {
-        if changed_uri.as_str().ends_with("tool.config") {
+        if changed_uri.as_str().ends_with("tool.config")
+            || changed_uri.as_str().ends_with("diagnostics.config")
+        {
             return ToolRestartChanges {
                 tool: Some(FakeToolBuilder.build_boxed(root_uri, options)),
-                diagnostic_reports: None,
                 watch_patterns: None,
             };
         }
         if changed_uri.as_str().ends_with("watcher.config") {
             return ToolRestartChanges {
                 tool: None,
-                diagnostic_reports: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
             };
         }
-        if changed_uri.as_str().ends_with("diagnostics.config") {
-            return ToolRestartChanges {
-                tool: None,
-                diagnostic_reports: Some(vec![(
-                    changed_uri.to_string(),
-                    vec![Diagnostic {
-                        message: "Fake diagnostic".to_string(),
-                        ..Default::default()
-                    }],
-                )]),
-                watch_patterns: None,
-            };
-        }
-        ToolRestartChanges { tool: None, diagnostic_reports: None, watch_patterns: None }
+
+        ToolRestartChanges { tool: None, watch_patterns: None }
     }
 
     fn get_code_actions_or_commands(

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -129,8 +129,6 @@ pub struct ToolRestartChanges {
     /// The tool that was restarted (linter, formatter).
     /// If None, no tool was restarted.
     pub tool: Option<Box<dyn Tool>>,
-    /// The diagnostic reports that need to be revalidated after the tool restart
-    pub diagnostic_reports: Option<Vec<(String, Vec<Diagnostic>)>>,
     /// The patterns that were added during the tool restart
     /// Old patterns will be automatically unregistered
     pub watch_patterns: Option<Vec<Pattern>>,


### PR DESCRIPTION
Before:
Linted all files which are not ignored & supported
After:
Lint all files which are got open inside the editor