### PR TITLE
style(linter/plugins): shorten code with destructuring

### DIFF
--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -21,7 +21,7 @@ const alwaysRunRule: Rule = {
     const topLevelThis = this;
 
     // Check that these APIs don't throw here
-    const cwd = context.cwd;
+    const { cwd } = context;
     const getCwd = context.getCwd();
 
     // Check that these APIs throw here

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -85,7 +85,7 @@ const testRule: Rule = {
 
       JSXElement(node) {
         const { isSpaceBetween, isSpaceBetweenTokens } = context.sourceCode,
-          openingElement = node.openingElement,
+          { openingElement } = node,
           closingElement = node.closingElement!;
 
         // We get this wrong.

--- a/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
@@ -20,11 +20,11 @@ const plugin: Plugin = {
         return {
           VariableDeclaration(node) {
             if (node.kind === "var") {
-              const declarations = node.declarations;
+              const { declarations } = node;
               if (declarations.length > 0) {
                 const firstDeclaration = declarations[0];
                 if (firstDeclaration.id.type === "Identifier") {
-                  const name = firstDeclaration.id.name;
+                  const { name } = firstDeclaration.id;
 
                   if (name === "testWithNoData") {
                     // Test with no placeholders, no data

--- a/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
@@ -10,11 +10,11 @@ const plugin: Plugin = {
         return {
           VariableDeclaration(node) {
             if (node.kind === "var") {
-              const declarations = node.declarations;
+              const { declarations } = node;
               if (declarations.length > 0) {
                 const firstDeclaration = declarations[0];
                 if (firstDeclaration.id.type === "Identifier") {
-                  const name = firstDeclaration.id.name;
+                  const { name } = firstDeclaration.id;
 
                   if (name === "testWithNoData") {
                     // Test with no placeholders, no data

--- a/apps/oxlint/test/fixtures/settings/plugin.ts
+++ b/apps/oxlint/test/fixtures/settings/plugin.ts
@@ -12,7 +12,7 @@ const SPAN: Node = {
 
 const rule: Rule = {
   create(context) {
-    const settings = context.settings;
+    const { settings } = context;
 
     // Report each setting key and value
     Object.keys(settings).forEach((key) => {

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -132,7 +132,7 @@ describe("isSpaceBetweenTokens()", () => {
         jsx: true,
       }),
       body = ast.body as unknown as Node[],
-      tokens = ast.tokens;
+      { tokens } = ast;
 
     expect(isSpaceBetweenTokens(tokens[0], body[0])).toBe(false);
 


### PR DESCRIPTION
Pure style change.

Came across these while testing ESLint's `prefer-destructuring` rule running as a JS plugin.