### PR TITLE
test(linter/plugins): allow filtering by rule or test case in conformance tester

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -1,0 +1,4 @@
+// Options to filter tests to a specific rule or specific code.
+// Useful for debugging a particular test case.
+export const FILTER_ONLY_RULE: string | null = null;
+export const FILTER_ONLY_CODE: string | null = null;

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -4,9 +4,13 @@
 
 import { RuleTester } from "#oxlint";
 import { describe, it } from "./capture.ts";
+import { FILTER_ONLY_CODE } from "./filter.ts";
+
+import type { Rule } from "#oxlint";
 
 type DescribeFn = RuleTester.DescribeFn;
 type ItFn = RuleTester.ItFn;
+type TestCases = RuleTester.TestCases;
 type ValidTestCase = RuleTester.ValidTestCase;
 type InvalidTestCase = RuleTester.InvalidTestCase;
 type TestCase = ValidTestCase | InvalidTestCase;
@@ -44,6 +48,21 @@ class RuleTesterShim extends RuleTester {
 
   static set itOnly(_value: ItFn) {
     throw new Error("Cannot override `itOnly` property");
+  }
+
+  // Apply filter to test cases.
+  run(ruleName: string, rule: Rule, tests: TestCases): void {
+    if (FILTER_ONLY_CODE !== null) {
+      tests = {
+        valid: tests.valid.filter((test) => {
+          const code = typeof test === "string" ? test : test.code;
+          return code === FILTER_ONLY_CODE;
+        }),
+        invalid: tests.invalid.filter((test) => test.code === FILTER_ONLY_CODE),
+      };
+    }
+
+    super.run(ruleName, rule, tests);
   }
 }
 

--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -7,6 +7,7 @@ import { join as pathJoin } from "node:path";
 import { fileURLToPath } from "node:url";
 import Module from "node:module";
 import { setCurrentRule, resetCurrentRule } from "./capture.ts";
+import { FILTER_ONLY_RULE } from "./filter.ts";
 
 import type { RuleResult } from "./capture.ts";
 
@@ -62,7 +63,9 @@ function findTestFiles(): string[] {
   const ruleNames = [];
   for (const filename of filenames) {
     if (!filename.endsWith(".js")) continue;
-    ruleNames.push(filename.slice(0, -3));
+    const ruleName = filename.slice(0, -3);
+    if (FILTER_ONLY_RULE !== null && ruleName !== FILTER_ONLY_RULE) continue;
+    ruleNames.push(ruleName);
   }
   return ruleNames;
 }


### PR DESCRIPTION
Add ability to filter tests in the conformance tester. This is useful while debugging specific test cases.