### PR TITLE
refactor(formatter): adjust the printing implementation of BindingProperty to be the same as other assignment-like nodes

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -948,32 +948,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectPattern<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BindingProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let group_id = f.group_id("assignment");
-        let format_inner = format_with(|f| {
-            if self.computed() {
-                write!(f, "[");
-            }
-            if !self.shorthand() {
-                write!(f, self.key());
-            }
-            if self.computed() {
-                write!(f, "]");
-            }
-            if self.shorthand() {
-                write!(f, self.value());
-            } else {
-                write!(
-                    f,
-                    [
-                        ":",
-                        group(&indent(&soft_line_break_or_space())).with_group_id(Some(group_id)),
-                        line_suffix_boundary(),
-                        indent_if_group_breaks(&self.value(), group_id)
-                    ]
-                );
-            }
-        });
-        write!(f, group(&format_inner));
+        AssignmentLike::BindingProperty(self).fmt(f);
     }
 }
 


### PR DESCRIPTION
Align the formatting logic of `BindingProperty` to be the same as Prettier. In Prettier, both `BindingProperty` and `ObjectProperty` are referred to as `ObjectProperty`.

The performance improved because the elements were reduced a little bit and avoided always using the following formatting logic to print the right-hand side of the `BindingProperty`, since `indent_if_group_breaks` is an expensive element.

```rs
 write!(
    f,
    [
        ":",
        group(&indent(&soft_line_break_or_space())).with_group_id(Some(group_id)),
        line_suffix_boundary(),
        indent_if_group_breaks(&self.value(), group_id)
    ]
);
```

<img width="1382" height="545" alt="image" src="https://github.com/user-attachments/assets/cd174578-6b4e-441c-8adf-600346ec7935" />
