### PR TITLE
feat(oxfmt): Prepare non-js/ts file support with prettier

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -10,4 +10,4 @@
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (fileName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, code: string) => Promise<string>): Promise<boolean>

--- a/apps/oxfmt/src-js/prettier-proxy.ts
+++ b/apps/oxfmt/src-js/prettier-proxy.ts
@@ -66,20 +66,17 @@ export async function formatEmbeddedCode(tagName: string, code: string): Promise
 /**
  * Format whole file content using Prettier.
  * NOTE: Called from Rust via NAPI ThreadsafeFunction with FnArgs
- * @param fileName - The file name (used to infer parser)
+ * @param parserName - The parser name
  * @param code - The code to format
  * @returns Formatted code
  */
-export async function formatFile(fileName: string, code: string): Promise<string> {
+export async function formatFile(parserName: string, code: string): Promise<string> {
   if (!prettierCache) {
     prettierCache = await import("prettier");
   }
 
-  // TODO: Tweak parser for `tsconfig.json` with `jsonc` parser?
-
   return prettierCache.format(code, {
-    // Let Prettier infer the parser
-    filepath: fileName,
+    parser: parserName,
     // TODO: Read config
   });
 }

--- a/apps/oxfmt/src/format.rs
+++ b/apps/oxfmt/src/format.rs
@@ -61,7 +61,7 @@ impl FormatRunner {
         // NOTE: Currently, we only load single config file.
         // - from `--config` if specified
         // - else, search nearest for the nearest `.oxfmtrc.json` from cwd upwards
-        let config = match load_config(&cwd, basic_options.config.as_ref()) {
+        let config = match load_config(&cwd, basic_options.config.as_deref()) {
             Ok(config) => config,
             Err(err) => {
                 print_and_flush(stderr, &format!("Failed to load configuration file.\n{err}\n"));
@@ -220,11 +220,11 @@ impl FormatRunner {
 /// Returns error if:
 /// - Config file is specified but not found or invalid
 /// - Config file parsing fails
-fn load_config(cwd: &Path, config_path: Option<&PathBuf>) -> Result<Oxfmtrc, String> {
+fn load_config(cwd: &Path, config_path: Option<&Path>) -> Result<Oxfmtrc, String> {
     let config_path = if let Some(config_path) = config_path {
         // If `--config` is explicitly specified, use that path
         Some(if config_path.is_absolute() {
-            PathBuf::from(config_path)
+            config_path.to_path_buf()
         } else {
             cwd.join(config_path)
         })

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -5,6 +5,7 @@ mod lsp;
 mod reporter;
 mod result;
 mod service;
+mod support;
 mod walk;
 
 // Public re-exports for use in main.rs and lib consumers

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -33,7 +33,7 @@ pub async fn format(
     args: Vec<String>,
     #[napi(ts_arg_type = "(tagName: string, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(ts_arg_type = "(fileName: string, code: string) => Promise<string>")]
+    #[napi(ts_arg_type = "(parserName: string, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
 ) -> bool {
     format_impl(args, format_embedded_cb, format_file_cb).await.report() == ExitCode::SUCCESS

--- a/apps/oxfmt/src/support.rs
+++ b/apps/oxfmt/src/support.rs
@@ -1,0 +1,46 @@
+use std::path::{Path, PathBuf};
+
+use oxc_formatter::get_supported_source_type;
+use oxc_span::SourceType;
+
+pub enum FormatFileSource {
+    OxcFormatter {
+        path: PathBuf,
+        source_type: SourceType,
+    },
+    #[expect(dead_code)]
+    ExternalFormatter {
+        path: PathBuf,
+        parser_name: String,
+    },
+}
+
+impl TryFrom<&Path> for FormatFileSource {
+    type Error = ();
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        // TODO: This logic should(can) move to this file, after LSP support is also moved here.
+        if let Some(source_type) = get_supported_source_type(path) {
+            return Ok(Self::OxcFormatter { path: path.to_path_buf(), source_type });
+        }
+
+        // TODO: Support more files with `ExternalFormatter`
+        // - JSON
+        // - HTML(include .vue)
+        // - CSS
+        // - GraphQL
+        // - Markdown
+        // - YAML
+        // - Handlebars
+
+        Err(())
+    }
+}
+
+impl FormatFileSource {
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::OxcFormatter { path, .. } | Self::ExternalFormatter { path, .. } => path,
+        }
+    }
+}

--- a/apps/oxfmt/src/walk.rs
+++ b/apps/oxfmt/src/walk.rs
@@ -5,7 +5,7 @@ use std::{
 
 use ignore::{gitignore::GitignoreBuilder, overrides::OverrideBuilder};
 
-use oxc_formatter::get_supported_source_type;
+use crate::support::FormatFileSource;
 
 pub struct Walk {
     inner: ignore::WalkParallel,
@@ -13,7 +13,7 @@ pub struct Walk {
 
 impl Walk {
     pub fn build(
-        cwd: &PathBuf,
+        cwd: &Path,
         paths: &[PathBuf],
         ignore_paths: &[PathBuf],
         with_node_modules: bool,
@@ -65,11 +65,9 @@ impl Walk {
 
         // NOTE: If return `false` here, it will not be `visit()`ed at all
         inner.filter_entry(move |entry| {
-            // Skip stdin for now
             let Some(file_type) = entry.file_type() else {
                 return false;
             };
-
             let is_dir = file_type.is_dir();
 
             if is_dir {
@@ -77,7 +75,7 @@ impl Walk {
                 // it means we want to include hidden files and directories.
                 // However, we (and also Prettier) still skip traversing certain directories.
                 // https://prettier.io/docs/ignore#ignoring-files-prettierignore
-                let is_skipped_dir = {
+                let is_ignored_dir = {
                     let dir_name = entry.file_name();
                     dir_name == ".git"
                         || dir_name == ".jj"
@@ -86,7 +84,7 @@ impl Walk {
                         || dir_name == ".hg"
                         || (!with_node_modules && dir_name == "node_modules")
                 };
-                if is_skipped_dir {
+                if is_ignored_dir {
                     return false;
                 }
             }
@@ -97,10 +95,10 @@ impl Walk {
                 return false;
             }
 
-            // NOTE: We can also check `get_supported_source_type()` here to skip.
-            // But we want to pass parsed `SourceType` to `FormatService`,
-            // so we do it later in the visitor instead.
-
+            // NOTE: In addition to ignoring based on ignore files and patterns here,
+            // we also apply extra filtering in the visitor `visit()` below.
+            // We need to return `bool` for `filter_entry()` here,
+            // but we don't want to duplicate logic in the visitor again.
             true
         });
 
@@ -121,8 +119,8 @@ impl Walk {
     }
 
     /// Stream entries through a channel as they are discovered
-    pub fn stream_entries(self) -> mpsc::Receiver<WalkEntry> {
-        let (sender, receiver) = mpsc::channel::<WalkEntry>();
+    pub fn stream_entries(self) -> mpsc::Receiver<FormatFileSource> {
+        let (sender, receiver) = mpsc::channel::<FormatFileSource>();
 
         // Spawn the walk operation in a separate thread
         rayon::spawn(move || {
@@ -199,12 +197,8 @@ fn load_ignore_paths(cwd: &Path, ignore_paths: &[PathBuf]) -> Vec<PathBuf> {
 
 // ---
 
-pub struct WalkEntry {
-    pub path: PathBuf,
-}
-
 struct WalkBuilder {
-    sender: mpsc::Sender<WalkEntry>,
+    sender: mpsc::Sender<FormatFileSource>,
 }
 
 impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
@@ -214,7 +208,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
 }
 
 struct WalkVisitor {
-    sender: mpsc::Sender<WalkEntry>,
+    sender: mpsc::Sender<FormatFileSource>,
 }
 
 impl ignore::ParallelVisitor for WalkVisitor {
@@ -227,14 +221,25 @@ impl ignore::ParallelVisitor for WalkVisitor {
 
                 // Use `is_file()` to detect symlinks to the directory named `.js`
                 #[expect(clippy::filetype_is_file)]
-                if file_type.is_file()
-                    // TODO: Remove it for napi, keep it for not(napi)
-                    && get_supported_source_type(entry.path()).is_some()
-                {
-                    let walk_entry = WalkEntry { path: entry.path().to_path_buf() };
+                if file_type.is_file() {
+                    let path = entry.path();
+                    // TODO: Determine this file should be handled or NOT
+                    // Tier 1 = `.js`, `.tsx`, etc: JS/TS files supported by `oxc_formatter`
+                    // Tier 2 = `.html`, `.json`, etc: Other files supported by Prettier
+                    // (Tier 3 = `.astro`, `.svelte`, etc: Other files supported by Prettier plugins)
+                    // Tier 4 = everything else: Not handled
+                    let Ok(format_file_source) = FormatFileSource::try_from(path) else {
+                        return ignore::WalkState::Continue;
+                    };
+
+                    #[cfg(not(feature = "napi"))]
+                    if matches!(format_file_source, FormatFileSource::ExternalFormatter { .. }) {
+                        return ignore::WalkState::Continue;
+                    }
+
                     // Send each entry immediately through the channel
                     // If send fails, the receiver has been dropped, so stop walking
-                    if self.sender.send(walk_entry).is_err() {
+                    if self.sender.send(format_file_source).is_err() {
                         return ignore::WalkState::Quit;
                     }
                 }


### PR DESCRIPTION
- [x] Implement
	- walk.rs: Only collect files that need formatting
	  - This is needed to ignore binaries like `.png`, etc
	- support.rs: Process to determine eligibility based on `path`
	  - Currently still only JS/TS
	  - Plan to add more supported files in the next PR
	- prettier-proxy.js: Changed the signature for calling Prettier from `file_name` to `parser` specification
	  - Allows skipping `inferParser`
- [x] Decide how to address problems below
  - 👉🏻 Maintain our own target list, same as prettier, biome
    - Bonus: specifying parser can skip `inferParser` step in prettier
    - For plugins, read config file beforehand in JS...
  - 👉🏻 Always ignore unknown files
    - It means we don't implement `--ignore-unknown`
    - Only supports JS/TS + Prettier default supported + Defined by plugins

<details>

<summary>Problems</summary>

- Let Prettier handle all non-JS/TS files is fine
- But there are still 2 kinds of unsupported files
  - Non binary unknown format like `.svelte`, etc
  - Binary format like `.png`, etc
- For former: Prettier throws `UndefinedParsererror`
  - We need to detect and handle this with `--ignore-unknown` or always ignore
- For latter
  - Prettier also throws if `prettier ./src/public/foo.png`
  - But NOT for `prettier ./src` 🤯
- Easiest solution is just let handle to prettier but it is really slow
  - Because it means: read file, call prettier, check result for every single file in the repo
- Non-binary detection may be good idea, but it still requires reading file

</details>

Also still doesn't affect existing use cases.