### PR TITLE
feat(linter/plugins): add `ignoreNonFatalErrors` option to `RuleTester`

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -92,6 +92,8 @@ export interface ParserOptions {
   lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts'
   /** Treat the source text as `script` or `module` code. */
   sourceType?: 'script' | 'module' | 'unambiguous' | undefined
+  /** Ignore non-fatal parsing errors */
+  ignoreNonFatalErrors?: boolean
 }
 
 /** Returns `true` if raw transfer is supported on this platform. */

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -155,6 +155,10 @@ interface ParserOptions {
    * Language variant to parse file as.
    */
   lang?: Language;
+  /**
+   * `true` to ignore non-fatal parsing errors.
+   */
+  ignoreNonFatalErrors?: boolean;
 }
 
 /**
@@ -799,8 +803,32 @@ function mergeLanguageOptions(
 ): LanguageOptions | undefined {
   if (localLanguageOptions == null) return baseLanguageOptions ?? undefined;
   if (baseLanguageOptions == null) return localLanguageOptions;
+
   // TODO: Merge deeply
-  return { ...baseLanguageOptions, ...localLanguageOptions };
+  return {
+    ...baseLanguageOptions,
+    ...localLanguageOptions,
+    parserOptions: mergeParserOptions(
+      localLanguageOptions.parserOptions,
+      baseLanguageOptions.parserOptions,
+    ),
+  };
+}
+
+/**
+ * Merge parser options from test case / config onto language options from base config.
+ * @param localParserOptions - Parser options from test case / config
+ * @param baseParserOptions - Parser options from base config
+ * @returns Merged parser options, or `undefined` if neither has parser options
+ */
+function mergeParserOptions(
+  localParserOptions?: ParserOptions | null,
+  baseParserOptions?: ParserOptions | null,
+): ParserOptions | undefined {
+  if (localParserOptions == null) return baseParserOptions ?? undefined;
+  if (baseParserOptions == null) return localParserOptions;
+  // TODO: Merge deeply
+  return { ...baseParserOptions, ...localParserOptions };
 }
 
 /**
@@ -909,6 +937,14 @@ function getParseOptions(test: TestCase): ParseOptions {
       }
 
       parseOptions.sourceType = sourceType;
+    }
+
+    // Handle `languageOptions.parserOptions.ignoreNonFatalErrors`
+    const { parserOptions } = languageOptions;
+    if (parserOptions != null) {
+      if (parserOptions.ignoreNonFatalErrors === true) {
+        parseOptions.ignoreNonFatalErrors = true;
+      }
     }
   }
 

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1462,5 +1462,263 @@ describe("RuleTester", () => {
         `);
       });
     });
+
+    describe("ignoreNonFatalErrors", () => {
+      it("default (off)", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: ["function f(x, x) {}"],
+          invalid: [],
+        });
+
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [Error: Parsing failed],
+          ]
+        `);
+      });
+
+      describe("disabled", () => {
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in `RuleTester` options, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases, overriding `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+      });
+
+      describe("enabled", () => {
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+
+        it("set in `RuleTester` options, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["function f(x, x) {}"],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+
+        it("set in individual test cases, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+
+        it("set in individual test cases, overriding `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "function f(x, x) {}",
+                languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null]);
+        });
+      });
+
+      it("mixed across test cases", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [
+            {
+              code: "function f(x, x) {}",
+            },
+            {
+              code: "function f(x, x) {}",
+              languageOptions: { parserOptions: { ignoreNonFatalErrors: false } },
+            },
+            {
+              code: "function f(x, x) {}",
+              languageOptions: { parserOptions: { ignoreNonFatalErrors: true } },
+            },
+          ],
+          invalid: [],
+        });
+
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            [Error: Parsing failed],
+            [Error: Parsing failed],
+            null,
+          ]
+        `);
+      });
+    });
   });
 });


### PR DESCRIPTION
Add an option to `RuleTester` to ignore non-fatal parsing errors.

```js
const tester = new RuleTester({
  languageOptions: {
    sourceType: "module",
    parserOptions: {
      ignoreNonFatalErrors: true,
    },
  },
});

tester.run("my-rule", rule, {
  valid: [
    // This is invalid code, but it gets a pass
    "function f(x, x) {}",
  ],
  invalid: [],
});
```

This will be useful in conformance tests, because ESLint's tests contain invalid syntax in many of their test cases!