### PR TITLE
feat(linter/plugins): add ESLint compat mode to `RuleTester`

### DIFF
--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -816,4 +816,101 @@ describe("RuleTester", () => {
       expect(test.after.mock.contexts[0]).toBe(test);
     }
   });
+
+  describe("ESLint compat mode", () => {
+    it("enabled globally", () => {
+      RuleTester.setDefaultConfig({ eslintCompat: true });
+
+      const tester = new RuleTester();
+      tester.run("no-foo", simpleRule, {
+        valid: [],
+        invalid: [
+          {
+            code: "foo;",
+            errors: [
+              {
+                message: "No foo!",
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4,
+              },
+            ],
+          },
+        ],
+      });
+      expect(runCases()).toEqual([null]);
+    });
+
+    it("enabled in `RuleTester` options", () => {
+      const tester = new RuleTester({ eslintCompat: true });
+      tester.run("no-foo", simpleRule, {
+        valid: [],
+        invalid: [
+          {
+            code: "foo;",
+            errors: [
+              {
+                message: "No foo!",
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4,
+              },
+            ],
+          },
+        ],
+      });
+      expect(runCases()).toEqual([null]);
+    });
+
+    it("enabled in in individual test cases", () => {
+      const tester = new RuleTester();
+      tester.run("no-foo", simpleRule, {
+        valid: [],
+        invalid: [
+          {
+            code: "foo = 1;",
+            // Default: eslintCompat: false
+            errors: [
+              {
+                message: "No foo!",
+                line: 1,
+                column: 0,
+                endLine: 1,
+                endColumn: 3,
+              },
+            ],
+          },
+          {
+            code: "foo = 1;",
+            eslintCompat: false,
+            errors: [
+              {
+                message: "No foo!",
+                line: 1,
+                column: 0,
+                endLine: 1,
+                endColumn: 3,
+              },
+            ],
+          },
+          {
+            code: "foo = 1;",
+            eslintCompat: true,
+            errors: [
+              {
+                message: "No foo!",
+                line: 1,
+                column: 1, // 1 not 0
+                endLine: 1,
+                endColumn: 4, // 4 not 3
+              },
+            ],
+          },
+        ],
+      });
+      expect(runCases()).toEqual([null, null, null]);
+    });
+  });
 });


### PR DESCRIPTION
### The problem

ESLint's `RuleTester` has a really unintutive behavior that it alters the `column` of diagnostics before comparing them to the test case.

This means that, bizarrely, this test fails:

```js
const rule = {
  create(context) {
    return {
      DebuggerStatement(node) {
        context.report({
          message: "No debugger",
          loc: {
            start: {
              line: 1,
              column: 0,
            },
            end: {
              line: 1,
              column: 8,
            },
          },
        });
      },
    };
  },
};

const tester = new RuleTester();

tester.run("no-debugger", rule, {
  valid: [],
  invalid: [{
    code: "debugger;",
    errors: [{
      message: "No debugger",
      line: 1,
      column: 0, // ESLint says this is wrong - should be 1!
      endLine: 1,
      endColumn: 8, // ESLint says this is wrong - should be 9!
    }],
  }],
});
```

### How to handle this?

This behavior is to my mind very unintuitive, and I don't think we want to follow it by default.

However, we want to allow people to be able to copy existing test cases written for ESLint's `RuleTester` when migrating to Oxlint. We also need to copy ESLint's behavior for running the tests of existing ESLint plugins against Oxlint, to avoid spurious test failures due to column mismatches.

### Solution

Add an `eslintCompat` option that replicates ESLint's behavior. The option is disabled by default.

The test above now passes by default. But using `eslintCompat: true`, the test passes when `column` and `endColumn` are provided in ESLint style:

```js
const tester = new RuleTester({
  eslintCompat: true,
});

tester.run("no-debugger", rule, {
  valid: [],
  invalid: [{
    code: "debugger;",
    errors: [{
      message: "No debugger",
      line: 1,
      column: 1, // Correct with `eslintCompat: true`
      endLine: 1,
      endColumn: 9, // Correct with `eslintCompat: true`
    }],
  }],
});
```