### PR TITLE
fix(linter): Fix jest/expect-expect rule docs.

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -35,8 +35,12 @@ pub struct ExpectExpect(Box<ExpectExpectConfig>);
 #[serde(rename_all = "camelCase", default)]
 pub struct ExpectExpectConfig {
     /// A list of function names that should be treated as assertion functions.
+    ///
+    /// NOTE: The default value is `["expect"]` for Jest and
+    /// `["expect", "expectTypeOf", "assert", "assertType"]` for Vitest.
+    #[serde(rename = "assertFunctionNames")]
     assert_function_names_jest: Vec<CompactStr>,
-    /// A list of function names that should be treated as assertion functions for Vitest.
+    #[schemars(skip)] // Skipped because this field isn't exposed to the user.
     assert_function_names_vitest: Vec<CompactStr>,
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,


### PR DESCRIPTION
Fixes #16491.

The default value here is a bit weird so I had to adjust the docs to make it clear that there's a distinction with jest vs vitest.

Generated docs:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### additionalTestBlockFunctions

type: `string[]`

default: `[]`

An array of function names that should also be treated as test blocks.

### assertFunctionNames

type: `string[]`

default: `["expect"]`

A list of function names that should be treated as assertion functions.

NOTE: The default value is `["expect"]` for Jest and
`["expect", "expectTypeOf", "assert", "assertType"]` for Vitest.

```