### PR TITLE
chore(lsp): make tool dependencies optional

### DIFF
--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -22,17 +22,17 @@ test = true
 doctest = false
 
 [dependencies]
-oxc_allocator = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["rope"] }
-oxc_diagnostics = { workspace = true }
+oxc_allocator = { workspace = true, optional = true }
+oxc_data_structures = { workspace = true, features = ["rope"], optional = true }
+oxc_diagnostics = { workspace = true, optional = true }
 oxc_formatter = { workspace = true, optional = true }
 oxc_linter = { workspace = true, optional = true }
-oxc_parser = { workspace = true }
+oxc_parser = { workspace = true, optional = true }
 
 #
 env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }
-ignore = { workspace = true, features = ["simd-accel"] }
+ignore = { workspace = true, features = ["simd-accel"], optional = true }
 log = { workspace = true }
 papaya = { workspace = true }
 rustc-hash = { workspace = true }
@@ -47,5 +47,19 @@ tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "io-util", 
 
 [features]
 default = ["linter", "formatter"]
-linter = ["dep:oxc_linter"]
-formatter = ["dep:oxc_formatter"]
+linter = [
+  "dep:oxc_allocator",
+  "dep:oxc_data_structures",
+  "dep:oxc_diagnostics",
+  "dep:oxc_linter",
+  #
+  "dep:ignore",
+]
+formatter = [
+  "dep:oxc_allocator",
+  "dep:oxc_data_structures",
+  "dep:oxc_formatter",
+  "dep:oxc_parser",
+  #
+  "dep:ignore",
+]


### PR DESCRIPTION
These dependencies are only used inside `oxc_language_server/src/linter` or `oxc_language_server/src/formatter`. 
The goal is removing these folders from the crate.
This PR restructured the dependency-graph and reflects what is needed by the server/linter/formatter.