### PR TITLE
feat(ast, parser, linter, codegen, formatter)!: rename `CommentKind::Block` to `CommentKind::SinglelineBlock`

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -15,8 +15,9 @@ pub enum CommentKind {
     /// Line comment
     #[default]
     Line = 0,
-    /// Block comment
-    Block = 1,
+    /// Singleline comment
+    #[estree(rename = "Block")]
+    SinglelineBlock = 1,
     /// Multiline block comment (contains line breaks)
     #[estree(rename = "Block")]
     MultilineBlock = 2,
@@ -175,7 +176,7 @@ impl Comment {
     pub fn content_span(&self) -> Span {
         match self.kind {
             CommentKind::Line => Span::new(self.span.start + 2, self.span.end),
-            CommentKind::Block | CommentKind::MultilineBlock => {
+            CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
                 Span::new(self.span.start + 2, self.span.end - 2)
             }
         }
@@ -187,10 +188,10 @@ impl Comment {
         self.kind == CommentKind::Line
     }
 
-    /// Returns `true` if this is a block comment.
+    /// Returns `true` if this is a singleline or multiline block comment.
     #[inline]
     pub fn is_block(self) -> bool {
-        matches!(self.kind, CommentKind::Block | CommentKind::MultilineBlock)
+        matches!(self.kind, CommentKind::SinglelineBlock | CommentKind::MultilineBlock)
     }
 
     /// Returns `true` if this is a multi-line block comment.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3233,7 +3233,7 @@ impl ESTree for CommentKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::Line => JsonSafeString("Line").serialize(serializer),
-            Self::Block => JsonSafeString("Block").serialize(serializer),
+            Self::SinglelineBlock => JsonSafeString("Block").serialize(serializer),
             Self::MultilineBlock => JsonSafeString("Block").serialize(serializer),
         }
     }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -225,9 +225,11 @@ mod test {
 
     #[test]
     fn test_is_inside_comment() {
-        let comments =
-            vec![Comment::new(0, 4, CommentKind::Line), Comment::new(10, 20, CommentKind::Block)]
-                .into_boxed_slice();
+        let comments = vec![
+            Comment::new(0, 4, CommentKind::Line),
+            Comment::new(10, 20, CommentKind::SinglelineBlock),
+        ]
+        .into_boxed_slice();
 
         assert!(is_inside_comment(&comments, 2));
         assert!(!is_inside_comment(&comments, 5));
@@ -237,9 +239,11 @@ mod test {
 
     #[test]
     fn test_get_comment_at() {
-        let comments =
-            vec![Comment::new(0, 4, CommentKind::Line), Comment::new(10, 20, CommentKind::Block)]
-                .into_boxed_slice();
+        let comments = vec![
+            Comment::new(0, 4, CommentKind::Line),
+            Comment::new(10, 20, CommentKind::SinglelineBlock),
+        ]
+        .into_boxed_slice();
 
         // Inside first comment
         let comment = get_comment_at(&comments, 2);

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -128,7 +128,7 @@ impl Codegen<'_> {
         };
         let comment_source = comment.span.source_text(source_text);
         match comment.kind {
-            CommentKind::Line | CommentKind::Block => {
+            CommentKind::Line | CommentKind::SinglelineBlock => {
                 self.print_str_escaping_script_close_tag(comment_source);
             }
             CommentKind::MultilineBlock => {

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -111,7 +111,7 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
                 write!(f, comment);
 
                 match comment.kind {
-                    CommentKind::Block | CommentKind::MultilineBlock => {
+                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
                         match f.source_text().lines_after(comment.span.end) {
                             0 => {
                                 let should_nestle =

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -174,7 +174,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                                         let single_line_comment: String = format!("//{comment}\n");
                                         comments_vec.push(single_line_comment);
                                     }
-                                    CommentKind::Block | CommentKind::MultilineBlock => {
+                                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
                                         let multi_line_comment: String = format!("/*{comment}*/\n");
                                         comments_vec.push(multi_line_comment);
                                     }

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -33,7 +33,9 @@ pub fn convert_utf8_to_utf16(
             Comment {
                 r#type: match comment.kind {
                     CommentKind::Line => String::from("Line"),
-                    CommentKind::Block | CommentKind::MultilineBlock => String::from("Block"),
+                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
+                        String::from("Block")
+                    }
                 },
                 value,
                 start: span.start,

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -154,7 +154,7 @@ impl<'a> Lexer<'a> {
         self.trivia_builder.add_block_comment(
             self.token.start(),
             self.offset(),
-            CommentKind::Block,
+            CommentKind::SinglelineBlock,
             self.source.whole(),
         );
         Kind::Skip

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -334,7 +334,7 @@ mod test {
         let expected = [
             Comment {
                 span: Span::new(9, 24),
-                kind: CommentKind::Block,
+                kind: CommentKind::SinglelineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -350,7 +350,7 @@ mod test {
             },
             Comment {
                 span: Span::new(54, 69),
-                kind: CommentKind::Block,
+                kind: CommentKind::SinglelineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading,
@@ -358,7 +358,7 @@ mod test {
             },
             Comment {
                 span: Span::new(76, 92),
-                kind: CommentKind::Block,
+                kind: CommentKind::SinglelineBlock,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
                 newlines: CommentNewlines::None,
@@ -398,7 +398,7 @@ token /* Trailing 1 */
         let expected = vec![
             Comment {
                 span: Span::new(20, 35),
-                kind: CommentKind::Block,
+                kind: CommentKind::SinglelineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 36,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -406,7 +406,7 @@ token /* Trailing 1 */
             },
             Comment {
                 span: Span::new(42, 58),
-                kind: CommentKind::Block,
+                kind: CommentKind::SinglelineBlock,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
                 newlines: CommentNewlines::Trailing,

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -717,10 +717,10 @@ mod test {
         let source_type = SourceType::default().with_typescript(true);
         let sources = [
             ("// line comment", CommentKind::Line),
-            ("/* line comment */", CommentKind::Block),
+            ("/* line comment */", CommentKind::SinglelineBlock),
             (
                 "type Foo = ( /* Require properties which are not generated automatically. */ 'bar')",
-                CommentKind::Block,
+                CommentKind::SinglelineBlock,
             ),
         ];
         for (source, kind) in sources {


### PR DESCRIPTION
https://github.com/oxc-project/oxc/pull/16479 introduced a new kind called `CommentKind::MultilineBlock`, which means a block comment that has at least one line break. Therefore, `CommentKind::Block` means it is a single-line block.

In this PR, rename `CommentKind::Block` to `CommentKind::SinglelineBlock` to make the kind name more descriptive.