### PR TITLE
chore(linter): Fix configuration instructions for various Vitest-compatible rules

### DIFF
--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -125,7 +125,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/consistent-test-it.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/expect-expect.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -61,7 +61,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-alias-methods.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-commented-out-tests.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-disabled-tests.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-focused-tests.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {
@@ -174,7 +174,7 @@ fn test() {
     let fail_vitest = vec![
         (
             r#"
-            import { it } from 'vitest'; 
+            import { it } from 'vitest';
             it.only("test", () => {});
             "#,
             None,

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-identical-title.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-test-prefixes.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -129,7 +129,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/prefer-hooks-in-order.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -60,7 +60,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/valid-describe-callback.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/valid-expect.md),
-    /// to use it, add the following configuration to your `.eslintrc.json`:
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
     ///
     /// ```json
     /// {

--- a/crates/oxc_linter/src/snapshots/jest_no_focused_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_focused_tests.snap
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(no-focused-tests): Unexpected focused test.
    ╭─[no_focused_tests.tsx:3:16]
- 2 │             import { it } from 'vitest'; 
+ 2 │             import { it } from 'vitest';
  3 │             it.only("test", () => {});
    ·                ────
  4 │             


### PR DESCRIPTION
Setting a config in an eslint config file is not applicable here. Probably a bad copy-paste or something?