### PR TITLE
chore(docs): Fix the header depths for the linter schema markdown file.

### DIFF
--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -192,7 +192,7 @@ impl Renderer {
                 .map(|subschema| {
                     let subschema = Self::get_schema_object(subschema);
                     let subschema = self.get_referenced_schema(subschema);
-                    let mut section = self.render_schema_impl(depth + 1, key, subschema);
+                    let mut section = self.render_schema_impl(depth, key, subschema);
                     if section.default.is_none() && !subschema.has_type(InstanceType::Object) {
                         section.default = Self::render_default(schema);
                     }

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -62,7 +62,7 @@ Example
 ```
 
 
-### categories
+## categories
 
 type: `object`
 
@@ -85,56 +85,56 @@ Example
 ```
 
 
-#### categories.correctness
+### categories.correctness
 
 
 
 
 
 
-#### categories.nursery
+### categories.nursery
 
 
 
 
 
 
-#### categories.pedantic
+### categories.pedantic
 
 
 
 
 
 
-#### categories.perf
+### categories.perf
 
 
 
 
 
 
-#### categories.restriction
+### categories.restriction
 
 
 
 
 
 
-#### categories.style
+### categories.style
 
 
 
 
 
 
-#### categories.suspicious
+### categories.suspicious
 
 
 
 
 
 
-### env
+## env
 
 type: `Record<string, boolean>`
 
@@ -157,7 +157,7 @@ property. The configuration files are merged from the first to the last, with th
 overriding the previous ones.
 
 
-### globals
+## globals
 
 type: `Record<string, string>`
 
@@ -207,7 +207,7 @@ Note: JS plugins are experimental and not subject to semver.
 They are not supported in language server at present.
 
 
-### overrides
+## overrides
 
 type: `array`
 
@@ -215,7 +215,7 @@ type: `array`
 
 
 
-#### overrides[n]
+### overrides[n]
 
 type: `object`
 
@@ -223,7 +223,7 @@ type: `object`
 
 
 
-##### overrides[n].env
+#### overrides[n].env
 
 type: `object | null`
 
@@ -231,7 +231,7 @@ type: `object | null`
 Environments enable and disable collections of global variables.
 
 
-###### overrides[n].files
+#### overrides[n].files
 
 type: `string[]`
 
@@ -239,7 +239,7 @@ type: `string[]`
 A set of glob patterns.
 
 
-##### overrides[n].globals
+#### overrides[n].globals
 
 type: `object | null`
 
@@ -247,7 +247,7 @@ type: `object | null`
 Enabled or disabled specific global variables.
 
 
-##### overrides[n].jsPlugins
+#### overrides[n].jsPlugins
 
 type: `string[]`
 
@@ -258,7 +258,7 @@ Note: JS plugins are experimental and not subject to semver.
 They are not supported in language server at present.
 
 
-##### overrides[n].plugins
+#### overrides[n].plugins
 
 type: `array | null`
 
@@ -268,7 +268,7 @@ Optionally change what plugins are enabled for this override. When
 omitted, the base config's plugins are used.
 
 
-###### overrides[n].plugins[n]
+##### overrides[n].plugins[n]
 
 type: `string`
 
@@ -276,7 +276,7 @@ type: `string`
 
 
 
-###### overrides[n].rules
+#### overrides[n].rules
 
 type: `object`
 
@@ -306,7 +306,7 @@ type: `string`
 
 
 
-### rules
+## rules
 
 type: `object`
 
@@ -314,7 +314,7 @@ type: `object`
 See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
 
 
-### settings
+## settings
 
 type: `object`
 
@@ -348,7 +348,7 @@ Here's an example if you're using Next.js in a monorepo:
 ```
 
 
-##### settings.jsdoc
+### settings.jsdoc
 
 type: `object`
 
@@ -356,7 +356,7 @@ type: `object`
 
 
 
-###### settings.jsdoc.augmentsExtendsReplacesDocs
+#### settings.jsdoc.augmentsExtendsReplacesDocs
 
 type: `boolean`
 
@@ -365,7 +365,7 @@ default: `false`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-###### settings.jsdoc.exemptDestructuredRootsFromChecks
+#### settings.jsdoc.exemptDestructuredRootsFromChecks
 
 type: `boolean`
 
@@ -374,7 +374,7 @@ default: `false`
 Only for `require-param-type` and `require-param-description` rule
 
 
-###### settings.jsdoc.ignoreInternal
+#### settings.jsdoc.ignoreInternal
 
 type: `boolean`
 
@@ -383,7 +383,7 @@ default: `false`
 For all rules but NOT apply to `empty-tags` rule
 
 
-###### settings.jsdoc.ignorePrivate
+#### settings.jsdoc.ignorePrivate
 
 type: `boolean`
 
@@ -392,7 +392,7 @@ default: `false`
 For all rules but NOT apply to `check-access` and `empty-tags` rule
 
 
-###### settings.jsdoc.ignoreReplacesDocs
+#### settings.jsdoc.ignoreReplacesDocs
 
 type: `boolean`
 
@@ -401,7 +401,7 @@ default: `true`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-###### settings.jsdoc.implementsReplacesDocs
+#### settings.jsdoc.implementsReplacesDocs
 
 type: `boolean`
 
@@ -410,7 +410,7 @@ default: `false`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-###### settings.jsdoc.overrideReplacesDocs
+#### settings.jsdoc.overrideReplacesDocs
 
 type: `boolean`
 
@@ -419,7 +419,7 @@ default: `true`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-###### settings.jsdoc.tagNamePreference
+#### settings.jsdoc.tagNamePreference
 
 type: `object`
 
@@ -428,7 +428,7 @@ default: `{}`
 
 
 
-##### settings.jsx-a11y
+### settings.jsx-a11y
 
 type: `object`
 
@@ -440,7 +440,7 @@ See
 configuration for a full reference.
 
 
-###### settings.jsx-a11y.attributes
+#### settings.jsx-a11y.attributes
 
 type: `Record<string, array>`
 
@@ -464,7 +464,7 @@ Example:
 ```
 
 
-###### settings.jsx-a11y.components
+#### settings.jsx-a11y.components
 
 type: `Record<string, string>`
 
@@ -489,7 +489,7 @@ Example:
 ```
 
 
-###### settings.jsx-a11y.polymorphicPropName
+#### settings.jsx-a11y.polymorphicPropName
 
 type: `string | null`
 
@@ -508,7 +508,7 @@ Will be treated as an `h3`. If not set, this component will be treated
 as a `Box`.
 
 
-##### settings.next
+### settings.next
 
 type: `object`
 
@@ -516,7 +516,7 @@ type: `object`
 Configure Next.js plugin rules.
 
 
-####### settings.next.rootDir
+#### settings.next.rootDir
 
 type: `array | string`
 
@@ -524,7 +524,7 @@ type: `array | string`
 
 
 
-######## settings.next.rootDir[n]
+##### settings.next.rootDir[n]
 
 type: `string`
 
@@ -532,7 +532,7 @@ type: `string`
 
 
 
-##### settings.react
+### settings.react
 
 type: `object`
 
@@ -542,7 +542,7 @@ Configure React plugin rules.
 Derived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)
 
 
-###### settings.react.formComponents
+#### settings.react.formComponents
 
 type: `array`
 
@@ -569,7 +569,7 @@ Example:
 ```
 
 
-####### settings.react.formComponents[n]
+##### settings.react.formComponents[n]
 
 type: `object | string`
 
@@ -577,7 +577,7 @@ type: `object | string`
 
 
 
-######## settings.react.formComponents[n].attribute
+###### settings.react.formComponents[n].attribute
 
 type: `string`
 
@@ -585,7 +585,7 @@ type: `string`
 
 
 
-######## settings.react.formComponents[n].name
+###### settings.react.formComponents[n].name
 
 type: `string`
 
@@ -593,7 +593,7 @@ type: `string`
 
 
 
-###### settings.react.linkComponents
+#### settings.react.linkComponents
 
 type: `array`
 
@@ -621,7 +621,7 @@ Example:
 ```
 
 
-####### settings.react.linkComponents[n]
+##### settings.react.linkComponents[n]
 
 type: `object | string`
 
@@ -629,7 +629,7 @@ type: `object | string`
 
 
 
-######## settings.react.linkComponents[n].attribute
+###### settings.react.linkComponents[n].attribute
 
 type: `string`
 
@@ -637,7 +637,7 @@ type: `string`
 
 
 
-######## settings.react.linkComponents[n].name
+###### settings.react.linkComponents[n].name
 
 type: `string`
 
@@ -645,7 +645,7 @@ type: `string`
 
 
 
-##### settings.vitest
+### settings.vitest
 
 type: `object`
 
@@ -656,7 +656,7 @@ See [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest)'s
 configuration for a full reference.
 
 
-###### settings.vitest.typecheck
+#### settings.vitest.typecheck
 
 type: `boolean`
 


### PR DESCRIPTION
Somehow raptor mini managed to figure out the needle in the haystack here after I wrote a sufficient prompt for it, neat. This retains the fix for the formatter markdown headers while also fixing the problem with the linter markdown :)

Prompt was:

```
How can we update the depth numbers in schema_markdown.rs in order to fix the header for `categories` in the snapshot? The `categories` header should be an `h2` (so `## categories`, but currently renders as 3).

We need to fix this somehow while ensuring that `arrowParens`, `bracketSameLine`, `useTabs`, etc. in `tasks/website_formatter/src/snapshots/schema_markdown.snap` are kept as `h2`s. You can regenerate these two snapshots by running `cargo test -p website_formatter -- test_schema_markdown && cargo test -p website_linter -- test_schema_markdown`
```