### PR TITLE
test(linter/plugins): add 1 more test case for `sourceType` in `RuleTester`

### DIFF
--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1420,6 +1420,9 @@ describe("RuleTester", () => {
           valid: [
             {
               code: "with (obj) {}",
+            },
+            {
+              code: "with (obj) {}",
               languageOptions: { sourceType: "script" },
             },
             {
@@ -1448,6 +1451,7 @@ describe("RuleTester", () => {
 
         expect(runCases()).toMatchInlineSnapshot(`
           [
+            [Error: Parsing failed],
             null,
             null,
             [Error: Parsing failed],


### PR DESCRIPTION
Follow-on after #16660. Add 1 more test that I missed in #16670.