### PR TITLE
refactor(codegen, syntax): move `LineTerminatorSplitter` from codegen to syntax crate

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -1,99 +1,13 @@
-use std::{borrow::Cow, iter::FusedIterator};
+use std::borrow::Cow;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::{Comment, CommentKind, ast::Program};
-use oxc_syntax::identifier::is_line_terminator;
+use oxc_syntax::{identifier::is_line_terminator, line_terminator::LineTerminatorSplitter};
 
-use crate::{
-    Codegen, LegalComment,
-    options::CommentOptions,
-    str::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES},
-};
+use crate::{Codegen, LegalComment, options::CommentOptions};
 
 pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
-
-/// Custom iterator that splits text on line terminators while handling CRLF as a single unit.
-/// This avoids creating empty strings between CR and LF characters.
-///
-/// Also splits on irregular line breaks (LS and PS).
-///
-/// # Example
-/// Standard split would turn `"line1\r\nline2"` into `["line1", "", "line2"]` because
-/// it treats `\r` and `\n` as separate terminators. This iterator correctly produces
-/// `["line1", "line2"]` by treating `\r\n` as a single terminator.
-struct LineTerminatorSplitter<'a> {
-    text: &'a str,
-}
-
-impl<'a> LineTerminatorSplitter<'a> {
-    fn new(text: &'a str) -> Self {
-        Self { text }
-    }
-}
-
-impl<'a> Iterator for LineTerminatorSplitter<'a> {
-    type Item = &'a str;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.text.is_empty() {
-            return None;
-        }
-
-        for (index, &byte) in self.text.as_bytes().iter().enumerate() {
-            match byte {
-                b'\n' => {
-                    // SAFETY: Byte at `index` is `\n`, so `index` and `index + 1` are both UTF-8 char boundaries.
-                    // Therefore, slices up to `index` and from `index + 1` are both valid `&str`s.
-                    unsafe {
-                        let line = self.text.get_unchecked(..index);
-                        self.text = self.text.get_unchecked(index + 1..);
-                        return Some(line);
-                    }
-                }
-                b'\r' => {
-                    // SAFETY: Byte at `index` is `\r`, so `index` is on a UTF-8 char boundary
-                    let line = unsafe { self.text.get_unchecked(..index) };
-                    // If the next byte is `\n`, consume it as well
-                    let skip_bytes =
-                        if self.text.as_bytes().get(index + 1) == Some(&b'\n') { 2 } else { 1 };
-                    // SAFETY: `index + skip_bytes` is after `\r` or `\n`, so on a UTF-8 char boundary.
-                    // Therefore slice from `index + skip_bytes` is a valid `&str`.
-                    self.text = unsafe { self.text.get_unchecked(index + skip_bytes..) };
-                    return Some(line);
-                }
-                LS_OR_PS_FIRST_BYTE => {
-                    let next2: [u8; 2] = {
-                        // SAFETY: 0xE2 is always the start of a 3-byte Unicode character,
-                        // so there must be 2 more bytes available to consume
-                        let next2 =
-                            unsafe { self.text.as_bytes().get_unchecked(index + 1..index + 3) };
-                        next2.try_into().unwrap()
-                    };
-                    // If this is LS or PS, treat it as a line terminator
-                    if matches!(next2, LS_LAST_2_BYTES | PS_LAST_2_BYTES) {
-                        // SAFETY: `index` is the start of a 3-byte Unicode character,
-                        // so `index` and `index + 3` are both UTF-8 char boundaries.
-                        // Therefore, slices up to `index` and from `index + 3` are both valid `&str`s.
-                        unsafe {
-                            let line = self.text.get_unchecked(..index);
-                            self.text = self.text.get_unchecked(index + 3..);
-                            return Some(line);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // No line break found - return the remaining text. Next call will return `None`.
-        let line = self.text;
-        self.text = "";
-        Some(line)
-    }
-}
-
-impl FusedIterator for LineTerminatorSplitter<'_> {}
 
 impl Codegen<'_> {
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -2,9 +2,10 @@ use std::path::Path;
 
 use oxc_index::{IndexVec, define_nonmax_u32_index_type};
 use oxc_span::Span;
-use oxc_syntax::identifier::{LS, PS};
-
-use crate::str::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES};
+use oxc_syntax::{
+    identifier::{LS, PS},
+    line_terminator::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES},
+};
 
 /// Number of lines to check with linear search when translating byte position to line index
 const LINE_SEARCH_LINEAR_ITERATIONS: usize = 16;

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -2,7 +2,10 @@ use std::slice;
 
 use oxc_ast::ast::StringLiteral;
 use oxc_data_structures::{assert_unchecked, slice_iter::SliceIter};
-use oxc_syntax::identifier::{LS, NBSP, PS};
+use oxc_syntax::{
+    identifier::NBSP,
+    line_terminator::{LS_LAST_2_BYTES, PS_LAST_2_BYTES},
+};
 
 use crate::Codegen;
 
@@ -292,22 +295,6 @@ const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
     ch.encode_utf8(&mut bytes);
     bytes
 }
-
-/// `LS` character as UTF-8 bytes.
-const LS_BYTES: [u8; 3] = to_bytes(LS);
-/// `PS` character as UTF-8 bytes.
-const PS_BYTES: [u8; 3] = to_bytes(PS);
-
-/// First byte of either `LS` or `PS`
-pub const LS_OR_PS_FIRST_BYTE: u8 = 0xE2;
-
-const _: () = assert!(LS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
-const _: () = assert!(PS_BYTES[0] == LS_OR_PS_FIRST_BYTE);
-
-/// Last 2 bytes of `LS` character.
-pub const LS_LAST_2_BYTES: [u8; 2] = [LS_BYTES[1], LS_BYTES[2]];
-/// Last 2 bytes of `PS` character.
-pub const PS_LAST_2_BYTES: [u8; 2] = [PS_BYTES[1], PS_BYTES[2]];
 
 /// `NBSP` character as UTF-8 bytes.
 const NBSP_BYTES: [u8; 2] = to_bytes(NBSP);

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -10,6 +10,7 @@ pub mod comment_node;
 pub mod es_target;
 pub mod identifier;
 pub mod keyword;
+pub mod line_terminator;
 pub mod module_record;
 pub mod node;
 pub mod number;

--- a/crates/oxc_syntax/src/line_terminator.rs
+++ b/crates/oxc_syntax/src/line_terminator.rs
@@ -1,0 +1,111 @@
+//! Line terminator utilities.
+//!
+//! ## References
+//! - [12.3 Line Terminators](https://tc39.es/ecma262/#sec-line-terminators)
+use std::iter::FusedIterator;
+
+use crate::identifier::{LS, PS};
+
+/// Convert `char` to UTF-8 bytes array.
+const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
+    assert!(ch.len_utf8() == N);
+    let mut bytes = [0u8; N];
+    ch.encode_utf8(&mut bytes);
+    bytes
+}
+
+/// `LS` character as UTF-8 bytes.
+const LS_BYTES: [u8; 3] = to_bytes(LS);
+/// `PS` character as UTF-8 bytes.
+const PS_BYTES: [u8; 3] = to_bytes(PS);
+
+/// First byte of either `LS` or `PS`
+pub const LS_OR_PS_FIRST_BYTE: u8 = 0xE2;
+
+/// Last 2 bytes of `LS` character.
+pub const LS_LAST_2_BYTES: [u8; 2] = [LS_BYTES[1], LS_BYTES[2]];
+/// Last 2 bytes of `PS` character.
+pub const PS_LAST_2_BYTES: [u8; 2] = [PS_BYTES[1], PS_BYTES[2]];
+
+/// Custom iterator that splits text on line terminators while handling CRLF as a single unit.
+/// This avoids creating empty strings between CR and LF characters.
+///
+/// Also splits on irregular line breaks (LS and PS).
+///
+/// # Example
+/// Standard split would turn `"line1\r\nline2"` into `["line1", "", "line2"]` because
+/// it treats `\r` and `\n` as separate terminators. This iterator correctly produces
+/// `["line1", "line2"]` by treating `\r\n` as a single terminator.
+pub struct LineTerminatorSplitter<'a> {
+    text: &'a str,
+}
+
+impl<'a> LineTerminatorSplitter<'a> {
+    /// Creates a new `LineTerminatorSplitter` for the given string.
+    pub fn new(text: &'a str) -> Self {
+        Self { text }
+    }
+}
+
+impl<'a> Iterator for LineTerminatorSplitter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.text.is_empty() {
+            return None;
+        }
+
+        for (index, &byte) in self.text.as_bytes().iter().enumerate() {
+            match byte {
+                b'\n' => {
+                    // SAFETY: Byte at `index` is `\n`, so `index` and `index + 1` are both UTF-8 char boundaries.
+                    // Therefore, slices up to `index` and from `index + 1` are both valid `&str`s.
+                    unsafe {
+                        let line = self.text.get_unchecked(..index);
+                        self.text = self.text.get_unchecked(index + 1..);
+                        return Some(line);
+                    }
+                }
+                b'\r' => {
+                    // SAFETY: Byte at `index` is `\r`, so `index` is on a UTF-8 char boundary
+                    let line = unsafe { self.text.get_unchecked(..index) };
+                    // If the next byte is `\n`, consume it as well
+                    let skip_bytes =
+                        if self.text.as_bytes().get(index + 1) == Some(&b'\n') { 2 } else { 1 };
+                    // SAFETY: `index + skip_bytes` is after `\r` or `\n`, so on a UTF-8 char boundary.
+                    // Therefore slice from `index + skip_bytes` is a valid `&str`.
+                    self.text = unsafe { self.text.get_unchecked(index + skip_bytes..) };
+                    return Some(line);
+                }
+                LS_OR_PS_FIRST_BYTE => {
+                    let next2: [u8; 2] = {
+                        // SAFETY: 0xE2 is always the start of a 3-byte Unicode character,
+                        // so there must be 2 more bytes available to consume
+                        let next2 =
+                            unsafe { self.text.as_bytes().get_unchecked(index + 1..index + 3) };
+                        next2.try_into().unwrap()
+                    };
+                    // If this is LS or PS, treat it as a line terminator
+                    if matches!(next2, LS_LAST_2_BYTES | PS_LAST_2_BYTES) {
+                        // SAFETY: `index` is the start of a 3-byte Unicode character,
+                        // so `index` and `index + 3` are both UTF-8 char boundaries.
+                        // Therefore, slices up to `index` and from `index + 3` are both valid `&str`s.
+                        unsafe {
+                            let line = self.text.get_unchecked(..index);
+                            self.text = self.text.get_unchecked(index + 3..);
+                            return Some(line);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // No line break found - return the remaining text. Next call will return `None`.
+        let line = self.text;
+        self.text = "";
+        Some(line)
+    }
+}
+
+impl FusedIterator for LineTerminatorSplitter<'_> {}


### PR DESCRIPTION
`LineTerminatorSplitter` is useful in formatter, so move it to syntax, so that we can reuse in the other crates