### PR TITLE
feat(oxfmt): Support non-js/ts(external) files with prettier

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -6,7 +6,8 @@
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
  * 2. `format_embedded_cb`: Callback to format embedded code in templates
+ * 3. `format_file_cb`: Callback to format files
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (fileName: string, code: string) => Promise<string>): Promise<boolean>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,5 +1,5 @@
 import { format } from "./bindings.js";
-import { formatEmbeddedCode } from "./embedded.js";
+import { formatEmbeddedCode } from "./prettier-proxy.js";
 
 const args = process.argv.slice(2);
 

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,10 +1,10 @@
 import { format } from "./bindings.js";
-import { formatEmbeddedCode } from "./prettier-proxy.js";
+import { formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 
 const args = process.argv.slice(2);
 
 // Call the Rust formatter with our JS callback
-const success = await format(args, formatEmbeddedCode);
+const success = await format(args, formatEmbeddedCode, formatFile);
 
 // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,2 +1,2 @@
 export * from "./bindings.js";
-export { formatEmbeddedCode } from "./embedded.js";
+export { formatEmbeddedCode, formatFile } from "./prettier-proxy.js";

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -11,7 +11,7 @@ use crate::{
     format::FormatRunner,
     init::{init_miette, init_tracing},
     lsp::run_lsp,
-    prettier_plugins::{JsFormatEmbeddedCb, create_external_formatter},
+    prettier_plugins::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb},
     result::CliRunResult,
 };
 
@@ -23,6 +23,7 @@ use crate::{
 /// JS side passes in:
 /// 1. `args`: Command line arguments (process.argv.slice(2))
 /// 2. `format_embedded_cb`: Callback to format embedded code in templates
+/// 3. `format_file_cb`: Callback to format files
 ///
 /// Returns `true` if formatting succeeded without errors, `false` otherwise.
 #[expect(clippy::allow_attributes)]
@@ -32,12 +33,18 @@ pub async fn format(
     args: Vec<String>,
     #[napi(ts_arg_type = "(tagName: string, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
+    #[napi(ts_arg_type = "(fileName: string, code: string) => Promise<string>")]
+    format_file_cb: JsFormatFileCb,
 ) -> bool {
-    format_impl(args, format_embedded_cb).await.report() == ExitCode::SUCCESS
+    format_impl(args, format_embedded_cb, format_file_cb).await.report() == ExitCode::SUCCESS
 }
 
 /// Run the formatter.
-async fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) -> CliRunResult {
+async fn format_impl(
+    args: Vec<String>,
+    format_embedded_cb: JsFormatEmbeddedCb,
+    format_file_cb: JsFormatFileCb,
+) -> CliRunResult {
     // Convert String args to OsString for compatibility with bpaf
     let args: Vec<OsString> = args.into_iter().map(OsString::from).collect();
 
@@ -67,7 +74,7 @@ async fn format_impl(args: Vec<String>, format_embedded_cb: JsFormatEmbeddedCb) 
     command.handle_threads();
 
     // Create external formatter from JS callback
-    let external_formatter = create_external_formatter(format_embedded_cb);
+    let external_formatter = ExternalFormatter::new(format_embedded_cb, format_file_cb);
 
     // stdio is blocked by LineWriter, use a BufWriter to reduce syscalls.
     // See `https://github.com/rust-lang/rust/issues/60673`.

--- a/apps/oxfmt/src/prettier_plugins/external_formatter.rs
+++ b/apps/oxfmt/src/prettier_plugins/external_formatter.rs
@@ -22,21 +22,47 @@ pub type JsFormatEmbeddedCb = ThreadsafeFunction<
     false,
 >;
 
+/// Type alias for the callback function signature.
+/// Takes (tag_name, code) as separate arguments and returns formatted code.
+pub type JsFormatFileCb = ThreadsafeFunction<
+    // Input arguments
+    FnArgs<(String, String)>, // (file_name, code) as separate arguments
+    // Return type (what JS function returns)
+    Promise<String>,
+    // Arguments (repeated)
+    FnArgs<(String, String)>,
+    // Error status
+    Status,
+    // CalleeHandled
+    false,
+>;
+
+/// Callback function type for formatting files.
+/// Takes (file_name, code) and returns formatted code or an error.
+type FileFormatterCallback = Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>;
+
 /// External formatter that wraps a JS callback.
 #[derive(Clone)]
 pub struct ExternalFormatter {
     pub format_embedded: EmbeddedFormatterCallback,
+    pub format_file: FileFormatterCallback,
 }
 
 impl std::fmt::Debug for ExternalFormatter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ExternalFormatter").field("format_embedded", &"<callback>").finish()
+        f.debug_struct("ExternalFormatter")
+            .field("format_embedded", &"<callback>")
+            .field("format_file", &"<callback>")
+            .finish()
     }
 }
 
 impl ExternalFormatter {
-    pub fn new(format_embedded: EmbeddedFormatterCallback) -> Self {
-        Self { format_embedded }
+    /// Create an [`ExternalFormatter`] from JS callbacks.
+    pub fn new(format_embedded_cb: JsFormatEmbeddedCb, format_file_cb: JsFormatFileCb) -> Self {
+        let rust_format_embedded = wrap_format_embedded(format_embedded_cb);
+        let rust_format_file = wrap_format_file(format_file_cb);
+        Self { format_embedded: rust_format_embedded, format_file: rust_format_file }
     }
 
     /// Convert this external formatter to the oxc_formatter::EmbeddedFormatter type
@@ -45,12 +71,15 @@ impl ExternalFormatter {
         // The callback already expects &str, so just use it directly
         oxc_formatter::EmbeddedFormatter::new(callback)
     }
+
+    /// Format non-js file using the JS callback.
+    pub fn format_file(&self, file_name: &str, code: &str) -> Result<String, String> {
+        (self.format_file)(file_name, code)
+    }
 }
 
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
-///
-/// Uses a channel to capture the result from the JS callback.
-pub fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback {
+fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback {
     Arc::new(move |tag_name: &str, code: &str| {
         block_on(async {
             let status =
@@ -70,8 +99,23 @@ pub fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback
     })
 }
 
-/// Create an [`ExternalFormatter`] from JS callbacks.
-pub fn create_external_formatter(format_embedded_cb: JsFormatEmbeddedCb) -> ExternalFormatter {
-    let rust_format_embedded = wrap_format_embedded(format_embedded_cb);
-    ExternalFormatter::new(rust_format_embedded)
+/// Wrap JS `formatFile` callback as a normal Rust function.
+fn wrap_format_file(cb: JsFormatFileCb) -> EmbeddedFormatterCallback {
+    Arc::new(move |file_name: &str, code: &str| {
+        block_on(async {
+            let status =
+                cb.call_async(FnArgs::from((file_name.to_string(), code.to_string()))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(formatted_code) => Ok(formatted_code),
+                    Err(err) => {
+                        Err(format!("JS formatter promise rejected for file '{file_name}': {err}"))
+                    }
+                },
+                Err(err) => Err(format!(
+                    "Failed to call JS formatting callback for file '{file_name}': {err}"
+                )),
+            }
+        })
+    })
 }

--- a/apps/oxfmt/src/prettier_plugins/mod.rs
+++ b/apps/oxfmt/src/prettier_plugins/mod.rs
@@ -1,3 +1,3 @@
 mod external_formatter;
 
-pub use external_formatter::{ExternalFormatter, JsFormatEmbeddedCb, create_external_formatter};
+pub use external_formatter::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb};

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -5,8 +5,6 @@ use std::{
 
 use ignore::{gitignore::GitignoreBuilder, overrides::OverrideBuilder};
 
-use oxc_formatter::get_supported_source_type;
-
 pub struct Walk {
     inner: ignore::WalkParallel,
 }
@@ -227,10 +225,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
 
                 // Use `is_file()` to detect symlinks to the directory named `.js`
                 #[expect(clippy::filetype_is_file)]
-                if file_type.is_file()
-                    // TODO: Remove it for napi, keep it for not(napi)
-                    && get_supported_source_type(entry.path()).is_some()
-                {
+                if file_type.is_file() {
                     let walk_entry = WalkEntry { path: entry.path().to_path_buf() };
                     // Send each entry immediately through the channel
                     // If send fails, the receiver has been dropped, so stop walking

--- a/crates/oxc_formatter/src/service/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/service/oxfmtrc.rs
@@ -69,13 +69,17 @@ pub struct Oxfmtrc {
     #[schemars(skip)]
     pub experimental_ternaries: Option<serde_json::Value>,
 
-    /// Control whether formats quoted code embedded in the file. (Default: "auto")
+    /// Control whether formats quoted code embedded in the file. (Default: "off")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedded_language_formatting: Option<EmbeddedLanguageFormattingConfig>,
 
     /// Experimental: Sort import statements. Disabled by default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental_sort_imports: Option<SortImportsConfig>,
+
+    /// Experimental: Use external formatter (Prettier) for non-JS/TS files. (Default: false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental_external_formatter: Option<bool>,
 
     /// Ignore files matching these glob patterns. Current working directory is used as the root.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -34,7 +34,7 @@ expression: json
       ]
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether formats quoted code embedded in the file. (Default: \"auto\")",
+      "description": "Control whether formats quoted code embedded in the file. (Default: \"off\")",
       "anyOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -53,6 +53,13 @@ expression: json
         {
           "type": "null"
         }
+      ]
+    },
+    "experimentalExternalFormatter": {
+      "description": "Experimental: Use external formatter (Prettier) for non-JS/TS files. (Default: false)",
+      "type": [
+        "boolean",
+        "null"
       ]
     },
     "experimentalSortImports": {

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -30,7 +30,7 @@
       ]
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether formats quoted code embedded in the file. (Default: \"auto\")",
+      "description": "Control whether formats quoted code embedded in the file. (Default: \"off\")",
       "anyOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -49,6 +49,13 @@
         {
           "type": "null"
         }
+      ]
+    },
+    "experimentalExternalFormatter": {
+      "description": "Experimental: Use external formatter (Prettier) for non-JS/TS files. (Default: false)",
+      "type": [
+        "boolean",
+        "null"
       ]
     },
     "experimentalSortImports": {


### PR DESCRIPTION
Finally, compiled all previous PRs and made them available.

- Added `config.experimentalExternalFormatter: bool`, disabled by default
  - For now, will be enabled by default after dogfooding
- Collect all files except for ignored
- Then, mark as not-handled if this options is disabled or napi feature is disabled
  - This is expected to negatively impact performance...
- Otherwise, call prettier to format them

Not yet covered:

- Option and variable names could be reconsidered
- Prettier also throws errors when encountering files it doesn't support by default
- No error handling when detecting parsing errors in files Prettier does support
- Enabling it will generate diffs for all existing snapshot tests
- Still doesn't support configuration files