### PR TITLE
refactor(linter): remove outdated comment

### DIFF
--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -52,8 +52,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self
     }
 
-    // NOTE(@DonIsaac): Internal methods shouldn't use `T: Into<Foo>` generics to optimize binary
-    // size. Only use such generics in public APIs.
     fn new_fix(&self, fix: CompositeFix, message: Option<Cow<'static, str>>) -> RuleFix {
         RuleFix::new(self.kind, message, fix)
     }


### PR DESCRIPTION
Pure refactor. Remove a comment which is no longer relevant.