### PR TITLE
feat(formatter): add debug assertion to ensure that there is no empty content is passed in

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -728,7 +728,17 @@ pub struct Indent<'a, 'ast> {
 impl<'ast> Format<'ast> for Indent<'_, 'ast> {
     fn fmt(&self, f: &mut Formatter<'_, 'ast>) {
         f.write_element(FormatElement::Tag(StartIndent));
+
+        let elements_length = f.elements().len();
+
         Arguments::from(&self.content).fmt(f);
+
+        debug_assert_ne!(
+            elements_length,
+            f.elements().len(),
+            "Indent's content must produce at least one element"
+        );
+
         f.write_element(FormatElement::Tag(EndIndent));
     }
 }


### PR DESCRIPTION
This is for https://github.com/oxc-project/oxc/pull/16474, similar to #16437, but for `Indent`.