### PR TITLE
chore(linter): Update whitespace trim in a few rule files

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
@@ -515,15 +515,15 @@ fn test() {
         ("var foo = () => { /* do nothing */ };", None),
         (
             "var foo = () => {
-			 /* do nothing */
-			};",
+              /* do nothing */
+            };",
             None,
         ),
         (
             "var foo = (retv, name) => {
-			retv[name] = true;
-			return retv;
-			};",
+              retv[name] = true;
+              return retv;
+            };",
             None,
         ),
         ("var foo = () => ({});", None),
@@ -553,15 +553,15 @@ fn test() {
         ),
         (
             "var foo = () => {
-			 /* do nothing */
-			};",
+             /* do nothing */
+            };",
             Some(serde_json::json!(["as-needed", { "requireReturnForObjectLiteral": true }])),
         ),
         (
             "var foo = (retv, name) => {
-			retv[name] = true;
-			return retv;
-			};",
+            retv[name] = true;
+            return retv;
+            };",
             Some(serde_json::json!(["as-needed", { "requireReturnForObjectLiteral": true }])),
         ),
         (
@@ -615,8 +615,8 @@ fn test() {
         ("var foo = () => {};", Some(serde_json::json!(["never"]))),
         (
             "var foo = () => {
-			return 0;
-			};",
+            return 0;
+            };",
             Some(serde_json::json!(["never"])),
         ),
         ("var foo = () => { return { bar: 0 }; };", Some(serde_json::json!(["as-needed"]))),
@@ -638,9 +638,9 @@ fn test() {
         ("var foo = () => { return { bar: 0 }.bar; };", Some(serde_json::json!(["as-needed"]))),
         (
             "var foo = (retv, name) => {
-			retv[name] = true;
-			return retv;
-			};",
+            retv[name] = true;
+            return retv;
+            };",
             Some(serde_json::json!(["never"])),
         ),
         ("var foo = () => { bar };", Some(serde_json::json!(["never"]))),
@@ -671,38 +671,38 @@ fn test() {
         ),
         (
             "var foo = () => {
-			return bar;
-			};",
+            return bar;
+            };",
             None,
         ),
         (
             "var foo = () => {
-			return bar;};",
+            return bar;};",
             None,
         ),
         (
             "var foo = () => {return bar;
-			};",
+            };",
             None,
         ),
         (
             "
-			              var foo = () => {
-			                return foo
-			                  .bar;
-			              };
-			            ",
+                          var foo = () => {
+                            return foo
+                              .bar;
+                          };
+                        ",
             None,
         ),
         (
             "
-			              var foo = () => {
-			                return {
-			                  bar: 1,
-			                  baz: 2
-			                };
-			              };
-			            ",
+                          var foo = () => {
+                            return {
+                              bar: 1,
+                              baz: 2
+                            };
+                          };
+                        ",
             None,
         ),
         ("var foo = () => ({foo: 1}).foo();", Some(serde_json::json!(["always"]))),
@@ -710,22 +710,22 @@ fn test() {
         ("var foo = () => ( {foo: 1} ).foo();", Some(serde_json::json!(["always"]))),
         (
             "
-			              var foo = () => ({
-			                  bar: 1,
-			                  baz: 2
-			                });
-			            ",
+                          var foo = () => ({
+                              bar: 1,
+                              baz: 2
+                            });
+                        ",
             Some(serde_json::json!(["always"])),
         ),
         (
             "
-			              parsedYears = _map(years, (year) => (
-			                  {
-			                      index : year,
-			                      title : splitYear(year)
-			                  }
-			              ));
-			            ",
+                          parsedYears = _map(years, (year) => (
+                              {
+                                  index : year,
+                                  title : splitYear(year)
+                              }
+                          ));
+                        ",
             Some(serde_json::json!(["always"])),
         ),
         (
@@ -874,8 +874,8 @@ fn test() {
         ),
         (
             "var foo = () => {
-    	return 0;
-    	};",
+        return 0;
+        };",
             "var foo = () => 0;",
             Some(serde_json::json!(["never"])),
         ),
@@ -942,51 +942,51 @@ fn test() {
         ),
         (
             "var foo = () => {
-    	return bar;
-    	};",
+        return bar;
+        };",
             "var foo = () => bar;",
             None,
         ),
         (
             "var foo = () => {
-    	return bar;};",
+        return bar;};",
             "var foo = () => bar;",
             None,
         ),
         (
             "var foo = () => {return bar;
-    	};",
+        };",
             "var foo = () => bar;",
             None,
         ),
         (
             "
-    	              var foo = () => {
-    	                return foo
-    	                  .bar;
-    	              };
-    	            ",
+                      var foo = () => {
+                        return foo
+                          .bar;
+                      };
+                    ",
             "
-    	              var foo = () => foo
-    	                  .bar;
-    	            ",
+                      var foo = () => foo
+                          .bar;
+                    ",
             None,
         ),
         (
             "
-    	              var foo = () => {
-    	                return {
-    	                  bar: 1,
-    	                  baz: 2
-    	                };
-    	              };
-    	            ",
+                      var foo = () => {
+                        return {
+                          bar: 1,
+                          baz: 2
+                        };
+                      };
+                    ",
             "
-    	              var foo = () => ({
-    	                  bar: 1,
-    	                  baz: 2
-    	                });
-    	            ",
+                      var foo = () => ({
+                          bar: 1,
+                          baz: 2
+                        });
+                    ",
             None,
         ),
         (
@@ -1006,34 +1006,34 @@ fn test() {
         ),
         (
             "
-    	              var foo = () => ({
-    	                  bar: 1,
-    	                  baz: 2
-    	                });
-    	            ",
+                      var foo = () => ({
+                          bar: 1,
+                          baz: 2
+                        });
+                    ",
             "
-    	              var foo = () => {return {
-    	                  bar: 1,
-    	                  baz: 2
-    	                }};
-    	            ",
+                      var foo = () => {return {
+                          bar: 1,
+                          baz: 2
+                        }};
+                    ",
             Some(serde_json::json!(["always"])),
         ),
         (
             "
-    	              parsedYears = _map(years, (year) => (
-    	                  {
-    	                      index : year,
-    	                      title : splitYear(year)
-    	                  }
-    	              ));
-    	            ",
+                      parsedYears = _map(years, (year) => (
+                          {
+                              index : year,
+                              title : splitYear(year)
+                          }
+                      ));
+                    ",
             "
-    	              parsedYears = _map(years, (year) => {return {
-    	                      index : year,
-    	                      title : splitYear(year)
-    	                  }});
-    	            ",
+                      parsedYears = _map(years, (year) => {return {
+                              index : year,
+                              title : splitYear(year)
+                          }});
+                    ",
             Some(serde_json::json!(["always"])),
         ),
         (

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -692,72 +692,72 @@ fn test() {
         "class A extends B { constructor(a) { super(); for (b in a) ( foo(b) ); } }",
         "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }",
         "class A extends Object {
-			    constructor() {
-			        super();
-			        for (let i = 0; i < 0; i++);
-			    }
-			}
-			",
+                constructor() {
+                    super();
+                    for (let i = 0; i < 0; i++);
+                }
+            }
+            ",
         "class A extends Object {
-			    constructor() {
-			        super();
-			        for (; i < 0; i++);
-			    }
-			}
-			",
+                constructor() {
+                    super();
+                    for (; i < 0; i++);
+                }
+            }
+            ",
         "class A extends Object {
-			    constructor() {
-			        super();
-			        for (let i = 0;; i++) {
-			            if (foo) break;
-			        }
-			    }
-			}
-			",
+                constructor() {
+                    super();
+                    for (let i = 0;; i++) {
+                        if (foo) break;
+                    }
+                }
+            }
+            ",
         "class A extends Object {
-			    constructor() {
-			        super();
-			        for (let i = 0; i < 0;);
-			    }
-			}
-			",
+                constructor() {
+                    super();
+                    for (let i = 0; i < 0;);
+                }
+            }
+            ",
         "class A extends Object {
-			    constructor() {
-			        super();
-			        for (let i = 0;;) {
-			            if (foo) break;
-			        }
-			    }
-			}
-			",
+                constructor() {
+                    super();
+                    for (let i = 0;;) {
+                        if (foo) break;
+                    }
+                }
+            }
+            ",
         "
-			            class A extends B {
-			                constructor(props) {
-			                    super(props);
+                        class A extends B {
+                            constructor(props) {
+                                super(props);
 
-			                    try {
-			                        let arr = [];
-			                        for (let a of arr) {
-			                        }
-			                    } catch (err) {
-			                    }
-			                }
-			            }
-			        ",
+                                try {
+                                    let arr = [];
+                                    for (let a of arr) {
+                                    }
+                                } catch (err) {
+                                }
+                            }
+                        }
+                    ",
         "class A extends obj?.prop { constructor() { super(); } }",
         "
-			            class A extends Base {
-			                constructor(list) {
-			                    for (const a of list) {
-			                        if (a.foo) {
-			                            super(a);
-			                            return;
-			                        }
-			                    }
-			                    super();
-			                }
-			            }
-			        ",
+                        class A extends Base {
+                            constructor(list) {
+                                for (const a of list) {
+                                    if (a.foo) {
+                                        super(a);
+                                        return;
+                                    }
+                                }
+                                super();
+                            }
+                        }
+                    ",
     ];
 
     let fail = vec![
@@ -797,51 +797,51 @@ fn test() {
         "class A extends B { constructor(a) { while (a) super(); } }",
         "class A extends B { constructor() { return; super(); } }",
         "class Foo extends Bar {
-			                constructor() {
-			                    for (a in b) for (c in d);
-			                }
-			            }",
+                            constructor() {
+                                for (a in b) for (c in d);
+                            }
+                        }",
         "class C extends D {
 
-			                constructor() {
-			                    do {
-			                        something();
-			                    } while (foo);
-			                }
+                            constructor() {
+                                do {
+                                    something();
+                                } while (foo);
+                            }
 
-			            }",
+                        }",
         "class C extends D {
 
-			                constructor() {
-			                    for (let i = 1;;i++) {
-			                        if (bar) {
-			                            break;
-			                        }
-			                    }
-			                }
+                            constructor() {
+                                for (let i = 1;;i++) {
+                                    if (bar) {
+                                        break;
+                                    }
+                                }
+                            }
 
-			            }",
+                        }",
         "class C extends D {
 
-			                constructor() {
-			                    do {
-			                        super();
-			                    } while (foo);
-			                }
+                            constructor() {
+                                do {
+                                    super();
+                                } while (foo);
+                            }
 
-			            }",
+                        }",
         "class C extends D {
 
-			                constructor() {
-			                    while (foo) {
-			                        if (bar) {
-			                            super();
-			                            break;
-			                        }
-			                    }
-			                }
+                            constructor() {
+                                while (foo) {
+                                    if (bar) {
+                                        super();
+                                        break;
+                                    }
+                                }
+                            }
 
-			            }",
+                        }",
     ];
 
     Tester::new(ConstructorSuper::NAME, ConstructorSuper::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -171,121 +171,113 @@ fn test() {
         ("switch (a) { case 1: break; case 2: default: break; }", None),
         (
             "switch (a) { case 1: break; default: break;
-			 //no default
-			 }",
+              //no default
+            }",
             None,
         ),
         (
             "switch (a) {
-			    case 1: break;
+                case 1: break;
 
-			//oh-oh
-			 // no default
-			 }",
+            //oh-oh
+             // no default
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1:
+                case 1:
 
-			// no default
-			 }",
+            // no default
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1:
+                case 1:
 
-			// No default
-			 }",
+            // No default
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1:
+                case 1:
 
-			// no deFAUlt
-			 }",
+            // no deFAUlt
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1:
+                case 1:
 
-			// NO DEFAULT
-			 }",
+            // NO DEFAULT
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1: a = 4;
+                case 1: a = 4;
 
-			// no default
-			 }",
+            // no default
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1: a = 4;
+                case 1: a = 4;
 
-			/* no default */
-			 }",
+            /* no default */
+             }",
             None,
         ),
         (
             "switch (a) {
-			    case 1: a = 4; break; break;
+                case 1: a = 4; break; break;
 
-			// no default
-			 }",
+            // no default
+             }",
             None,
         ),
         (
             "switch (a) { // no default
-			 }",
+             }",
             None,
         ),
         ("switch (a) { }", None),
         (
             "switch (a) { case 1: break; default: break; }",
-            Some(serde_json::json!([{
-                "commentPattern": "default case omitted"
-            }])),
+            Some(serde_json::json!([{ "commentPattern": "default case omitted" }])),
         ),
         (
             "switch (a) { case 1: break;
-			 // skip default case
-			 }",
-            Some(serde_json::json!([{
-                "commentPattern": "^skip default"
-            }])),
+             // skip default case
+             }",
+            Some(serde_json::json!([{ "commentPattern": "^skip default" }])),
         ),
         (
             "switch (a) { case 1: break;
-			 // skip default case
-			 }",
+             // skip default case
+             }",
             Some(serde_json::json!([{
                 "commentPattern": "^skip\\sdefault" // this is escaped for JSON.
             }])),
         ),
         (
             "switch (a) { case 1: break;
-			 /*
-			TODO:
-			 throw error in default case
-			*/
-			 }",
-            Some(serde_json::json!([{
-                "commentPattern": "default"
-            }])),
+             /*
+            TODO:
+             throw error in default case
+            */
+             }",
+            Some(serde_json::json!([{ "commentPattern": "default" }])),
         ),
         (
             "switch (a) { case 1: break;
-			//
-			 }",
-            Some(serde_json::json!([{
-                "commentPattern": ".?"
-            }])),
+            //
+             }",
+            Some(serde_json::json!([{ "commentPattern": ".?" }])),
         ),
     ];
 
@@ -293,42 +285,36 @@ fn test() {
         ("switch (a) { case 1: break; }", None),
         (
             "switch (a) {
-			 // no default
-			 case 1: break;  }",
+             // no default
+             case 1: break;  }",
             None,
         ),
         (
             "switch (a) { case 1: break;
-			 // no default
-			 // nope
-			  }",
+             // no default
+             // nope
+              }",
             None,
         ),
         (
             "switch (a) { case 1: break;
-			 // no default
-			 }",
-            Some(serde_json::json!([{
-                "commentPattern": "skipped default case"
-            }])),
+             // no default
+             }",
+            Some(serde_json::json!([{ "commentPattern": "skipped default case" }])),
         ),
         (
             "switch (a) {
-			case 1: break;
-			// default omitted intentionally
-			// TODO: add default case
-			}",
-            Some(serde_json::json!([{
-                "commentPattern": "default omitted"
-            }])),
+            case 1: break;
+            // default omitted intentionally
+            // TODO: add default case
+            }",
+            Some(serde_json::json!([{ "commentPattern": "default omitted" }])),
         ),
         (
             "switch (a) {
-			case 1: break;
-			}",
-            Some(serde_json::json!([{
-                "commentPattern": ".?"
-            }])),
+            case 1: break;
+            }",
+            Some(serde_json::json!([{ "commentPattern": ".?" }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/func_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_style.rs
@@ -357,7 +357,7 @@ fn test() {
     let pass = vec![
         (
             "function foo(){}
-			 function bar(){}",
+             function bar(){}",
             Some(serde_json::json!(["declaration"])),
         ),
         ("foo.bar = function(){};", Some(serde_json::json!(["declaration"]))),
@@ -368,12 +368,12 @@ fn test() {
         ("foo.bar = function(){};", Some(serde_json::json!(["expression"]))),
         (
             "var foo = function(){};
-			 var bar = function(){};",
+             var bar = function(){};",
             Some(serde_json::json!(["expression"])),
         ),
         (
             "var foo = () => {};
-			 var bar = () => {}",
+             var bar = () => {}",
             Some(serde_json::json!(["expression"])),
         ), // { "ecmaVersion": 6 },
         ("var foo = function() { this; }.bind(this);", Some(serde_json::json!(["declaration"]))),
@@ -483,7 +483,7 @@ fn test() {
         ("switch ($0) { case $1: function $2() { } }", Some(serde_json::json!(["declaration"]))),
         (
             "function foo(): void {}
-			 function bar(): void {}",
+             function bar(): void {}",
             Some(serde_json::json!(["declaration"])),
         ),
         ("(function(): void { /* code */ }());", Some(serde_json::json!(["declaration"]))),
@@ -498,12 +498,12 @@ fn test() {
         ("Array.prototype.foo = function(): void {};", Some(serde_json::json!(["declaration"]))),
         (
             "const foo: () => void = function(): void {};
-			 const bar: () => void = function(): void {};",
+             const bar: () => void = function(): void {};",
             Some(serde_json::json!(["expression"])),
         ),
         (
             "const foo: () => void = (): void => {};
-			 const bar: () => void = (): void => {}",
+             const bar: () => void = (): void => {}",
             Some(serde_json::json!(["expression"])),
         ),
         (
@@ -538,13 +538,13 @@ fn test() {
         (
             "export function foo(): void {};",
             Some(
-                serde_json::json!(["expression",{ "overrides": { "namedExports": "declaration" } },			]),
+                serde_json::json!(["expression",{ "overrides": { "namedExports": "declaration" } },            ]),
             ),
         ),
         (
             "export function foo(): void {};",
             Some(
-                serde_json::json!(["declaration",{ "overrides": { "namedExports": "declaration" } },			]),
+                serde_json::json!(["declaration",{ "overrides": { "namedExports": "declaration" } },            ]),
             ),
         ),
         (
@@ -598,7 +598,7 @@ fn test() {
         (
             "export const expression: Fn = function () {}",
             Some(
-                serde_json::json!(["expression", { "allowTypeAnnotation": true,	"overrides": { "namedExports": "declaration" } }]),
+                serde_json::json!(["expression", { "allowTypeAnnotation": true,    "overrides": { "namedExports": "declaration" } }]),
             ),
         ),
         (
@@ -614,61 +614,61 @@ fn test() {
         ),
         (
             "
-					function test(a: string): string;
-					function test(a: number): number;
-					function test(a: unknown) {
-					  return a;
-					}
-					",
+                    function test(a: string): string;
+                    function test(a: number): number;
+                    function test(a: unknown) {
+                      return a;
+                    }
+                    ",
             None,
         ),
         (
             "
-					export function test(a: string): string;
-					export function test(a: number): number;
-					export function test(a: unknown) {
-					  return a;
-					}
-					",
+                    export function test(a: string): string;
+                    export function test(a: number): number;
+                    export function test(a: unknown) {
+                      return a;
+                    }
+                    ",
             None,
         ),
         (
             "
-						export function test(a: string): string;
-					    export function test(a: number): number;
-					    export function test(a: unknown) {
-					      return a;
-					    }
-						",
+                        export function test(a: string): string;
+                        export function test(a: number): number;
+                        export function test(a: unknown) {
+                          return a;
+                        }
+                        ",
             Some(
                 serde_json::json!(["expression", { "overrides": { "namedExports": "expression" } }]),
             ),
         ),
         (
             "
-					switch ($0) {
-						case $1:
-						function test(a: string): string;
-						function test(a: number): number;
-						function test(a: unknown) {
-						return a;
-						}
-					}
-					",
+                    switch ($0) {
+                        case $1:
+                        function test(a: string): string;
+                        function test(a: number): number;
+                        function test(a: unknown) {
+                        return a;
+                        }
+                    }
+                    ",
             None,
         ),
         (
             "
-					switch ($0) {
-						case $1:
-						function test(a: string): string;
-						break;
-						case $2:
-						function test(a: unknown) {
-						return a;
-						}
-					}
-					",
+                    switch ($0) {
+                        case $1:
+                        function test(a: string): string;
+                        break;
+                        case $2:
+                        function test(a: unknown) {
+                        return a;
+                        }
+                    }
+                    ",
             None,
         ),
     ];
@@ -836,59 +836,59 @@ fn test() {
         ("if (foo) function bar(): string {}", None),
         (
             "
-						function test1(a: string): string;
-						function test2(a: number): number;
-						function test3(a: unknown) {
-						  return a;
-						}",
+                        function test1(a: string): string;
+                        function test2(a: number): number;
+                        function test3(a: unknown) {
+                          return a;
+                        }",
             None,
         ),
         (
             "
-						export function test1(a: string): string;
-						export function test2(a: number): number;
-						export function test3(a: unknown) {
-						  return a;
-						}",
+                        export function test1(a: string): string;
+                        export function test2(a: number): number;
+                        export function test3(a: unknown) {
+                          return a;
+                        }",
             None,
         ),
         (
             "
-						export function test1(a: string): string;
-					    export function test2(a: number): number;
-					    export function test3(a: unknown) {
-					      return a;
-					    }
-						",
+                        export function test1(a: string): string;
+                        export function test2(a: number): number;
+                        export function test3(a: unknown) {
+                          return a;
+                        }
+                        ",
             Some(
                 serde_json::json!(["expression", { "overrides": { "namedExports": "expression" } }]),
             ),
         ),
         (
             "
-						switch ($0) {
-							case $1:
-							function test1(a: string): string;
-							function test2(a: number): number;
-							function test3(a: unknown) {
-								return a;
-							}
-						}
-						",
+                        switch ($0) {
+                            case $1:
+                            function test1(a: string): string;
+                            function test2(a: number): number;
+                            function test3(a: unknown) {
+                                return a;
+                            }
+                        }
+                        ",
             None,
         ),
         (
             "
-						switch ($0) {
-							case $1:
-							function test1(a: string): string;
-							break;
-							case $2:
-							function test2(a: unknown) {
-							return a;
-							}
-						}
-						",
+                        switch ($0) {
+                            case $1:
+                            function test1(a: string): string;
+                            break;
+                            case $2:
+                            function test2(a: unknown) {
+                            return a;
+                            }
+                        }
+                        ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -570,19 +570,19 @@ fn test() {
         (
             "function BEFORE_send() {};",
             Some(
-                serde_json::json!([				{ "min": 3, "max": 5, "exceptionPatterns": ["^BEFORE_", "send$"] },			]),
+                serde_json::json!([{ "min": 3, "max": 5, "exceptionPatterns": ["^BEFORE_", "send$"] },]),
             ),
         ),
         (
             "function BEFORE_send() {};",
             Some(
-                serde_json::json!([				{ "min": 3, "max": 5, "exceptionPatterns": ["^BEFORE_", "^A", "^Z"] },			]),
+                serde_json::json!([{ "min": 3, "max": 5, "exceptionPatterns": ["^BEFORE_", "^A", "^Z"] }]),
             ),
         ),
         (
             "function BEFORE_send() {};",
             Some(
-                serde_json::json!([				{ "min": 3, "max": 5, "exceptionPatterns": ["^A", "^BEFORE_", "^Z"] },			]),
+                serde_json::json!([{ "min": 3, "max": 5, "exceptionPatterns": ["^A", "^BEFORE_", "^Z"] }]),
             ),
         ),
         (
@@ -597,46 +597,46 @@ fn test() {
         ("class Foo { #abc = 1 }", Some(serde_json::json!([{ "max": 3 }]))), // { "ecmaVersion": 2022 },
         ("var 𠮟 = 2", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6 },
         ("var 葛󠄀 = 2", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6 },
-        ("var a = { 𐌘: 1 };", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("(𐌘) => { 𐌘 * 𐌘 };", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("class 𠮟 { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("class F { 𐌘() {} }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("class F { #𐌘() {} }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 2022,			},
-        ("class F { 𐌘 = 1 }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 2022,			},
-        ("class F { #𐌘 = 1 }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 2022,			},
-        ("function f(...𐌘) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("function f([𐌘]) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("var [ 𐌘 ] = a;", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("var { p: [𐌘]} = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("function f({𐌘}) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("var { 𐌘 } = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("var { p: 𐌘} = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
-        ("({ prop: o.𐌘 } = {});", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // {				"ecmaVersion": 6,			},
+        ("var a = { 𐌘: 1 };", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("(𐌘) => { 𐌘 * 𐌘 };", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("class 𠮟 { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("class F { 𐌘() {} }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("class F { #𐌘() {} }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 2022, },
+        ("class F { 𐌘 = 1 }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 2022, },
+        ("class F { #𐌘 = 1 }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 2022, },
+        ("function f(...𐌘) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("function f([𐌘]) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("var [ 𐌘 ] = a;", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("var { p: [𐌘]} = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("function f({𐌘}) { }", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("var { 𐌘 } = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("var { p: 𐌘} = {};", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
+        ("({ prop: o.𐌘 } = {});", Some(serde_json::json!([{ "min": 1, "max": 1 }]))), // { "ecmaVersion": 6, },
         (
             "import foo from 'foo.json' with { type: 'json' }",
             Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-        ), // {				"ecmaVersion": 2025,			},
+        ), // { "ecmaVersion": 2025 },
         (
             "export * from 'foo.json' with { type: 'json' }",
             Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-        ), // {				"ecmaVersion": 2025,			},
+        ), // { "ecmaVersion": 2025 },
         (
             "export { default } from 'foo.json' with { type: 'json' }",
             Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-        ), // {				"ecmaVersion": 2025,			},
+        ), // { "ecmaVersion": 2025 },
                                                                                       // TODO:
                                                                                       // (
                                                                                       //     "import('foo.json', { with: { type: 'json' } })",
                                                                                       //     Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-                                                                                      // ), // {				"ecmaVersion": 2025,			},
+                                                                                      // ), // { "ecmaVersion": 2025 },
                                                                                       // (
                                                                                       //     "import('foo.json', { 'with': { type: 'json' } })",
                                                                                       //     Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-                                                                                      // ), // {				"ecmaVersion": 2025,			},
+                                                                                      // ), // { "ecmaVersion": 2025 },
                                                                                       // (
                                                                                       //     "import('foo.json', { with: { type } })",
                                                                                       //     Some(serde_json::json!([{ "min": 1, "max": 3, "properties": "always" }])),
-                                                                                      // ), // {				"ecmaVersion": 2025,			}
+                                                                                      // ), // { "ecmaVersion": 2025 }
     ];
 
     let fail = vec![
@@ -715,21 +715,21 @@ fn test() {
         ("class Foo { #abcdefg = 1 }", Some(serde_json::json!([{ "max": 3 }]))), // { "ecmaVersion": 2022 },
         ("var 𠮟 = 2", None),              // { "ecmaVersion": 6 },
         ("var 葛󠄀 = 2", None),              // { "ecmaVersion": 6 },
-        ("var myObj = { 𐌘: 1 };", None),   // {				"ecmaVersion": 6,			},
-        ("(𐌘) => { 𐌘 * 𐌘 };", None),       // {				"ecmaVersion": 6,			},
-        ("class 𠮟 { }", None),            // {				"ecmaVersion": 6,			},
-        ("class Foo { 𐌘() {} }", None),    // {				"ecmaVersion": 6,			},
-        ("class Foo1 { #𐌘() {} }", None),  // {				"ecmaVersion": 2022,			},
-        ("class Foo2 { 𐌘 = 1 }", None),    // {				"ecmaVersion": 2022,			},
-        ("class Foo3 { #𐌘 = 1 }", None),   // {				"ecmaVersion": 2022,			},
-        ("function foo1(...𐌘) { }", None), // {				"ecmaVersion": 6,			},
-        ("function foo([𐌘]) { }", None),   // {				"ecmaVersion": 6,			},
-        ("var [ 𐌘 ] = arr;", None),        // {				"ecmaVersion": 6,			},
-        ("var { prop: [𐌘]} = {};", None),  // {				"ecmaVersion": 6,			},
-        ("function foo({𐌘}) { }", None),   // {				"ecmaVersion": 6,			},
-        ("var { 𐌘 } = {};", None),         // {				"ecmaVersion": 6,			},
-        ("var { prop: 𐌘} = {};", None),    // {				"ecmaVersion": 6,			},
-        ("({ prop: obj.𐌘 } = {});", None), // {				"ecmaVersion": 6,			}
+        ("var myObj = { 𐌘: 1 };", None),   // { "ecmaVersion": 6, },
+        ("(𐌘) => { 𐌘 * 𐌘 };", None),       // { "ecmaVersion": 6, },
+        ("class 𠮟 { }", None),            // { "ecmaVersion": 6, },
+        ("class Foo { 𐌘() {} }", None),    // { "ecmaVersion": 6, },
+        ("class Foo1 { #𐌘() {} }", None),  // { "ecmaVersion": 2022 },
+        ("class Foo2 { 𐌘 = 1 }", None),    // { "ecmaVersion": 2022 },
+        ("class Foo3 { #𐌘 = 1 }", None),   // { "ecmaVersion": 2022 },
+        ("function foo1(...𐌘) { }", None), // { "ecmaVersion": 6, },
+        ("function foo([𐌘]) { }", None),   // { "ecmaVersion": 6, },
+        ("var [ 𐌘 ] = arr;", None),        // { "ecmaVersion": 6, },
+        ("var { prop: [𐌘]} = {};", None),  // { "ecmaVersion": 6, },
+        ("function foo({𐌘}) { }", None),   // { "ecmaVersion": 6, },
+        ("var { 𐌘 } = {};", None),         // { "ecmaVersion": 6, },
+        ("var { prop: 𐌘} = {};", None),    // { "ecmaVersion": 6, },
+        ("({ prop: obj.𐌘 } = {});", None), // { "ecmaVersion": 6, }
     ];
 
     Tester::new(IdLength::NAME, IdLength::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -140,28 +140,26 @@ fn test() {
         ("class Foo {}", Some(serde_json::json!([1]))),
         (
             "class Foo {}
-			class Bar {}",
+            class Bar {}",
             Some(serde_json::json!([2])),
         ),
         ("class Foo {}", Some(serde_json::json!([{ "max": 1 }]))),
         (
             "class Foo {}
-			class Bar {}",
+            class Bar {}",
             Some(serde_json::json!([{ "max": 2 }])),
         ),
         (
             "
-			                class Foo {}
-			                const myExpression = class {}
-			            ",
+                class Foo {}
+                const myExpression = class {}",
             Some(serde_json::json!([{ "ignoreExpressions": true, "max": 1 }])),
         ),
         (
             "
-			                class Foo {}
-			                class Bar {}
-			                const myExpression = class {}
-			            ",
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}",
             Some(serde_json::json!([{ "ignoreExpressions": true, "max": 2 }])),
         ),
     ];
@@ -169,41 +167,39 @@ fn test() {
     let fail = vec![
         (
             "class Foo {}
-			class Bar {}",
+            class Bar {}",
             None,
         ),
         (
             "class Foo {}
-			const myExpression = class {}",
+            const myExpression = class {}",
             None,
         ),
         (
             "var x = class {};
-			var y = class {};",
+            var y = class {};",
             None,
         ),
         (
             "class Foo {}
-			var x = class {};",
+            var x = class {};",
             None,
         ),
         ("class Foo {} class Bar {}", Some(serde_json::json!([1]))),
         ("class Foo {} class Bar {} class Baz {}", Some(serde_json::json!([2]))),
         (
             "
-			                class Foo {}
-			                class Bar {}
-			                const myExpression = class {}
-			            ",
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}",
             Some(serde_json::json!([{ "ignoreExpressions": true, "max": 1 }])),
         ),
         (
             "
-			                class Foo {}
-			                class Bar {}
-			                class Baz {}
-			                const myExpression = class {}
-			            ",
+                class Foo {}
+                class Bar {}
+                class Baz {}
+                const myExpression = class {}",
             Some(serde_json::json!([{ "ignoreExpressions": true, "max": 2 }])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -214,188 +214,188 @@ fn test() {
     let pass = vec![
         (
             "var x = 5;
-			var x = 2;
-			",
+            var x = 2;
+            ",
             Some(serde_json::json!([1])),
         ),
         ("function name() {}", Some(serde_json::json!([1]))),
         (
             "function name() {
-			var x = 5;
-			var x = 2;
-			}",
+            var x = 5;
+            var x = 2;
+            }",
             Some(serde_json::json!([4])),
         ),
         ("const bar = () => 2", Some(serde_json::json!([1]))),
         (
             "const bar = () => {
-			const x = 2 + 1;
-			return x;
-			}",
+            const x = 2 + 1;
+            return x;
+            }",
             Some(serde_json::json!([4])),
         ),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 7, "skipComments": false, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 4, "skipComments": false, "skipBlankLines": true }])),
         ),
         (
             "function name() {
-			var x = 5;
-			var x = 2; // end of line comment
-			}",
+            var x = 5;
+            var x = 2; // end of line comment
+            }",
             Some(serde_json::json!([{ "max": 4, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
-			// a comment on it's own line
-			var x = 2; // end of line comment
-			}",
+            var x = 5;
+            // a comment on it's own line
+            var x = 2; // end of line comment
+            }",
             Some(serde_json::json!([{ "max": 4, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
-			// a comment on it's own line
-			// and another line comment
-			var x = 2; // end of line comment
-			}",
+            var x = 5;
+            // a comment on it's own line
+            // and another line comment
+            var x = 2; // end of line comment
+            }",
             Some(serde_json::json!([{ "max": 4, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
-			/* a
-			 multi
-			 line
-			 comment
-			*/
+            var x = 5;
+            /* a
+             multi
+             line
+             comment
+            */
 
-			var x = 2; // end of line comment
-			}",
+            var x = 2; // end of line comment
+            }",
             Some(serde_json::json!([{ "max": 5, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
-				/* a comment with leading whitespace */
-			/* a comment with trailing whitespace */
-				/* a comment with trailing and leading whitespace */
-			/* a
-			 multi
-			 line
-			 comment
-			*/
+            var x = 5;
+                /* a comment with leading whitespace */
+            /* a comment with trailing whitespace */
+                /* a comment with trailing and leading whitespace */
+            /* a
+             multi
+             line
+             comment
+            */
 
-			var x = 2; // end of line comment
-			}",
+            var x = 2; // end of line comment
+            }",
             Some(serde_json::json!([{ "max": 5, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function foo(
-			    aaa = 1,
-			    bbb = 2,
-			    ccc = 3
-			) {
-			    return aaa + bbb + ccc
-			}",
+                aaa = 1,
+                bbb = 2,
+                ccc = 3
+            ) {
+                return aaa + bbb + ccc
+            }",
             Some(serde_json::json!([{ "max": 7, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "(
-			function
-			()
-			{
-			}
-			)
-			()",
+            function
+            ()
+            {
+            }
+            )
+            ()",
             Some(
                 serde_json::json!([{ "max": 4, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),
         ),
         (
             "function parent() {
-			var x = 0;
-			function nested() {
-			    var y = 0;
-			    x = 2;
-			}
-			if ( x === y ) {
-			    x++;
-			}
-			}",
+            var x = 0;
+            function nested() {
+                var y = 0;
+                x = 2;
+            }
+            if ( x === y ) {
+                x++;
+            }
+            }",
             Some(serde_json::json!([{ "max": 10, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "class foo {
-			    method() {
-			        let y = 10;
-			        let x = 20;
-			        return y + x;
-			    }
-			}",
+                method() {
+                    let y = 10;
+                    let x = 20;
+                    return y + x;
+                }
+            }",
             Some(serde_json::json!([{ "max": 5, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "(function(){
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			}());",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            }());",
             Some(
                 serde_json::json!([{ "max": 7, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),
         ),
         (
             "(function(){
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			}());",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            }());",
             Some(
                 serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false, "IIFEs": false }]),
             ),
         ),
         (
             "(() => {
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			})();",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            })();",
             Some(
                 serde_json::json!([{ "max": 7, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),
         ),
         (
             "(() => {
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			})();",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            })();",
             Some(
                 serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false, "IIFEs": false }]),
             ),
@@ -407,221 +407,221 @@ fn test() {
     let fail = vec![
         (
             "function name() {
-			}",
+            }",
             Some(serde_json::json!([1])),
         ),
         (
             "var func = function() {
-			}",
+            }",
             Some(serde_json::json!([1])),
         ),
         (
             "const bar = () => {
-			const x = 2 + 1;
-			return x;
-			}",
+            const x = 2 + 1;
+            return x;
+            }",
             Some(serde_json::json!([3])),
         ),
         (
             "const bar = () =>
-			 2",
+             2",
             Some(serde_json::json!([1])),
         ),
         (&repeat_60, Some(serde_json::json!([{}]))),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 6, "skipComments": false, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 6, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": true }])),
         ),
         (
             "function name() {
-			var x = 5;
+            var x = 5;
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": true }])),
         ),
         (
             "function name() { // end of line comment
-			var x = 5; /* mid line comment */
-				// single line comment taking up whole line
+            var x = 5; /* mid line comment */
+                // single line comment taking up whole line
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 6, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function name() { // end of line comment
-			var x = 5; /* mid line comment */
-				// single line comment taking up whole line
+            var x = 5; /* mid line comment */
+                // single line comment taking up whole line
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 1, "skipComments": true, "skipBlankLines": true }])),
         ),
         (
             "function name() { // end of line comment
-			var x = 5; /* mid line comment */
-				// single line comment taking up whole line
+            var x = 5; /* mid line comment */
+                // single line comment taking up whole line
 
 
 
-			var x = 2;
-			}",
+            var x = 2;
+            }",
             Some(serde_json::json!([{ "max": 1, "skipComments": false, "skipBlankLines": true }])),
         ),
         (
             "function foo(
-			    aaa = 1,
-			    bbb = 2,
-			    ccc = 3
-			) {
-			    return aaa + bbb + ccc
-			}",
+                aaa = 1,
+                bbb = 2,
+                ccc = 3
+            ) {
+                return aaa + bbb + ccc
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "(
-			function
-			()
-			{
-			}
-			)
-			()",
+            function
+            ()
+            {
+            }
+            )
+            ()",
             Some(
                 serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),
         ),
         (
             "function parent() {
-			var x = 0;
-			function nested() {
-			    var y = 0;
-			    x = 2;
-			}
-			if ( x === y ) {
-			    x++;
-			}
-			}",
+            var x = 0;
+            function nested() {
+                var y = 0;
+                x = 2;
+            }
+            if ( x === y ) {
+                x++;
+            }
+            }",
             Some(serde_json::json!([{ "max": 9, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "function parent() {
-			var x = 0;
-			function nested() {
-			    var y = 0;
-			    x = 2;
-			}
-			if ( x === y ) {
-			    x++;
-			}
-			}",
+            var x = 0;
+            function nested() {
+                var y = 0;
+                x = 2;
+            }
+            if ( x === y ) {
+                x++;
+            }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "class foo {
-			    method() {
-			        let y = 10;
-			        let x = 20;
-			        return y + x;
-			    }
-			}",
+                method() {
+                    let y = 10;
+                    let x = 20;
+                    return y + x;
+                }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "class A {
-			    static
-			    foo
-			    (a) {
-			        return a
-			    }
-			}",
+                static
+                foo
+                (a) {
+                    return a
+                }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "var obj = {
-			    get
-			    foo
-			    () {
-			        return 1
-			    }
-			}",
+                get
+                foo
+                () {
+                    return 1
+                }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "var obj = {
-			    set
-			    foo
-			    ( val ) {
-			        this._foo = val;
-			    }
-			}",
+                set
+                foo
+                ( val ) {
+                    this._foo = val;
+                }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "class A {
-			    static
-			    [
-			        foo +
-			            bar
-			    ]
-			    (a) {
-			        return a
-			    }
-			}",
+                static
+                [
+                    foo +
+                        bar
+                ]
+                (a) {
+                    return a
+                }
+            }",
             Some(serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false }])),
         ),
         (
             "(function(){
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			}());",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            }());",
             Some(
                 serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),
         ),
         (
             "(() => {
-			    let x = 0;
-			    let y = 0;
-			    let z = x + y;
-			    let foo = {};
-			    return bar;
-			})();",
+                let x = 0;
+                let y = 0;
+                let z = x + y;
+                let foo = {};
+                return bar;
+            })();",
             Some(
                 serde_json::json!([{ "max": 2, "skipComments": true, "skipBlankLines": false, "IIFEs": true }]),
             ),

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -622,7 +622,7 @@ fn test() {
         ),
         ("var r = /[[👶🏻]]/v", None), // { "ecmaVersion": 2024 },
         // flag overrides, see oxc-project/oxc#13436
-        // ("new RegExp(/^[👍]$/v, '')", None), // {				"ecmaVersion": 2024,			},
+        // ("new RegExp(/^[👍]$/v, '')", None), // { "ecmaVersion": 2024, },
         (r"/[Á]/", Some(serde_json::json!([{ "allowEscape": false }]))),
         (r"/[\\̶]/", Some(serde_json::json!([{ "allowEscape": true }]))),
         (r"/[\n̅]/", Some(serde_json::json!([{ "allowEscape": true }]))),

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -188,12 +188,12 @@ fn test() {
             None,
         ), // { "ecmaVersion": 9 },
         ("var undefined; undefined = 5;", None),
-        ("class undefined {}", None),   // {				"ecmaVersion": 2015,			},
-        ("(class undefined {})", None), // {				"ecmaVersion": 2015,			},
-        ("import undefined from 'foo';", None), // {				"ecmaVersion": 2015,				"sourceType": "module",			},
-        ("import { undefined } from 'foo';", None), // {				"ecmaVersion": 2015,				"sourceType": "module",			},
-        ("import { baz as undefined } from 'foo';", None), // {				"ecmaVersion": 2015,				"sourceType": "module",			},
-        ("import * as undefined from 'foo';", None), // {				"ecmaVersion": 2015,				"sourceType": "module",			},
+        ("class undefined {}", None),   // { "ecmaVersion": 2015, },
+        ("(class undefined {})", None), // { "ecmaVersion": 2015, },
+        ("import undefined from 'foo';", None), // { "ecmaVersion": 2015, "sourceType": "module", },
+        ("import { undefined } from 'foo';", None), // { "ecmaVersion": 2015, "sourceType": "module", },
+        ("import { baz as undefined } from 'foo';", None), // { "ecmaVersion": 2015, "sourceType": "module", },
+        ("import * as undefined from 'foo';", None), // { "ecmaVersion": 2015, "sourceType": "module", },
         (
             "function globalThis(globalThis) { var globalThis; !function globalThis(globalThis) { try {} catch(globalThis) {} }; }",
             Some(json!([{ "reportGlobalThis": true }])),
@@ -210,10 +210,10 @@ fn test() {
         ("let globalThis; globalThis = 5;", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020 },
         ("class globalThis {}", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020 },
         ("(class globalThis {})", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020 },
-        ("import globalThis from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // {				"ecmaVersion": 2020,				"sourceType": "module",			},
-        ("import { globalThis } from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // {				"ecmaVersion": 2020,				"sourceType": "module",			},
-        ("import { baz as globalThis } from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // {				"ecmaVersion": 2020,				"sourceType": "module",			},
-        ("import * as globalThis from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // {				"ecmaVersion": 2020,				"sourceType": "module",			}
+        ("import globalThis from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020, "sourceType": "module", },
+        ("import { globalThis } from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020, "sourceType": "module", },
+        ("import { baz as globalThis } from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020, "sourceType": "module", },
+        ("import * as globalThis from 'foo';", Some(json!([{ "reportGlobalThis": true }]))), // { "ecmaVersion": 2020, "sourceType": "module", }
     ];
 
     Tester::new(NoShadowRestrictedNames::NAME, NoShadowRestrictedNames::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -37,12 +37,12 @@ declare_oxc_lint!(
     ///
     /// it('bar', () => {
     ///   switch (mode) {
-    /// 	case 'none':
-    /// 	  generateNone();
-    /// 	case 'single':
-    /// 	  generateOne();
-    /// 	case 'multiple':
-    /// 	  generateMany();
+    ///     case 'none':
+    ///       generateNone();
+    ///     case 'single':
+    ///       generateOne();
+    ///     case 'multiple':
+    ///       generateMany();
     ///   }
     ///
     ///   expect(fixtures.length).toBeGreaterThan(-1);
@@ -50,9 +50,9 @@ declare_oxc_lint!(
     ///
     /// it('baz', async () => {
     ///   const promiseValue = () => {
-    /// 	return something instanceof Promise
-    /// 	  ? something
-    /// 	  : Promise.resolve(something);
+    ///     return something instanceof Promise
+    ///       ? something
+    ///       : Promise.resolve(something);
     ///   };
     ///
     ///   await expect(promiseValue()).resolves.toBe(1);
@@ -63,20 +63,20 @@ declare_oxc_lint!(
     /// ```js
     /// describe('my tests', () => {
     ///   if (true) {
-    /// 	it('foo', () => {
-    /// 	  doTheThing();
-    /// 	});
+    ///     it('foo', () => {
+    ///       doTheThing();
+    ///     });
     ///   }
     /// });
     ///
     /// beforeEach(() => {
     ///   switch (mode) {
-    /// 	case 'none':
-    /// 	  generateNone();
-    /// 	case 'single':
-    /// 	  generateOne();
-    /// 	case 'multiple':
-    /// 	  generateMany();
+    ///     case 'none':
+    ///       generateNone();
+    ///     case 'single':
+    ///       generateOne();
+    ///     case 'multiple':
+    ///       generateMany();
     ///   }
     /// });
     ///
@@ -140,509 +140,509 @@ fn test() {
     let pass = vec![
         "const x = y ? 1 : 0",
         "
-			      const foo = function (bar) {
-			        return foo ? bar : null;
-			      };
-			
-			      it('foo', () => {
-			        foo();
-			      });
-			    ",
+                  const foo = function (bar) {
+                    return foo ? bar : null;
+                  };
+
+                  it('foo', () => {
+                    foo();
+                  });
+                ",
         "
-			      const foo = function (bar) {
-			        return foo ? bar : null;
-			      };
-			
-			      it.each()('foo', function () {
-			        foo();
-			      });
-			    ",
+                  const foo = function (bar) {
+                    return foo ? bar : null;
+                  };
+
+                  it.each()('foo', function () {
+                    foo();
+                  });
+                ",
         "
-			      fit.concurrent('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  fit.concurrent('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "it('foo', () => {})",
         "
-			      switch (true) {
-			        case true: {}
-			      }
-			    ",
+                  switch (true) {
+                    case true: {}
+                  }
+                ",
         "
-			      it('foo', () => {});
-			      function myTest() {
-			        switch ('bar') {
-			        }
-			      }
-			    ",
+                  it('foo', () => {});
+                  function myTest() {
+                    switch ('bar') {
+                    }
+                  }
+                ",
         "
-			      foo('bar', () => {
-			        switch(baz) {}
-			      })
-			    ",
+                  foo('bar', () => {
+                    switch(baz) {}
+                  })
+                ",
         "
-			      describe('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  describe('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "
-			      describe.skip('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  describe.skip('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "
-			      describe.skip.each()('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  describe.skip.each()('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "
-			      xdescribe('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  xdescribe('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "
-			      fdescribe('foo', () => {
-			        switch('bar') {}
-			      })
-			    ",
+                  fdescribe('foo', () => {
+                    switch('bar') {}
+                  })
+                ",
         "
-			      describe('foo', () => {
-			        switch('bar') {}
-			      })
-			      switch('bar') {}
-			    ",
+                  describe('foo', () => {
+                    switch('bar') {}
+                  })
+                  switch('bar') {}
+                ",
         "
-			      describe('foo', () => {
-			        afterEach(() => {
-			          switch('bar') {}
-			        });
-			      });
-			    ",
+                  describe('foo', () => {
+                    afterEach(() => {
+                      switch('bar') {}
+                    });
+                  });
+                ",
         "
-			      const values = something.map(thing => {
-			        switch (thing.isFoo) {
-			          case true:
-			            return thing.foo;
-			          default:
-			            return thing.bar;
-			        }
-			      });
-			
-			      it('valid', () => {
-			        expect(values).toStrictEqual(['foo']);
-			      });
-			    ",
+                  const values = something.map(thing => {
+                    switch (thing.isFoo) {
+                      case true:
+                        return thing.foo;
+                      default:
+                        return thing.bar;
+                    }
+                  });
+
+                  it('valid', () => {
+                    expect(values).toStrictEqual(['foo']);
+                  });
+                ",
         "
-			      describe('valid', () => {
-			        const values = something.map(thing => {
-			          switch (thing.isFoo) {
-			            case true:
-			              return thing.foo;
-			            default:
-			              return thing.bar;
-			          }
-			        });
-			        it('still valid', () => {
-			          expect(values).toStrictEqual(['foo']);
-			        });
-			      });
-			    ",
+                  describe('valid', () => {
+                    const values = something.map(thing => {
+                      switch (thing.isFoo) {
+                        case true:
+                          return thing.foo;
+                        default:
+                          return thing.bar;
+                      }
+                    });
+                    it('still valid', () => {
+                      expect(values).toStrictEqual(['foo']);
+                    });
+                  });
+                ",
         "if (foo) {}",
         "it('foo', () => {})",
         r#"it("foo", function () {})"#,
         "it('foo', () => {}); function myTest() { if ('bar') {} }",
         "
-			      foo('bar', () => {
-			        if (baz) {}
-			      })
-			    ",
+                  foo('bar', () => {
+                    if (baz) {}
+                  })
+                ",
         "
-			      describe('foo', () => {
-			        if ('bar') {}
-			      })
-			    ",
+                  describe('foo', () => {
+                    if ('bar') {}
+                  })
+                ",
         "
-			      describe.skip('foo', () => {
-			        if ('bar') {}
-			      })
-			    ",
+                  describe.skip('foo', () => {
+                    if ('bar') {}
+                  })
+                ",
         "
-			      xdescribe('foo', () => {
-			        if ('bar') {}
-			      })
-			    ",
+                  xdescribe('foo', () => {
+                    if ('bar') {}
+                  })
+                ",
         "
-			      fdescribe('foo', () => {
-			        if ('bar') {}
-			      })
-			    ",
+                  fdescribe('foo', () => {
+                    if ('bar') {}
+                  })
+                ",
         "
-			      describe('foo', () => {
-			        if ('bar') {}
-			      })
-			      if ('baz') {}
-			    ",
+                  describe('foo', () => {
+                    if ('bar') {}
+                  })
+                  if ('baz') {}
+                ",
         "
-			      describe('foo', () => {
-			        afterEach(() => {
-			          if ('bar') {}
-			        });
-			      })
-			    ",
+                  describe('foo', () => {
+                    afterEach(() => {
+                      if ('bar') {}
+                    });
+                  })
+                ",
         "
-			      describe.each``('foo', () => {
-			        afterEach(() => {
-			          if ('bar') {}
-			        });
-			      })
-			    ",
+                  describe.each``('foo', () => {
+                    afterEach(() => {
+                      if ('bar') {}
+                    });
+                  })
+                ",
         "
-			      describe('foo', () => {
-			        beforeEach(() => {
-			          if ('bar') {}
-			        });
-			      })
-			    ",
+                  describe('foo', () => {
+                    beforeEach(() => {
+                      if ('bar') {}
+                    });
+                  })
+                ",
         "const foo = bar ? foo : baz;",
         "
-			      const values = something.map((thing) => {
-			        if (thing.isFoo) {
-			          return thing.foo
-			        } else {
-			          return thing.bar;
-			        }
-			      });
-			
-			      describe('valid', () => {
-			        it('still valid', () => {
-			          expect(values).toStrictEqual(['foo']);
-			        });
-			      });
-			    ",
+                  const values = something.map((thing) => {
+                    if (thing.isFoo) {
+                      return thing.foo
+                    } else {
+                      return thing.bar;
+                    }
+                  });
+
+                  describe('valid', () => {
+                    it('still valid', () => {
+                      expect(values).toStrictEqual(['foo']);
+                    });
+                  });
+                ",
         "
-			      describe('valid', () => {
-			        const values = something.map((thing) => {
-			          if (thing.isFoo) {
-			            return thing.foo
-			          } else {
-			            return thing.bar;
-			          }
-			        });
-			
-			        describe('still valid', () => {
-			          it('really still valid', () => {
-			            expect(values).toStrictEqual(['foo']);
-			          });
-			        });
-			      });
-			    ",
+                  describe('valid', () => {
+                    const values = something.map((thing) => {
+                      if (thing.isFoo) {
+                        return thing.foo
+                      } else {
+                        return thing.bar;
+                      }
+                    });
+
+                    describe('still valid', () => {
+                      it('really still valid', () => {
+                        expect(values).toStrictEqual(['foo']);
+                      });
+                    });
+                  });
+                ",
         "
-			      fit.concurrent('foo', () => {
-			        if ('bar') {}
-			      })
-			    ",
+                  fit.concurrent('foo', () => {
+                    if ('bar') {}
+                  })
+                ",
     ];
 
     let fail = vec![
         "
-			        it('foo', () => {
-			          expect(bar ? foo : baz).toBe(boo);
-			        })
-			      ",
+                    it('foo', () => {
+                      expect(bar ? foo : baz).toBe(boo);
+                    })
+                  ",
         "
-			        it('foo', function () {
-			          const foo = function (bar) {
-			            return foo ? bar : null;
-			          };
-			        });
-			      ",
+                    it('foo', function () {
+                      const foo = function (bar) {
+                        return foo ? bar : null;
+                      };
+                    });
+                  ",
         "
-			        it('foo', () => {
-			          const foo = bar ? foo : baz;
-			        })
-			      ",
+                    it('foo', () => {
+                      const foo = bar ? foo : baz;
+                    })
+                  ",
         "
-			        it('foo', () => {
-			          const foo = bar ? foo : baz;
-			        })
-			        const foo = bar ? foo : baz;
-			      ",
+                    it('foo', () => {
+                      const foo = bar ? foo : baz;
+                    })
+                    const foo = bar ? foo : baz;
+                  ",
         "
-			        it('foo', () => {
-			          const foo = bar ? foo : baz;
-			          const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
-			        })
-			      ",
+                    it('foo', () => {
+                      const foo = bar ? foo : baz;
+                      const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
+                    })
+                  ",
         "
-			        it('is invalid', () => {
-			          const values = something.map(thing => {
-			            switch (thing.isFoo) {
-			              case true:
-			                return thing.foo;
-			              default:
-			                return thing.bar;
-			            }
-			          });
-			
-			          expect(values).toStrictEqual(['foo']);
-			        });
-			      ",
+                    it('is invalid', () => {
+                      const values = something.map(thing => {
+                        switch (thing.isFoo) {
+                          case true:
+                            return thing.foo;
+                          default:
+                            return thing.bar;
+                        }
+                      });
+
+                      expect(values).toStrictEqual(['foo']);
+                    });
+                  ",
         "
-			        it('foo', () => {
-			          switch (true) {
-			            case true: {}
-			          }
-			        })
-			      ",
+                    it('foo', () => {
+                      switch (true) {
+                        case true: {}
+                      }
+                    })
+                  ",
         "
-			        it('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    it('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        it.skip('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    it.skip('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        it.only('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    it.only('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        xit('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    xit('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        fit('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    fit('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        test('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    test('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        test.skip('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    test.skip('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        test.only('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    test.only('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        xtest('foo', () => {
-			          switch('bar') {}
-			        })
-			      ",
+                    xtest('foo', () => {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        xtest('foo', function () {
-			          switch('bar') {}
-			        })
-			      ",
+                    xtest('foo', function () {
+                      switch('bar') {}
+                    })
+                  ",
         "
-			        describe('foo', () => {
-			          it('bar', () => {
-			
-			            switch('bar') {}
-			          })
-			        })
-			      ",
+                    describe('foo', () => {
+                      it('bar', () => {
+
+                        switch('bar') {}
+                      })
+                    })
+                  ",
         "
-			        describe('foo', () => {
-			          it('bar', () => {
-			            switch('bar') {}
-			          })
-			          it('baz', () => {
-			            switch('qux') {}
-			            switch('quux') {}
-			          })
-			        })
-			      ",
+                    describe('foo', () => {
+                      it('bar', () => {
+                        switch('bar') {}
+                      })
+                      it('baz', () => {
+                        switch('qux') {}
+                        switch('quux') {}
+                      })
+                    })
+                  ",
         "
-			        it('foo', () => {
-			          callExpression()
-			          switch ('bar') {}
-			        })
-			      ",
+                    it('foo', () => {
+                      callExpression()
+                      switch ('bar') {}
+                    })
+                  ",
         "
-			        describe('valid', () => {
-			          describe('still valid', () => {
-			            it('is not valid', () => {
-			              const values = something.map((thing) => {
-			                switch (thing.isFoo) {
-			                  case true:
-			                    return thing.foo;
-			                  default:
-			                    return thing.bar;
-			                }
-			              });
-			
-			              switch('invalid') {
-			                case true:
-			                  expect(values).toStrictEqual(['foo']);
-			              }
-			            });
-			          });
-			        });
-			      ",
+                    describe('valid', () => {
+                      describe('still valid', () => {
+                        it('is not valid', () => {
+                          const values = something.map((thing) => {
+                            switch (thing.isFoo) {
+                              case true:
+                                return thing.foo;
+                              default:
+                                return thing.bar;
+                            }
+                          });
+
+                          switch('invalid') {
+                            case true:
+                              expect(values).toStrictEqual(['foo']);
+                          }
+                        });
+                      });
+                    });
+                  ",
         "
-			        it('foo', () => {
-			          const foo = function(bar) {
-			            if (bar) {
-			              return 1;
-			            } else {
-			              return 2;
-			            }
-			          };
-			        });
-			      ",
+                    it('foo', () => {
+                      const foo = function(bar) {
+                        if (bar) {
+                          return 1;
+                        } else {
+                          return 2;
+                        }
+                      };
+                    });
+                  ",
         "
-			        it('foo', () => {
-			          function foo(bar) {
-			            if (bar) {
-			              return 1;
-			            } else {
-			              return 2;
-			            }
-			          };
-			        });
-			      ",
+                    it('foo', () => {
+                      function foo(bar) {
+                        if (bar) {
+                          return 1;
+                        } else {
+                          return 2;
+                        }
+                      };
+                    });
+                  ",
         "
-			        it('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    it('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.skip('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    it.skip('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.skip('foo', function () {
-			          if ('bar') {}
-			        })
-			      ",
+                    it.skip('foo', function () {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.only('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    it.only('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        xit('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    xit('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        fit('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    fit('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        test('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    test('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        test.skip('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    test.skip('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        test.only('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    test.only('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        xtest('foo', () => {
-			          if ('bar') {}
-			        })
-			      ",
+                    xtest('foo', () => {
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        describe('foo', () => {
-			          it('bar', () => {
-			            if ('bar') {}
-			          })
-			        })
-			      ",
+                    describe('foo', () => {
+                      it('bar', () => {
+                        if ('bar') {}
+                      })
+                    })
+                  ",
         "
-			        describe('foo', () => {
-			          it('bar', () => {
-			            if ('bar') {}
-			          })
-			          it('baz', () => {
-			            if ('qux') {}
-			            if ('quux') {}
-			          })
-			        })
-			      ",
+                    describe('foo', () => {
+                      it('bar', () => {
+                        if ('bar') {}
+                      })
+                      it('baz', () => {
+                        if ('qux') {}
+                        if ('quux') {}
+                      })
+                    })
+                  ",
         "
-			        it('foo', () => {
-			          callExpression()
-			          if ('bar') {}
-			        })
-			      ",
+                    it('foo', () => {
+                      callExpression()
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.each``('foo', () => {
-			          callExpression()
-			          if ('bar') {}
-			        })
-			      ",
+                    it.each``('foo', () => {
+                      callExpression()
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.each()('foo', () => {
-			          callExpression()
-			          if ('bar') {}
-			        })
-			      ",
+                    it.each()('foo', () => {
+                      callExpression()
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.only.each``('foo', () => {
-			          callExpression()
-			          if ('bar') {}
-			        })
-			      ",
+                    it.only.each``('foo', () => {
+                      callExpression()
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        it.only.each()('foo', () => {
-			          callExpression()
-			          if ('bar') {}
-			        })
-			      ",
+                    it.only.each()('foo', () => {
+                      callExpression()
+                      if ('bar') {}
+                    })
+                  ",
         "
-			        describe('valid', () => {
-			          describe('still valid', () => {
-			            it('is invalid', () => {
-			              const values = something.map((thing) => {
-			                if (thing.isFoo) {
-			                  return thing.foo
-			                } else {
-			                  return thing.bar;
-			                }
-			              });
-			
-			              if ('invalid') {
-			                expect(values).toStrictEqual(['foo']);
-			              }
-			            });
-			          });
-			        });
-			      ",
+                    describe('valid', () => {
+                      describe('still valid', () => {
+                        it('is invalid', () => {
+                          const values = something.map((thing) => {
+                            if (thing.isFoo) {
+                              return thing.foo
+                            } else {
+                              return thing.bar;
+                            }
+                          });
+
+                          if ('invalid') {
+                            expect(values).toStrictEqual(['foo']);
+                          }
+                        });
+                      });
+                    });
+                  ",
         r#"
-			        test("shows error", () => {
-			          if (1 === 2) {
-			            expect(true).toBe(false);
-			          }
-			        });
-			
-			        test("does not show error", () => {
-			          setTimeout(() => console.log("noop"));
-			          if (1 === 2) {
-			            expect(true).toBe(false);
-			          }
-			        });
-			      "#,
+                    test("shows error", () => {
+                      if (1 === 2) {
+                        expect(true).toBe(false);
+                      }
+                    });
+
+                    test("does not show error", () => {
+                      setTimeout(() => console.log("noop"));
+                      if (1 === 2) {
+                        expect(true).toBe(false);
+                      }
+                    });
+                  "#,
     ];
 
     Tester::new(NoConditionalInTest::NAME, NoConditionalInTest::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -1170,13 +1170,13 @@ fn test() {
                     it('foo nested', () => {
                         // this is a test
                     });
-                    
-                    describe('deeply nested', () => { 
+
+                    describe('deeply nested', () => {
                         afterAll(() => {});
                         afterAll(() => {});
                         // This comment does nothing
                         afterEach(() => {});
-                
+
                         it('foo nested', () => {
                             // this is a test
                         });
@@ -1201,7 +1201,7 @@ fn test() {
                 it('foo', () => {
                     // this is a test
                 });
-            
+
                 describe('my nested test', () => {
                     afterAll(() => {});
                     afterEach(() => {});
@@ -1225,26 +1225,26 @@ fn test() {
                 it('accepts this input', () => {
                     // ...
                 });
-                
+
                 it('returns that value', () => {
                     // ...
                 });
 
                 describe('when the database has specific values', () => {
                     const specificValue = '...';
-                
+
                     beforeEach(() => {
                         seedMyDatabase(specificValue);
                     });
-                
+
                     it('accepts that input', () => {
                         // ...
                     });
-                
+
                     it('throws an error', () => {
                         // ...
                     });
-                
+
                     afterEach(() => {
                         clearLogger();
                     });
@@ -1252,12 +1252,12 @@ fn test() {
                     beforeEach(() => {
                         mockLogger();
                     });
-                
+
                     it('logs a message', () => {
                         // ...
                     });
                 });
-                
+
                 afterAll(() => {
                     removeMyDatabase();
                 });

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -156,15 +156,15 @@ fn test() {
         r#"describe.concurrent("failing", () => { it("should fail", () => { expect(true).toMatchInlineSnapshot("true") }) })"#,
         r#"it.concurrent("something", (context) => { expect(true).toMatchSnapshot() })"#,
         r#"it.concurrent("something", () => {
-			                 expect(true).toMatchSnapshot();
-			
-			                 expect(true).toMatchSnapshot();
-			            })"#,
+                        expect(true).toMatchSnapshot();
+
+                         expect(true).toMatchSnapshot();
+                    })"#,
         r#"it.concurrent("something", () => {
-			                 expect(true).toBe(true);
-			
-			                 expect(true).toMatchSnapshot();
-			            })"#,
+                         expect(true).toBe(true);
+
+                         expect(true).toMatchSnapshot();
+                    })"#,
         r#"it.concurrent("should fail", () => { expect(true).toMatchFileSnapshot("./test/basic.output.html") })"#,
         r#"it.concurrent("should fail", () => { expect(foo()).toThrowErrorMatchingSnapshot() })"#,
         r#"it.concurrent("should fail", () => { expect(foo()).toThrowErrorMatchingInlineSnapshot("bar") })"#,

--- a/crates/oxc_linter/src/snapshots/eslint_arrow_body_style.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_arrow_body_style.snap
@@ -224,8 +224,8 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶             };
    ╰────
   help: Replace `{
-        			return 0;
-        			}` with `0`.
+                    return 0;
+                    }` with `0`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
    ╭─[arrow_body_style.tsx:1:17]
@@ -351,8 +351,8 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶             };
    ╰────
   help: Replace `{
-        			return bar;
-        			}` with `bar`.
+                    return bar;
+                    }` with `bar`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
    ╭─[arrow_body_style.tsx:1:17]
@@ -360,7 +360,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ ╰─▶             return bar;};
    ╰────
   help: Replace `{
-        			return bar;}` with `bar`.
+                    return bar;}` with `bar`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
    ╭─[arrow_body_style.tsx:1:17]
@@ -368,10 +368,10 @@ source: crates/oxc_linter/src/tester.rs
  2 │ ╰─▶             };
    ╰────
   help: Replace `{return bar;
-        			}` with `bar`.
+                    }` with `bar`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
-   ╭─[arrow_body_style.tsx:2:34]
+   ╭─[arrow_body_style.tsx:2:43]
  1 │     
  2 │ ╭─▶                           var foo = () => {
  3 │ │                               return foo
@@ -380,13 +380,13 @@ source: crates/oxc_linter/src/tester.rs
  6 │                             
    ╰────
   help: Replace `{
-        			                return foo
-        			                  .bar;
-        			              }` with `foo
-        			                  .bar`.
+                                    return foo
+                                      .bar;
+                                  }` with `foo
+                                      .bar`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
-   ╭─[arrow_body_style.tsx:2:34]
+   ╭─[arrow_body_style.tsx:2:43]
  1 │     
  2 │ ╭─▶                           var foo = () => {
  3 │ │                               return {
@@ -397,14 +397,14 @@ source: crates/oxc_linter/src/tester.rs
  8 │                             
    ╰────
   help: Replace `{
-        			                return {
-        			                  bar: 1,
-        			                  baz: 2
-        			                };
-        			              }` with `({
-        			                  bar: 1,
-        			                  baz: 2
-        			                })`.
+                                    return {
+                                      bar: 1,
+                                      baz: 2
+                                    };
+                                  }` with `({
+                                      bar: 1,
+                                      baz: 2
+                                    })`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
@@ -428,7 +428,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `( {foo: 1} ).foo()` with `{return ( {foo: 1} ).foo()}`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
-   ╭─[arrow_body_style.tsx:2:34]
+   ╭─[arrow_body_style.tsx:2:43]
  1 │     
  2 │ ╭─▶                           var foo = () => ({
  3 │ │                                 bar: 1,
@@ -437,15 +437,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │                             
    ╰────
   help: Replace `({
-        			                  bar: 1,
-        			                  baz: 2
-        			                })` with `{return {
-        			                  bar: 1,
-        			                  baz: 2
-        			                }}`.
+                                      bar: 1,
+                                      baz: 2
+                                    })` with `{return {
+                                      bar: 1,
+                                      baz: 2
+                                    }}`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
-   ╭─[arrow_body_style.tsx:2:54]
+   ╭─[arrow_body_style.tsx:2:63]
  1 │     
  2 │ ╭─▶                           parsedYears = _map(years, (year) => (
  3 │ │                                 {
@@ -456,14 +456,14 @@ source: crates/oxc_linter/src/tester.rs
  8 │                             
    ╰────
   help: Replace `(
-        			                  {
-        			                      index : year,
-        			                      title : splitYear(year)
-        			                  }
-        			              )` with `{return {
-        			                      index : year,
-        			                      title : splitYear(year)
-        			                  }}`.
+                                      {
+                                          index : year,
+                                          title : splitYear(year)
+                                      }
+                                  )` with `{return {
+                                          index : year,
+                                          title : splitYear(year)
+                                      }}`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:33]

--- a/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_constructor_super.snap
@@ -254,7 +254,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a 'super()' call to the constructor
 
   ⚠ eslint(constructor-super): Expected to call 'super()'.
-   ╭─[constructor_super.tsx:2:20]
+   ╭─[constructor_super.tsx:2:29]
  1 │     class Foo extends Bar {
  2 │ ╭─▶                             constructor() {
  3 │ │                                   for (a in b) for (c in d);
@@ -264,7 +264,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a 'super()' call to the constructor
 
   ⚠ eslint(constructor-super): Expected to call 'super()'.
-   ╭─[constructor_super.tsx:3:20]
+   ╭─[constructor_super.tsx:3:29]
  2 │     
  3 │ ╭─▶                             constructor() {
  4 │ │                                   do {
@@ -276,7 +276,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a 'super()' call to the constructor
 
   ⚠ eslint(constructor-super): Expected to call 'super()'.
-    ╭─[constructor_super.tsx:3:20]
+    ╭─[constructor_super.tsx:3:29]
   2 │     
   3 │ ╭─▶                             constructor() {
   4 │ │                                   for (let i = 1;;i++) {
@@ -290,7 +290,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a 'super()' call to the constructor
 
   ⚠ eslint(constructor-super): Lacked a call of 'super()' in some code paths.
-   ╭─[constructor_super.tsx:3:20]
+   ╭─[constructor_super.tsx:3:29]
  2 │     
  3 │ ╭─▶                             constructor() {
  4 │ │                                   do {
@@ -302,7 +302,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Ensure 'super()' is called in all code paths
 
   ⚠ eslint(constructor-super): Lacked a call of 'super()' in some code paths.
-    ╭─[constructor_super.tsx:3:20]
+    ╭─[constructor_super.tsx:3:29]
   2 │     
   3 │ ╭─▶                             constructor() {
   4 │ │                                   while (foo) {

--- a/crates/oxc_linter/src/snapshots/eslint_func_style.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_func_style.snap
@@ -296,7 +296,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Enforce the consistent use of either `function` declarations or expressions assigned to variables
 
   ⚠ eslint(func-style): Expected a function expression.
-   ╭─[func_style.tsx:4:7]
+   ╭─[func_style.tsx:4:25]
  3 │                             function test2(a: number): number;
  4 │ ╭─▶                         function test3(a: unknown) {
  5 │ │                             return a;
@@ -305,7 +305,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Enforce the consistent use of either `function` declarations or expressions assigned to variables
 
   ⚠ eslint(func-style): Expected a function expression.
-   ╭─[func_style.tsx:4:14]
+   ╭─[func_style.tsx:4:32]
  3 │                             export function test2(a: number): number;
  4 │ ╭─▶                         export function test3(a: unknown) {
  5 │ │                             return a;
@@ -314,7 +314,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Enforce the consistent use of either `function` declarations or expressions assigned to variables
 
   ⚠ eslint(func-style): Expected a function expression.
-   ╭─[func_style.tsx:4:17]
+   ╭─[func_style.tsx:4:32]
  3 │                             export function test2(a: number): number;
  4 │ ╭─▶                         export function test3(a: unknown) {
  5 │ │                             return a;
@@ -324,7 +324,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Enforce the consistent use of either `function` declarations or expressions assigned to variables
 
   ⚠ eslint(func-style): Expected a function expression.
-   ╭─[func_style.tsx:6:8]
+   ╭─[func_style.tsx:6:29]
  5 │                                 function test2(a: number): number;
  6 │ ╭─▶                             function test3(a: unknown) {
  7 │ │                                   return a;
@@ -334,7 +334,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Enforce the consistent use of either `function` declarations or expressions assigned to variables
 
   ⚠ eslint(func-style): Expected a function expression.
-    ╭─[func_style.tsx:7:8]
+    ╭─[func_style.tsx:7:29]
   6 │                                 case $2:
   7 │ ╭─▶                             function test2(a: unknown) {
   8 │ │                               return a;

--- a/crates/oxc_linter/src/snapshots/eslint_max_classes_per_file.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_max_classes_per_file.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:4]
+   ╭─[max_classes_per_file.tsx:2:13]
  1 │ class Foo {}
  2 │             class Bar {}
    ·             ────────────
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:25]
+   ╭─[max_classes_per_file.tsx:2:34]
  1 │ class Foo {}
  2 │             const myExpression = class {}
    ·                                  ────────
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:12]
+   ╭─[max_classes_per_file.tsx:2:21]
  1 │ var x = class {};
  2 │             var y = class {};
    ·                     ────────
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:12]
+   ╭─[max_classes_per_file.tsx:2:21]
  1 │ class Foo {}
  2 │             var x = class {};
    ·                     ────────
@@ -48,19 +48,19 @@ source: crates/oxc_linter/src/tester.rs
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:3:20]
- 2 │                             class Foo {}
- 3 │                             class Bar {}
-   ·                             ────────────
- 4 │                             const myExpression = class {}
+   ╭─[max_classes_per_file.tsx:3:17]
+ 2 │                 class Foo {}
+ 3 │                 class Bar {}
+   ·                 ────────────
+ 4 │                 const myExpression = class {}
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (3). Maximum allowed is 2
-   ╭─[max_classes_per_file.tsx:4:20]
- 3 │                             class Bar {}
- 4 │                             class Baz {}
-   ·                             ────────────
- 5 │                             const myExpression = class {}
+   ╭─[max_classes_per_file.tsx:4:17]
+ 3 │                 class Bar {}
+ 4 │                 class Baz {}
+   ·                 ────────────
+ 5 │                 const myExpression = class {}
    ╰────
   help: Reduce the number of classes in this file

--- a/crates/oxc_linter/src/snapshots/eslint_max_lines_per_function.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_max_lines_per_function.snap
@@ -197,7 +197,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The function has too many lines (4). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:2:4]
+   ╭─[max_lines_per_function.tsx:2:13]
  1 │     (
  2 │ ╭─▶             function
  3 │ │               ()
@@ -238,7 +238,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The function `nested` has too many lines (4). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:3:4]
+   ╭─[max_lines_per_function.tsx:3:13]
  2 │                 var x = 0;
  3 │ ╭─▶             function nested() {
  4 │ │                   var y = 0;
@@ -249,7 +249,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The method `method` has too many lines (5). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:2:14]
+   ╭─[max_lines_per_function.tsx:2:23]
  1 │     class foo {
  2 │ ╭─▶                 method() {
  3 │ │                       let y = 10;
@@ -261,7 +261,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The static method `foo` has too many lines (3). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:4:8]
+   ╭─[max_lines_per_function.tsx:4:17]
  3 │                     foo
  4 │ ╭─▶                 (a) {
  5 │ │                       return a
@@ -271,7 +271,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The function `foo` has too many lines (3). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:4:8]
+   ╭─[max_lines_per_function.tsx:4:17]
  3 │                     foo
  4 │ ╭─▶                 () {
  5 │ │                       return 1
@@ -281,7 +281,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The function `foo` has too many lines (3). Maximum allowed is 2.
-   ╭─[max_lines_per_function.tsx:4:8]
+   ╭─[max_lines_per_function.tsx:4:17]
  3 │                     foo
  4 │ ╭─▶                 ( val ) {
  5 │ │                       this._foo = val;
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider splitting it into smaller functions.
 
   ⚠ eslint(max-lines-per-function): The static method has too many lines (3). Maximum allowed is 2.
-    ╭─[max_lines_per_function.tsx:7:8]
+    ╭─[max_lines_per_function.tsx:7:17]
   6 │                     ]
   7 │ ╭─▶                 (a) {
   8 │ │                       return a

--- a/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:21]
+   ╭─[no_conditional_in_test.tsx:3:30]
  2 │                     it('foo', () => {
  3 │                       expect(bar ? foo : baz).toBe(boo);
    ·                              ───────────────
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:23]
+   ╭─[no_conditional_in_test.tsx:4:32]
  3 │                       const foo = function (bar) {
  4 │                         return foo ? bar : null;
    ·                                ────────────────
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:26]
+   ╭─[no_conditional_in_test.tsx:3:35]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:26]
+   ╭─[no_conditional_in_test.tsx:3:35]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
@@ -34,7 +34,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:26]
+   ╭─[no_conditional_in_test.tsx:3:35]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:33]
+   ╭─[no_conditional_in_test.tsx:4:42]
  3 │                       const foo = bar ? foo : baz;
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
    ·                                          ────────────────────────────────────
@@ -50,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:4:16]
+    ╭─[no_conditional_in_test.tsx:4:25]
   3 │                           const values = something.map(thing => {
   4 │ ╭─▶                         switch (thing.isFoo) {
   5 │ │                             case true:
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                         it('foo', () => {
  3 │ ╭─▶                       switch (true) {
  4 │ │                           case true: {}
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -79,7 +79,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it.skip('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -87,7 +87,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it.only('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -95,7 +95,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     xit('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -103,7 +103,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     fit('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -119,7 +119,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test.skip('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -127,7 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test.only('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     xtest('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     xtest('foo', function () {
  3 │                       switch('bar') {}
    ·                       ────────────────
@@ -151,15 +151,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:5:16]
- 4 │             
+   ╭─[no_conditional_in_test.tsx:5:25]
+ 4 │ 
  5 │                         switch('bar') {}
    ·                         ────────────────
  6 │                       })
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:16]
+   ╭─[no_conditional_in_test.tsx:4:25]
  3 │                       it('bar', () => {
  4 │                         switch('bar') {}
    ·                         ────────────────
@@ -167,7 +167,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:7:16]
+   ╭─[no_conditional_in_test.tsx:7:25]
  6 │                       it('baz', () => {
  7 │                         switch('qux') {}
    ·                         ────────────────
@@ -175,7 +175,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:8:16]
+   ╭─[no_conditional_in_test.tsx:8:25]
  7 │                         switch('qux') {}
  8 │                         switch('quux') {}
    ·                         ─────────────────
@@ -183,7 +183,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       switch ('bar') {}
    ·                       ─────────────────
@@ -191,7 +191,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:6:20]
+    ╭─[no_conditional_in_test.tsx:6:29]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             switch (thing.isFoo) {
   7 │ │                                 case true:
@@ -203,8 +203,8 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:14:18]
- 13 │                 
+    ╭─[no_conditional_in_test.tsx:14:27]
+ 13 │     
  14 │ ╭─▶                           switch('invalid') {
  15 │ │                               case true:
  16 │ │                                 expect(values).toStrictEqual(['foo']);
@@ -213,7 +213,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:16]
+   ╭─[no_conditional_in_test.tsx:4:25]
  3 │                           const foo = function(bar) {
  4 │ ╭─▶                         if (bar) {
  5 │ │                             return 1;
@@ -224,7 +224,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:16]
+   ╭─[no_conditional_in_test.tsx:4:25]
  3 │                           function foo(bar) {
  4 │ ╭─▶                         if (bar) {
  5 │ │                             return 1;
@@ -235,7 +235,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -243,7 +243,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it.skip('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -251,7 +251,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it.skip('foo', function () {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -259,7 +259,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     it.only('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -267,7 +267,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     xit('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -275,7 +275,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     fit('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -283,7 +283,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test.skip('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -299,7 +299,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     test.only('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -307,7 +307,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                     xtest('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
@@ -315,7 +315,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:16]
+   ╭─[no_conditional_in_test.tsx:4:25]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
    ·                         ─────────────
@@ -323,7 +323,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:16]
+   ╭─[no_conditional_in_test.tsx:4:25]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
    ·                         ─────────────
@@ -331,7 +331,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:7:16]
+   ╭─[no_conditional_in_test.tsx:7:25]
  6 │                       it('baz', () => {
  7 │                         if ('qux') {}
    ·                         ─────────────
@@ -339,7 +339,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:8:16]
+   ╭─[no_conditional_in_test.tsx:8:25]
  7 │                         if ('qux') {}
  8 │                         if ('quux') {}
    ·                         ──────────────
@@ -347,7 +347,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
@@ -355,7 +355,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
@@ -363,7 +363,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
@@ -371,7 +371,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
@@ -379,7 +379,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:4:14]
+   ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
@@ -387,7 +387,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:6:20]
+    ╭─[no_conditional_in_test.tsx:6:29]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             if (thing.isFoo) {
   7 │ │                                 return thing.foo
@@ -398,8 +398,8 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:13:18]
- 12 │                 
+    ╭─[no_conditional_in_test.tsx:13:27]
+ 12 │     
  13 │ ╭─▶                           if ('invalid') {
  14 │ │                               expect(values).toStrictEqual(['foo']);
  15 │ ╰─▶                           }
@@ -407,7 +407,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-   ╭─[no_conditional_in_test.tsx:3:14]
+   ╭─[no_conditional_in_test.tsx:3:23]
  2 │                         test("shows error", () => {
  3 │ ╭─▶                       if (1 === 2) {
  4 │ │                           expect(true).toBe(false);
@@ -416,7 +416,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
-    ╭─[no_conditional_in_test.tsx:10:14]
+    ╭─[no_conditional_in_test.tsx:10:23]
   9 │                           setTimeout(() => console.log("noop"));
  10 │ ╭─▶                       if (1 === 2) {
  11 │ │                           expect(true).toBe(false);

--- a/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
@@ -540,7 +540,7 @@ source: crates/oxc_linter/src/tester.rs
  23 │                         afterEach(() => {});
     ·                         ─────────┬─────────
     ·                                  ╰── this should be moved to before the "afterAll" hook
- 24 │                 
+ 24 │ 
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
@@ -591,7 +591,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:34:21]
- 33 │                     
+ 33 │     
  34 │ ╭─▶                     afterEach(() => {
  35 │ │                           clearLogger();
  36 │ ├─▶                     });
@@ -601,6 +601,6 @@ source: crates/oxc_linter/src/tester.rs
  39 │ │                           mockLogger();
  40 │ ├─▶                     });
     · ╰──── this should be moved to before the "afterEach" hook
- 41 │                     
+ 41 │     
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks

--- a/crates/oxc_linter/src/snapshots/vitest_require_local_test_context_for_concurrent_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_require_local_test_context_for_concurrent_snapshots.snap
@@ -37,29 +37,29 @@ source: crates/oxc_linter/src/tester.rs
   help: Use local Test Context instead
 
   ⚠ eslint-plugin-vitest(require-local-test-context-for-concurrent-snapshots): Require local Test Context for concurrent snapshot tests
-   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:2:21]
+   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:2:25]
  1 │ it.concurrent("something", () => {
- 2 │                              expect(true).toMatchSnapshot();
-   ·                              ──────────────────────────────
- 3 │             
+ 2 │                         expect(true).toMatchSnapshot();
+   ·                         ──────────────────────────────
+ 3 │ 
    ╰────
   help: Use local Test Context instead
 
   ⚠ eslint-plugin-vitest(require-local-test-context-for-concurrent-snapshots): Require local Test Context for concurrent snapshot tests
-   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:21]
- 3 │             
- 4 │                              expect(true).toMatchSnapshot();
-   ·                              ──────────────────────────────
- 5 │                         })
+   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:26]
+ 3 │ 
+ 4 │                          expect(true).toMatchSnapshot();
+   ·                          ──────────────────────────────
+ 5 │                     })
    ╰────
   help: Use local Test Context instead
 
   ⚠ eslint-plugin-vitest(require-local-test-context-for-concurrent-snapshots): Require local Test Context for concurrent snapshot tests
-   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:21]
- 3 │             
- 4 │                              expect(true).toMatchSnapshot();
-   ·                              ──────────────────────────────
- 5 │                         })
+   ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:26]
+ 3 │ 
+ 4 │                          expect(true).toMatchSnapshot();
+   ·                          ──────────────────────────────
+ 5 │                     })
    ╰────
   help: Use local Test Context instead
 


### PR DESCRIPTION
Otherwise the next person that edits these files will end up with goofy problems if they use an editor that actually follows the editorconfig (like mine does).

I found the problematic files by just doing a find+replace on "What it does", since that should be in every rule file, which caused my editor to save and applied to the editorconfig settings accordingly. The only one I left with this problem was `curly`, as it seemed to be reliant on the weird whitespace.

And then also replaces some usage of tabs in some rule tests with equivalent spaces. None of these rules are stylistic, so the difference is not relevant to the behavior of the rule.