### PR TITLE
test(lsp): activate test for filepath with brackets

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/nextjs/[[..rest]]/debugger.ts
+++ b/crates/oxc_language_server/fixtures/linter/nextjs/[[..rest]]/debugger.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -962,8 +962,8 @@ mod test {
         Tester::new("fixtures/linter/vue", json!({})).test_and_snapshot_single_file("debugger.vue");
         Tester::new("fixtures/linter/svelte", json!({}))
             .test_and_snapshot_single_file("debugger.svelte");
-        // ToDo: fix Tester to work only with Uris and do not access the file system
-        // Tester::new("fixtures/linter/nextjs").test_and_snapshot_single_file("%5B%5B..rest%5D%5D/debugger.ts");
+        Tester::new("fixtures/linter/nextjs", json!({}))
+            .test_and_snapshot_single_file("[[..rest]]/debugger.ts");
     }
 
     #[test]

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_nextjs@[[..rest]]__debugger.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_nextjs@[[..rest]]__debugger.ts.snap
@@ -1,0 +1,71 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+########## 
+file: fixtures/linter/nextjs/[[..rest]]/debugger.ts
+----------
+########## Diagnostic Reports
+
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/nextjs/%5B%5B..rest%5D%5D/debugger.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+########### Code Actions/Commands
+CodeAction: 
+Title: Remove the debugger statement
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable-next-line no-debugger\n",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable no-debugger\n",
+}


### PR DESCRIPTION
Activates the test, which was blocked by a bug which does not percent encode the file path.
The Tester was updated a long time ago with the fix of https://github.com/tower-lsp-community/tower-lsp-server/pull/53 which correctly converts file path to URI