### PR TITLE
ci(lint): enable `prefer-destructuring` lint rule

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -19,7 +19,7 @@ export class ConfigService implements IDisposable {
 
   constructor() {
     this.vsCodeConfig = new VSCodeConfig();
-    const workspaceFolders = workspace.workspaceFolders;
+    const { workspaceFolders } = workspace;
     if (workspaceFolders) {
       for (const folder of workspaceFolders) {
         this.addWorkspaceConfig(folder);

--- a/editors/vscode/tests/commands.spec.ts
+++ b/editors/vscode/tests/commands.spec.ts
@@ -49,7 +49,7 @@ suite('commands', () => {
     await sleep(500);
 
     notEqual(window.activeTextEditor, undefined);
-    const uri = window.activeTextEditor!.document.uri;
+    const { uri } = window.activeTextEditor!.document;
     strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc');
 
     await commands.executeCommand('workbench.action.closeActiveEditor');

--- a/napi/minify/webcontainer-fallback.cjs
+++ b/napi/minify/webcontainer-fallback.cjs
@@ -2,7 +2,7 @@ const fs = require("node:fs");
 const childProcess = require("node:child_process");
 
 const pkg = JSON.parse(fs.readFileSync(require.resolve("oxc-minify/package.json"), "utf-8"));
-const version = pkg.version;
+const { version } = pkg;
 const baseDir = `/tmp/oxc-minify-${version}`;
 const bindingEntry = `${baseDir}/node_modules/@oxc-minify/binding-wasm32-wasi/minify.wasi.cjs`;
 

--- a/napi/parser/src-js/webcontainer-fallback.cjs
+++ b/napi/parser/src-js/webcontainer-fallback.cjs
@@ -2,7 +2,7 @@ const fs = require("node:fs");
 const childProcess = require("node:child_process");
 
 const pkg = JSON.parse(fs.readFileSync(require.resolve("oxc-parser/package.json"), "utf-8"));
-const version = pkg.version;
+const { version } = pkg;
 const baseDir = `/tmp/oxc-parser-${version}`;
 const bindingEntry = `${baseDir}/node_modules/@oxc-parser/binding-wasm32-wasi/parser.wasi.cjs`;
 

--- a/napi/parser/test/parser.ts
+++ b/napi/parser/test/parser.ts
@@ -25,5 +25,9 @@ type OverrideOptions<F extends (...args: any[]) => any> = F extends (
   ? (filename: A, sourceText: B, options?: C & ExperimentalParserOptions) => R
   : never;
 
-export const parse: OverrideOptions<typeof parser.parse> = parser.parse;
-export const parseSync: OverrideOptions<typeof parser.parseSync> = parser.parseSync;
+interface ParseMethods {
+  parse: OverrideOptions<typeof parser.parse>;
+  parseSync: OverrideOptions<typeof parser.parseSync>;
+}
+
+export const { parse, parseSync }: ParseMethods = parser;

--- a/napi/transform/webcontainer-fallback.cjs
+++ b/napi/transform/webcontainer-fallback.cjs
@@ -2,7 +2,7 @@ const fs = require("node:fs");
 const childProcess = require("node:child_process");
 
 const pkg = JSON.parse(fs.readFileSync(require.resolve("oxc-transform/package.json"), "utf-8"));
-const version = pkg.version;
+const { version } = pkg;
 const baseDir = `/tmp/oxc-transform-${version}`;
 const bindingEntry = `${baseDir}/node_modules/@oxc-transform/binding-wasm32-wasi/transform.wasi.cjs`;
 

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -18,6 +18,9 @@
   },
   "rules": {
     "no-console": "error",
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": { "array": false, "object": true }
+    }],
     "typescript/consistent-indexed-object-style": ["error", "record"]
   },
   "overrides": [


### PR DESCRIPTION
Enable `prefer-destructuring` rule in our linting setup.

Not related to JS plugins, I just like this rule, and it's useful not to make nitty comments on PRs, when linter can do it for me...
