### PR TITLE
fix(linter): fix false positive in no-invalid-fetch-options for conditional expressions

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -222,7 +222,9 @@ fn is_invalid_fetch_options<'a>(
                         _ => {}
                     }
                 }
-                _ => {}
+                _ => {
+                    method_name = UNKNOWN_METHOD_NAME;
+                }
             }
         }
     }
@@ -296,6 +298,9 @@ fn test() {
          body: "",
         });"#,
         ("const response = await fetch('', { method, headers, body, });"),
+        (r#"fetch("/url", { method: logic ? "PATCH" : "POST", body: "some body" });"#),
+        (r#"new Request("/url", { method: logic ? "PATCH" : "POST", body: "some body" });"#),
+        (r#"fetch("/url", { method: getMethod(), body: "some body" });"#),
     ];
 
     let fail = vec![


### PR DESCRIPTION
When the method property is a conditional expression (e.g., `logic ? "PATCH" : "POST"`), the rule should not report an error since the method cannot be statically determined.

Previously, unrecognized expression types would fall through to a no-op case, leaving the method_name at its default value of "GET", causing false positives.

Closes #16569

🤖 generated with help from Claude Opus 4.5