### PR TITLE
chore(lsp): rename `remove_diagnostics` to `remove_uri_cache`

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -566,7 +566,7 @@ impl LanguageServer for Backend {
         };
 
         self.file_system.write().await.remove(uri);
-        worker.remove_diagnostics(&params.text_document.uri).await;
+        worker.remove_uri_cache(&params.text_document.uri).await;
     }
 
     /// It will return code actions or commands for the given range.

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -525,7 +525,7 @@ impl Tool for ServerLinter {
         self.run_diagnostic(uri, content)
     }
 
-    fn remove_diagnostics(&self, uri: &Uri) {
+    fn remove_uri_cache(&self, uri: &Uri) {
         self.code_actions.pin().remove(uri);
     }
 }

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -114,8 +114,8 @@ pub trait Tool: Send + Sync {
         None
     }
 
-    /// Remove diagnostics associated with the given URI.
-    fn remove_diagnostics(&self, _uri: &Uri) {
+    /// Remove internal cache for the given URI, if any.
+    fn remove_uri_cache(&self, _uri: &Uri) {
         // Default implementation does nothing.
     }
 

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -94,10 +94,10 @@ impl WorkspaceWorker {
         self.options.lock().await.is_none()
     }
 
-    /// Remove all diagnostics for the given URI
-    pub async fn remove_diagnostics(&self, uri: &Uri) {
+    /// Remove all internal cache for the given URI, if any.
+    pub async fn remove_uri_cache(&self, uri: &Uri) {
         self.tools.read().await.iter().for_each(|tool| {
-            tool.remove_diagnostics(uri);
+            tool.remove_uri_cache(uri);
         });
     }
 


### PR DESCRIPTION
Renaming the method to make it more clear.
There is no diagnostic anymore to be removed. Instead remove the cache of an given URI.