### PR TITLE
fix(linter): Correct the config option docs for `eslint/init-declarations` and `eslint/grouped-accessor-pairs`.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -192,11 +192,9 @@ impl Rule for GroupedAccessorPairs {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let GroupedAccessorPairs(pair_order, config) = &self;
-        let enforce_for_ts_types = config.enforce_for_ts_types;
-
         match node.kind() {
             AstKind::ObjectExpression(obj_expr) => {
+                let GroupedAccessorPairs(pair_order, _config) = &self;
                 let mut prop_map =
                     FxHashMap::<(String, bool), Vec<(usize, &OBox<ObjectProperty>)>>::default();
                 let properties = &obj_expr.properties;
@@ -253,6 +251,7 @@ impl Rule for GroupedAccessorPairs {
                 }
             }
             AstKind::ClassBody(class_body) => {
+                let GroupedAccessorPairs(pair_order, _config) = &self;
                 let method_defines = &class_body.body;
                 let mut prop_map = FxHashMap::<
                     (String, bool, bool, bool),
@@ -322,10 +321,10 @@ impl Rule for GroupedAccessorPairs {
                     }
                 }
             }
-            AstKind::TSInterfaceBody(interface_body) if enforce_for_ts_types => {
+            AstKind::TSInterfaceBody(interface_body) if self.1.enforce_for_ts_types => {
                 self.check_ts_interface_body(interface_body, ctx);
             }
-            AstKind::TSTypeLiteral(type_literal) if enforce_for_ts_types => {
+            AstKind::TSTypeLiteral(type_literal) if self.1.enforce_for_ts_types => {
                 self.check_ts_type_literal(type_literal, ctx);
             }
             _ => {}


### PR DESCRIPTION
These rules accept tuple options, so this updates the code accordingly to support that. Part of #16023.

init-declarations:

```md
## Configuration

### The 1st option

type: `"always" | "never"`

#### `"always"`

Requires that variables be initialized on declaration. This is the default behavior.

#### `"never"`

Disallows initialization during declaration.

### The 2nd option

This option is an object with the following properties:

#### ignoreForLoopInit

type: `boolean`

default: `false`

When set to `true`, allows uninitialized variables in the init expression of `for`, `for-in`, and `for-of` loops.
Only applies when mode is set to `"never"`.
```

grouped-accessor-pairs:

```md
## Configuration

### The 1st option

type: `"anyOrder" | "getBeforeSet" | "setBeforeGet"`

#### `"anyOrder"`

Accessors can be in any order. This is the default.

#### `"getBeforeSet"`

Getters must come before setters.

#### `"setBeforeGet"`

Setters must come before getters.

### The 2nd option

This option is an object with the following properties:

#### enforceForTSTypes

type: `boolean`

default: `false`

When `enforceForTSTypes` is enabled, this rule also applies to TypeScript interfaces
and type aliases.

Examples of **incorrect** TypeScript code:

\```ts
interface Foo {
  get a(): string;
  someProperty: string;
  set a(value: string);
}

type Bar = {
  get b(): string;
  someProperty: string;
  set b(value: string);
};
\```

Examples of **correct** TypeScript code:

\```ts
interface Foo {
  get a(): string;
  set a(value: string);
  someProperty: string;
}

type Bar = {
  get b(): string;
  set b(value: string);
  someProperty: string;
};
\```
```