### PR TITLE
test(lsp): add tests for diagnostics on `didOpen|didChange|didSave`

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -506,7 +506,8 @@ impl LanguageServer for Backend {
         // saving the file means we can read again from the file system
         self.file_system.write().await.remove(uri);
 
-        if let Some(diagnostics) = worker.run_diagnostic_on_save(uri, None).await {
+        if let Some(diagnostics) = worker.run_diagnostic_on_save(uri, params.text.as_deref()).await
+        {
             self.client.publish_diagnostics(uri.clone(), diagnostics, None).await;
         }
     }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -563,4 +563,123 @@ mod tests {
             panic!("Expected CodeAction");
         }
     }
+
+    #[tokio::test]
+    async fn test_run_diagnostic() {
+        let worker = WorkspaceWorker::new(Uri::from_str("file:///root/").unwrap());
+        let tools: Vec<Box<dyn ToolBuilder>> = vec![Box::new(FakeToolBuilder)];
+        worker.start_worker(serde_json::Value::Null, &tools).await;
+
+        let diagnostics_no_content = worker
+            .run_diagnostic(&Uri::from_str("file:///root/diagnostics.config").unwrap(), None)
+            .await;
+
+        assert!(diagnostics_no_content.is_some());
+        assert_eq!(diagnostics_no_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_no_content.unwrap()[0].message,
+            "Fake diagnostic for content: <no content>"
+        );
+
+        let diagnostics_with_content = worker
+            .run_diagnostic(
+                &Uri::from_str("file:///root/diagnostics.config").unwrap(),
+                Some("helloworld"),
+            )
+            .await;
+
+        assert!(diagnostics_with_content.is_some());
+        assert_eq!(diagnostics_with_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_with_content.unwrap()[0].message,
+            "Fake diagnostic for content: helloworld"
+        );
+
+        let no_diagnostics =
+            worker.run_diagnostic(&Uri::from_str("file:///root/unknown.file").unwrap(), None).await;
+
+        assert!(no_diagnostics.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_run_diagnostic_on_change() {
+        let worker = WorkspaceWorker::new(Uri::from_str("file:///root/").unwrap());
+        let tools: Vec<Box<dyn ToolBuilder>> = vec![Box::new(FakeToolBuilder)];
+        worker.start_worker(serde_json::Value::Null, &tools).await;
+
+        let diagnostics_no_content = worker
+            .run_diagnostic_on_change(
+                &Uri::from_str("file:///root/diagnostics.config").unwrap(),
+                None,
+            )
+            .await;
+
+        assert!(diagnostics_no_content.is_some());
+        assert_eq!(diagnostics_no_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_no_content.unwrap()[0].message,
+            "Fake diagnostic for content: <no content>"
+        );
+
+        let diagnostics_with_content = worker
+            .run_diagnostic_on_change(
+                &Uri::from_str("file:///root/diagnostics.config").unwrap(),
+                Some("helloworld"),
+            )
+            .await;
+
+        assert!(diagnostics_with_content.is_some());
+        assert_eq!(diagnostics_with_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_with_content.unwrap()[0].message,
+            "Fake diagnostic for content: helloworld"
+        );
+
+        let no_diagnostics = worker
+            .run_diagnostic_on_change(&Uri::from_str("file:///root/unknown.file").unwrap(), None)
+            .await;
+
+        assert!(no_diagnostics.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_run_diagnostic_on_save() {
+        let worker = WorkspaceWorker::new(Uri::from_str("file:///root/").unwrap());
+        let tools: Vec<Box<dyn ToolBuilder>> = vec![Box::new(FakeToolBuilder)];
+        worker.start_worker(serde_json::Value::Null, &tools).await;
+
+        let diagnostics_no_content = worker
+            .run_diagnostic_on_save(
+                &Uri::from_str("file:///root/diagnostics.config").unwrap(),
+                None,
+            )
+            .await;
+
+        assert!(diagnostics_no_content.is_some());
+        assert_eq!(diagnostics_no_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_no_content.unwrap()[0].message,
+            "Fake diagnostic for content: <no content>"
+        );
+
+        let diagnostics_with_content = worker
+            .run_diagnostic_on_save(
+                &Uri::from_str("file:///root/diagnostics.config").unwrap(),
+                Some("helloworld"),
+            )
+            .await;
+
+        assert!(diagnostics_with_content.is_some());
+        assert_eq!(diagnostics_with_content.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            diagnostics_with_content.unwrap()[0].message,
+            "Fake diagnostic for content: helloworld"
+        );
+
+        let no_diagnostics = worker
+            .run_diagnostic_on_save(&Uri::from_str("file:///root/unknown.file").unwrap(), None)
+            .await;
+
+        assert!(no_diagnostics.is_none());
+    }
 }


### PR DESCRIPTION
> This PR adds comprehensive test coverage for diagnostic functionality in the Language Server Protocol (LSP) implementation, specifically testing diagnostics on didOpen, didChange, and didSave events. The changes include both unit tests for the worker module and integration tests for the backend

>  along with a bug fix in the did_save handler.

This is not really a bug fix, just a little refactoring to pass the tests. 
In general, I do not expect that `params.text (didSave)` has changed from `didChange` content
