### PR TITLE
test(linter/plugins): remove extraneous code from `RuleTester` tests

### DIFF
--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -113,24 +113,20 @@ describe("RuleTester", () => {
         "valid code string",
         {
           code: "valid code from object",
-          options: [],
         },
         {
           name: "valid case name",
           code: "let x = 1;",
-          options: [],
         },
       ],
       invalid: [
         {
           code: "invalid code from object",
-          options: [],
           errors: 1,
         },
         {
           name: "invalid case name",
           code: "let x = 1;",
-          options: [],
           errors: 1,
         },
       ],


### PR DESCRIPTION
Nit: These `options` properties aren't necessary for the test, so it's confusing that they're there. Remove them.