### PR TITLE
docs(linter): Updated `eslint/yoda` rule with auto-gen config options, I have.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -225,11 +225,11 @@ impl Rule for Yoda {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let Yoda(allow_yoda, options) = self;
-
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };
+
+        let Yoda(allow_yoda, options) = self;
 
         let parent_node = ctx.nodes().parent_node(node.id());
         if let AstKind::LogicalExpression(logical_expr) = parent_node.kind() {

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -34,7 +34,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "eslint/no-empty-function",
         "eslint/no-restricted-imports",
         "eslint/no-warning-comments",
-        "eslint/yoda",
         // jest
         "jest/valid-title",
         // react


### PR DESCRIPTION
Uses DefaultRuleConfig now, this rule does. Updated to use a proper tuple config, it has been.
    
Continue to pass, the tests do.

Part of #14743 and dependent on #16555, this PR is.

Generated docs:

```md
## Configuration

### The 1st option

type: `"never" | "always"`

#### `"never"`

The default `"never"` option can have exception options in an object literal, via `exceptRange` and `onlyEquality`.

#### `"always"`

The `"always"` option requires that literal values must always come first in comparisons.

### The 2nd option

This option is an object with the following properties:

#### exceptRange

type: `boolean`

default: `false`

If the `"exceptRange"` property is `true`, the rule _allows_ yoda conditions
in range comparisons which are wrapped directly in parentheses, including the
parentheses of an `if` or `while` condition.
A _range_ comparison tests whether a variable is inside or outside the range
between two literal values.

#### onlyEquality

type: `boolean`

default: `false`

If the `"onlyEquality"` property is `true`, the rule reports yoda
conditions _only_ for the equality operators `==` and `===`. The `onlyEquality`
option allows a superset of the exceptions which `exceptRange` allows, thus
both options are not useful together.
```