### PR TITLE
perf(oxlint): run e2e tests concurrently

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { PACKAGE_ROOT_PATH, getFixtures, testFixtureWithCommand } from "./utils.ts";
 
 import type { Fixture } from "./utils.ts";
+import type { ExpectStatic } from "vitest";
 
 const CLI_PATH = pathJoin(PACKAGE_ROOT_PATH, "dist/cli.js");
 
@@ -22,21 +23,22 @@ const NODE_BIN_PATH = process.execPath;
  *
  * Fixtures with an `options.json` file containing `"oxlint": false` are skipped.
  */
-describe("oxlint CLI", () => {
+describe.concurrent("oxlint CLI", () => {
   const fixtures = getFixtures();
   for (const fixture of fixtures) {
     if (!fixture.options.oxlint) continue;
 
     // oxlint-disable-next-line jest/expect-expect
-    it(`fixture: ${fixture.name}`, () => runFixture(fixture));
+    it.concurrent(`fixture: ${fixture.name}`, ({ expect }) => runFixture(fixture, expect));
   }
 });
 
 /**
  * Run Oxlint on a test fixture.
  * @param fixture - Fixture object
+ * @param expect - Vitest expect function from test context
  */
-async function runFixture(fixture: Fixture): Promise<void> {
+async function runFixture(fixture: Fixture, expect: ExpectStatic): Promise<void> {
   // Run Oxlint without `--fix` option
   await testFixtureWithCommand({
     command: NODE_BIN_PATH,
@@ -44,6 +46,7 @@ async function runFixture(fixture: Fixture): Promise<void> {
     fixture,
     snapshotName: "output",
     isESLint: false,
+    expect,
   });
 
   // Run Oxlint with `--fix` option
@@ -54,6 +57,7 @@ async function runFixture(fixture: Fixture): Promise<void> {
       fixture,
       snapshotName: "fix",
       isESLint: false,
+      expect,
     });
   }
 }

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -3,7 +3,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join as pathJoin, sep as pathSep } from "node:path";
 
 import { execa } from "execa";
-import { expect } from "vitest";
+import { expect as defaultExpect, type ExpectStatic } from "vitest";
 
 // Replace backslashes with forward slashes on Windows. Do nothing on Mac/Linux.
 const normalizeSlashes =
@@ -88,6 +88,8 @@ interface TestFixtureOptions {
   snapshotName: string;
   // `true` if the command is ESLint
   isESLint: boolean;
+  // Vitest expect function (required for concurrent tests)
+  expect?: ExpectStatic;
 }
 
 /**
@@ -95,6 +97,7 @@ interface TestFixtureOptions {
  * @param options - Options for running the test
  */
 export async function testFixtureWithCommand(options: TestFixtureOptions): Promise<void> {
+  const { expect = defaultExpect } = options;
   const { name: fixtureName, dirPath } = options.fixture,
     pathPrefixLen = dirPath.length + 1;
 
@@ -151,7 +154,6 @@ export async function testFixtureWithCommand(options: TestFixtureOptions): Promi
     }
   }
 
-  // Assert snapshot is as expected
   await expect(snapshot).toMatchFileSnapshot(snapshotPath);
 }
 


### PR DESCRIPTION
Tests in the same file typically run in sequence. we can improve the performance by running these in parallel:

https://vitest.dev/guide/parallelism.html#test-parallelism

 - Before (sequential): ~5.2s total, e2e.test.ts ~5000ms
 - After (concurrent):  ~1.50s total, e2e.test.ts ~1200ms
    
~3.5x faster
