### PR TITLE
perf(formatter): avoid using an indent with a empty content

### DIFF
--- a/crates/oxc_formatter/src/write/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/write/binary_like_expression.rs
@@ -272,9 +272,9 @@ impl<'a> Format<'a> for BinaryLikeExpression<'a, '_> {
                 f,
                 [group(&format_args!(
                     first,
-                    indent(&format_with(|f| {
+                    (!tail_parts.is_empty()).then_some(indent(&format_with(|f| {
                         f.join().entries(tail_parts.iter());
-                    }))
+                    })))
                 ))
                 .with_group_id(Some(group_id))]
             );

--- a/crates/oxc_formatter/src/write/jsx/mod.rs
+++ b/crates/oxc_formatter/src/write/jsx/mod.rs
@@ -73,6 +73,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXFragment<'a>> {
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningFragment> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
+
+        if comments.is_empty() {
+            write!(f, "<>");
+            return;
+        }
+
         let has_own_line_comment = comments.iter().any(|c| c.is_line());
 
         let format_comments = format_with(|f| {
@@ -96,6 +102,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningFragment> {
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingFragment> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
+
+        if comments.is_empty() {
+            write!(f, "</>");
+            return;
+        }
+
         let has_own_line_comment = comments.iter().any(|c| c.is_line());
 
         let format_comments = format_with(|f| {


### PR DESCRIPTION
Slight improvement; this can avoid inserting useless `FormatElement::Tag(StartIndent)` and `FormatElement::Tag(StartIndent)`.