### PR TITLE
perf(linter/plugins): do not remove `messageId` field from `DiagnosticReport` before sending to Rust

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -22,8 +22,6 @@ import { walkProgram } from '../generated/walk.js';
 // @ts-expect-error we need to generate `.d.ts` file for this module
 import { walkProgram } from "../generated/walk.js";
 
-import type { SetOptional } from "type-fest";
-import type { DiagnosticReport } from "../plugins/report.ts";
 import type { AfterHook, BufferWithArrays } from "./types.ts";
 
 // Buffers cache.
@@ -63,11 +61,8 @@ export function lintFile(
   try {
     lintFileImpl(filePath, bufferId, buffer, ruleIds, optionsIds, settingsJSON);
 
-    // Remove `messageId` field from diagnostics. It's not needed on Rust side.
-    for (let i = 0, len = diagnostics.length; i < len; i++) {
-      (diagnostics[i] as SetOptional<DiagnosticReport, "messageId">).messageId = undefined;
-    }
-
+    // Note: `messageId` field of `DiagnosticReport` is not needed on Rust side, but we assume it's cheaper to leave it
+    // in place and let `serde` skip over it on Rust side, than to iterate over all diagnostics and remove it here.
     return JSON.stringify({ Success: diagnostics });
   } catch (err) {
     return JSON.stringify({ Failure: getErrorMessage(err) });


### PR DESCRIPTION
As @camc314 pointed out in https://github.com/oxc-project/oxc/pull/16296#pullrequestreview-3524629951:

It's probably cheaper to leave the `messageId` field present in the JSON sent over to Rust and let `serde` handle skipping it, than to loop through all the diagnostics on JS side to remove it.

`RuleTester` should be moved into a separate NPM package (#16018), at which point we can do a different build for that package, and not have `messageId` stored in `DiagnosticReport` in the first place in the main build. So then this issue will become moot.