### PR TITLE
feat(semantic): expose get_comment_at method

### DIFF
--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -84,7 +84,7 @@ pub fn is_inside_comment(comments: &[Comment], pos: u32) -> bool {
 /// Get the comment containing a position, if any
 ///
 /// Returns a reference to the comment if the specified position is inside any
-/// comment's span. The start position is included, but the end position is excluded. this is some
+/// comment's span. The start position is included, but the end position is excluded.
 ///
 /// Uses binary search for efficient lookup in O(log n) time.
 ///

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -8,7 +8,7 @@
 use std::ops::RangeBounds;
 
 use oxc_ast::{
-    AstKind, Comment, CommentsRange, ast::IdentifierReference, comments_range,
+    AstKind, Comment, CommentsRange, ast::IdentifierReference, comments_range, get_comment_at,
     has_comments_between, is_inside_comment,
 };
 #[cfg(feature = "cfg")]
@@ -161,6 +161,11 @@ impl<'a> Semantic<'a> {
 
     pub fn is_inside_comment(&self, pos: u32) -> bool {
         is_inside_comment(self.comments, pos)
+    }
+
+    /// Get the comment containing a position, if any.
+    pub fn get_comment_at(&self, pos: u32) -> Option<&Comment> {
+        get_comment_at(self.comments, pos)
     }
 
     pub fn irregular_whitespaces(&self) -> &[Span] {


### PR DESCRIPTION
This just exposes the method introduced into `oxc_ast`​ in #16438



🤖 generated with help from Claude Opus 4.5