### PR TITLE
docs(linter): Fix the name of the IIFEs config option in eslint/max-lines-per-function

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -41,6 +41,7 @@ pub struct MaxLinesPerFunctionConfig {
     /// The `IIFEs` option controls whether IIFEs are included in the line count.
     /// By default, IIFEs are not considered, but when set to `true`, they will
     /// be included in the line count for the function.
+    #[serde(rename = "IIFEs")]
     iifes: bool,
 }
 


### PR DESCRIPTION
This option name was not cased correctly in the docs previously.

```md
## Configuration

This rule accepts a configuration object with the following properties:

### IIFEs

type: `boolean`

default: `false`

The `IIFEs` option controls whether IIFEs are included in the line count.
By default, IIFEs are not considered, but when set to `true`, they will
be included in the line count for the function.

### max

type: `integer`

default: `50`

Maximum number of lines allowed in a function.

### skipBlankLines

type: `boolean`

default: `false`

Skip lines made up purely of whitespace.

### skipComments

type: `boolean`

default: `false`

Skip lines containing just comments.
```