### PR TITLE
refactor(oxlint/lsp): `IsolatedLintHandlerFileSystem` is now a `FxHashMap`

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -5,7 +5,7 @@ use std::{
 
 use log::{debug, warn};
 use oxc_data_structures::rope::Rope;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::Uri;
 
 use oxc_allocator::Allocator;
@@ -34,14 +34,14 @@ pub struct IsolatedLintHandler {
     unused_directives_severity: Option<AllowWarnDeny>,
 }
 
+#[derive(Default)]
 pub struct IsolatedLintHandlerFileSystem {
-    path_to_lint: PathBuf,
-    source_text: Arc<str>,
+    map: FxHashMap<PathBuf, Arc<str>>,
 }
 
 impl IsolatedLintHandlerFileSystem {
-    pub fn new(path_to_lint: PathBuf, source_text: Arc<str>) -> Self {
-        Self { path_to_lint, source_text }
+    pub fn add_file(&mut self, path: PathBuf, content: Arc<str>) {
+        self.map.insert(path, content);
     }
 }
 
@@ -51,11 +51,10 @@ impl RuntimeFileSystem for IsolatedLintHandlerFileSystem {
         path: &Path,
         allocator: &'a Allocator,
     ) -> Result<&'a str, std::io::Error> {
-        if path == self.path_to_lint {
-            return Ok(&self.source_text);
+        match self.map.get(path) {
+            Some(s) => Ok(&**s),
+            None => read_to_arena_str(path, allocator),
         }
-
-        read_to_arena_str(path, allocator)
     }
 
     fn write_file(&self, _path: &Path, _content: &str) -> Result<(), std::io::Error> {
@@ -121,7 +120,8 @@ impl IsolatedLintHandler {
         debug!("lint {}", path.display());
         let rope = &Rope::from_str(source_text);
 
-        let fs = IsolatedLintHandlerFileSystem::new(path.to_path_buf(), Arc::from(source_text));
+        let mut fs = IsolatedLintHandlerFileSystem::default();
+        fs.add_file(path.to_path_buf(), Arc::from(source_text));
 
         let mut messages: Vec<DiagnosticReport> = self
             .runner


### PR DESCRIPTION
The language server wants to lint in the future multiple files at the same time.  
These files could still be in memory, so extend `IsolatedLintHandlerFileSystem` to be a `FxHashMap`