### PR TITLE
docs(linter): Fix the rule config docs for `eslint/no-inner-declarations` rule.

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -168,17 +168,15 @@ where
                 Ok(DefaultRuleConfig(T::default()))
             }
             _ => {
-                // Try parsing the whole array into T (covers tuple-form configs).
-                if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr.clone())) {
+                let first = arr.get(0).cloned();
+
+                if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr)) {
                     return Ok(DefaultRuleConfig(t));
                 }
 
-                // Otherwise parse only the first element or use default.
-                let config = arr
-                    .into_iter()
-                    .next()
-                    .and_then(|v| serde_json::from_value(v).ok())
-                    .unwrap_or_else(T::default);
+                // Parsing the whole array failed; parse first element if present.
+                let config =
+                    first.and_then(|v| serde_json::from_value(v).ok()).unwrap_or_else(T::default);
 
                 Ok(DefaultRuleConfig(config))
             }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -168,7 +168,7 @@ where
                 Ok(DefaultRuleConfig(T::default()))
             }
             _ => {
-                let first = arr.get(0).cloned();
+                let first = arr.first().cloned();
 
                 if let Ok(t) = serde_json::from_value::<T>(serde_json::Value::Array(arr)) {
                     return Ok(DefaultRuleConfig(t));
@@ -552,9 +552,9 @@ mod test {
         let de: DefaultRuleConfig<u32> = serde_json::from_str("[123]").unwrap();
         assert_eq!(de.into_inner(), 123u32);
         let de: DefaultRuleConfig<bool> = serde_json::from_str("[true]").unwrap();
-        assert_eq!(de.into_inner(), true);
+        assert!(de.into_inner());
         let de: DefaultRuleConfig<bool> = serde_json::from_str("[false]").unwrap();
-        assert_eq!(de.into_inner(), false);
+        assert!(!de.into_inner());
 
         // empty array should use defaults
         let de: DefaultRuleConfig<String> = serde_json::from_str("[]").unwrap();
@@ -648,9 +648,8 @@ mod test {
         // A basic enum config option.
         let json = r#"["optionA"]"#;
         let de: DefaultRuleConfig<EnumOptions> = serde_json::from_str(json).unwrap();
-        let cfg = de.into_inner();
 
-        assert_eq!(cfg, EnumOptions::OptionA);
+        assert_eq!(de.into_inner(), EnumOptions::OptionA);
     }
 
     #[derive(serde::Deserialize, Default, Debug, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -80,7 +80,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///
 /// # Examples
 ///
-/// ```rs
+/// ```rust
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         let config = serde_json::from_value::<DefaultRuleConfig<MyRuleConfig>>(value)
@@ -91,7 +91,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// ```
 ///
 /// For rules that take a tuple configuration object, e.g. `["foobar", { param: true, other_param: false }]`, you can also use this with a tuple struct:
-/// ```rs
+/// ```rust
 /// pub struct MyRuleWithTupleConfig(FirstParamType, SecondParamType);
 ///
 /// impl Rule for MyRuleWithTupleConfig {
@@ -591,7 +591,8 @@ mod test {
         assert_eq!(de.into_inner(), Pair(42u32, Obj { foo: "abc".to_string() }));
 
         // only first element present -> parsing the entire array into `Pair`
-        // will fail, so we fall back to the old behaviour and use T::default().
+        // will fail, so we parse the first element. Since Pair has #[serde(default)],
+        // serde will use the default value for the missing second field.
         let de: DefaultRuleConfig<Pair> = serde_json::from_str("[10]").unwrap();
         assert_eq!(de.into_inner(), Pair(10u32, Obj { foo: "defaultval".to_string() }));
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -98,7 +98,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         serde_json::from_value::<DefaultRuleConfig<MyRuleWithTupleConfig>>(value)
 ///             .unwrap_or_default()
-///             .into_inner();
+///             .into_inner()
 ///     }
 /// }
 /// ```

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -80,7 +80,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
 ///         let config = serde_json::from_value::<DefaultRuleConfig<MyRuleConfig>>(value)
@@ -91,7 +91,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// ```
 ///
 /// For rules that take a tuple configuration object, e.g. `["foobar", { param: true, other_param: false }]`, you can also use this with a tuple struct:
-/// ```rust
+/// ```ignore
 /// pub struct MyRuleWithTupleConfig(FirstParamType, SecondParamType);
 ///
 /// impl Rule for MyRuleWithTupleConfig {

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -25,6 +25,7 @@ pub struct NoInnerDeclarations(NoInnerDeclarationsMode, NoInnerDeclarationsConfi
 #[serde(rename_all = "camelCase", default)]
 struct NoInnerDeclarationsConfigObject {
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
+    #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
 }
 
@@ -89,8 +90,7 @@ impl Rule for NoInnerDeclarations {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let NoInnerDeclarations(mode, NoInnerDeclarationsConfigObject { block_scoped_functions }) =
-            &self;
+        let NoInnerDeclarations(mode, config) = &self;
 
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
@@ -106,7 +106,7 @@ impl Rule for NoInnerDeclarations {
                 }
 
                 if mode == &NoInnerDeclarationsMode::Functions
-                    && block_scoped_functions == &Some(BlockScopedFunctions::Allow)
+                    && config.block_scoped_functions == Some(BlockScopedFunctions::Allow)
                 {
                     let is_module = ctx.source_type().is_module();
                     let scope_id = node.scope_id();

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -5,7 +5,11 @@ use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
@@ -15,9 +19,11 @@ fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> 
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
-pub struct NoInnerDeclarations {
-    /// Determines what type of declarations to check.
-    config: NoInnerDeclarationsConfig,
+pub struct NoInnerDeclarations(NoInnerDeclarationsMode, NoInnerDeclarationsConfigObject);
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+struct NoInnerDeclarationsConfigObject {
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
     #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
@@ -25,7 +31,7 @@ pub struct NoInnerDeclarations {
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-enum NoInnerDeclarationsConfig {
+enum NoInnerDeclarationsMode {
     /// Disallows function declarations in nested blocks.
     #[default]
     Functions,
@@ -78,48 +84,31 @@ declare_oxc_lint!(
 
 impl Rule for NoInnerDeclarations {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = value.get(0).and_then(serde_json::Value::as_str).map_or_else(
-            NoInnerDeclarationsConfig::default,
-            |value| match value {
-                "functions" => NoInnerDeclarationsConfig::Functions,
-                _ => NoInnerDeclarationsConfig::Both,
-            },
-        );
-
-        let block_scoped_functions = if value.is_array() && !value.is_null() {
-            value
-                .get(1)
-                .and_then(|v| v.get("blockScopedFunctions"))
-                .and_then(serde_json::Value::as_str)
-                .map(|value| match value {
-                    "disallow" => BlockScopedFunctions::Disallow,
-                    _ => BlockScopedFunctions::Allow,
-                })
-                .or(Some(BlockScopedFunctions::Allow))
-        } else {
-            None
-        };
-
-        Self { config, block_scoped_functions }
+        serde_json::from_value::<DefaultRuleConfig<NoInnerDeclarations>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
-                if self.config == NoInnerDeclarationsConfig::Functions || !decl.kind.is_var() {
+                let NoInnerDeclarations(mode, _config) = &self;
+
+                if mode == &NoInnerDeclarationsMode::Functions || !decl.kind.is_var() {
                     return;
                 }
 
                 check_rule(node, ctx);
             }
             AstKind::Function(func) => {
+                let NoInnerDeclarations(mode, config) = &self;
+
                 if !func.is_function_declaration() {
                     return;
                 }
 
-                if self.config == NoInnerDeclarationsConfig::Functions
-                    && let Some(block_scoped_functions) = self.block_scoped_functions
-                    && block_scoped_functions == BlockScopedFunctions::Allow
+                if mode == &NoInnerDeclarationsMode::Functions
+                    && config.block_scoped_functions == Some(BlockScopedFunctions::Allow)
                 {
                     let is_module = ctx.source_type().is_module();
                     let scope_id = node.scope_id();
@@ -200,8 +189,8 @@ fn test() {
         ("if (test) { var foo; }", None),
         ("if (test) { let x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
         ("if (test) { const x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
-        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
-        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
+        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
+        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
         ("function doSomething() { while (test) { var foo; } }", None),
         ("var foo;", Some(serde_json::json!(["both"]))),
         ("var foo = 42;", Some(serde_json::json!(["both"]))),

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -5,11 +5,7 @@ use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    AstNode,
-    context::LintContext,
-    rule::{DefaultRuleConfig, Rule},
-};
+use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
@@ -19,11 +15,9 @@ fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> 
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
-pub struct NoInnerDeclarations(NoInnerDeclarationsMode, NoInnerDeclarationsConfigObject);
-
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-struct NoInnerDeclarationsConfigObject {
+pub struct NoInnerDeclarations {
+    /// Determines what type of declarations to check.
+    config: NoInnerDeclarationsConfig,
     /// Controls whether function declarations in nested blocks are allowed in strict mode (ES6+ behavior).
     #[schemars(with = "BlockScopedFunctions")]
     block_scoped_functions: Option<BlockScopedFunctions>,
@@ -31,7 +25,7 @@ struct NoInnerDeclarationsConfigObject {
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-enum NoInnerDeclarationsMode {
+enum NoInnerDeclarationsConfig {
     /// Disallows function declarations in nested blocks.
     #[default]
     Functions,
@@ -84,31 +78,48 @@ declare_oxc_lint!(
 
 impl Rule for NoInnerDeclarations {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoInnerDeclarations>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        let config = value.get(0).and_then(serde_json::Value::as_str).map_or_else(
+            NoInnerDeclarationsConfig::default,
+            |value| match value {
+                "functions" => NoInnerDeclarationsConfig::Functions,
+                _ => NoInnerDeclarationsConfig::Both,
+            },
+        );
+
+        let block_scoped_functions = if value.is_array() && !value.is_null() {
+            value
+                .get(1)
+                .and_then(|v| v.get("blockScopedFunctions"))
+                .and_then(serde_json::Value::as_str)
+                .map(|value| match value {
+                    "disallow" => BlockScopedFunctions::Disallow,
+                    _ => BlockScopedFunctions::Allow,
+                })
+                .or(Some(BlockScopedFunctions::Allow))
+        } else {
+            None
+        };
+
+        Self { config, block_scoped_functions }
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
-                let NoInnerDeclarations(mode, _config) = &self;
-
-                if mode == &NoInnerDeclarationsMode::Functions || !decl.kind.is_var() {
+                if self.config == NoInnerDeclarationsConfig::Functions || !decl.kind.is_var() {
                     return;
                 }
 
                 check_rule(node, ctx);
             }
             AstKind::Function(func) => {
-                let NoInnerDeclarations(mode, config) = &self;
-
                 if !func.is_function_declaration() {
                     return;
                 }
 
-                if mode == &NoInnerDeclarationsMode::Functions
-                    && config.block_scoped_functions == Some(BlockScopedFunctions::Allow)
+                if self.config == NoInnerDeclarationsConfig::Functions
+                    && let Some(block_scoped_functions) = self.block_scoped_functions
+                    && block_scoped_functions == BlockScopedFunctions::Allow
                 {
                     let is_module = ctx.source_type().is_module();
                     let scope_id = node.scope_id();
@@ -189,8 +200,8 @@ fn test() {
         ("if (test) { var foo; }", None),
         ("if (test) { let x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
         ("if (test) { const x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 6 },
-        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
-        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // { "ecmaVersion": 2026, "sourceType": "module" },
+        ("if (test) { using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
+        ("if (test) { await using x = 1; }", Some(serde_json::json!(["both"]))), // {				"ecmaVersion": 2026,				"sourceType": "module",			},
         ("function doSomething() { while (test) { var foo; } }", None),
         ("var foo;", Some(serde_json::json!(["both"]))),
         ("var foo = 42;", Some(serde_json::json!(["both"]))),

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -90,10 +90,10 @@ impl Rule for NoInnerDeclarations {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let NoInnerDeclarations(mode, config) = &self;
-
         match node.kind() {
             AstKind::VariableDeclaration(decl) => {
+                let NoInnerDeclarations(mode, _config) = &self;
+
                 if mode == &NoInnerDeclarationsMode::Functions || !decl.kind.is_var() {
                     return;
                 }
@@ -101,6 +101,8 @@ impl Rule for NoInnerDeclarations {
                 check_rule(node, ctx);
             }
             AstKind::Function(func) => {
+                let NoInnerDeclarations(mode, config) = &self;
+
                 if !func.is_function_declaration() {
                     return;
                 }

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -8,14 +8,18 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct SortKeys(Box<SortKeysConfig>);
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Sorting order for keys. Accepts "asc" for ascending or "desc" for descending.
 pub enum SortOrder {
@@ -24,7 +28,7 @@ pub enum SortOrder {
     Asc,
 }
 
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct SortKeysOptions {
     /// Whether the sort comparison is case-sensitive (A < a when true).
@@ -49,18 +53,9 @@ impl Default for SortKeysOptions {
     }
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(default)]
 pub struct SortKeysConfig(SortOrder, SortKeysOptions);
-
-impl SortKeys {
-    fn sort_order(&self) -> &SortOrder {
-        &(*self.0).0
-    }
-    fn options(&self) -> &SortKeysOptions {
-        &(*self.0).1
-    }
-}
 
 fn sort_properties_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Object keys should be sorted").with_label(span)
@@ -102,50 +97,18 @@ declare_oxc_lint!(
 
 impl Rule for SortKeys {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let Some(config_array) = value.as_array() else {
-            return Self::default();
-        };
-
-        let sort_order = if config_array.is_empty() {
-            SortOrder::Asc
-        } else {
-            config_array[0].as_str().map_or(SortOrder::Asc, |s| match s {
-                "desc" => SortOrder::Desc,
-                _ => SortOrder::Asc,
-            })
-        };
-
-        let config = if config_array.len() > 1 {
-            config_array[1].as_object().unwrap()
-        } else {
-            &serde_json::Map::new()
-        };
-
-        let case_sensitive =
-            config.get("caseSensitive").and_then(serde_json::Value::as_bool).unwrap_or(true);
-        let natural = config.get("natural").and_then(serde_json::Value::as_bool).unwrap_or(false);
-        let min_keys = config
-            .get("minKeys")
-            .and_then(serde_json::Value::as_u64)
-            .map_or(2, |n| n.try_into().unwrap_or(2));
-        let allow_line_separated_groups = config
-            .get("allowLineSeparatedGroups")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-
-        Self(Box::new(SortKeysConfig(
-            sort_order,
-            SortKeysOptions { case_sensitive, natural, min_keys, allow_line_separated_groups },
-        )))
+        serde_json::from_value::<DefaultRuleConfig<SortKeys>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ObjectExpression(dec) = node.kind() {
-            let options = self.options();
+            let SortKeysConfig(sort_order, options) = &*self.0;
+
             if dec.properties.len() < options.min_keys {
                 return;
             }
-            let sort_order = self.sort_order().clone();
 
             let mut property_groups: Vec<Vec<String>> = vec![vec![]];
 
@@ -194,7 +157,7 @@ impl Rule for SortKeys {
                     alphanumeric_sort(group);
                 }
 
-                if sort_order == SortOrder::Desc {
+                if sort_order == &SortOrder::Desc {
                     group.reverse();
                 }
             }
@@ -277,7 +240,7 @@ impl Rule for SortKeys {
                     } else {
                         alphanumeric_sort(&mut sorted_keys);
                     }
-                    if sort_order == SortOrder::Desc {
+                    if sort_order == &SortOrder::Desc {
                         sorted_keys.reverse();
                     }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
-use serde::{Deserialize};
+use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -30,7 +30,6 @@ fn test_rules_with_custom_configuration_have_schema() {
     // list - newly-created rules should always be documented before being merged!
     let exceptions: &[&str] = &[
         // eslint
-        "eslint/arrow-body-style",
         "eslint/func-names",
         "eslint/no-empty-function",
         "eslint/no-restricted-imports",


### PR DESCRIPTION
This fixes the `no-inner-declarations` docs by treating them as a tuple. Although, it also breaks the tests for no-inner-declarations. 🙃 

I _think_ there may be a bug in the tests/logic for our `no-inner-declarations` rule (I think oxc assumes strict mode by default maybe?). We previously returned `None` for `block_scoped_expressions` instead of `allow`, which [the original rule](https://github.com/eslint/eslint/blob/main/lib/rules/no-inner-declarations.js) does not do. It always just sets `allow` as the default value as far as I can tell.

I'm unsure if I should add an `impl Default for NoInnerDeclarationsConfigObject` and set it to return None, and retain that behavior, or if we should fix this behavior to match the original ESLint rule better? Up to cam, probably.

Generated docs:

```md
## Configuration

### The 1st option

type: `"functions" | "both"`

#### `"functions"`

Disallows function declarations in nested blocks.

#### `"both"`

Disallows function and var declarations in nested blocks.

### The 2nd option

This option is an object with the following properties:

#### blockScopedFunctions

type: `"allow" | "disallow"`

##### `"allow"`

Allow function declarations in nested blocks in strict mode (ES6+ behavior).

##### `"disallow"`

Disallow function declarations in nested blocks regardless of strict mode.
```
