### PR TITLE
feat(linter/plugins): add `SourceCode#isESTree` property

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -143,6 +143,12 @@ export const SOURCE_CODE = Object.freeze({
   },
 
   /**
+   * `true` if the AST is in ESTree format.
+   */
+  // This property is present in ESLint's `SourceCode`, but is undocumented
+  isESTree: true,
+
+  /**
    * `ScopeManager` for the file.
    */
   get scopeManager(): ScopeManager {

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -36,6 +36,7 @@
   |   25 => { line: 5, column: 0 }("<EOF>")
   | ast: "foo"
   | visitorKeys: left, right
+  | isESTree: true
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -83,6 +84,7 @@
   |   25 => { line: 5, column: 0 }("<EOF>")
   | ast: "foo"
   | visitorKeys: left, right
+  | isESTree: true
    ,-[files/1.js:1:1]
  1 | let foo, bar;
    : ^
@@ -174,6 +176,7 @@
   |   9 => { line: 2, column: 0 }("<EOF>")
   | ast: "qux"
   | visitorKeys: left, right
+  | isESTree: true
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^
@@ -203,6 +206,7 @@
   |   9 => { line: 2, column: 0 }("<EOF>")
   | ast: "qux"
   | visitorKeys: left, right
+  | isESTree: true
    ,-[files/2.js:1:1]
  1 | let qux;
    : ^

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -39,7 +39,8 @@ const createRule: Rule = {
         `locs:${locs}\n` +
         // @ts-ignore
         `ast: "${ast.body[0].declarations[0].id.name}"\n` +
-        `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
+        `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}\n` +
+        `isESTree: ${sourceCode.isESTree}`,
       node: SPAN,
     });
 
@@ -103,7 +104,8 @@ const createOnceRule: Rule = {
             `locs:${locs}\n` +
             // @ts-ignore
             `ast: "${ast.body[0].declarations[0].id.name}"\n` +
-            `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}`,
+            `visitorKeys: ${sourceCode.visitorKeys.BinaryExpression.join(", ")}\n` +
+            `isESTree: ${sourceCode.isESTree}`,
           node: SPAN,
         });
       },


### PR DESCRIPTION
Add `isESTree` property to `SourceCode`. ESLint's has this property, though it's undocumented.