### PR TITLE
fix(linter): Fix default behavior of the `eslint/eqeqeq` rule, and also the config option docs for it

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -51,9 +51,9 @@ enum NullType {
     /// This is the default.
     #[default]
     Always,
-    /// Never require triple-equals when comparing with null, always use `== null`/`!= null`
+    /// Never require triple-equals when comparing with null, always use `== null`/`!= null`.
     Never,
-    /// Ignore null comparisons, allow either `== null`/`!= null` and `=== null`/`!== null`
+    /// Ignore null comparisons, allow either `== null`/`!= null` or `=== null`/`!== null`.
     Ignore,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -36,22 +36,24 @@ pub struct EqeqeqOptions {
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 enum CompareType {
-    /// `"always"` - always require `===`/`!==`
+    /// Always require triple-equal comparisons, `===`/`!==`.
+    /// This is the default.
     #[default]
     Always,
-    /// `"smart"` - allow safe comparisons (`typeof`, literals, nullish)
+    /// Allow certain safe comparisons to use `==`/`!=` (`typeof`, literals, nullish).
     Smart,
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 enum NullType {
-    /// `"always"` - always require `=== null`/`!== null`
+    /// Always require triple-equals when comparing with null, `=== null`/`!== null`.
+    /// This is the default.
     #[default]
     Always,
-    /// `"never"` - always require `== null`/`!= null`
+    /// Never require triple-equals when comparing with null, always use `== null`/`!= null`
     Never,
-    /// `"ignore"` - allow both `== null`/`!= null` and `=== null`/`!== null`
+    /// Ignore null comparisons, allow either `== null`/`!= null` and `=== null`/`!== null`
     Ignore,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -24,6 +24,42 @@ pub struct Eqeqeq {
     null_type: NullType,
 }
 
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum CompareType {
+    #[default]
+    Always,
+    Smart,
+}
+
+impl CompareType {
+    pub fn from(raw: &str) -> Self {
+        match raw {
+            "smart" => Self::Smart,
+            _ => Self::Always,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum NullType {
+    #[default]
+    Always,
+    Never,
+    Ignore,
+}
+
+impl NullType {
+    pub fn from(raw: &str) -> Self {
+        match raw {
+            "always" => Self::Always,
+            "never" => Self::Never,
+            _ => Self::Ignore,
+        }
+    }
+}
+
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -163,42 +199,6 @@ declare_oxc_lint!(
     fix = conditional_fix_dangerous,
     config = Eqeqeq,
 );
-
-#[derive(Debug, Default, Clone, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum CompareType {
-    #[default]
-    Always,
-    Smart,
-}
-
-impl CompareType {
-    pub fn from(raw: &str) -> Self {
-        match raw {
-            "smart" => Self::Smart,
-            _ => Self::Always,
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum NullType {
-    #[default]
-    Always,
-    Never,
-    Ignore,
-}
-
-impl NullType {
-    pub fn from(raw: &str) -> Self {
-        match raw {
-            "always" => Self::Always,
-            "never" => Self::Never,
-            _ => Self::Ignore,
-        }
-    }
-}
 
 impl Eqeqeq {
     fn report_inverse_null_comparison(&self, binary_expr: &BinaryExpression, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -21,18 +21,12 @@ fn eqeqeq_diagnostic(actual: &str, expected: &str, span: Span) -> OxcDiagnostic 
         .with_label(span)
 }
 
-#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Eqeqeq(CompareType, EqeqeqOptions);
 
-impl Default for Eqeqeq {
-    fn default() -> Self {
-        Self(CompareType::Always, EqeqeqOptions { null: NullType::Always })
-    }
-}
-
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct EqeqeqOptions {
     /// Configuration for whether to allow/disallow comparisons against `null`,
     /// e.g. `foo == null` or `foo != null`

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -7,10 +7,13 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use schemars::JsonSchema;
-use serde::{Deserialize};
+use serde::Deserialize;
 
-use crate::{fixer::{RuleFix, RuleFixer}, rule::DefaultRuleConfig};
 use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    fixer::{RuleFix, RuleFixer},
+    rule::DefaultRuleConfig,
+};
 
 fn eqeqeq_diagnostic(actual: &str, expected: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Expected {expected} and instead saw {actual}"))
@@ -195,9 +198,7 @@ impl Eqeqeq {
 
 impl Rule for Eqeqeq {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Eqeqeq>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<Eqeqeq>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -333,19 +334,18 @@ fn test() {
         ("foo == null", Some(json!(["smart"]))),
         ("foo === null", None),
         // Always use === or !== with `null`
-        ("null === null", Some(json!(["always", {"null": "always"}]))),
+        ("null === null", Some(json!(["always", { "null": "always" }]))),
         // Never use === or !== with `null`
-        ("null == null", Some(json!(["always", {"null": "never"}]))),
+        ("null == null", Some(json!(["always", { "null": "never" }]))),
         // Do not apply this rule to `null`.
-        ("null == null", Some(json!(["smart", {"null": "ignore"}]))),
+        ("null == null", Some(json!(["smart", { "null": "ignore" }]))),
         // Issue: <https://github.com/oxc-project/oxc/issues/8773>
-        // TODO: Do we actually want to allow skipping the string option like this?? Currently this fails.
-        ("href != null", Some(json!([{"null": "ignore"}]))),
+        ("href != null", Some(json!(["always", { "null": "ignore" }]))),
     ];
 
     let fail = vec![
         // ESLint will perform like below case
-        ("null >= 1", Some(json!(["always", {"null": "never"}]))),
+        ("null >= 1", Some(json!(["always", { "null": "never" }]))),
         ("typeof foo == 'undefined'", None),
         ("'hello' != 'world'", None),
         ("0 == 0", None),
@@ -355,7 +355,7 @@ fn test() {
         ("foo == true", None),
         ("bananas != 1", None),
         ("value == undefined", None),
-        ("null == null", Some(json!(["always", {"null": "always"}]))),
+        ("null == null", Some(json!(["always", { "null": "always" }]))),
     ];
 
     let fix = vec![


### PR DESCRIPTION
This is part of #16023.

See [the tests for the original rule](https://github.com/eslint/eslint/blob/b017f094d4e53728f8d335b9cf8b16dc074afda3/tests/lib/rules/eqeqeq.js).

We have a test in [the eqeqeq.rs implementation](https://github.com/oxc-project/oxc/blob/e24aabdfa65044a7223e4ea7b294ad3bf5dfb1ec/crates/oxc_linter/src/rules/eslint/eqeqeq.rs) like so:

```rs
// Issue: <https://github.com/oxc-project/oxc/issues/8773>
("href != null", Some(json!([{"null": "ignore"}]))),
```

The problem is that this test has an incorrect shape for the config object, see here:

```jsonc
// Should always be in one of these three formats, all three work in the original rule as well:
"eslint/eqeqeq": ["error", "always", { "null": "never" }],
"eslint/eqeqeq": ["error", "always"],
"eslint/eqeqeq": ["error"],

// But right now the tests have a case where the string arg is skipped, while the ESLint rule does not allow this:
"eslint/eqeqeq": ["error", { "null": "ignore" }],
```

The problem is that the code _did_ previously handle this config array as invalid. However, because the implementation of `from` on NullType would fall back to `ignore` if it received bad data, it looked like it worked:

```rs
impl NullType {
    pub fn from(raw: &str) -> Self {
        match raw {
            "always" => Self::Always,
            "never" => Self::Never,
            _ => Self::Ignore,
        }
    }
}
```

Because `always` is marked as the default value (and is also the default value in the original ESLint rule), and so should be the default case. The test was just hitting the fallback value, so it looked like it worked, but really the fallback value was incorrect previously and did not match the docs _or_ the ESLint behavior.

This fixes that issue by correcting the fallback value, and also fixes the auto-generated config shape/docs, so it correctly represents itself as taking a tuple.

Generated docs:

```md
## Configuration

### The 1st option

type: `"always" | "smart"`

#### `"always"`

Always require triple-equal comparisons, `===`/`!==`.
This is the default.

#### `"smart"`

Allow certain safe comparisons to use `==`/`!=` (`typeof`, literals, nullish).

### The 2nd option

This option is an object with the following properties:

#### null

type: `"always" | "never" | "ignore"`

##### `"always"`

Always require triple-equals when comparing with null, `=== null`/`!== null`.
This is the default.

##### `"never"`

Never require triple-equals when comparing with null, always use `== null`/`!= null`

##### `"ignore"`

Ignore null comparisons, allow either `== null`/`!= null` and `=== null`/`!== null`
```