### PR TITLE
fix(linter/plugins): handle errors sending data from JS back to Rust

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -1,7 +1,7 @@
 use std::sync::{atomic::Ordering, mpsc::channel};
 
 use napi::{
-    Status,
+    Error as NapiError, Status,
     bindgen_prelude::{FnArgs, Uint8Array},
     threadsafe_function::ThreadsafeFunctionCallMode,
 };
@@ -85,8 +85,8 @@ fn wrap_setup_configs(cb: JsSetupConfigsCb) -> ExternalLinterSetupConfigsCb {
             options_json,
             ThreadsafeFunctionCallMode::NonBlocking,
             move |result, _env| {
-                let _ = tx.send(result);
-                Ok(())
+                tx.send(result)
+                    .map_err(|_| NapiError::from_reason("Failed to send result of `setupConfigs`"))
             },
         );
 
@@ -146,8 +146,8 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
                 FnArgs::from((file_path, buffer_id, buffer, rule_ids, options_ids, settings_json)),
                 ThreadsafeFunctionCallMode::NonBlocking,
                 move |result, _env| {
-                    let _ = tx.send(result);
-                    Ok(())
+                    tx.send(result)
+                        .map_err(|_| NapiError::from_reason("Failed to send result of `lintFile`"))
                 },
             );
 


### PR DESCRIPTION
Previously if there was an error passing data back from a `ThreadsafeFunction` callback into Rust calling thread using the `mpsc::channel`, we'd just ignore it. Presumably then the later call to `rx.recv()` would just hang forever waiting for a message.

I'm not that familiar with `mpsc::channel`, but from the docs it looks like this is impossible in these functions, because we definitely don't drop the receiver before the `tx.send()` call happens - because we block on `rx.recv()`.

But nonetheless, it seems wise to handle this, just in case there's a bug in NAPI-RS or something.

If `tx.send()` fails, return a `napi::Error` from the callback. This causes the error to be thrown on JS side, where it's unhandled and so will crash the NodeJS process. But this is probably what we want to happen, as there's no way to gracefully recover.

(it's not documented what behavior is if you return `Err` from the callback, but I've tried it out, and this is what happens)