### PR TITLE
refactor(linter): rename `GlobalValue::Writeable` to `Writable`

### DIFF
--- a/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
+++ b/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
@@ -14,7 +14,7 @@
         "jquery": false
       },
       "globals": {
-        "Foo": "writeable"
+        "Foo": "writable"
       }
     },
     {
@@ -25,7 +25,7 @@
         "jquery": false
       },
       "globals": {
-        "Foo": "writeable"
+        "Foo": "writable"
       }
     }
   ]

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -673,7 +673,7 @@ mod test {
             files: GlobSet::new(vec!["*.tsx"]),
             env: None,
             plugins: None,
-            globals: Some(from_json!({ "React": "readonly", "Secret": "writeable" })),
+            globals: Some(from_json!({ "React": "readonly", "Secret": "writable" })),
             rules: ResolvedOxlintOverrideRules { builtin_rules: vec![], external_rules: vec![] },
         }]);
 
@@ -739,7 +739,7 @@ mod test {
             plugins: LintPlugins::ESLINT,
             globals: from_json!({
                 "React": "readonly",
-                "Secret": "writeable"
+                "Secret": "writable"
             }),
             ..Default::default()
         };

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -61,8 +61,7 @@ impl OxlintGlobals {
 #[serde(rename_all = "lowercase")]
 pub enum GlobalValue {
     Readonly,
-    // TODO: #[serde(rename = "writable")] for ESLint compatibility
-    Writeable,
+    Writable,
     Off,
 }
 
@@ -70,7 +69,7 @@ impl GlobalValue {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Readonly => "readonly",
-            Self::Writeable => "writeable",
+            Self::Writable => "writable",
             Self::Off => "off",
         }
     }
@@ -88,7 +87,7 @@ impl<'de> Deserialize<'de> for GlobalValue {
 impl From<bool> for GlobalValue {
     #[inline]
     fn from(value: bool) -> Self {
-        if value { GlobalValue::Writeable } else { GlobalValue::Readonly }
+        if value { GlobalValue::Writable } else { GlobalValue::Readonly }
     }
 }
 
@@ -98,7 +97,7 @@ impl TryFrom<&str> for GlobalValue {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "readonly" | "readable" => Ok(GlobalValue::Readonly),
-            "writable" | "writeable" => Ok(GlobalValue::Writeable),
+            "writable" | "writeable" => Ok(GlobalValue::Writable),
             "off" => Ok(GlobalValue::Off),
             _ => Err("Invalid global value"),
         }
@@ -181,7 +180,7 @@ mod test {
     #[test]
     fn test_override_globals() {
         let mut globals = OxlintGlobals::deserialize(&serde_json::json!({
-            "Foo": "writeable",
+            "Foo": "writable",
         }))
         .unwrap();
         let override_globals = OxlintGlobals::deserialize(&serde_json::json!({

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -232,7 +232,7 @@ expression: json
       "type": "string",
       "enum": [
         "readonly",
-        "writeable",
+        "writable",
         "off"
       ]
     },

--- a/editors/vscode/tests/test-helpers.ts
+++ b/editors/vscode/tests/test-helpers.ts
@@ -4,7 +4,7 @@ import path = require('path');
 
 type OxlintConfigPlugins = string[];
 type OxlintConfigCategories = Record<string, unknown>;
-type OxlintConfigGlobals = Record<string, 'readonly' | 'writeable' | 'off'>;
+type OxlintConfigGlobals = Record<string, 'readonly' | 'writable' | 'off'>;
 type OxlintConfigEnv = Record<string, boolean>;
 type OxlintConfigIgnorePatterns = string[];
 type OxlintRuleSeverity = 'off' | 'warn' | 'error';

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -228,7 +228,7 @@
       "type": "string",
       "enum": [
         "readonly",
-        "writeable",
+        "writable",
         "off"
       ]
     },


### PR DESCRIPTION
"Writeable" is a mis-spelling. In addition:

Oxlint docs say:

> You may also use `"writeable"` or `true` to represent `"writable"`.

[ESLint's docs](https://eslint.org/docs/v8.x/use/configure/language-options#using-configuration-files-1) state "writable" (without an "e") as the name of the option.

This suggests that "writable" is the "real" name of this option, and "writeable" (with an "e") is an alias provided for backwards compat.

Therefore, I think it makes more sense to call the enum variant `GlobalValue::Writable` (with the correct spelling).

Main motivation is that it means globals get serialized with the right spelling, allowing removing a JS-side workaround from JS plugins code (#16610).

For consistency, I've changed "writeable" to "writable" in all test cases, except for 1 test which specifically aims to check that that "legacy" spelling is accepted.

https://github.com/oxc-project/oxc/blob/00c5614d1f1bb3465ba7aa5ad668a936b8ec1266/crates/oxc_linter/src/config/globals.rs#L161-L168