### PR TITLE
perf(oxfmt): make time measurement conditional

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -35,7 +35,7 @@ impl FormatService {
         tx_success: &mpsc::Sender<SuccessResult>,
     ) {
         rx_entry.into_iter().par_bridge().for_each(|entry| {
-            let start_time = Instant::now();
+            let start_time = matches!(self.output_options, OutputOptions::Check).then(Instant::now);
 
             let path = entry.path();
             let Ok(source_text) = utils::read_to_string(path) else {
@@ -72,8 +72,6 @@ impl FormatService {
                 }
             };
 
-            let elapsed = start_time.elapsed();
-
             // Write back if needed
             if matches!(self.output_options, OutputOptions::Write) && is_changed {
                 fs::write(path, code)
@@ -92,9 +90,9 @@ impl FormatService {
                         // Normalize path separators for consistent output across platforms
                         .cow_replace('\\', "/")
                         .to_string();
-                    let elapsed = elapsed.as_millis();
 
                     if matches!(self.output_options, OutputOptions::Check) {
+                        let elapsed = start_time.unwrap().elapsed().as_millis();
                         SuccessResult::Changed(format!("{display_path} ({elapsed}ms)"))
                     } else {
                         SuccessResult::Changed(display_path)


### PR DESCRIPTION
## Summary

- Make time measurement conditional based on output mode to reduce unnecessary overhead
- `Instant::now()` is only called when using `--check` mode
- Elapsed time calculation moved to only when it's actually displayed

## Test plan

- [ ] Verify timing information still appears correctly in `--check` mode
- [ ] Confirm no timing overhead in `--write` mode
- [ ] Confirm no timing overhead in `--list-different` mode
- [ ] Run `cargo check -p oxfmt` passes
- [ ] Run `just fmt` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)