### PR TITLE
ci(pr): label PRs as `A-linter-plugins` if they touch `apps/oxlint/conformance` directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,7 +32,7 @@ A-linter:
 
 A-linter-plugins:
   - changed-files:
-      - any-glob-to-any-file: ["apps/oxlint/src-js/**", "apps/oxlint/test/**"]
+      - any-glob-to-any-file: ["apps/oxlint/src-js/**", "apps/oxlint/test/**", "apps/oxlint/conformance/**"]
 
 A-minifier:
   - changed-files:


### PR DESCRIPTION
#16650 added conformance tests for Oxlint JS plugins in `apps/oxlint/conformance`. Tag any PRs which alter the contents of this directory with `A-linter-plugins` label.