### PR TITLE
ci(pr): label PRs as `A-linter-plugins` if they touch `apps/oxlint/test` directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,7 +32,7 @@ A-linter:
 
 A-linter-plugins:
   - changed-files:
-      - any-glob-to-any-file: ["apps/oxlint/src-js/**"]
+      - any-glob-to-any-file: ["apps/oxlint/src-js/**", "apps/oxlint/test/**"]
 
 A-minifier:
   - changed-files:


### PR DESCRIPTION
These tests almost exclusively relate to JS plugins.