### PR TITLE
chore(linter): replaces docs column with hyperlinked name

### DIFF
--- a/tasks/lint_rules/src/markdown-renderer.mjs
+++ b/tasks/lint_rules/src/markdown-renderer.mjs
@@ -72,15 +72,15 @@ const renderRulesList = ({ title, counters, views, defaultOpen = true }) => `
   ✅: ${counters.isImplemented}, 🚫: ${counters.isNotSupported}, ⏳: ${counters.isPendingFix} / total: ${counters.total}
 </summary>
 
-| Status | Name | Docs |
-| :----: | :--- | :--- |
+| Status | Name |
+| :----: | :--- |
 ${views
   .map((v) => {
     let status = "";
     if (v.isImplemented) status += "✅";
     if (v.isNotSupported) status += "🚫";
     if (v.isPendingFix) status += "⏳";
-    return `| ${status} | ${v.name} | ${v.docsUrl} |`;
+    return `| ${status} | [${v.name}](${v.docsUrl}) |`;
   })
   .join("\n")}
 


### PR DESCRIPTION
> Make the name of each rule a hyperlink to that rule's docs
> The full links in the "Docs" column take up a lot of space


See: https://github.com/oxc-project/oxc/issues/15927