### PR TITLE
fix(linter): fix VisitorObject type to allow specific typed methods with index signature

### DIFF
--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -3,7 +3,7 @@
 
 import * as ESTree from "./types.d.ts";
 
-export interface VisitorObject {
+type VisitorObjectBase = {
   DebuggerStatement?: (node: ESTree.DebuggerStatement) => void;
   "DebuggerStatement:exit"?: (node: ESTree.DebuggerStatement) => void;
   EmptyStatement?: (node: ESTree.EmptyStatement) => void;
@@ -384,5 +384,8 @@ export interface VisitorObject {
   "TSTypeReference:exit"?: (node: ESTree.TSTypeReference) => void;
   TSUnionType?: (node: ESTree.TSUnionType) => void;
   "TSUnionType:exit"?: (node: ESTree.TSUnionType) => void;
+};
+
+export type VisitorObject = VisitorObjectBase & {
   [key: string]: (node: ESTree.Node) => void;
-}
+};

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -438,8 +438,12 @@ fn generate(codegen: &Codegen) -> Codes {
     let visitor_type_oxlint = format!("
         import * as ESTree from './types.d.ts';
 
-        export interface VisitorObject {{
-            {visitor_type} [key: string]: (node: ESTree.Node) => void;
+        type VisitorObjectBase = {{
+            {visitor_type}
+        }};
+
+        export type VisitorObject = VisitorObjectBase & {{
+            [key: string]: (node: ESTree.Node) => void;
         }}
     ");
 


### PR DESCRIPTION
Use intersection type instead of interface to avoid TypeScript strict mode errors when using defineRule with specific visitor methods like Program().

This works as intersection types allow one type to overwrite another. So if i write a key that matches `VisitorObjectBase` it will infer the correct type, but if I write a random key, it'll just be inferred as `ESTree.Node`

Closes #14745

🤖 generated with help from Claude Opus 4.5