### PR TITLE
refactor(ast): change capitalization of `CommentKind` variants

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -15,12 +15,12 @@ pub enum CommentKind {
     /// Line comment
     #[default]
     Line = 0,
-    /// Singleline comment
+    /// Single-line comment
     #[estree(rename = "Block")]
-    SinglelineBlock = 1,
-    /// Multiline block comment (contains line breaks)
+    SingleLineBlock = 1,
+    /// Multi-line block comment (contains line breaks)
     #[estree(rename = "Block")]
-    MultilineBlock = 2,
+    MultiLineBlock = 2,
 }
 
 /// Information about a comment's position relative to a token.
@@ -176,7 +176,7 @@ impl Comment {
     pub fn content_span(&self) -> Span {
         match self.kind {
             CommentKind::Line => Span::new(self.span.start + 2, self.span.end),
-            CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
+            CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                 Span::new(self.span.start + 2, self.span.end - 2)
             }
         }
@@ -188,16 +188,16 @@ impl Comment {
         self.kind == CommentKind::Line
     }
 
-    /// Returns `true` if this is a singleline or multiline block comment.
+    /// Returns `true` if this is a block comment (either single-line or multi-line).
     #[inline]
     pub fn is_block(self) -> bool {
-        matches!(self.kind, CommentKind::SinglelineBlock | CommentKind::MultilineBlock)
+        matches!(self.kind, CommentKind::SingleLineBlock | CommentKind::MultiLineBlock)
     }
 
     /// Returns `true` if this is a multi-line block comment.
     #[inline]
     pub fn is_multiline_block(self) -> bool {
-        self.kind == CommentKind::MultilineBlock
+        self.kind == CommentKind::MultiLineBlock
     }
 
     /// Returns `true` if this comment is before a token.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3233,8 +3233,8 @@ impl ESTree for CommentKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::Line => JsonSafeString("Line").serialize(serializer),
-            Self::SinglelineBlock => JsonSafeString("Block").serialize(serializer),
-            Self::MultilineBlock => JsonSafeString("Block").serialize(serializer),
+            Self::SingleLineBlock => JsonSafeString("Block").serialize(serializer),
+            Self::MultiLineBlock => JsonSafeString("Block").serialize(serializer),
         }
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -227,7 +227,7 @@ mod test {
     fn test_is_inside_comment() {
         let comments = vec![
             Comment::new(0, 4, CommentKind::Line),
-            Comment::new(10, 20, CommentKind::SinglelineBlock),
+            Comment::new(10, 20, CommentKind::SingleLineBlock),
         ]
         .into_boxed_slice();
 
@@ -241,7 +241,7 @@ mod test {
     fn test_get_comment_at() {
         let comments = vec![
             Comment::new(0, 4, CommentKind::Line),
-            Comment::new(10, 20, CommentKind::SinglelineBlock),
+            Comment::new(10, 20, CommentKind::SingleLineBlock),
         ]
         .into_boxed_slice();
 

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -128,10 +128,10 @@ impl Codegen<'_> {
         };
         let comment_source = comment.span.source_text(source_text);
         match comment.kind {
-            CommentKind::Line | CommentKind::SinglelineBlock => {
+            CommentKind::Line | CommentKind::SingleLineBlock => {
                 self.print_str_escaping_script_close_tag(comment_source);
             }
-            CommentKind::MultilineBlock => {
+            CommentKind::MultiLineBlock => {
                 for line in LineTerminatorSplitter::new(comment_source) {
                     if !line.starts_with("/*") {
                         self.print_indent();

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -111,7 +111,7 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
                 write!(f, comment);
 
                 match comment.kind {
-                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
+                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                         match f.source_text().lines_after(comment.span.end) {
                             0 => {
                                 let should_nestle =

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -174,7 +174,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
                                         let single_line_comment: String = format!("//{comment}\n");
                                         comments_vec.push(single_line_comment);
                                     }
-                                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
+                                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                                         let multi_line_comment: String = format!("/*{comment}*/\n");
                                         comments_vec.push(multi_line_comment);
                                     }

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -33,7 +33,7 @@ pub fn convert_utf8_to_utf16(
             Comment {
                 r#type: match comment.kind {
                     CommentKind::Line => String::from("Line"),
-                    CommentKind::SinglelineBlock | CommentKind::MultilineBlock => {
+                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                         String::from("Block")
                     }
                 },

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -154,7 +154,7 @@ impl<'a> Lexer<'a> {
         self.trivia_builder.add_block_comment(
             self.token.start(),
             self.offset(),
-            CommentKind::SinglelineBlock,
+            CommentKind::SingleLineBlock,
             self.source.whole(),
         );
         Kind::Skip
@@ -176,7 +176,7 @@ impl<'a> Lexer<'a> {
             self.trivia_builder.add_block_comment(
                 self.token.start(),
                 self.offset(),
-                CommentKind::MultilineBlock,
+                CommentKind::MultiLineBlock,
                 self.source.whole(),
             );
             Kind::Skip

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -334,7 +334,7 @@ mod test {
         let expected = [
             Comment {
                 span: Span::new(9, 24),
-                kind: CommentKind::SinglelineBlock,
+                kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -350,7 +350,7 @@ mod test {
             },
             Comment {
                 span: Span::new(54, 69),
-                kind: CommentKind::SinglelineBlock,
+                kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading,
@@ -358,7 +358,7 @@ mod test {
             },
             Comment {
                 span: Span::new(76, 92),
-                kind: CommentKind::SinglelineBlock,
+                kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
                 newlines: CommentNewlines::None,
@@ -398,7 +398,7 @@ token /* Trailing 1 */
         let expected = vec![
             Comment {
                 span: Span::new(20, 35),
-                kind: CommentKind::SinglelineBlock,
+                kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 36,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -406,7 +406,7 @@ token /* Trailing 1 */
             },
             Comment {
                 span: Span::new(42, 58),
-                kind: CommentKind::SinglelineBlock,
+                kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Trailing,
                 attached_to: 0,
                 newlines: CommentNewlines::Trailing,
@@ -431,7 +431,7 @@ token /* Trailing 1 */
         let expected = vec![
             Comment {
                 span: Span::new(1, 13),
-                kind: CommentKind::MultilineBlock,
+                kind: CommentKind::MultiLineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
@@ -439,7 +439,7 @@ token /* Trailing 1 */
             },
             Comment {
                 span: Span::new(14, 26),
-                kind: CommentKind::MultilineBlock,
+                kind: CommentKind::MultiLineBlock,
                 position: CommentPosition::Leading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -717,10 +717,10 @@ mod test {
         let source_type = SourceType::default().with_typescript(true);
         let sources = [
             ("// line comment", CommentKind::Line),
-            ("/* line comment */", CommentKind::SinglelineBlock),
+            ("/* line comment */", CommentKind::SingleLineBlock),
             (
                 "type Foo = ( /* Require properties which are not generated automatically. */ 'bar')",
-                CommentKind::SinglelineBlock,
+                CommentKind::SingleLineBlock,
             ),
         ];
         for (source, kind) in sources {


### PR DESCRIPTION
Pure refactor. "multiline" is OK, but "singleline" is ungrammatical - it should be hyphenated ("single-line"). So rename the `CommentKind` variant to `SingleLineBlock`. Also rename `MultilineBlock` -> `MultiLineBlock` for consistency.

Obviously, this is not important. But as changing the variants of `CommentKind` is already a breaking change, it seems like the right moment to nitpick - and avoid getting stuck with it, or having to make another breaking change later.