### PR TITLE
fix(linter): preserve original quote style in no-hex-escape fixer

### DIFF
--- a/crates/oxc_linter/src/snapshots/unicorn_no_hex_escape.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_hex_escape.snap
@@ -6,7 +6,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const foo = "\xb1"
    ·             ──────
    ╰────
-  help: Replace `"\xb1"` with `'\u00b1'`.
+  help: Replace `"\xb1"` with `"\u00b1"`.
 
   ⚠ eslint-plugin-unicorn(no-hex-escape): Use Unicode escapes instead of hexadecimal escapes.
    ╭─[no_hex_escape.tsx:1:41]


### PR DESCRIPTION
The fixer was always using single quotes when replacing hex escapes with
unicode escapes, which caused invalid syntax when the string contained
unescaped single quotes.