### PR TITLE
refactor(linter/plugins): rename `LoadPluginResult`

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use oxc_allocator::{Allocator, free_fixed_size_allocator};
 use oxc_linter::{
     ExternalLinter, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
-    ExternalLinterSetupConfigsCb, LintFileResult, PluginLoadResult,
+    ExternalLinterSetupConfigsCb, LintFileResult, LoadPluginResult,
 };
 
 use crate::{
@@ -48,7 +48,7 @@ fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
 
         match res {
             // `loadPlugin` returns JSON string if plugin loaded successfully, or an error occurred
-            Ok(json) => match serde_json::from_str::<PluginLoadResult>(&json) {
+            Ok(json) => match serde_json::from_str::<LoadPluginResult>(&json) {
                 // Plugin loaded successfully, or error occurred on JS side
                 Ok(result) => Ok(result),
                 // Invalid JSON - should be impossible, because we control serialization on JS side

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -525,7 +525,7 @@ impl ConfigStoreBuilder {
         resolver: &Resolver,
         external_plugin_store: &mut ExternalPluginStore,
     ) -> Result<(), ConfigBuilderError> {
-        use crate::PluginLoadResult;
+        use crate::LoadPluginResult;
 
         // Print warning on 1st attempt to load a plugin
         #[expect(clippy::print_stderr)]
@@ -563,7 +563,7 @@ impl ConfigStoreBuilder {
         })?;
 
         match result {
-            PluginLoadResult::Success { name, offset, rule_names } => {
+            LoadPluginResult::Success { name, offset, rule_names } => {
                 // Normalize plugin name (e.g., "eslint-plugin-foo" -> "foo", "@foo/eslint-plugin" -> "@foo")
                 use crate::config::plugins::normalize_plugin_name;
                 let normalized_name = normalize_plugin_name(&name).into_owned();
@@ -582,7 +582,7 @@ impl ConfigStoreBuilder {
                     })
                 }
             }
-            PluginLoadResult::Failure(e) => Err(ConfigBuilderError::PluginLoadFailed {
+            LoadPluginResult::Failure(e) => Err(ConfigBuilderError::PluginLoadFailed {
                 plugin_specifier: plugin_specifier.to_string(),
                 error: e,
             }),

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use oxc_allocator::Allocator;
 
 pub type ExternalLinterLoadPluginCb =
-    Box<dyn Fn(String, Option<String>) -> Result<PluginLoadResult, String> + Send + Sync>;
+    Box<dyn Fn(String, Option<String>) -> Result<LoadPluginResult, String> + Send + Sync>;
 
 pub type ExternalLinterSetupConfigsCb = Box<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
@@ -16,7 +16,7 @@ pub type ExternalLinterLintFileCb = Box<
 >;
 
 #[derive(Clone, Debug, Deserialize)]
-pub enum PluginLoadResult {
+pub enum LoadPluginResult {
     #[serde(rename_all = "camelCase")]
     Success {
         name: String,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::{
     context::{ContextSubHost, LintContext},
     external_linter::{
         ExternalLinter, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
-        ExternalLinterSetupConfigsCb, JsFix, LintFileResult, PluginLoadResult,
+        ExternalLinterSetupConfigsCb, JsFix, LintFileResult, LoadPluginResult,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
     fixer::{Fix, FixKind, Message, PossibleFixes},


### PR DESCRIPTION
Pure refactor. Rename `PluginLoadResult` to `LoadPluginResult`. The function that returns it is called `load_plugin`, so this naming makes more sense.