### PR TITLE
feat(oxfmt): Support config for prettier `formatFile()`

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -20,7 +20,8 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
-    "prettier": "3.7.4"
+    "prettier": "3.7.4",
+    "tiny-jsonc": "1.0.2"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -6,8 +6,15 @@ use oxc_formatter::get_supported_source_type;
 use oxc_span::SourceType;
 
 pub enum FormatFileSource {
-    OxcFormatter { path: PathBuf, source_type: SourceType },
-    ExternalFormatter { path: PathBuf, parser_name: &'static str },
+    OxcFormatter {
+        path: PathBuf,
+        source_type: SourceType,
+    },
+    #[cfg_attr(not(feature = "napi"), allow(dead_code))]
+    ExternalFormatter {
+        path: PathBuf,
+        parser_name: &'static str,
+    },
 }
 
 impl TryFrom<PathBuf> for FormatFileSource {

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: ["src-js/index.ts", "src-js/cli.ts"],
@@ -10,5 +11,5 @@ export default defineConfig({
   outDir: "dist",
   shims: false,
   fixedExtension: false,
-  noExternal: ["prettier"],
+  noExternal: Object.keys(pkg.dependencies),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       prettier:
         specifier: 3.7.4
         version: 3.7.4
+      tiny-jsonc:
+        specifier: 1.0.2
+        version: 1.0.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -4018,6 +4021,9 @@ packages:
   textextensions@6.11.0:
     resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
     engines: {node: '>=4'}
+
+  tiny-jsonc@1.0.2:
+    resolution: {integrity: sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8085,6 +8091,8 @@ snapshots:
   textextensions@6.11.0:
     dependencies:
       editions: 6.22.0
+
+  tiny-jsonc@1.0.2: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
- When calling Prettier, pass config file path and read it in JS
  - It is possible because our current config file is almost as-is with Prettier's
- And, since there is only single config, just load it once and cache it
- We don't need to enumerate every field to deserialize with `serde`
  - We have no way of knowing what fields the plugin will define in the first place