### PR TITLE
refactor(formatter, codegen): use `Comment::newlines` to checking if there is a newline around

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -276,6 +276,12 @@ impl Comment {
         self.newlines.contains(CommentNewlines::Trailing)
     }
 
+    /// Returns `true` if this comment has newlines either before or after it.
+    #[inline]
+    pub fn has_newlines_around(self) -> bool {
+        self.newlines != CommentNewlines::None
+    }
+
     /// Sets the state of `newlines` to include/exclude a newline before the comment.
     #[inline]
     pub fn set_preceded_by_newline(&mut self, preceded_by_newline: bool) {

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -750,9 +750,9 @@ impl Gen for FunctionBody<'_> {
         let span_end = self.span.end;
         let comments_at_end = if span_end > 0 { p.get_comments(span_end - 1) } else { None };
         let single_line = if self.is_empty() {
-            comments_at_end.as_ref().is_none_or(|comments| {
-                comments.iter().all(|c| !c.preceded_by_newline() && !c.followed_by_newline())
-            })
+            comments_at_end
+                .as_ref()
+                .is_none_or(|comments| comments.iter().all(|c| !c.has_newlines_around()))
         } else {
             false
         };

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -154,7 +154,7 @@ fn format_left_trailing_comments(
 
     let comments = if end_of_line_comments.is_empty() {
         let comments = f.context().comments().comments_before_character(start, b'=');
-        if comments.iter().any(|c| f.comments().is_own_line_comment(c)) { &[] } else { comments }
+        if comments.iter().any(|c| c.preceded_by_newline()) { &[] } else { comments }
     } else if should_print_as_leading || end_of_line_comments.last().is_some_and(|c| c.is_block()) {
         // No trailing comments for these expressions or if the trailing comment is a block comment
         &[]
@@ -633,12 +633,9 @@ fn should_break_after_operator<'a>(
         return false;
     }
 
-    let comments = f.comments();
-    let source_text = f.source_text();
-    for comment in comments.comments_before(right.span().start) {
-        if source_text.lines_after(comment.span.end) > 0
-            || f.source_text().has_newline_before(comment.span.start)
-        {
+    let comments = f.context().comments();
+    for comment in comments.comments_before_iter(right.span().start) {
+        if comment.has_newlines_around() {
             return true;
         }
 

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -139,7 +139,7 @@ fn format_trailing_comments<'a>(mut start: u32, end: u32, operator: u8, f: &mut 
                 return &comments[..index];
             }
             // If this comment is a line comment or an end of line comment, so we stop here and return the comments with this comment
-            else if comment.is_line() || f.comments().is_end_of_line_comment(comment) {
+            else if comment.is_line() || comment.followed_by_newline() {
                 return &comments[..=index];
             }
             // Store the index of the comment before the operator, if no line comment or no new line is found, then return all comments before operator

--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -147,11 +147,9 @@ pub fn can_concisely_print_array_list(
     // ]
     // ```
 
-    !comments.comments_before_iter(array_expression_span.end).any(|comment| {
-        comment.is_line()
-            && !comments.is_own_line_comment(comment)
-            && comments.is_end_of_line_comment(comment)
-    })
+    !comments
+        .comments_before_iter(array_expression_span.end)
+        .any(|comment| comment.is_line() && !comment.preceded_by_newline())
 }
 
 // ```js

--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -332,7 +332,7 @@ fn should_group_first_argument(
         || f.comments()
             .comments_in_range(first_span.end, second.span().start)
             .iter()
-            .any(|c| f.comments().is_end_of_line_comment(c))
+            .any(|c| c.followed_by_newline())
     {
         return false;
     }
@@ -373,7 +373,7 @@ fn should_group_last_argument_impl(
             |c| {
                 // Exclude end-of-line comments (treated as previous node's comment)
                 // and comments followed by a comma
-                !f.comments().is_end_of_line_comment(c)
+                !c.followed_by_newline()
                     && !f.source_text().next_non_whitespace_byte_is(c.span.end, b',')
             },
         )

--- a/crates/oxc_formatter/src/write/class.rs
+++ b/crates/oxc_formatter/src/write/class.rs
@@ -321,7 +321,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
             // after the class name, maintaining their position before the extends clause.
             if let Some(super_class) = &super_class {
                 let comments = f.context().comments().comments_before(super_class.span().start);
-                if comments.iter().any(|c| f.comments().is_own_line_comment(c)) {
+                if comments.iter().any(|c| c.preceded_by_newline()) {
                     indent(&FormatTrailingComments::Comments(comments)).fmt(f);
                 }
             }

--- a/crates/oxc_formatter/src/write/decorators.rs
+++ b/crates/oxc_formatter/src/write/decorators.rs
@@ -101,5 +101,5 @@ fn should_expand_decorators<'a>(
     decorators: &AstNode<'a, Vec<'a, Decorator<'a>>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
-    decorators.iter().any(|decorator| f.source_text().lines_after(decorator.span().end) > 0)
+    decorators.iter().any(|decorator| f.source_text().has_newline_after(decorator.span().end))
 }

--- a/crates/oxc_formatter/src/write/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/write/return_or_throw_statement.rs
@@ -123,14 +123,14 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
 
         if leading_comments.iter().any(|comment| {
             (comment.is_block() && source_text.contains_newline(comment.span))
-                || comments.is_end_of_line_comment(comment)
+                || comment.followed_by_newline()
         }) {
             return true;
         }
 
         let is_own_line_comment_or_multi_line_comment = |leading_comments: &[Comment]| {
             leading_comments.iter().any(|comment| {
-                comments.is_own_line_comment(comment)
+                comment.preceded_by_newline()
                     || (comment.is_block() && source_text.contains_newline(comment.span))
             })
         };

--- a/crates/oxc_formatter/src/write/union_type.rs
+++ b/crates/oxc_formatter/src/write/union_type.rs
@@ -61,7 +61,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                     !f.comments().printed_comments().last().is_some_and(|comment| {
                         comment.span.start
                             > alias.type_parameters().map_or(alias.id.span.end, |tp| tp.span.end)
-                            && f.comments().is_end_of_line_comment(comment)
+                            && comment.followed_by_newline()
                     })
                 }
                 AstNodes::TSTypeAssertion(_)
@@ -132,8 +132,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             let (has_own_line_comment, has_end_of_line_comment) =
                 leading_comments.iter().fold((false, false), |(own_line, end_of_line), comment| {
                     (
-                        own_line || f.comments().is_own_line_comment(comment),
-                        end_of_line || f.comments().is_end_of_line_comment(comment),
+                        own_line || comment.preceded_by_newline(),
+                        end_of_line || comment.followed_by_newline(),
                     )
                 });
 


### PR DESCRIPTION
`Comment::preceded_by_newline` is the same as `is_own_line_comment`
`Comment::followed_by_newline` is the same as `is_end_of_line_comment`

This PR removes `is_own_line_comment` and `is_end_of_line_comment` methods, and changes usages to use `Comment::preceded_by_newline` and `Comment::followed_by_newline` to eliminate extra line break checking.