### PR TITLE
fix(formatter): should not expand the object pattern if its parent is an `AssignmentPattern`

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/assignments/issue-16520.js
+++ b/crates/oxc_formatter/tests/fixtures/js/assignments/issue-16520.js
@@ -1,0 +1,5 @@
+const {
+  data: { args: { something } } = {
+    args: { something: []},
+  }
+} = obj;

--- a/crates/oxc_formatter/tests/fixtures/js/assignments/issue-16520.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/assignments/issue-16520.js.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const {
+  data: { args: { something } } = {
+    args: { something: []},
+  }
+} = obj;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const {
+  data: { args: { something } } = {
+    args: { something: [] },
+  },
+} = obj;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const {
+  data: { args: { something } } = {
+    args: { something: [] },
+  },
+} = obj;
+
+===================== End =====================


### PR DESCRIPTION
close: #16520
