### PR TITLE
feat(oxfmt): Pass filepath field to prettier formatting

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -11,4 +11,4 @@
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, setupConfigCb: (configJSON: string) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, setupConfigCb: (configJSON: string) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<boolean>

--- a/apps/oxfmt/src-js/prettier-proxy.ts
+++ b/apps/oxfmt/src-js/prettier-proxy.ts
@@ -98,10 +98,15 @@ export async function formatEmbeddedCode(tagName: string, code: string): Promise
  * Format whole file content using Prettier.
  * NOTE: Called from Rust via NAPI ThreadsafeFunction with FnArgs
  * @param parserName - The parser name
+ * @param fileName - The file name (e.g., "package.json")
  * @param code - The code to format
  * @returns Formatted code
  */
-export async function formatFile(parserName: string, code: string): Promise<string> {
+export async function formatFile(
+  parserName: string,
+  fileName: string,
+  code: string,
+): Promise<string> {
   if (!prettierCache) {
     prettierCache = await import("prettier");
   }
@@ -109,5 +114,6 @@ export async function formatFile(parserName: string, code: string): Promise<stri
   return prettierCache.format(code, {
     ...configCache,
     parser: parserName,
+    filepath: fileName,
   });
 }

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -33,7 +33,9 @@ pub async fn format(
     setup_config_cb: JsSetupConfigCb,
     #[napi(ts_arg_type = "(tagName: string, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(ts_arg_type = "(parserName: string, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(parserName: string, fileName: string, code: string) => Promise<string>"
+    )]
     format_file_cb: JsFormatFileCb,
 ) -> bool {
     format_impl(args, setup_config_cb, format_embedded_cb, format_file_cb).await.report()


### PR DESCRIPTION
- Pass `filepath` to Prettier

Doing this means that plugins that depend on `filepath` now work.