### PR TITLE
chore(linter): remove unused builtin `regex` plugin

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -317,10 +317,6 @@ pub struct EnablePlugins {
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub node_plugin: OverrideToggle,
 
-    /// Enable the regex plugin and detect regex usage problems
-    #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
-    pub regex_plugin: OverrideToggle,
-
     /// Enable the vue plugin and detect vue usage problems
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub vue_plugin: OverrideToggle,
@@ -398,7 +394,6 @@ impl EnablePlugins {
         self.react_perf_plugin.inspect(|yes| plugins.set(LintPlugins::REACT_PERF, yes));
         self.promise_plugin.inspect(|yes| plugins.set(LintPlugins::PROMISE, yes));
         self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
-        self.regex_plugin.inspect(|yes| plugins.set(LintPlugins::REGEX, yes));
         self.vue_plugin.inspect(|yes| plugins.set(LintPlugins::VUE, yes));
 
         // Without this, jest plugins adapted to vitest will not be enabled.

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -384,7 +384,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "regex", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -78,10 +78,8 @@ bitflags! {
         const PROMISE = 1 << 11;
         /// `eslint-plugin-node`
         const NODE = 1 << 12;
-        /// `eslint-plugin-regex`
-        const REGEX = 1 << 13;
         /// `eslint-plugin-vue`
-        const VUE = 1 << 14;
+        const VUE = 1 << 13;
     }
 }
 
@@ -145,7 +143,6 @@ impl TryFrom<&str> for LintPlugins {
             "react-perf" | "react_perf" => Ok(LintPlugins::REACT_PERF),
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
-            "regex" => Ok(LintPlugins::REGEX),
             "vue" => Ok(LintPlugins::VUE),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
@@ -171,7 +168,6 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::REACT_PERF => "react-perf",
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
-            LintPlugins::REGEX => "regex",
             LintPlugins::VUE => "vue",
             _ => "",
         }
@@ -243,7 +239,6 @@ impl JsonSchema for LintPlugins {
             ReactPerf,
             Promise,
             Node,
-            Regex,
             Vue,
         }
 

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -343,7 +343,6 @@ expression: json
         "react-perf",
         "promise",
         "node",
-        "regex",
         "vue"
       ]
     },

--- a/justfile
+++ b/justfile
@@ -170,7 +170,6 @@ new-react-perf-rule name: (new-rule name "react-perf")
 new-n-rule name: (new-rule name "n")
 new-promise-rule name: (new-rule name "promise")
 new-vitest-rule name: (new-rule name "vitest")
-new-regexp-rule name: (new-rule name "regexp")
 new-vue-rule name: (new-rule name "vue")
 
 # Alias for backward compatibility

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -339,7 +339,6 @@
         "react-perf",
         "promise",
         "node",
-        "regex",
         "vue"
       ]
     },

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -86,10 +86,6 @@ const VITEST_TEST_PATH: &str =
 const VITEST_RULES_PATH: &str =
     "https://raw.githubusercontent.com/veritem/eslint-plugin-vitest/main/src/rules";
 
-const REGEXP_TEST_PATH: &str = "https://raw.githubusercontent.com/ota-meshi/eslint-plugin-regexp/refs/heads/master/tests/lib/rules";
-const REGEXP_RULES_PATH: &str =
-    "https://raw.githubusercontent.com/ota-meshi/eslint-plugin-regexp/refs/heads/master/lib/rules";
-
 const VUE_TEST_PATH: &str =
     "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules/";
 const VUE_RULES_PATH: &str =
@@ -1335,7 +1331,6 @@ pub enum RuleKind {
     Node,
     Promise,
     Vitest,
-    Regexp,
     Vue,
 }
 
@@ -1358,7 +1353,6 @@ impl TryFrom<&str> for RuleKind {
             "n" => Ok(Self::Node),
             "promise" => Ok(Self::Promise),
             "vitest" => Ok(Self::Vitest),
-            "regexp" => Ok(Self::Regexp),
             "vue" => Ok(Self::Vue),
             _ => Err(format!("Invalid `RuleKind`, got `{value}`")),
         }
@@ -1382,7 +1376,6 @@ impl Display for RuleKind {
             Self::Node => "eslint-plugin-n",
             Self::Promise => "eslint-plugin-promise",
             Self::Vitest => "eslint-plugin-vitest",
-            Self::Regexp => "eslint-plugin-regexp",
             Self::Vue => "eslint-plugin-vue",
         };
         f.write_str(kind_name)
@@ -1414,7 +1407,6 @@ fn main() {
         RuleKind::Node => format!("{NODE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Promise => format!("{PROMISE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Vitest => format!("{VITEST_TEST_PATH}/{kebab_rule_name}.test.ts"),
-        RuleKind::Regexp => format!("{REGEXP_TEST_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Vue => format!("{VUE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
     };
@@ -1432,7 +1424,6 @@ fn main() {
         RuleKind::Node => format!("{NODE_RULES_PATH}/{kebab_rule_name}.js"),
         RuleKind::Promise => format!("{PROMISE_RULES_PATH}/{kebab_rule_name}.js"),
         RuleKind::Vitest => format!("{VITEST_RULES_PATH}/{kebab_rule_name}.ts"),
-        RuleKind::Regexp => format!("{REGEXP_RULES_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Vue => format!("{VUE_RULES_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
     };
@@ -1638,7 +1629,6 @@ fn get_mod_name(rule_kind: RuleKind) -> String {
         RuleKind::Promise => "promise".into(),
         RuleKind::Vitest => "vitest".into(),
         RuleKind::Node => "node".into(),
-        RuleKind::Regexp => "regexp".into(),
         RuleKind::Vue => "vue".into(),
     }
 }

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -44,7 +44,6 @@ impl<'a> Template<'a> {
             RuleKind::Node => Path::new("crates/oxc_linter/src/rules/node"),
             RuleKind::Promise => Path::new("crates/oxc_linter/src/rules/promise"),
             RuleKind::Vitest => Path::new("crates/oxc_linter/src/rules/vitest"),
-            RuleKind::Regexp => Path::new("crates/oxc_linter/src/rules/regexp"),
             RuleKind::Vue => Path::new("crates/oxc_linter/src/rules/vue"),
         };
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -1,5 +1,5 @@
 ---
-source: tasks/website/src/linter/cli.rs
+source: tasks/website_linter/src/cli.rs
 expression: snapshot
 ---
 ---
@@ -78,8 +78,6 @@ Arguments:
   Enable the promise plugin and detect promise usage problems
 - **`    --node-plugin`** &mdash; 
   Enable the node plugin and detect node usage problems
-- **`    --regex-plugin`** &mdash; 
-  Enable the regex plugin and detect regex usage problems
 - **`    --vue-plugin`** &mdash; 
   Enable the vue plugin and detect vue usage problems
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -1,5 +1,5 @@
 ---
-source: tasks/website/src/linter/cli.rs
+source: tasks/website_linter/src/cli.rs
 expression: snapshot
 ---
 Usage: [-c=<./.oxlintrc.json>] [PATH]...
@@ -47,7 +47,6 @@ Enable/Disable Plugins
                               problems
         --promise-plugin      Enable the promise plugin and detect promise usage problems
         --node-plugin         Enable the node plugin and detect node usage problems
-        --regex-plugin        Enable the regex plugin and detect regex usage problems
         --vue-plugin          Enable the vue plugin and detect vue usage problems
 
 Fix Problems


### PR DESCRIPTION
Closes #11439

6 months after adding opening the eslint plugin regex issue, and adding
support for regex rules in rule gen, we have implemented none of the
regex rule. Given this, and the fact that these rules can be implemented
via JS plugins, it makes a the most sense to remove support for this
plugin.

cc @connorshea 