### PR TITLE
refactor(syntax): move line terminator related variables/methods from identifier to `line_terminator` module

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::{Comment, CommentKind, ast::Program};
-use oxc_syntax::{identifier::is_line_terminator, line_terminator::LineTerminatorSplitter};
+use oxc_syntax::line_terminator::{LineTerminatorSplitter, is_line_terminator};
 
 use crate::{Codegen, LegalComment, options::CommentOptions};
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -2,10 +2,7 @@ use std::path::Path;
 
 use oxc_index::{IndexVec, define_nonmax_u32_index_type};
 use oxc_span::Span;
-use oxc_syntax::{
-    identifier::{LS, PS},
-    line_terminator::{LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS_LAST_2_BYTES},
-};
+use oxc_syntax::line_terminator::{LS, LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS, PS_LAST_2_BYTES};
 
 /// Number of lines to check with linear search when translating byte position to line index
 const LINE_SEARCH_LINEAR_ITERATIONS: usize = 16;

--- a/crates/oxc_ecmascript/src/string_to_number.rs
+++ b/crates/oxc_ecmascript/src/string_to_number.rs
@@ -1,4 +1,4 @@
-use oxc_syntax::identifier::{is_line_terminator, is_white_space};
+use oxc_syntax::{identifier::is_white_space, line_terminator::is_line_terminator};
 
 pub trait StringToNumber {
     fn string_to_number(&self) -> f64;

--- a/crates/oxc_formatter/src/formatter/source_text.rs
+++ b/crates/oxc_formatter/src/formatter/source_text.rs
@@ -1,7 +1,10 @@
 use std::ops::Deref;
 
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::identifier::{CR, LF, is_line_terminator, is_white_space_single_line};
+use oxc_syntax::{
+    identifier::is_white_space_single_line,
+    line_terminator::{CR, LF, is_line_terminator},
+};
 
 use super::Comments;
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::{identifier::is_line_terminator, operator::BinaryOperator};
+use oxc_syntax::{line_terminator::is_line_terminator, operator::BinaryOperator};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -1,6 +1,6 @@
 use memchr::memmem::Finder;
 
-use oxc_syntax::identifier::is_line_terminator;
+use oxc_syntax::line_terminator::is_line_terminator;
 
 use crate::diagnostics;
 

--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -1,4 +1,4 @@
-use oxc_syntax::identifier::is_line_terminator;
+use oxc_syntax::line_terminator::is_line_terminator;
 
 use crate::diagnostics;
 

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -2,13 +2,15 @@ use std::{borrow::Cow, fmt::Write};
 
 use cow_utils::CowUtils;
 
-use oxc_allocator::StringBuilder;
-use oxc_syntax::identifier::{
-    CR, FF, LF, LS, PS, TAB, VT, is_identifier_part, is_identifier_start,
-    is_identifier_start_unicode, is_irregular_line_terminator, is_irregular_whitespace,
-};
-
 use crate::diagnostics;
+use oxc_allocator::StringBuilder;
+use oxc_syntax::{
+    identifier::{
+        FF, TAB, VT, is_identifier_part, is_identifier_start, is_identifier_start_unicode,
+        is_irregular_whitespace,
+    },
+    line_terminator::{CR, LF, LS, PS, is_irregular_line_terminator},
+};
 
 use super::{Kind, Lexer, Span};
 

--- a/crates/oxc_syntax/src/identifier.rs
+++ b/crates/oxc_syntax/src/identifier.rs
@@ -4,6 +4,8 @@ use unicode_id_start::{is_id_continue_unicode, is_id_start_unicode};
 
 use oxc_data_structures::assert_unchecked;
 
+use crate::line_terminator::{CR, LF, LS, PS};
+
 pub const EOF: char = '\0';
 
 // 11.1 Unicode Format-Control Characters
@@ -79,32 +81,6 @@ pub fn is_white_space_single_line(c: char) -> bool {
     // Note: nextLine is in the Zs space, and should be considered to be a whitespace.
     // It is explicitly not a line-break as it isn't in the exact set specified by EcmaScript.
     matches!(c, SP | TAB) || is_irregular_whitespace(c)
-}
-
-// 11.3 Line Terminators
-
-///  U+000A LINE FEED, abbreviated in the spec as `<LF>`.
-pub const LF: char = '\u{a}';
-
-/// U+000D CARRIAGE RETURN, abbreviated in the spec as `<CR>`.
-pub const CR: char = '\u{d}';
-
-/// U+2028 LINE SEPARATOR, abbreviated `<LS>`.
-pub const LS: char = '\u{2028}';
-
-/// U+2029 PARAGRAPH SEPARATOR, abbreviated `<PS>`.
-pub const PS: char = '\u{2029}';
-
-pub fn is_regular_line_terminator(c: char) -> bool {
-    matches!(c, LF | CR)
-}
-
-pub fn is_irregular_line_terminator(c: char) -> bool {
-    matches!(c, LS | PS)
-}
-
-pub fn is_line_terminator(c: char) -> bool {
-    is_regular_line_terminator(c) || is_irregular_line_terminator(c)
 }
 
 const XX: bool = true;

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -1,5 +1,4 @@
 //! Common code for JavaScript Syntax
-#![warn(missing_docs)]
 
 use std::num::NonZeroU32;
 

--- a/crates/oxc_syntax/src/line_terminator.rs
+++ b/crates/oxc_syntax/src/line_terminator.rs
@@ -4,7 +4,32 @@
 //! - [12.3 Line Terminators](https://tc39.es/ecma262/#sec-line-terminators)
 use std::iter::FusedIterator;
 
-use crate::identifier::{LS, PS};
+/// U+000A LINE FEED, abbreviated in the spec as `<LF>`.
+pub const LF: char = '\u{a}';
+
+/// U+000D CARRIAGE RETURN, abbreviated in the spec as `<CR>`.
+pub const CR: char = '\u{d}';
+
+/// U+2028 LINE SEPARATOR, abbreviated `<LS>`.
+pub const LS: char = '\u{2028}';
+
+/// U+2029 PARAGRAPH SEPARATOR, abbreviated `<PS>`.
+pub const PS: char = '\u{2029}';
+
+/// Checks if the character is a regular line terminator (`LF` or `CR`).
+pub fn is_regular_line_terminator(c: char) -> bool {
+    matches!(c, LF | CR)
+}
+
+/// Checks if the character is an irregular line terminator (`LS` or `PS`).
+pub fn is_irregular_line_terminator(c: char) -> bool {
+    matches!(c, LS | PS)
+}
+
+/// Checks if the character is any line terminator (`LF`, `CR`, `LS`, or `PS`).
+pub fn is_line_terminator(c: char) -> bool {
+    is_regular_line_terminator(c) || is_irregular_line_terminator(c)
+}
 
 /// Convert `char` to UTF-8 bytes array.
 const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -95,10 +95,8 @@ use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
 use oxc_span::{Atom, SPAN, Span};
 use oxc_syntax::{
-    identifier::{is_line_terminator, is_white_space_single_line},
-    reference::ReferenceFlags,
-    symbol::SymbolFlags,
-    xml_entities::XML_ENTITIES,
+    identifier::is_white_space_single_line, line_terminator::is_line_terminator,
+    reference::ReferenceFlags, symbol::SymbolFlags, xml_entities::XML_ENTITIES,
 };
 use oxc_traverse::{BoundIdentifier, Traverse};
 


### PR DESCRIPTION
Now, we have a `line_terminator` module, so moving line terminator-related variables and methods to their own module would be better for maintainability.