### PR TITLE
perf(oxfmt): Use `worker_threads` by `tinypool` for prettier formatting

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -20,7 +20,8 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
-    "prettier": "3.7.4"
+    "prettier": "3.7.4",
+    "tinypool": "2.0.0"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -11,4 +11,4 @@
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, setupConfigCb: (configJSON: string) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<boolean>

--- a/apps/oxfmt/src-js/prettier-worker.ts
+++ b/apps/oxfmt/src-js/prettier-worker.ts
@@ -1,0 +1,61 @@
+import { workerData } from "node:worker_threads";
+import type { Options } from "prettier";
+
+// Lazy load Prettier in each worker thread
+//
+// NOTE: In the past, statically importing caused issues with `oxfmt --lsp` not starting.
+// However, this issue has not been observed recently, possibly due to changes in the bundling configuration.
+// Nevertheless, we will keep it as lazy loading just in case.
+let prettierCache: typeof import("prettier");
+
+export type WorkerData = {
+  prettierConfig: Options;
+};
+
+// Initialize config from `workerData` (passed during pool creation)
+// NOTE: The 1st element is thread id, passed by `tinypool`
+const [, { prettierConfig }] = workerData satisfies [unknown, WorkerData];
+
+// ---
+
+export type FormatEmbeddedCodeArgs = {
+  parser: string;
+  code: string;
+};
+
+export async function formatEmbeddedCode({
+  parser,
+  code,
+}: FormatEmbeddedCodeArgs): Promise<string> {
+  if (!prettierCache) {
+    prettierCache = await import("prettier");
+  }
+
+  return prettierCache
+    .format(code, {
+      ...prettierConfig,
+      parser,
+    })
+    .then((formatted) => formatted.trimEnd())
+    .catch(() => code);
+}
+
+// ---
+
+export type FormatFileArgs = {
+  parserName: string;
+  fileName: string;
+  code: string;
+};
+
+export async function formatFile({ parserName, fileName, code }: FormatFileArgs): Promise<string> {
+  if (!prettierCache) {
+    prettierCache = await import("prettier");
+  }
+
+  return prettierCache.format(code, {
+    ...prettierConfig,
+    parser: parserName,
+    filepath: fileName,
+  });
+}

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -60,6 +60,7 @@ impl FormatRunner {
         let cwd = self.cwd;
         let FormatCommand { paths, output_options, basic_options, ignore_options, misc_options } =
             self.options;
+        let num_of_threads = rayon::current_num_threads();
 
         // Find config file
         // NOTE: Currently, we only load single config file.
@@ -90,7 +91,7 @@ impl FormatRunner {
             .external_formatter
             .as_ref()
             .expect("External formatter must be set when `napi` feature is enabled")
-            .setup_config(&external_config.to_string())
+            .setup_config(&external_config.to_string(), num_of_threads)
         {
             print_and_flush(
                 stderr,
@@ -130,8 +131,6 @@ impl FormatRunner {
             print_and_flush(stdout, "Checking formatting...\n");
             print_and_flush(stdout, "\n");
         }
-
-        let num_of_threads = rayon::current_num_threads();
 
         // Create `SourceFormatter` instance
         let source_formatter = SourceFormatter::new(num_of_threads, format_options);

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -29,7 +29,7 @@ use crate::{
 #[napi]
 pub async fn format(
     args: Vec<String>,
-    #[napi(ts_arg_type = "(configJSON: string) => Promise<string[]>")]
+    #[napi(ts_arg_type = "(configJSON: string, numThreads: number) => Promise<string[]>")]
     setup_config_cb: JsSetupConfigCb,
     #[napi(ts_arg_type = "(tagName: string, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src-js/index.ts", "src-js/cli.ts"],
+  // Build all entry points together to share Prettier chunks
+  entry: ["src-js/index.ts", "src-js/cli.ts", "src-js/prettier-worker.ts"],
   format: "esm",
   platform: "node",
   target: "node20",
@@ -10,5 +11,11 @@ export default defineConfig({
   outDir: "dist",
   shims: false,
   fixedExtension: false,
-  noExternal: ["prettier"],
+  noExternal: [
+    // Bundle it to control version
+    "prettier",
+    // Cannot bundle: worker.js runs in separate thread and can't resolve bundled chunks
+    // Be sure to add it to "dependencies" in `npm/oxfmt/package.json`!
+    // "tinypool",
+  ],
 });

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -21,6 +21,9 @@
   "funding": {
     "url": "https://github.com/sponsors/Boshen"
   },
+  "dependencies": {
+    "tinypool": "2.0.0"
+  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       prettier:
         specifier: 3.7.4
         version: 3.7.4
+      tinypool:
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -259,7 +262,11 @@ importers:
 
   npm/oxc-types: {}
 
-  npm/oxfmt: {}
+  npm/oxfmt:
+    dependencies:
+      tinypool:
+        specifier: 2.0.0
+        version: 2.0.0
 
   npm/oxlint: {}
 


### PR DESCRIPTION
Part of #16606 

- Use `worker_threads` via `tinypool` lib
  - Until now, the Rust side had been operating entirely in a multithreaded manner, while the JS side remained single-threaded, resulting in sequential execution and waiting
  - Number of threads are the same value for Rust side
- Also can be applied to embedded formatting path
- Since `tinypool` couldn't be bundled, defined as `dependencies` in the `npm/oxfmt/package.json`