### PR TITLE
refactor(oxlint/lsp): accept multiple files inside `LintRunner`

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -125,7 +125,7 @@ impl IsolatedLintHandler {
 
         let mut messages: Vec<DiagnosticReport> = self
             .runner
-            .run_source(&Arc::from(path.as_os_str()), &fs)
+            .run_source(&[Arc::from(path.as_os_str())], &fs)
             .into_iter()
             .map(|message| message_to_lsp_diagnostic(message, uri, source_text, rope))
             .collect();


### PR DESCRIPTION
The Isolated linter from the language server stills sends only one file at the moment, but everything is ready to accept multiple files at the same time :) 