### PR TITLE
feat(ast, parser, codegen): add `CommentKind::MultilineBlock`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5651,6 +5651,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -17,6 +17,9 @@ pub enum CommentKind {
     Line = 0,
     /// Block comment
     Block = 1,
+    /// Multiline block comment (contains line breaks)
+    #[estree(rename = "Block")]
+    MultilineBlock = 2,
 }
 
 /// Information about a comment's position relative to a token.
@@ -172,7 +175,9 @@ impl Comment {
     pub fn content_span(&self) -> Span {
         match self.kind {
             CommentKind::Line => Span::new(self.span.start + 2, self.span.end),
-            CommentKind::Block => Span::new(self.span.start + 2, self.span.end - 2),
+            CommentKind::Block | CommentKind::MultilineBlock => {
+                Span::new(self.span.start + 2, self.span.end - 2)
+            }
         }
     }
 
@@ -185,7 +190,13 @@ impl Comment {
     /// Returns `true` if this is a block comment.
     #[inline]
     pub fn is_block(self) -> bool {
-        self.kind == CommentKind::Block
+        matches!(self.kind, CommentKind::Block | CommentKind::MultilineBlock)
+    }
+
+    /// Returns `true` if this is a multi-line block comment.
+    #[inline]
+    pub fn is_multiline_block(self) -> bool {
+        self.kind == CommentKind::MultilineBlock
     }
 
     /// Returns `true` if this comment is before a token.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3234,6 +3234,7 @@ impl ESTree for CommentKind {
         match self {
             Self::Line => JsonSafeString("Line").serialize(serializer),
             Self::Block => JsonSafeString("Block").serialize(serializer),
+            Self::MultilineBlock => JsonSafeString("Block").serialize(serializer),
         }
     }
 }

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::{Comment, CommentKind, ast::Program};
-use oxc_syntax::line_terminator::{LineTerminatorSplitter, is_line_terminator};
+use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{Codegen, LegalComment, options::CommentOptions};
 
@@ -128,10 +128,10 @@ impl Codegen<'_> {
         };
         let comment_source = comment.span.source_text(source_text);
         match comment.kind {
-            CommentKind::Line => {
+            CommentKind::Line | CommentKind::Block => {
                 self.print_str_escaping_script_close_tag(comment_source);
             }
-            CommentKind::Block => {
+            CommentKind::MultilineBlock => {
                 for line in LineTerminatorSplitter::new(comment_source) {
                     if !line.starts_with("/*") {
                         self.print_indent();
@@ -163,7 +163,7 @@ impl Codegen<'_> {
         let source_text = program.source_text;
         for comment in program.comments.iter().filter(|c| c.is_legal()) {
             let mut text = Cow::Borrowed(comment.span.source_text(source_text));
-            if comment.is_block() && text.contains(is_line_terminator) {
+            if comment.is_multiline_block() {
                 let mut buffer = String::with_capacity(text.len());
                 // Print block comments with our own indentation.
                 for line in LineTerminatorSplitter::new(&text) {

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -117,28 +117,31 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
                 write!(f, comment);
 
                 match comment.kind {
-                    CommentKind::Block => match f.source_text().lines_after(comment.span.end) {
-                        0 => {
-                            let should_nestle =
-                                leading_comments_iter.peek().is_some_and(|next_comment| {
-                                    should_nestle_adjacent_doc_comments(
-                                        comment,
-                                        next_comment,
-                                        f.source_text(),
-                                    )
-                                });
+                    CommentKind::Block | CommentKind::MultilineBlock => {
+                        match f.source_text().lines_after(comment.span.end) {
+                            0 => {
+                                let should_nestle =
+                                    leading_comments_iter.peek().is_some_and(|next_comment| {
+                                        should_nestle_adjacent_doc_comments(
+                                            comment,
+                                            next_comment,
+                                            f.source_text(),
+                                        )
+                                    });
 
-                            write!(f, [maybe_space(!should_nestle)]);
-                        }
-                        1 => {
-                            if f.source_text().get_lines_before(comment.span, f.comments()) == 0 {
-                                write!(f, [soft_line_break_or_space()]);
-                            } else {
-                                write!(f, [hard_line_break()]);
+                                write!(f, [maybe_space(!should_nestle)]);
                             }
+                            1 => {
+                                if f.source_text().get_lines_before(comment.span, f.comments()) == 0
+                                {
+                                    write!(f, [soft_line_break_or_space()]);
+                                } else {
+                                    write!(f, [hard_line_break()]);
+                                }
+                            }
+                            _ => write!(f, [empty_line()]),
                         }
-                        _ => write!(f, [empty_line()]),
-                    },
+                    }
                     CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
                         0 | 1 => write!(f, [hard_line_break()]),
                         _ => write!(f, [empty_line()]),

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -1,6 +1,5 @@
 use cow_utils::CowUtils;
 use lazy_regex::Regex;
-use oxc_ast::CommentKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -193,9 +192,7 @@ impl Rule for BanTsComment {
             if let Some(captures) = find_ts_comment_directive(raw, comm.is_line()) {
                 // safe to unwrap, if capture success, it can always capture one of the four directives
                 let (directive, description) = (captures.0, captures.1);
-                if CommentKind::Block == comm.kind
-                    && (directive == "check" || directive == "nocheck")
-                {
+                if comm.is_block() && (directive == "check" || directive == "nocheck") {
                     continue;
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -174,7 +174,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                                         let single_line_comment: String = format!("//{comment}\n");
                                         comments_vec.push(single_line_comment);
                                     }
-                                    CommentKind::Block => {
+                                    CommentKind::Block | CommentKind::MultilineBlock => {
                                         let multi_line_comment: String = format!("/*{comment}*/\n");
                                         comments_vec.push(multi_line_comment);
                                     }

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -33,7 +33,7 @@ pub fn convert_utf8_to_utf16(
             Comment {
                 r#type: match comment.kind {
                     CommentKind::Line => String::from("Line"),
-                    CommentKind::Block => String::from("Block"),
+                    CommentKind::Block | CommentKind::MultilineBlock => String::from("Block"),
                 },
                 value,
                 start: span.start,

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -59,8 +59,14 @@ impl TriviaBuilder {
         self.add_comment(Comment::new(start, end, CommentKind::Line), source_text);
     }
 
-    pub fn add_block_comment(&mut self, start: u32, end: u32, source_text: &str) {
-        self.add_comment(Comment::new(start, end, CommentKind::Block), source_text);
+    pub fn add_block_comment(
+        &mut self,
+        start: u32,
+        end: u32,
+        kind: CommentKind,
+        source_text: &str,
+    ) {
+        self.add_comment(Comment::new(start, end, kind), source_text);
     }
 
     // For block comments only. This function is not called after line comments because the lexer skips
@@ -425,7 +431,7 @@ token /* Trailing 1 */
         let expected = vec![
             Comment {
                 span: Span::new(1, 13),
-                kind: CommentKind::Block,
+                kind: CommentKind::MultilineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -433,7 +439,7 @@ token /* Trailing 1 */
             },
             Comment {
                 span: Span::new(14, 26),
-                kind: CommentKind::Block,
+                kind: CommentKind::MultilineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -4210,6 +4210,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/js_parent.js
+++ b/napi/parser/generated/deserialize/js_parent.js
@@ -4943,6 +4943,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/js_range.js
+++ b/napi/parser/generated/deserialize/js_range.js
@@ -4656,6 +4656,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/js_range_parent.js
+++ b/napi/parser/generated/deserialize/js_range_parent.js
@@ -5190,6 +5190,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4463,6 +4463,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/ts_parent.js
+++ b/napi/parser/generated/deserialize/ts_parent.js
@@ -5204,6 +5204,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/ts_range.js
+++ b/napi/parser/generated/deserialize/ts_range.js
@@ -4908,6 +4908,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/generated/deserialize/ts_range_parent.js
@@ -5458,6 +5458,8 @@ function deserializeCommentKind(pos) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }

--- a/napi/parser/generated/lazy/constructors.js
+++ b/napi/parser/generated/lazy/constructors.js
@@ -11743,6 +11743,8 @@ function constructCommentKind(pos, ast) {
       return "Line";
     case 1:
       return "Block";
+    case 2:
+      return "Block";
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for CommentKind`);
   }


### PR DESCRIPTION
Add `CommentKind::MultilineBlock` to indicate a block comment that has at least one linebreak, which would be useful in the Codegen and Formatter

Examples:

CommentKind::Block:
```js
/* single line block comment */
```

CommentKind::MultilineBlock

```js
/* multiline 
block
 comment */
```

Maybe it would be better to rename `CommentKind::Block` to `CommentKind::SinglelineBlock.` as well



