### PR TITLE
feat(linter/eslint-plugin-vitest): reuse no-mocks-import jest linter rule

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -7,15 +7,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_mocks_jest_import_diagnostic(span: Span) -> OxcDiagnostic {
+fn no_mocks_import_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Mocks should not be manually imported from a `__mocks__` directory.")
-        .with_help("Instead use `jest.mock` and import from the original module path.")
-        .with_label(span)
-}
-
-fn no_mocks_vitest_import_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Mocks should not be manually imported from a `__mocks__` directory.")
-        .with_help("Instead use `vi.mock` and import from the original module path.")
+        .with_help("Instead use `jest.mock` or `vi.mock` and import from the original module path.")
         .with_label(span)
 }
 
@@ -72,17 +66,7 @@ impl Rule for NoMocksImport {
         for import_entry in &module_records.import_entries {
             let module_specifier = import_entry.module_request.name();
             if contains_mocks_dir(module_specifier) {
-                if ctx.frameworks().is_vitest() {
-                    ctx.diagnostic(no_mocks_vitest_import_diagnostic(
-                        import_entry.module_request.span,
-                    ));
-                }
-
-                if ctx.frameworks().is_jest() {
-                    ctx.diagnostic(no_mocks_jest_import_diagnostic(
-                        import_entry.module_request.span,
-                    ));
-                }
+                ctx.diagnostic(no_mocks_import_diagnostic(import_entry.module_request.span));
             }
         }
 
@@ -103,13 +87,7 @@ impl Rule for NoMocksImport {
             };
 
             if contains_mocks_dir(&string_literal.value) {
-                if ctx.frameworks().is_vitest() {
-                    ctx.diagnostic(no_mocks_vitest_import_diagnostic(string_literal.span));
-                }
-
-                if ctx.frameworks().is_jest() {
-                    ctx.diagnostic(no_mocks_jest_import_diagnostic(string_literal.span));
-                }
+                ctx.diagnostic(no_mocks_import_diagnostic(string_literal.span));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -118,5 +118,6 @@ fn test() {
 
     Tester::new(NoMocksImport::NAME, NoMocksImport::PLUGIN, pass, fail)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -43,6 +43,17 @@ declare_oxc_lint!(
     /// import thing from 'thing';
     /// require('thing');
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-mocks-import": "error"
+    ///   }
+    /// }
+    /// ```
     NoMocksImport,
     jest,
     style

--- a/crates/oxc_linter/src/snapshots/jest_no_mocks_import.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_mocks_import.snap
@@ -6,95 +6,95 @@ source: crates/oxc_linter/src/tester.rs
  1 │ require('./__mocks__')
    ·         ─────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('./__mocks__/')
    ·         ──────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('./__mocks__/index')
    ·         ───────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__')
    ·         ───────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__/')
    ·         ────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__/index')
    ·         ─────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:19]
  1 │ import thing from './__mocks__/index'
    ·                   ───────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('./__mocks__')
    ·         ─────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('./__mocks__/')
    ·         ──────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('./__mocks__/index')
    ·         ───────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__')
    ·         ───────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__/')
    ·         ────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:9]
  1 │ require('__mocks__/index')
    ·         ─────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.
 
   ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
    ╭─[no_mocks_import.tsx:1:19]
  1 │ import thing from './__mocks__/index'
    ·                   ───────────────────
    ╰────
-  help: Instead use `jest.mock` and import from the original module path.
+  help: Instead use `jest.mock` or `vi.mock` and import from the original module path.

--- a/crates/oxc_linter/src/snapshots/jest_no_mocks_import.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_mocks_import.snap
@@ -49,3 +49,52 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────────────────
    ╰────
   help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('./__mocks__')
+   ·         ─────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('./__mocks__/')
+   ·         ──────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('./__mocks__/index')
+   ·         ───────────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('__mocks__')
+   ·         ───────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('__mocks__/')
+   ·         ────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:9]
+ 1 │ require('__mocks__/index')
+   ·         ─────────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.
+
+  ⚠ eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.
+   ╭─[no_mocks_import.tsx:1:19]
+ 1 │ import thing from './__mocks__/index'
+   ·                   ───────────────────
+   ╰────
+  help: Instead use `jest.mock` and import from the original module path.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 36] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -48,6 +48,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 35] = [
     "no-hooks",
     "no-identical-title",
     "no-interpolation-in-snapshots",
+    "no-mocks-import",
     "no-restricted-jest-methods",
     "no-restricted-matchers",
     "no-standalone-expect",


### PR DESCRIPTION
Related to #4656

Implement [no-mocks-import](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md) lint ruler adding a new entry in the mapping between jest and vitest compatible rules.

Oxlint-migrate PR related: https://github.com/oxc-project/oxlint-migrate/pull/269