### PR TITLE
fix(linter): use import type for ESTree in visitor.d.ts

### DIFF
--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
 
-import * as ESTree from "./types.d.ts";
+import type * as ESTree from "./types.d.ts";
 
 export interface VisitorObject {
   DebuggerStatement?: (node: ESTree.DebuggerStatement) => void;

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -436,7 +436,7 @@ fn generate(codegen: &Codegen) -> Codes {
 
     #[rustfmt::skip]
     let visitor_type_oxlint = format!("
-        import * as ESTree from './types.d.ts';
+        import type * as ESTree from './types.d.ts';
 
         export interface VisitorObject {{
             {visitor_type} [key: string]: (node: ESTree.Node) => void;


### PR DESCRIPTION
Use `import type` instead of `import` for type-only imports to follow, TypeScript best practices.

This is also in prepartation for #16473 which converts this file to a `.ts` file rather than a declaration file. Using a `.ts` file is an advantage as it means that typescript will actually check it rather than skipping it ([skipLibCheck](https://www.typescriptlang.org/tsconfig/#skipLibCheck))

🤖 generated with help from Claude Opus 4.5