### PR TITLE
perf(formatter): optimize formatting of JSX element/fragment with a single child

### DIFF
--- a/crates/oxc_formatter/src/write/jsx/element.rs
+++ b/crates/oxc_formatter/src/write/jsx/element.rs
@@ -138,6 +138,9 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                         .fmt_children(children, f);
 
                     match format_children {
+                        FormatChildrenResult::SingleChild(child) => {
+                            write!(f, group(&format_args!(format_opening, child, format_closing)));
+                        }
                         FormatChildrenResult::ForceMultiline(multiline) => {
                             write!(f, [format_opening, multiline, format_closing]);
                         }


### PR DESCRIPTION
Add `FormatSingleChild` for optimizing JSX elements/fragments with a single meaningful child.

When there is only a single child, we do not need to write the child into a temporary buffer and then take it when formatting. Instead, we can directly write the child into the root buffer.

Also, this can avoid calling costly `best_fitting!` formatting in some situations.