### PR TITLE
perf(napi/parser): do not remove extraneous options on JS side

### DIFF
--- a/napi/parser/src-js/raw-transfer/eager.js
+++ b/napi/parser/src-js/raw-transfer/eager.js
@@ -12,8 +12,6 @@ const require = createRequire(import.meta.url);
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
  */
 export function parseSyncRaw(filename, sourceText, options) {
-  let _;
-  ({ experimentalRawTransfer: _, ...options } = options);
   return parseSyncRawImpl(filename, sourceText, options, deserialize);
 }
 
@@ -36,8 +34,6 @@ export function parseSyncRaw(filename, sourceText, options) {
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
  */
 export function parse(filename, sourceText, options) {
-  let _;
-  ({ experimentalRawTransfer: _, ...options } = options);
   return parseAsyncRawImpl(filename, sourceText, options, deserialize);
 }
 

--- a/napi/parser/src-js/raw-transfer/lazy.js
+++ b/napi/parser/src-js/raw-transfer/lazy.js
@@ -30,8 +30,6 @@ export { Visitor } from "./visitor.js";
  *   and `dispose` and `visit` methods
  */
 export function parseSyncLazy(filename, sourceText, options) {
-  let _;
-  ({ experimentalLazy: _, ...options } = options);
   return parseSyncRawImpl(filename, sourceText, options, construct);
 }
 
@@ -63,8 +61,6 @@ export function parseSyncLazy(filename, sourceText, options) {
  *   and `dispose` and `visit` methods
  */
 export function parse(filename, sourceText, options) {
-  let _;
-  ({ experimentalLazy: _, ...options } = options);
   return parseAsyncRawImpl(filename, sourceText, options, construct);
 }
 


### PR DESCRIPTION
Similar to #16442.

There's no need to remove the `experimental*` properties from `options` object on JS side. They'll be ignored by NAPI-RS on Rust side anyway, so creating a new object on JS side is pointless overhead.
