### PR TITLE
chore(linter): Mark all remaining upstream-deprecated rules as not-supported

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -136,6 +136,11 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "import/imports-first", // replaced by import/first, which we support
   "react/jsx-sort-default-props", // replaced by react/sort-default-props
   "vitest/no-done-callback", // [deprecated in eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/issues/158)
+  "eslint/no-return-await", // deprecated, not recommended anymore by ESLint
+  "eslint/prefer-reflect", // deprecated, not recommended anymore by ESLint
+  "jsx-a11y/accessible-emoji", // deprecated
+  "jsx-a11y/label-has-for", // deprecated, replaced by jsx-a11y/label-has-associated-control
+  "jsx-a11y/no-onchange", // deprecated, based on behavior of very old browsers, and so no longer necessary
 
   // ESLint rules that are deprecated in ESLint and replaced by rules in eslint-plugin-n:
   "eslint/no-process-env", // replaced by node/no-process-env, which we already support
@@ -148,6 +153,7 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "eslint/no-mixed-requires", // replaced by node/no-mixed-requires
   "eslint/global-require", // replaced by node/global-require
   "eslint/handle-callback-err", // replaced by node/handle-callback-err
+  "eslint/callback-return", // replaced by node/callback-return
 
   // Stylistic rules from eslint-plugin-react:
   "react/jsx-equals-spacing",
@@ -159,6 +165,11 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "react/jsx-props-no-multi-spaces",
   "react/jsx-tag-spacing",
   "react/jsx-space-before-closing",
+
+  // Deprecated typescript-eslint rules:
+  "typescript/sort-type-constituents", // replaced by `perfectionist/sort-intersection-types` and `perfectionist/sort-union-types` rules.
+  "typescript/no-type-alias", // replaced by `typescript-eslint/consistent-type-definitions` rule.
+  "typescript/typedef", // just generally deprecated
 
   // The following ESLint rules are deprecated in the main package, and are all stylistic:
   "eslint/array-bracket-newline",
@@ -403,6 +414,7 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "vue/no-v-for-template-key-on-child",
   "vue/no-v-model-argument",
   "vue/valid-v-bind-sync",
+  "vue/valid-model-definition", // deprecated
 ]);
 
 /**


### PR DESCRIPTION
Fixes #16304. Finishes up some work started by #16305.

With this PR, all rules that are deprecated in upstream plugins are now either implemented or marked as no-need-to-implement in the linter plan issues.