### PR TITLE
refactor(formatter): simplify checking multiline block comment

### DIFF
--- a/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/write/as_or_satisfies_expression.rs
@@ -49,8 +49,7 @@ fn format_as_or_satisfies_expression<'a>(
         // https://github.com/prettier/prettier/blob/fdfa6701767f5140a85902ecc9fb6444f5b4e3f8/src/language-js/comments/handle-comments.js#L1131
         // See also https://github.com/prettier/prettier/blob/3.7.3/tests/format/typescript/as/comments/18160.ts
         let comments = f.context().comments().comments_in_range(expression.span().end, type_start);
-        let multiline_comment_position =
-            comments.iter().position(|c| c.is_block() && f.source_text().contains_newline(c.span));
+        let multiline_comment_position = comments.iter().position(|c| c.is_multiline_block());
         let block_comments =
             if let Some(pos) = multiline_comment_position { &comments[..pos] } else { comments };
 

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -114,25 +114,22 @@ impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
 /// Traversing the left nodes is necessary in case the first node is parenthesized because
 /// parentheses will be removed (and be re-added by the return statement, but only if the argument breaks)
 fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'_, '_>) -> bool {
-    let source_text = f.source_text();
-
     for left_side in ExpressionLeftSide::from(argument).iter() {
         let start = left_side.span().start;
         let comments = f.context().comments();
         let leading_comments = comments.comments_before(start);
 
-        if leading_comments.iter().any(|comment| {
-            (comment.is_block() && source_text.contains_newline(comment.span))
-                || comment.followed_by_newline()
-        }) {
+        if leading_comments
+            .iter()
+            .any(|comment| comment.is_multiline_block() || comment.followed_by_newline())
+        {
             return true;
         }
 
         let is_own_line_comment_or_multi_line_comment = |leading_comments: &[Comment]| {
-            leading_comments.iter().any(|comment| {
-                comment.preceded_by_newline()
-                    || (comment.is_block() && source_text.contains_newline(comment.span))
-            })
+            leading_comments
+                .iter()
+                .any(|comment| comment.is_multiline_block() || comment.preceded_by_newline())
         };
 
         // Yield expressions only need to check the leading comments on the left side.


### PR DESCRIPTION
use `Comment::is_multiline_block` to check whether the comment has a line break