### PR TITLE
refactor(oxlint/lsp): prefill `FixedContent.message` and remove `Option` wrapper

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -126,7 +126,7 @@ impl IsolatedLintHandler {
         let mut messages: Vec<DiagnosticReport> = self
             .runner
             .run_source(&Arc::from(path.as_os_str()), source_text.to_string(), &fs)
-            .iter()
+            .into_iter()
             .map(|message| message_to_lsp_diagnostic(message, uri, source_text, rope))
             .collect();
 
@@ -136,7 +136,7 @@ impl IsolatedLintHandler {
         {
             messages.extend(
                 create_unused_directives_messages(&directives, severity, source_text)
-                    .iter()
+                    .into_iter()
                     .map(|message| message_to_lsp_diagnostic(message, uri, source_text, rope)),
             );
         }

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -496,7 +496,7 @@ impl Tool for ServerLinter {
             let Some(ref code_action) = report.code_action else {
                 continue;
             };
-            let fix_actions = apply_fix_code_actions(code_action, &report.diagnostic.message, uri);
+            let fix_actions = apply_fix_code_actions(code_action, uri);
             code_actions_vec.extend(fix_actions.into_iter().map(CodeActionOrCommand::CodeAction));
         }
 


### PR DESCRIPTION
> This PR refactors the linter's fix message handling by removing the Option wrapper from FixedContent.message and prefilling messages earlier in the processing pipeline. The change simplifies code action generation by moving the fallback message logic from fix_content_to_code_action into message_to_lsp_diagnostic, where fix messages are now populated before being converted to FixedContent.

The goal in the next PR is that the alternative message (from diagnostic) is no longer be stored in memory. So the title should be updated beforehand.