### PR TITLE
refactor(linter/plugins): simplify return value of `load_plugin`

### DIFF
--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -16,14 +16,11 @@ pub type ExternalLinterLintFileCb = Box<
 >;
 
 #[derive(Clone, Debug, Deserialize)]
-pub enum LoadPluginResult {
-    #[serde(rename_all = "camelCase")]
-    Success {
-        name: String,
-        offset: usize,
-        rule_names: Vec<String>,
-    },
-    Failure(String),
+#[serde(rename_all = "camelCase")]
+pub struct LoadPluginResult {
+    pub name: String,
+    pub offset: usize,
+    pub rule_names: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Previously `load_plugin` returned a `Result<LoadPluginResult>`, where `LoadPluginResult` was an enum with one variant being an error case - so it was essentially `Result<Result<Data>>`.

Flatten it so that `LoadPluginResult` is a now struct containing details of success case, and the error case that `LoadPluginResult::Failure` previously covered becomes `Err`.

This simplifies the logic, and matches the pattern used by `lint_file` + `LintFileResult`.