### PR TITLE
refactor(oxlint/lsp): use fs as param in TsGoLintState, instead of source text

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -125,7 +125,7 @@ impl IsolatedLintHandler {
 
         let mut messages: Vec<DiagnosticReport> = self
             .runner
-            .run_source(&Arc::from(path.as_os_str()), source_text.to_string(), &fs)
+            .run_source(&Arc::from(path.as_os_str()), &fs)
             .into_iter()
             .map(|message| message_to_lsp_diagnostic(message, uri, source_text, rope))
             .collect();

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -236,14 +236,13 @@ impl LintRunner {
     pub fn run_source(
         &self,
         file: &Arc<OsStr>,
-        source_text: String,
         file_system: &(dyn crate::RuntimeFileSystem + Sync + Send),
     ) -> Vec<Message> {
         let mut messages = self.lint_service.run_source(file_system, vec![Arc::clone(file)]);
 
         if let Some(type_aware_linter) = &self.type_aware_linter {
             let tsgo_messages =
-                match type_aware_linter.lint_source(file, source_text, self.directives_store.map())
+                match type_aware_linter.lint_source(file, file_system, self.directives_store.map())
                 {
                     Ok(msgs) => msgs,
                     Err(err) => {


### PR DESCRIPTION
In the future, the language server wants to lint multiple files at the same time.  
Refactored the code to accept the RuntimeFS (like the CLI tool) for reading the source text.