### PR TITLE
feat(oxfmt): Rename `embedded.ts` with preparing `formatFile()` function

### DIFF
--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,5 +1,5 @@
 import { format } from "./bindings.js";
-import { formatEmbeddedCode } from "./embedded.js";
+import { formatEmbeddedCode } from "./prettier-proxy.js";
 
 const args = process.argv.slice(2);
 

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,2 +1,2 @@
 export * from "./bindings.js";
-export { formatEmbeddedCode } from "./embedded.js";
+export { formatEmbeddedCode, formatFile } from "./prettier-proxy.js";


### PR DESCRIPTION
- Rename `embedded.ts` > `prettier-proxy.ts`
- Add `formatFile(fileName, code)` fn to use later

Doesn't affect existing use cases; it just slightly increases the size of the JS.