### PR TITLE
refactor(ast): return `&str` for static property name instead of `Atom`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -613,9 +613,7 @@ impl<'a> MemberExpression<'a> {
     /// - `a.#b` would return `None`
     pub fn static_property_name(&self) -> Option<&'a str> {
         match self {
-            MemberExpression::ComputedMemberExpression(expr) => {
-                expr.static_property_name().map(|name| name.as_str())
-            }
+            MemberExpression::ComputedMemberExpression(expr) => expr.static_property_name(),
             MemberExpression::StaticMemberExpression(expr) => Some(expr.property.name.as_str()),
             MemberExpression::PrivateFieldExpression(_) => None,
         }
@@ -672,11 +670,13 @@ impl<'a> MemberExpression<'a> {
 
 impl<'a> ComputedMemberExpression<'a> {
     /// Returns the static property name of this member expression, if it has one, or `None` otherwise.
-    pub fn static_property_name(&self) -> Option<Atom<'a>> {
+    pub fn static_property_name(&self) -> Option<&'a str> {
         match &self.expression {
-            Expression::StringLiteral(lit) => Some(lit.value),
-            Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => lit.quasis[0].value.cooked,
-            Expression::RegExpLiteral(lit) => lit.raw,
+            Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+            Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => {
+                lit.quasis[0].value.cooked.map(|cooked| cooked.as_str())
+            }
+            Expression::RegExpLiteral(lit) => lit.raw.map(|raw| raw.as_str()),
             _ => None,
         }
     }

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -625,10 +625,10 @@ impl<'a> MemberExpressionKind<'a> {
     /// Returns the property name of the member expression, otherwise `None`.
     ///
     /// Example: returns the `prop` in `obj.prop` or `obj["prop"]`.
-    pub fn static_property_name(&self) -> Option<Atom<'a>> {
+    pub fn static_property_name(&self) -> Option<&'a str> {
         match self {
             Self::Computed(member_expr) => member_expr.static_property_name(),
-            Self::Static(member_expr) => Some(member_expr.property.name),
+            Self::Static(member_expr) => Some(member_expr.property.name.as_str()),
             Self::PrivateField(_) => None,
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -82,13 +82,11 @@ impl Rule for NoNewFunc {
                     return;
                 }
 
-                let Some(static_property_name) =
-                    &member_expr.static_property_name().map(|s| s.as_str())
-                else {
+                let Some(static_property_name) = member_expr.static_property_name() else {
                     return;
                 };
 
-                if !["apply", "bind", "call"].contains(static_property_name) {
+                if !["apply", "bind", "call"].contains(&static_property_name) {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -141,9 +141,7 @@ impl Rule for NoCommonjs {
                 let Some(member_expr_kind) = member_expr.as_member_expression_kind() else {
                     return;
                 };
-                let Some(property_name) =
-                    member_expr_kind.static_property_name().map(|s| s.as_str())
-                else {
+                let Some(property_name) = member_expr_kind.static_property_name() else {
                     return;
                 };
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -125,9 +125,7 @@ impl Rule for NoNamedAsDefaultMember {
                     let Expression::Identifier(ident) = member_expr_kind.object() else {
                         continue;
                     };
-                    let Some(prop_str) =
-                        member_expr_kind.static_property_name().map(|n| n.as_str())
-                    else {
+                    let Some(prop_str) = member_expr_kind.static_property_name() else {
                         continue;
                     };
                     if let Some(module_name) =

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -140,7 +140,7 @@ impl Rule for NoDeprecatedFunctions {
         }
 
         if let Some(name) = mem_expr.static_property_name() {
-            chain.push(Cow::Borrowed(name.as_str()));
+            chain.push(Cow::Borrowed(name));
         }
 
         let node_name = chain.join(".");

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -86,7 +86,7 @@ impl Rule for NoProcessEnv {
                 mem.span
             }
             AstKind::ComputedMemberExpression(mem)
-                if mem.static_property_name().is_some_and(|name| name.as_str() == "env")
+                if mem.static_property_name().is_some_and(|name| name == "env")
                     && is_process_global_object(&mem.object, ctx) =>
             {
                 mem.span

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -75,11 +75,8 @@ impl Rule for BadArrayMethodOnArguments {
         let Some(name) = member_expr.static_property_name() else {
             return;
         };
-        if ARRAY_METHODS.binary_search(&name.as_str()).is_ok() {
-            ctx.diagnostic(bad_array_method_on_arguments_diagnostic(
-                name.as_str(),
-                member_expr.span(),
-            ));
+        if ARRAY_METHODS.binary_search(&name).is_ok() {
+            ctx.diagnostic(bad_array_method_on_arguments_diagnostic(name, member_expr.span()));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -77,7 +77,7 @@ impl Rule for SpecOnly {
             return;
         }
 
-        let Some(prop_name) = member_expr.static_property_name().map(|s| s.as_str()) else {
+        let Some(prop_name) = member_expr.static_property_name() else {
             return;
         };
         if PROMISE_STATIC_METHODS.contains(&prop_name) {

--- a/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
@@ -251,9 +251,7 @@ fn is_property_write<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
 
 fn get_member_expr_key_name<'a>(expr: &'a MemberExpressionKind) -> Option<&'a str> {
     match expr {
-        MemberExpressionKind::Computed(expr) => {
-            expr.static_property_name().map(|name| name.as_str())
-        }
+        MemberExpressionKind::Computed(expr) => expr.static_property_name(),
         MemberExpressionKind::Static(expr) => Some(expr.property.name.as_str()),
         MemberExpressionKind::PrivateField(priv_field) => Some(priv_field.field.name.as_str()),
     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -111,7 +111,7 @@ impl Rule for PreferNumberProperties {
                         || (name == "Infinity" && self.check_infinity)
                     {
                         ctx.diagnostic_with_fix(
-                            prefer_number_properties_diagnostic(member_expr.span(), name.as_str()),
+                            prefer_number_properties_diagnostic(member_expr.span(), name),
                             |fixer| fixer.replace(ident_name.span, "Number"),
                         );
                     }

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -93,7 +93,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName<'a, '_> {
                     // so we diverge from Babel here, but that's probably an improvement
                     AssignmentTarget::ComputedMemberExpression(expr) => {
                         if let Some(name) = expr.static_property_name() {
-                            break name;
+                            break Atom::from(name);
                         }
                         return;
                     }


### PR DESCRIPTION
Don't expose `Atom` as part of the API when we only need a `&str`. This will make changing the type for identifiers easier later.