### PR TITLE
feat(linter): promote no_map_spread rule from nursery to perf

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -310,7 +310,7 @@ declare_oxc_lint!(
     /// - [JSPerf - `concat` vs array spread performance](https://jsperf.app/pihevu)
     NoMapSpread,
     oxc,
-    nursery, // TODO: make this `perf` once we've battle-tested this a bit
+    perf,
     conditional_fix_suggestion,
     config = NoMapSpreadConfig,
 );


### PR DESCRIPTION
This rule has been in nursery for 13 months, we have (hopefully) fixed all issues relating to it, so it should be ready to promote to performance