### PR TITLE
fix(formatter): disable layout assertions on some 32-bit platforms

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -25,7 +25,11 @@ const _: () = {
             size_of::<FormatElement>() == 40,
             "`FormatElement` size exceeds 40 bytes, expected 40 bytes in 64-bit platforms"
         );
-    } else {
+    } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
+        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
+        //
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
+        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
         assert!(
             size_of::<FormatElement>() == 24,
             "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
@@ -40,7 +44,11 @@ const _: () = {
             size_of::<FormatElement>() == 24,
             "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 64-bit platforms"
         );
-    } else {
+    } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
+        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
+        //
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
+        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
         assert!(
             size_of::<FormatElement>() == 16,
             "`FormatElement` size exceeds 16 bytes, expected 16 bytes in 32-bit platforms"


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/issues/15984. Same as https://github.com/oxc-project/oxc/issues/15984
