### PR TITLE
fix(transformer): `import.meta.foo.bar` matches and `replaces import.meta.bar`

### DIFF
--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -545,7 +545,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
                             // `import.meta.env` should not match `import.meta.env.*`
                             return has_matched_part && !is_full_match;
                         }
-                        return true;
+                        return i == 0;
                     }
                     Expression::Identifier(_) => {
                         return false;

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -81,6 +81,14 @@ fn dot() {
 }
 
 #[test]
+fn dot_with_partial_overlap() {
+    let config = config(&[("import.meta.foo.bar", "1")]);
+    test("console.log(import.meta.bar)", "console.log(import.meta.bar)", &config);
+    test("console.log(import.meta.foo)", "console.log(import.meta.foo)", &config);
+    test("console.log(import.meta.foo.bar)", "console.log(1)", &config);
+}
+
+#[test]
 fn dot_with_overlap() {
     let config =
         config(&[("import.meta.env.FOO", "import.meta.env.BAR"), ("import.meta.env", "__foo__")]);


### PR DESCRIPTION
This commit fix issue https://github.com/oxc-project/oxc/issues/16623

Fixes https://github.com/oxc-project/oxc/issues/16623