### PR TITLE
docs(linter): Handle rules that use tuple config options with DefaultRuleConfig

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -593,10 +593,6 @@ mod test {
         let de: DefaultRuleConfig<Obj> = serde_json::from_str(r#"[{ "foo": "xyz" }]"#).unwrap();
         assert_eq!(de.into_inner(), Obj { foo: "xyz".to_string() });
 
-        // Extra elements in the array should be ignored when parsing the object
-        let de: DefaultRuleConfig<Obj> = serde_json::from_str(r#"[{ "foo": "yyy" }, 42]"#).unwrap();
-        assert_eq!(de.into_inner(), Obj { foo: "yyy".to_string() });
-
         // Empty array -> default
         let de: DefaultRuleConfig<Obj> = serde_json::from_str("[]").unwrap();
         assert_eq!(de.into_inner(), Obj { foo: "defaultval".to_string() });

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -635,6 +635,12 @@ mod test {
         let de: DefaultRuleConfig<EnumOptions> = serde_json::from_str(json).unwrap();
 
         assert_eq!(de.into_inner(), EnumOptions::OptionA);
+
+        // Works with non-default value as well.
+        let json = r#"["optionB"]"#;
+        let de: DefaultRuleConfig<EnumOptions> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(de.into_inner(), EnumOptions::OptionB);
     }
 
     #[derive(serde::Deserialize, Default, Debug, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -168,17 +168,15 @@ where
                 Ok(DefaultRuleConfig(T::default()))
             }
             _ => {
-                // Try parsing the whole array into T (covers tuple-form configs).
-                if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr.clone())) {
+                let first = arr.get(0).cloned();
+
+                if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr)) {
                     return Ok(DefaultRuleConfig(t));
                 }
 
-                // Otherwise parse only the first element or use default.
-                let config = arr
-                    .into_iter()
-                    .next()
-                    .and_then(|v| serde_json::from_value(v).ok())
-                    .unwrap_or_else(T::default);
+                // Parsing the whole array failed; parse first element if present.
+                let config =
+                    first.and_then(|v| serde_json::from_value(v).ok()).unwrap_or_else(T::default);
 
                 Ok(DefaultRuleConfig(config))
             }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -600,19 +600,17 @@ mod test {
     #[derive(serde::Deserialize, Debug, PartialEq, Eq, Default)]
     #[serde(default)]
     struct ComplexConfig {
-        foo: FxHashMap<String, serde_json::Value>,
+        foo: FxHashMap<String, String>,
     }
 
     #[test]
     fn test_deserialize_default_rule_config_with_complex_shape() {
         // A complex object shape for the rule config, like
         // `[ { "foo": { "obj": "value" } } ]`.
-        let json = r#"[ { "foo": { "obj": "value" } } ]"#;
-        let de: DefaultRuleConfig<ComplexConfig> = serde_json::from_str(json).unwrap();
-        let cfg = de.into_inner();
-
-        let val = cfg.foo.get("obj").expect("obj key present");
-        assert_eq!(val, &serde_json::Value::String("value".to_string()));
+        assert_default_rule_config(
+            r#"[ { "foo": { "obj": "value" } } ]"#,
+            ComplexConfig { foo: [("obj".to_string(), "value".to_string())].into_iter().collect() },
+        );
     }
 
     #[derive(serde::Deserialize, Debug, PartialEq, Eq, Default)]

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -168,7 +168,7 @@ where
                 Ok(DefaultRuleConfig(T::default()))
             }
             _ => {
-                let first = arr.get(0).cloned();
+                let first = arr.first().cloned();
 
                 if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr)) {
                     return Ok(DefaultRuleConfig(t));
@@ -552,9 +552,9 @@ mod test {
         let de: DefaultRuleConfig<u32> = serde_json::from_str("[123]").unwrap();
         assert_eq!(de.into_inner(), 123u32);
         let de: DefaultRuleConfig<bool> = serde_json::from_str("[true]").unwrap();
-        assert_eq!(de.into_inner(), true);
+        assert!(de.into_inner());
         let de: DefaultRuleConfig<bool> = serde_json::from_str("[false]").unwrap();
-        assert_eq!(de.into_inner(), false);
+        assert!(!de.into_inner());
 
         // empty array should use defaults
         let de: DefaultRuleConfig<String> = serde_json::from_str("[]").unwrap();
@@ -648,9 +648,8 @@ mod test {
         // A basic enum config option.
         let json = r#"["optionA"]"#;
         let de: DefaultRuleConfig<EnumOptions> = serde_json::from_str(json).unwrap();
-        let cfg = de.into_inner();
 
-        assert_eq!(cfg, EnumOptions::OptionA);
+        assert_eq!(de.into_inner(), EnumOptions::OptionA);
     }
 
     #[derive(serde::Deserialize, Default, Debug, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -80,7 +80,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///
 /// # Examples
 ///
-/// ```rs
+/// ```rust
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         let config = serde_json::from_value::<DefaultRuleConfig<MyRuleConfig>>(value)
@@ -91,7 +91,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// ```
 ///
 /// For rules that take a tuple configuration object, e.g. `["foobar", { param: true, other_param: false }]`, you can also use this with a tuple struct:
-/// ```rs
+/// ```rust
 /// pub struct MyRuleWithTupleConfig(FirstParamType, SecondParamType);
 ///
 /// impl Rule for MyRuleWithTupleConfig {
@@ -591,7 +591,8 @@ mod test {
         assert_eq!(de.into_inner(), Pair(42u32, Obj { foo: "abc".to_string() }));
 
         // only first element present -> parsing the entire array into `Pair`
-        // will fail, so we fall back to the old behaviour and use T::default().
+        // will fail, so we parse the first element. Since Pair has #[serde(default)],
+        // serde will use the default value for the missing second field.
         let de: DefaultRuleConfig<Pair> = serde_json::from_str("[10]").unwrap();
         assert_eq!(de.into_inner(), Pair(10u32, Obj { foo: "defaultval".to_string() }));
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -98,7 +98,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         serde_json::from_value::<DefaultRuleConfig<MyRuleWithTupleConfig>>(value)
 ///             .unwrap_or_default()
-///             .into_inner();
+///             .into_inner()
 ///     }
 /// }
 /// ```

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -145,7 +145,9 @@ where
             return Ok(DefaultRuleConfig(T::default()));
         }
 
-        // Fast path: Single-element array.
+        // Single-element array.
+        // - `["foo"]`
+        // - `[{ "foo": "bar" }]`
         if arr.len() == 1 {
             let elem = arr.into_iter().next().unwrap();
 
@@ -163,7 +165,9 @@ where
             return Ok(DefaultRuleConfig(t));
         }
 
-        // Multi-element arrays (tuples like [42, { "foo": "abc" }] or ["optionA", { "foo": "bar" }]).
+        // Multi-element arrays
+        // - `[42, { "foo": "abc" }]`
+        // - `["optionA", { "foo": "bar" }]`
         let t = serde_json::from_value::<T>(serde_json::Value::Array(arr))
             .unwrap_or_else(|_| T::default());
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -645,24 +645,18 @@ mod test {
 
     #[derive(serde::Deserialize, Default, Debug, PartialEq, Eq)]
     #[serde(default)]
-    struct TupleWithEnumAndObjectConfig {
-        option: EnumOptions,
-        extra: Obj,
-    }
+    struct TupleWithEnumAndObjectConfig(EnumOptions, Obj);
 
     #[test]
     fn test_deserialize_default_rule_config_with_enum_and_object() {
-        // A basic enum config option.
+        // A basic enum config option with an object.
         let json = r#"["optionA", { "foo": "bar" }]"#;
         let de: DefaultRuleConfig<TupleWithEnumAndObjectConfig> =
             serde_json::from_str(json).unwrap();
 
         assert_eq!(
             de.into_inner(),
-            TupleWithEnumAndObjectConfig {
-                option: EnumOptions::OptionA,
-                extra: Obj { foo: "bar".to_string() }
-            }
+            TupleWithEnumAndObjectConfig(EnumOptions::OptionA, Obj { foo: "bar".to_string() })
         );
 
         // Ensure that we can pass just one value and it'll provide the default for the second.
@@ -672,10 +666,10 @@ mod test {
 
         assert_eq!(
             de.into_inner(),
-            TupleWithEnumAndObjectConfig {
-                option: EnumOptions::OptionB,
-                extra: Obj { foo: "defaultval".to_string() }
-            }
+            TupleWithEnumAndObjectConfig(
+                EnumOptions::OptionB,
+                Obj { foo: "defaultval".to_string() }
+            )
         );
     }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -80,7 +80,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         let config = serde_json::from_value::<DefaultRuleConfig<MyRuleConfig>>(value)
@@ -91,7 +91,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// ```
 ///
 /// For rules that take a tuple configuration object, e.g. `["foobar", { param: true, other_param: false }]`, you can also use this with a tuple struct:
-/// ```rust
+/// ```ignore
 /// pub struct MyRuleWithTupleConfig(FirstParamType, SecondParamType);
 ///
 /// impl Rule for MyRuleWithTupleConfig {

--- a/crates/oxc_linter/src/rules/eslint/func_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_style.rs
@@ -13,8 +13,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-fn func_style_diagnostic(span: Span, style: &Style) -> OxcDiagnostic {
-    let style_str = if style == &Style::Declaration { "declaration" } else { "expression" };
+fn func_style_diagnostic(span: Span, style: Style) -> OxcDiagnostic {
+    let style_str = if style == Style::Declaration { "declaration" } else { "expression" };
     OxcDiagnostic::warn(format!("Expected a function {style_str}."))
         .with_help("Enforce the consistent use of either `function` declarations or expressions assigned to variables")
         .with_label(span)
@@ -244,17 +244,14 @@ impl Rule for FuncStyle {
                                     _ => true,
                                 };
                                 if should_diagnostic {
-                                    ctx.diagnostic(func_style_diagnostic(func.span, style));
+                                    ctx.diagnostic(func_style_diagnostic(func.span, *style));
                                 }
                             }
 
                             if config.overrides.named_exports == Some(NamedExports::Expression)
                                 && matches!(parent.kind(), AstKind::ExportNamedDeclaration(_))
                             {
-                                ctx.diagnostic(func_style_diagnostic(
-                                    func.span,
-                                    &Style::Expression,
-                                ));
+                                ctx.diagnostic(func_style_diagnostic(func.span, Style::Expression));
                             }
                         }
                         FunctionType::FunctionExpression => {
@@ -269,7 +266,7 @@ impl Rule for FuncStyle {
                                     && (config.overrides.named_exports.is_none()
                                         || !is_ancestor_export)
                                 {
-                                    ctx.diagnostic(func_style_diagnostic(decl.span, style));
+                                    ctx.diagnostic(func_style_diagnostic(decl.span, *style));
                                 }
 
                                 if config.overrides.named_exports == Some(NamedExports::Declaration)
@@ -277,7 +274,7 @@ impl Rule for FuncStyle {
                                 {
                                     ctx.diagnostic(func_style_diagnostic(
                                         decl.span,
-                                        &Style::Declaration,
+                                        Style::Declaration,
                                     ));
                                 }
                             }
@@ -318,13 +315,13 @@ impl Rule for FuncStyle {
                     if is_decl_style
                         && (config.overrides.named_exports.is_none() || !is_ancestor_export)
                     {
-                        ctx.diagnostic(func_style_diagnostic(decl.span, &Style::Declaration));
+                        ctx.diagnostic(func_style_diagnostic(decl.span, Style::Declaration));
                     }
 
                     if config.overrides.named_exports == Some(NamedExports::Declaration)
                         && is_ancestor_export
                     {
-                        ctx.diagnostic(func_style_diagnostic(decl.span, &Style::Declaration));
+                        ctx.diagnostic(func_style_diagnostic(decl.span, Style::Declaration));
                     }
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -25,6 +25,7 @@ pub struct NoInnerDeclarations(NoInnerDeclarationsMode, NoInnerDeclarationsConfi
 #[serde(rename_all = "camelCase", default)]
 struct NoInnerDeclarationsConfigObject {
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
+    #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
 }
 
@@ -89,8 +90,7 @@ impl Rule for NoInnerDeclarations {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let NoInnerDeclarations(mode, NoInnerDeclarationsConfigObject { block_scoped_functions }) =
-            &self;
+        let NoInnerDeclarations(mode, config) = &self;
 
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
@@ -106,7 +106,7 @@ impl Rule for NoInnerDeclarations {
                 }
 
                 if mode == &NoInnerDeclarationsMode::Functions
-                    && block_scoped_functions == &Some(BlockScopedFunctions::Allow)
+                    && config.block_scoped_functions == Some(BlockScopedFunctions::Allow)
                 {
                     let is_module = ctx.source_type().is_module();
                     let scope_id = node.scope_id();

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -5,11 +5,7 @@ use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    AstNode,
-    context::LintContext,
-    rule::{DefaultRuleConfig, Rule},
-};
+use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
@@ -19,11 +15,9 @@ fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> 
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
-pub struct NoInnerDeclarations(NoInnerDeclarationsMode, NoInnerDeclarationsConfigObject);
-
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-struct NoInnerDeclarationsConfigObject {
+pub struct NoInnerDeclarations {
+    /// Determines what type of declarations to check.
+    config: NoInnerDeclarationsConfig,
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
     #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
@@ -31,7 +25,7 @@ struct NoInnerDeclarationsConfigObject {
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-enum NoInnerDeclarationsMode {
+enum NoInnerDeclarationsConfig {
     /// Disallows function declarations in nested blocks.
     #[default]
     Functions,
@@ -84,31 +78,48 @@ declare_oxc_lint!(
 
 impl Rule for NoInnerDeclarations {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoInnerDeclarations>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        let config = value.get(0).and_then(serde_json::Value::as_str).map_or_else(
+            NoInnerDeclarationsConfig::default,
+            |value| match value {
+                "functions" => NoInnerDeclarationsConfig::Functions,
+                _ => NoInnerDeclarationsConfig::Both,
+            },
+        );
+
+        let block_scoped_functions = if value.is_array() && !value.is_null() {
+            value
+                .get(1)
+                .and_then(|v| v.get("blockScopedFunctions"))
+                .and_then(serde_json::Value::as_str)
+                .map(|value| match value {
+                    "disallow" => BlockScopedFunctions::Disallow,
+                    _ => BlockScopedFunctions::Allow,
+                })
+                .or(Some(BlockScopedFunctions::Allow))
+        } else {
+            None
+        };
+
+        Self { config, block_scoped_functions }
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
-                let NoInnerDeclarations(mode, _config) = &self;
-
-                if mode == &NoInnerDeclarationsMode::Functions || !decl.kind.is_var() {
+                if self.config == NoInnerDeclarationsConfig::Functions || !decl.kind.is_var() {
                     return;
                 }
 
                 check_rule(node, ctx);
             }
             AstKind::Function(func) => {
-                let NoInnerDeclarations(mode, config) = &self;
-
                 if !func.is_function_declaration() {
                     return;
                 }
 
-                if mode == &NoInnerDeclarationsMode::Functions
-                    && config.block_scoped_functions == Some(BlockScopedFunctions::Allow)
+                if self.config == NoInnerDeclarationsConfig::Functions
+                    && let Some(block_scoped_functions) = self.block_scoped_functions
+                    && block_scoped_functions == BlockScopedFunctions::Allow
                 {
                     let is_module = ctx.source_type().is_module();
                     let scope_id = node.scope_id();
@@ -189,8 +200,8 @@ fn test() {
         ("if (test) { var foo; }", None),
         ("if (test) { let x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
         ("if (test) { const x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
-        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
-        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
+        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
+        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
         ("function doSomething() { while (test) { var foo; } }", None),
         ("var foo;", Some(serde_json::json!(["both"]))),
         ("var foo = 42;", Some(serde_json::json!(["both"]))),

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -90,10 +90,10 @@ impl Rule for NoInnerDeclarations {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let NoInnerDeclarations(mode, config) = &self;
-
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
+                let NoInnerDeclarations(mode, _config) = &self;
+
                 if mode == &NoInnerDeclarationsMode::Functions || !decl.kind.is_var() {
                     return;
                 }
@@ -101,6 +101,8 @@ impl Rule for NoInnerDeclarations {
                 check_rule(node, ctx);
             }
             AstKind::Function(func) => {
+                let NoInnerDeclarations(mode, config) = &self;
+
                 if !func.is_function_declaration() {
                     return;
                 }

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
-use serde::{Deserialize};
+use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -9,8 +9,15 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{ToBigInt, WithoutGlobalReferenceInformation};
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule, utils::is_same_expression};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_same_expression,
+};
 
 fn yoda_diagnostic(span: Span, never: bool, operator: &str) -> OxcDiagnostic {
     let expected_side = if never { "right" } else { "left" };
@@ -19,16 +26,39 @@ fn yoda_diagnostic(span: Span, never: bool, operator: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
-pub struct Yoda {
-    never: bool,
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Yoda(AllowYoda, YodaOptions);
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct YodaOptions {
+    /// If the `"exceptRange"` property is `true`, the rule *allows* yoda conditions
+    /// in range comparisons which are wrapped directly in parentheses, including the
+    /// parentheses of an `if` or `while` condition.
+    /// A *range* comparison tests whether a variable is inside or outside the range
+    /// between two literal values.
     except_range: bool,
+    /// If the `"onlyEquality"` property is `true`, the rule reports yoda
+    /// conditions *only* for the equality operators `==` and `===`. The `onlyEquality`
+    /// option allows a superset of the exceptions which `exceptRange` allows, thus
+    /// both options are not useful together.
     only_equality: bool,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum AllowYoda {
+    /// The default `"never"` option can have exception options in an object literal, via `exceptRange` and `onlyEquality`.
+    #[default]
+    Never,
+    /// The `"always"` option requires that literal values must always come first in comparisons.
+    Always,
 }
 
 impl Default for Yoda {
     fn default() -> Self {
-        Self { never: true, except_range: false, only_equality: false }
+        Self(AllowYoda::Never, YodaOptions { except_range: false, only_equality: false })
     }
 }
 
@@ -46,25 +76,20 @@ declare_oxc_lint!(
     //     // ...
     /// }
     /// ```
+    ///
     /// This is called a Yoda condition because it reads as, "if red equals the color", similar to the way the Star Wars character Yoda speaks. Compare to the other way of arranging the operands:
+    ///
     /// ```js
     /// if (color === "red") {
     ///     // ...
     /// }
     /// ```
+    ///
     /// This typically reads, "if the color equals red", which is arguably a more natural way to describe the comparison.
     /// Proponents of Yoda conditions highlight that it is impossible to mistakenly use `=` instead of `==` because you cannot assign to a literal value. Doing so will cause a syntax error and you will be informed of the mistake early on. This practice was therefore very common in early programming where tools were not yet available.
     /// Opponents of Yoda conditions point out that tooling has made us better programmers because tools will catch the mistaken use of `=` instead of `==` (ESLint will catch this for you). Therefore, they argue, the utility of the pattern doesn't outweigh the readability hit the code takes while using Yoda conditions.
     ///
-    /// ### Options
-    ///
-    /// This rule can take a string option:
-    /// * If it is the default `"never"`, then comparisons must never be Yoda conditions.
-    /// * If it is `"always"`, then the literal value must always come first.
-    /// The default `"never"` option can have exception options in an object literal:
-    /// * If the `"exceptRange"` property is `true`, the rule *allows* yoda conditions in range comparisons which are wrapped directly in parentheses, including the parentheses of an `if` or `while` condition. The default value is `false`. A *range* comparison tests whether a variable is inside or outside the range between two literal values.
-    /// * If the `"onlyEquality"` property is `true`, the rule reports yoda conditions *only* for the equality operators `==` and `===`. The default value is `false`.
-    /// The `onlyEquality` option allows a superset of the exceptions which `exceptRange` allows, thus both options are not useful together.
+    /// ### Examples
     ///
     /// #### never
     ///
@@ -119,6 +144,7 @@ declare_oxc_lint!(
     /// #### exceptRange
     ///
     /// Examples of **correct** code for the `"never", { "exceptRange": true }` options:
+    ///
     /// ```js
     /// function isReddish(color) {
     ///     return (color.hue < 60 || 300 < color.hue);
@@ -189,34 +215,13 @@ declare_oxc_lint!(
     Yoda,
     eslint,
     style,
-    fix
+    fix,
+    config = Yoda,
 );
 
 impl Rule for Yoda {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let mut config = Self::default();
-
-        let Some(arr) = value.as_array() else {
-            return config;
-        };
-
-        let option1 = arr.first().and_then(serde_json::Value::as_str);
-        let option2 = arr.get(1).and_then(serde_json::Value::as_object);
-
-        if option1 == Some("always") {
-            config.never = false;
-        }
-
-        if let Some(option2) = option2 {
-            if option2.get("exceptRange").and_then(serde_json::Value::as_bool) == Some(true) {
-                config.except_range = true;
-            }
-            if option2.get("onlyEquality").and_then(serde_json::Value::as_bool) == Some(true) {
-                config.only_equality = true;
-            }
-        }
-
-        config
+        serde_json::from_value::<DefaultRuleConfig<Yoda>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -224,11 +229,13 @@ impl Rule for Yoda {
             return;
         };
 
+        let Yoda(allow_yoda, options) = self;
+
         let parent_node = ctx.nodes().parent_node(node.id());
         if let AstKind::LogicalExpression(logical_expr) = parent_node.kind() {
             let parent_logical_expr = ctx.nodes().parent_node(parent_node.id());
 
-            if self.except_range
+            if options.except_range
                 && is_parenthesized(parent_logical_expr)
                 && is_range(logical_expr, ctx)
             {
@@ -240,18 +247,18 @@ impl Rule for Yoda {
             return;
         }
 
-        if self.only_equality && !is_equality(expr) {
+        if options.only_equality && !is_equality(expr) {
             return;
         }
 
         // never
-        if self.never && is_yoda(expr) {
-            do_diagnostic_with_fix(expr, ctx, self.never);
+        if allow_yoda == &AllowYoda::Never && is_yoda(expr) {
+            do_diagnostic_with_fix(expr, ctx, true);
         }
 
         // always
-        if !self.never && is_not_yoda(expr) {
-            do_diagnostic_with_fix(expr, ctx, self.never);
+        if allow_yoda == &AllowYoda::Always && is_not_yoda(expr) {
+            do_diagnostic_with_fix(expr, ctx, false);
         }
     }
 }

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -34,7 +34,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "eslint/no-empty-function",
         "eslint/no-restricted-imports",
         "eslint/no-warning-comments",
-        "eslint/yoda",
         // jest
         "jest/valid-title",
         // react

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -30,7 +30,6 @@ fn test_rules_with_custom_configuration_have_schema() {
     // list - newly-created rules should always be documented before being merged!
     let exceptions: &[&str] = &[
         // eslint
-        "eslint/arrow-body-style",
         "eslint/func-names",
         "eslint/no-empty-function",
         "eslint/no-restricted-imports",


### PR DESCRIPTION
This enables DefaultRuleConfig to handle tuple structs properly so we can have an easier time resolving #16023.

This is also part of #14743.

This allows us to refactor the way we handle the config for SortKeys, so it's much simpler. And also updates func-style and arrow-body-style to use the tuple pattern and have correct config option docs. I initially tried to update the no-inner-declarations rule to use the tuple pattern, but it lead to test failures due to what I suspect is a bug in the implementation of that rule. So I split that into its own PR.

This was done with help from GitHub Copilot + their Raptor mini model, but I've added enough tests - and all the rules that currently use DefaultRuleConfig still pass their tests - that I feel pretty good about it being functional, albeit probably not elegant. Happy to take feedback on improving this in that regard especially.

Updated the `eslint/func-style` rule:

```md
## Configuration

### The 1st option

type: `"expression" | "declaration"`

### The 2nd option

This option is an object with the following properties:

#### allowArrowFunctions

type: `boolean`

default: `false`

When true, arrow functions are allowed regardless of the style setting.

#### allowTypeAnnotation

type: `boolean`

default: `false`

When true, functions with type annotations are allowed regardless of the style setting.

#### overrides

type: `object`

##### overrides.namedExports

type: `string | null`

default: `null`
```

For `eslint/arrow-body-style`:

```md
## Configuration

### The 1st option

type: `"as-needed" | "always" | "never"`

#### `"as-needed"`

`as-needed` enforces no braces where they can be omitted (default).

Examples of **incorrect** code for this rule with the `as-needed` option:

\```js
/* arrow-body-style: ["error", "as-needed"] */

/* ✘ Bad: */
const foo = () => {
  return 0;
};
\```

Examples of **correct** code for this rule with the `as-needed` option:

\```js
/* arrow-body-style: ["error", "as-needed"] */

/* ✔ Good: */
const foo1 = () => 0;

const foo2 = (retv, name) => {
  retv[name] = true;
  return retv;
};

const foo3 = () => {
  bar();
};
\```

#### `"always"`

`always` enforces braces around the function body.

Examples of **incorrect** code for this rule with the `always` option:

\```js
/* arrow-body-style: ["error", "always"] */

/* ✘ Bad: */
const foo = () => 0;
\```

Examples of **correct** code for this rule with the `always` option:

\```js
/* arrow-body-style: ["error", "always"] */

/* ✔ Good: */
const foo = () => {
  return 0;
};
\```

#### `"never"`

`never` enforces no braces around the function body (constrains arrow functions to the role of returning an expression)

Examples of **incorrect** code for this rule with the `never` option:

\```js
/* arrow-body-style: ["error", "never"] */

/* ✘ Bad: */
const foo = () => {
  return 0;
};
\```

Examples of **correct** code for this rule with the `never` option:

\```js
/* arrow-body-style: ["error", "never"] */

/* ✔ Good: */
const foo = () => 0;
const bar = () => ({ foo: 0 });
\```

### The 2nd option

This option is an object with the following properties:

#### requireReturnForObjectLiteral

type: `boolean`

default: `false`

If `true`, requires braces and an explicit return for object literals.

Note: This option only applies when the first option is `"as-needed"`.

Examples of **incorrect** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:

\```js
/* arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/

/* ✘ Bad: */
const foo = () => ({});
const bar = () => ({ bar: 0 });
\```

Examples of **correct** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:

\```js
/* arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/

/* ✔ Good: */
const foo = () => {};
const bar = () => {
  return { bar: 0 };
};
\```
```