### PR TITLE
test(linter/plugins): shorten code in `SourceCode` test fixture

### DIFF
--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -16,14 +16,15 @@ const SPAN: Node = {
 
 const createRule: Rule = {
   create(context) {
-    const { ast, lines, text } = context.sourceCode;
+    const { sourceCode } = context,
+      { ast, lines, text } = sourceCode;
 
-    assert(context.getSourceCode() === context.sourceCode);
+    assert(context.getSourceCode() === sourceCode);
 
     let locs = "";
     for (let offset = 0; offset <= text.length; offset++) {
-      const loc = context.sourceCode.getLocFromIndex(offset);
-      assert(context.sourceCode.getIndexFromLoc(loc) === offset);
+      const loc = sourceCode.getLocFromIndex(offset);
+      assert(sourceCode.getIndexFromLoc(loc) === offset);
       locs +=
         `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
         `(${JSON.stringify(text[offset] || "<EOF>")})`;
@@ -33,12 +34,12 @@ const createRule: Rule = {
       message:
         "create:\n" +
         `text: ${JSON.stringify(text)}\n` +
-        `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
+        `getText(): ${JSON.stringify(sourceCode.getText())}\n` +
         `lines: ${JSON.stringify(lines)}\n` +
         `locs:${locs}\n` +
         // @ts-ignore
         `ast: "${ast.body[0].declarations[0].id.name}"\n` +
-        `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
+        `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
       node: SPAN,
     });
 
@@ -48,23 +49,23 @@ const createRule: Rule = {
       },
       VariableDeclaration(node) {
         context.report({
-          message: `var decl:\nsource: "${context.sourceCode.getText(node)}"`,
+          message: `var decl:\nsource: "${sourceCode.getText(node)}"`,
           node,
         });
       },
       Identifier(node) {
-        const startLoc = context.sourceCode.getLocFromIndex(node.start);
-        const endLoc = context.sourceCode.getLocFromIndex(node.end);
-        assert(context.sourceCode.getIndexFromLoc(startLoc) === node.start);
-        assert(context.sourceCode.getIndexFromLoc(endLoc) === node.end);
+        const startLoc = sourceCode.getLocFromIndex(node.start);
+        const endLoc = sourceCode.getLocFromIndex(node.end);
+        assert(sourceCode.getIndexFromLoc(startLoc) === node.start);
+        assert(sourceCode.getIndexFromLoc(endLoc) === node.end);
 
         context.report({
           message:
             `ident "${node.name}":\n` +
-            `source: "${context.sourceCode.getText(node)}"\n` +
-            `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
-            `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
-            `source with both: "${context.sourceCode.getText(node, 2, 1)}"\n` +
+            `source: "${sourceCode.getText(node)}"\n` +
+            `source with before: "${sourceCode.getText(node, 2)}"\n` +
+            `source with after: "${sourceCode.getText(node, null, 1)}"\n` +
+            `source with both: "${sourceCode.getText(node, 2, 1)}"\n` +
             `start loc: ${JSON.stringify(startLoc)}\n` +
             `end loc: ${JSON.stringify(endLoc)}`,
           node,
@@ -80,13 +81,14 @@ const createOnceRule: Rule = {
 
     return {
       before() {
-        ast = context.sourceCode.ast;
-        const { lines, text } = context.sourceCode;
+        const { sourceCode } = context;
+        ast = sourceCode.ast;
+        const { lines, text } = sourceCode;
 
         let locs = "";
         for (let offset = 0; offset <= text.length; offset++) {
-          const loc = context.sourceCode.getLocFromIndex(offset);
-          assert(context.sourceCode.getIndexFromLoc(loc) === offset);
+          const loc = sourceCode.getLocFromIndex(offset);
+          assert(sourceCode.getIndexFromLoc(loc) === offset);
           locs +=
             `\n  ${offset} => { line: ${loc.line}, column: ${loc.column} }` +
             `(${JSON.stringify(text[offset] || "<EOF>")})`;
@@ -96,12 +98,12 @@ const createOnceRule: Rule = {
           message:
             "before:\n" +
             `text: ${JSON.stringify(text)}\n` +
-            `getText(): ${JSON.stringify(context.sourceCode.getText())}\n` +
+            `getText(): ${JSON.stringify(sourceCode.getText())}\n` +
             `lines: ${JSON.stringify(lines)}\n` +
             `locs:${locs}\n` +
             // @ts-ignore
             `ast: "${ast.body[0].declarations[0].id.name}"\n` +
-            `visitorKeys: ${context.sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
+            `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
           node: SPAN,
         });
       },
@@ -115,29 +117,33 @@ const createOnceRule: Rule = {
         });
       },
       Identifier(node) {
-        const startLoc = context.sourceCode.getLocFromIndex(node.start);
-        const endLoc = context.sourceCode.getLocFromIndex(node.end);
-        assert(context.sourceCode.getIndexFromLoc(startLoc) === node.start);
-        assert(context.sourceCode.getIndexFromLoc(endLoc) === node.end);
+        const { sourceCode } = context;
+
+        const startLoc = sourceCode.getLocFromIndex(node.start);
+        const endLoc = sourceCode.getLocFromIndex(node.end);
+        assert(sourceCode.getIndexFromLoc(startLoc) === node.start);
+        assert(sourceCode.getIndexFromLoc(endLoc) === node.end);
 
         context.report({
           message:
             `ident "${node.name}":\n` +
-            `source: "${context.sourceCode.getText(node)}"\n` +
-            `source with before: "${context.sourceCode.getText(node, 2)}"\n` +
-            `source with after: "${context.sourceCode.getText(node, null, 1)}"\n` +
-            `source with both: "${context.sourceCode.getText(node, 2, 1)}"\n` +
+            `source: "${sourceCode.getText(node)}"\n` +
+            `source with before: "${sourceCode.getText(node, 2)}"\n` +
+            `source with after: "${sourceCode.getText(node, null, 1)}"\n` +
+            `source with both: "${sourceCode.getText(node, 2, 1)}"\n` +
             `start loc: ${JSON.stringify(startLoc)}\n` +
             `end loc: ${JSON.stringify(endLoc)}`,
           node,
         });
       },
       after() {
-        assert(context.sourceCode.ast === ast);
+        const { sourceCode } = context;
+
+        assert(sourceCode.ast === ast);
         ast = null;
 
         context.report({
-          message: "after:\n" + `source: ${JSON.stringify(context.sourceCode.text)}`,
+          message: "after:\n" + `source: ${JSON.stringify(sourceCode.text)}`,
           node: SPAN,
         });
       },


### PR DESCRIPTION
Pure refactor of tests. Shorten code by putting `sourceCode` in a local var, rather than repeating `context.sourceCode` over and over.