### PR TITLE
refactor(linter/plugins): simplify JS callback type

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -555,10 +555,10 @@ impl ConfigStoreBuilder {
         // Note: `unwrap()` here is infallible as `plugin_path` is an absolute path.
         let plugin_url = Url::from_file_path(&plugin_path).unwrap().as_str().to_string();
 
-        let result = (external_linter.load_plugin)(plugin_url, package_name).map_err(|e| {
+        let result = (external_linter.load_plugin)(plugin_url, package_name).map_err(|error| {
             ConfigBuilderError::PluginLoadFailed {
                 plugin_specifier: plugin_specifier.to_string(),
-                error: e.to_string(),
+                error,
             }
         })?;
 

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -1,14 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::fmt::Debug;
 
 use serde::Deserialize;
 
 use oxc_allocator::Allocator;
 
-pub type ExternalLinterLoadPluginCb = Box<
-    dyn Fn(String, Option<String>) -> Result<PluginLoadResult, Box<dyn Error + Send + Sync>>
-        + Send
-        + Sync,
->;
+pub type ExternalLinterLoadPluginCb =
+    Box<dyn Fn(String, Option<String>) -> Result<PluginLoadResult, String> + Send + Sync>;
 
 pub type ExternalLinterSetupConfigsCb = Box<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 


### PR DESCRIPTION
Simplify the type for `ExternalLinterLoadPluginCb` by converting errors to `String`s in the closure returned by `wrap_load_plugin`, rather than doing it later.