### PR TITLE
feat(oxfmt): Expose `setupConfig(configJSON: string)` napi callback

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -5,9 +5,10 @@
  *
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
- * 2. `format_embedded_cb`: Callback to format embedded code in templates
- * 3. `format_file_cb`: Callback to format files
+ * 2. `setup_config_cb`: Callback to setup Prettier config
+ * 3. `format_embedded_cb`: Callback to format embedded code in templates
+ * 4. `format_file_cb`: Callback to format files
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, setupConfigCb: (configJSON: string) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, code: string) => Promise<string>): Promise<boolean>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,10 +1,10 @@
 import { format } from "./bindings.js";
-import { formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
+import { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 
 const args = process.argv.slice(2);
 
 // Call the Rust formatter with our JS callback
-const success = await format(args, formatEmbeddedCode, formatFile);
+const success = await format(args, setupConfig, formatEmbeddedCode, formatFile);
 
 // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,2 +1,2 @@
 export * from "./bindings.js";
-export { formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
+export { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";

--- a/apps/oxfmt/src-js/prettier-proxy.ts
+++ b/apps/oxfmt/src-js/prettier-proxy.ts
@@ -1,3 +1,5 @@
+import type { Options } from "prettier";
+
 // Import Prettier lazily.
 // This helps to reduce initial load time if not needed.
 //
@@ -10,6 +12,37 @@
 // Yes, this seems completely fine!
 // But actually, this makes `oxfmt --lsp` immediately stop with `Parse error` JSON-RPC error
 let prettierCache: typeof import("prettier");
+
+// Cache for Prettier options.
+// Set by `setupConfig` function once.
+//
+// Read `.oxfmtrc.json(c)` directly does not work,
+// because our brand new defaults are not compatible with Prettier's defaults.
+// So we need to pass the config from Rust side after merging with our defaults.
+let configCache: Options = {};
+
+// ---
+
+/**
+ * Setup Prettier configuration.
+ * NOTE: Called from Rust via NAPI ThreadsafeFunction with FnArgs
+ * @param configJSON - Prettier configuration as JSON string
+ * @returns Array of loaded plugin's `languages` info
+ * */
+export async function setupConfig(configJSON: string): Promise<string[]> {
+  // NOTE: `napi-rs` has ability to pass `Object` directly.
+  // But since we don't know what options various plugins may specify,
+  // we have to receive it as a JSON string and parse it.
+  //
+  // SAFETY: This is valid JSON string generated in Rust side
+  configCache = JSON.parse(configJSON) as Options;
+
+  // TODO: Plugins support
+  // - Read `plugins` field
+  // - Load plugins dynamically and parse `languages` field
+  // - Map file extensions and filenames to Prettier parsers
+  return [];
+}
 
 // ---
 
@@ -52,16 +85,14 @@ export async function formatEmbeddedCode(tagName: string, code: string): Promise
 
   return prettierCache
     .format(code, {
+      ...configCache,
       parser,
-      // TODO: Read config
-      printWidth: 80,
-      tabWidth: 2,
-      semi: true,
-      singleQuote: false,
     })
     .then((formatted) => formatted.trimEnd())
     .catch(() => code);
 }
+
+// ---
 
 /**
  * Format whole file content using Prettier.
@@ -76,7 +107,7 @@ export async function formatFile(parserName: string, code: string): Promise<stri
   }
 
   return prettierCache.format(code, {
+    ...configCache,
     parser: parserName,
-    // TODO: Read config
   });
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -8,4 +8,6 @@ pub use format::{FormatResult, SourceFormatter};
 pub use support::FormatFileSource;
 
 #[cfg(feature = "napi")]
-pub use external_formatter::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb};
+pub use external_formatter::{
+    ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsSetupConfigCb,
+};

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 
 use crate::{
     cli::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing},
-    core::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb},
+    core::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsSetupConfigCb},
     lsp::run_lsp,
 };
 
@@ -19,8 +19,9 @@ use crate::{
 ///
 /// JS side passes in:
 /// 1. `args`: Command line arguments (process.argv.slice(2))
-/// 2. `format_embedded_cb`: Callback to format embedded code in templates
-/// 3. `format_file_cb`: Callback to format files
+/// 2. `setup_config_cb`: Callback to setup Prettier config
+/// 3. `format_embedded_cb`: Callback to format embedded code in templates
+/// 4. `format_file_cb`: Callback to format files
 ///
 /// Returns `true` if formatting succeeded without errors, `false` otherwise.
 #[expect(clippy::allow_attributes)]
@@ -28,17 +29,21 @@ use crate::{
 #[napi]
 pub async fn format(
     args: Vec<String>,
+    #[napi(ts_arg_type = "(configJSON: string) => Promise<string[]>")]
+    setup_config_cb: JsSetupConfigCb,
     #[napi(ts_arg_type = "(tagName: string, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(parserName: string, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
 ) -> bool {
-    format_impl(args, format_embedded_cb, format_file_cb).await.report() == ExitCode::SUCCESS
+    format_impl(args, setup_config_cb, format_embedded_cb, format_file_cb).await.report()
+        == ExitCode::SUCCESS
 }
 
 /// Run the formatter.
 async fn format_impl(
     args: Vec<String>,
+    setup_config_cb: JsSetupConfigCb,
     format_embedded_cb: JsFormatEmbeddedCb,
     format_file_cb: JsFormatFileCb,
 ) -> CliRunResult {
@@ -71,7 +76,8 @@ async fn format_impl(
     command.handle_threads();
 
     // Create external formatter from JS callback
-    let external_formatter = ExternalFormatter::new(format_embedded_cb, format_file_cb);
+    let external_formatter =
+        ExternalFormatter::new(setup_config_cb, format_embedded_cb, format_file_cb);
 
     // stdio is blocked by LineWriter, use a BufWriter to reduce syscalls.
     // See `https://github.com/rust-lang/rust/issues/60673`.


### PR DESCRIPTION
First step for #16530 

- Added new napi callback `setupConfig()`
- And call it after resolving config in Rust side

At this time, there is no impact on end users. Passing `{}` is equivalent to passing nothing.