### PR TITLE
refactor(transformer): correct spelling

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -177,9 +177,9 @@ impl<'a> ClassesStack<'a> {
         })
     }
 
-    /// Lookup details of writeable private property referred to by `ident`.
+    /// Lookup details of writable private property referred to by `ident`.
     /// Returns `Some` if it refers to a private prop and setter method
-    pub fn find_writeable_private_prop<'b>(
+    pub fn find_writable_private_prop<'b>(
         &'b mut self,
         ident: &PrivateIdentifier<'a>,
     ) -> Option<ResolvedPrivateProp<'a, 'b>> {
@@ -229,7 +229,7 @@ impl<'a> ClassesStack<'a> {
 ///
 /// This is the return value of [`ClassesStack::find_private_prop`],
 /// [`ClassesStack::find_readable_private_prop`] and
-/// [`ClassesStack::find_writeable_private_prop`].
+/// [`ClassesStack::find_writable_private_prop`].
 pub(super) struct ResolvedPrivateProp<'a, 'b> {
     /// Binding for temp var representing the property
     pub prop_binding: &'b BoundIdentifier<'a>,

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -60,7 +60,7 @@ impl<'a> ClassProperties<'a, '_> {
         let span = field_expr.span;
         let object = field_expr.object.take_in(ctx.ast);
         let resolved = if is_assignment {
-            match self.classes_stack.find_writeable_private_prop(&field_expr.field) {
+            match self.classes_stack.find_writable_private_prop(&field_expr.field) {
                 Some(prop) => prop,
                 _ => {
                     // Early return for read-only error

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -49,7 +49,7 @@ impl<'a> ClassProperties<'a, '_> {
         let mut function = value.take_in_box(ctx.ast);
 
         let resolved_private_prop = if *kind == MethodDefinitionKind::Set {
-            self.classes_stack.find_writeable_private_prop(ident)
+            self.classes_stack.find_writable_private_prop(ident)
         } else {
             self.classes_stack.find_readable_private_prop(ident)
         };


### PR DESCRIPTION
Pure refactor. "writable" is the correct spelling. Correct "writeable" to "writable" in a few places.