### PR TITLE
fix(linter/plugins): prevent user modifying the default config

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -126,7 +126,8 @@ const DEFAULT_SHARED_CONFIG: Config = {
 };
 
 // `RuleTester` uses this config as its default. Can be overwritten via `RuleTester.setDefaultConfig()`.
-let sharedConfig: Config = DEFAULT_SHARED_CONFIG;
+// Clone, so that user can't get `DEFAULT_SHARED_CONFIG` with `getDefaultConfig()` and modify it.
+let sharedConfig: Config = { ...DEFAULT_SHARED_CONFIG };
 
 // ------------------------------------------------------------------------------
 // Test cases
@@ -254,7 +255,8 @@ export class RuleTester {
    * @returns {void}
    */
   static resetDefaultConfig() {
-    sharedConfig = DEFAULT_SHARED_CONFIG;
+    // Clone, so that user can't get `DEFAULT_SHARED_CONFIG` with `getDefaultConfig()` and modify it
+    sharedConfig = { ...DEFAULT_SHARED_CONFIG };
   }
 
   // Getters/setters for `describe` and `it` functions

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -149,6 +149,33 @@ describe("RuleTester", () => {
     ]);
   });
 
+  describe("config", () => {
+    // TODO: More tests for config
+
+    it("can be set globally", () => {
+      const config = { whatever: true };
+      RuleTester.setDefaultConfig(config);
+      expect(RuleTester.getDefaultConfig()).toBe(config);
+    });
+
+    it("is reset to default by `resetDefaultConfig`", () => {
+      RuleTester.setDefaultConfig({ whatever: true });
+      expect(RuleTester.getDefaultConfig()).toHaveProperty("whatever", true);
+
+      RuleTester.resetDefaultConfig();
+      expect(RuleTester.getDefaultConfig()).not.toHaveProperty("whatever");
+    });
+
+    it("cannot permanently change default config", () => {
+      const defaultConfig = RuleTester.getDefaultConfig();
+      defaultConfig.whatever = true;
+      expect(RuleTester.getDefaultConfig()).toBe(defaultConfig);
+
+      RuleTester.resetDefaultConfig();
+      expect(RuleTester.getDefaultConfig()).not.toHaveProperty("whatever");
+    });
+  });
+
   describe("tests valid cases", () => {
     it("which are correct", () => {
       const tester = new RuleTester();


### PR DESCRIPTION
Fix a bug where user could obtain the default config object with `RuleTester.getDefaultConfig()`, mutate it, and then that change would be made permanently, preventing `RuleTester.resetDefaultConfig()` from properly resetting config.