### PR TITLE
feat(formatter): support `consistent` quote props

### DIFF
--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -441,6 +441,13 @@ impl QuoteStyle {
         }
     }
 
+    pub fn as_str(self) -> &'static str {
+        match self {
+            QuoteStyle::Double => "\"",
+            QuoteStyle::Single => "'",
+        }
+    }
+
     pub fn as_byte(self) -> u8 {
         self.as_char() as u8
     }
@@ -528,7 +535,7 @@ pub enum QuoteProperties {
     AsNeeded,
     /// Respect the input use of quotes in object properties.
     Preserve,
-    /// If at least one property in an object requires quotes, quote all properties. [**NOT SUPPORTED YET**]
+    /// If at least one property in an object requires quotes, quote all properties.
     Consistent,
 }
 

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -976,8 +976,7 @@ fn is_short_argument(expression: &Expression, threshold: u16, f: &Formatter) -> 
                 StringLiteralParentKind::Expression,
             );
 
-            formatter.clean_text(f.context().source_type(), f.options()).width()
-                <= threshold as usize
+            formatter.clean_text(f).width() <= threshold as usize
         }
         Expression::TemplateLiteral(literal) => {
             // Besides checking length exceed we also need to check that the template doesn't have any expressions.

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -5,7 +5,9 @@ use crate::{
     Buffer, Format,
     ast_nodes::{AstNode, AstNodes},
     formatter::Formatter,
-    utils::string::{FormatLiteralStringToken, StringLiteralParentKind},
+    utils::string::{
+        FormatLiteralStringToken, StringLiteralParentKind, is_identifier_name_patched,
+    },
     write,
 };
 
@@ -42,7 +44,7 @@ pub fn write_member_name<'a>(
             false,
             StringLiteralParentKind::Member,
         )
-        .clean_text(f.context().source_type(), f.options());
+        .clean_text(f);
 
         string.format_leading_comments(f);
         write!(f, format);
@@ -54,4 +56,12 @@ pub fn write_member_name<'a>(
 
         f.source_text().span_width(key.span())
     }
+}
+
+/// Determine if the property key string literal should preserve its quotes
+pub fn should_preserve_quote(key: &PropertyKey<'_>, f: &Formatter<'_, '_>) -> bool {
+    matches!(&key, PropertyKey::StringLiteral(string) if {
+        let quote_less_content = f.source_text().text_for(&string.span.shrink(1));
+        !is_identifier_name_patched(quote_less_content)
+    })
 }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -69,7 +69,7 @@ use crate::{
         expression::ExpressionLeftSide,
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
         member_chain::MemberChain,
-        object::format_property_key,
+        object::{format_property_key, should_preserve_quote},
         statement_body::FormatStatementBody,
         string::{FormatLiteralStringToken, StringLiteralParentKind},
     },
@@ -99,7 +99,23 @@ pub trait FormatWrite<'ast, T = ()> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        write!(f, text_without_whitespace(self.name().as_str()));
+        let text = text_without_whitespace(self.name().as_str());
+        let is_property_key_parent = matches!(
+            self.parent,
+            AstNodes::ObjectProperty(_)
+                | AstNodes::TSPropertySignature(_)
+                | AstNodes::TSMethodSignature(_)
+                | AstNodes::MethodDefinition(_)
+                | AstNodes::PropertyDefinition(_)
+                | AstNodes::AccessorProperty(_)
+                | AstNodes::ImportAttribute(_)
+        );
+        if is_property_key_parent && f.context().is_quote_needed() {
+            let quote_str = f.options().quote_style.as_str();
+            write!(f, [quote_str, text, quote_str]);
+        } else {
+            write!(f, text);
+        }
     }
 }
 
@@ -139,7 +155,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Elision> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
+        if f.options().quote_properties.is_consistent() {
+            let quote_needed = self.properties.iter().any(|kind| {
+                kind.as_property().is_some_and(|property| should_preserve_quote(&property.key, f))
+            });
+            f.context_mut().push_quote_needed(quote_needed);
+        }
+
         ObjectLike::ObjectExpression(self).fmt(f);
+
+        if f.options().quote_properties.is_consistent() {
+            f.context_mut().pop_quote_needed();
+        }
     }
 }
 
@@ -1485,6 +1512,18 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        if f.options().quote_properties.is_consistent() {
+            let quote_needed = self.as_ref().iter().any(|signature| {
+                let key = match signature {
+                    TSSignature::TSPropertySignature(property) => &property.key,
+                    TSSignature::TSMethodSignature(property) => &property.key,
+                    _ => return false,
+                };
+                should_preserve_quote(key, f)
+            });
+            f.context_mut().push_quote_needed(quote_needed);
+        }
+
         let mut joiner = f.join_nodes_with_soft_line();
 
         let mut iter = self.iter().peekable();
@@ -1493,6 +1532,10 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
                 signature.span(),
                 &FormatTSSignature { signature, next_signature: iter.peek().copied() },
             );
+        }
+
+        if f.options().quote_properties.is_consistent() {
+            f.context_mut().pop_quote_needed();
         }
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/classes.js
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/classes.js
@@ -1,0 +1,41 @@
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  'b' = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  'c2' = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  'd-2' = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  'method-2'() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() { return 1; }
+  get 'getter-2'() { return 2; }
+  set setter1(v) {}
+  set 'setter-2'(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor 'prop-2' = 2;
+}

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/classes.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/classes.js.snap
@@ -1,0 +1,440 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  'b' = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  'c2' = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  'd-2' = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  'method-2'() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() { return 1; }
+  get 'getter-2'() { return 2; }
+  set setter1(v) {}
+  set 'setter-2'(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor 'prop-2' = 2;
+}
+
+==================== Output ====================
+-------------------------------------------
+{ printWidth: 80, quoteProps: "as-needed" }
+-------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  b = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  c2 = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set setter1(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor "prop-2" = 2;
+}
+
+--------------------------------------------
+{ printWidth: 100, quoteProps: "as-needed" }
+--------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  b = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  c2 = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set setter1(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor "prop-2" = 2;
+}
+
+------------------------------------------
+{ printWidth: 80, quoteProps: "preserve" }
+------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  "b" = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  "c2" = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set setter1(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor "prop-2" = 2;
+}
+
+-------------------------------------------
+{ printWidth: 100, quoteProps: "preserve" }
+-------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  "b" = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  "c2" = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  d1 = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  method1() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get getter1() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set setter1(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor prop1 = 1;
+  accessor "prop-2" = 2;
+}
+
+--------------------------------------------
+{ printWidth: 80, quoteProps: "consistent" }
+--------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  b = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  c2 = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  "d1" = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  "method1"() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get "getter1"() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set "setter1"(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor "prop1" = 1;
+  accessor "prop-2" = 2;
+}
+
+---------------------------------------------
+{ printWidth: 100, quoteProps: "consistent" }
+---------------------------------------------
+// Class with no quotes needed
+class A {
+  a = "a";
+}
+
+// Class with quotes preserved
+class B {
+  b = "b";
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = "c1";
+  c2 = "c2";
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  "d1" = "d1";
+  "d-2" = "d2";
+}
+
+// Class with methods
+class E {
+  "method1"() {}
+  "method-2"() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get "getter1"() {
+    return 1;
+  }
+  get "getter-2"() {
+    return 2;
+  }
+  set "setter1"(v) {}
+  set "setter-2"(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor "prop1" = 1;
+  accessor "prop-2" = 2;
+}
+
+---------------------------------------------------------------
+{ printWidth: 80, quoteProps: "consistent", singleQuote: true }
+---------------------------------------------------------------
+// Class with no quotes needed
+class A {
+  a = 'a';
+}
+
+// Class with quotes preserved
+class B {
+  b = 'b';
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = 'c1';
+  c2 = 'c2';
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  'd1' = 'd1';
+  'd-2' = 'd2';
+}
+
+// Class with methods
+class E {
+  'method1'() {}
+  'method-2'() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get 'getter1'() {
+    return 1;
+  }
+  get 'getter-2'() {
+    return 2;
+  }
+  set 'setter1'(v) {}
+  set 'setter-2'(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor 'prop1' = 1;
+  accessor 'prop-2' = 2;
+}
+
+----------------------------------------------------------------
+{ printWidth: 100, quoteProps: "consistent", singleQuote: true }
+----------------------------------------------------------------
+// Class with no quotes needed
+class A {
+  a = 'a';
+}
+
+// Class with quotes preserved
+class B {
+  b = 'b';
+}
+
+// Class with mixed - consistent should quote all
+class C {
+  c1 = 'c1';
+  c2 = 'c2';
+}
+
+// Class with required quotes - consistent should quote all
+class D {
+  'd1' = 'd1';
+  'd-2' = 'd2';
+}
+
+// Class with methods
+class E {
+  'method1'() {}
+  'method-2'() {}
+}
+
+// Class with getter/setter methods
+class F {
+  get 'getter1'() {
+    return 1;
+  }
+  get 'getter-2'() {
+    return 2;
+  }
+  set 'setter1'(v) {}
+  set 'setter-2'(v) {}
+}
+
+// Class with auto-accessors (ES2022) - consistent should quote all
+class G {
+  accessor 'prop1' = 1;
+  accessor 'prop-2' = 2;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/objects.js
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/objects.js
@@ -1,0 +1,58 @@
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b"
+};
+
+// Object with quotes preserved
+a = {
+  'b': "b"
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  'c2': "c2"
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  'd-2': "d2"
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value"
+  },
+  outer2: "value"
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    'inner-2': "value"
+  },
+  outer2: "value"
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value"
+  },
+  'outer-2': "value"
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    'inner-2': "value"
+  },
+  'outer-2': "value"
+};

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/objects.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/objects.js.snap
@@ -1,0 +1,561 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b"
+};
+
+// Object with quotes preserved
+a = {
+  'b': "b"
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  'c2': "c2"
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  'd-2': "d2"
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value"
+  },
+  outer2: "value"
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    'inner-2': "value"
+  },
+  outer2: "value"
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value"
+  },
+  'outer-2': "value"
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    'inner-2': "value"
+  },
+  'outer-2': "value"
+};
+
+==================== Output ====================
+-------------------------------------------
+{ printWidth: 80, quoteProps: "as-needed" }
+-------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  b: "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  c2: "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+--------------------------------------------
+{ printWidth: 100, quoteProps: "as-needed" }
+--------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  b: "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  c2: "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+------------------------------------------
+{ printWidth: 80, quoteProps: "preserve" }
+------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  "b": "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  "c2": "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+-------------------------------------------
+{ printWidth: 100, quoteProps: "preserve" }
+-------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  "b": "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  "c2": "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  d1: "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  outer1: {
+    inner1: "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+--------------------------------------------
+{ printWidth: 80, quoteProps: "consistent" }
+--------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  b: "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  c2: "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  "d1": "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    "inner1": "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  "outer1": {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  "outer1": {
+    "inner1": "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+---------------------------------------------
+{ printWidth: 100, quoteProps: "consistent" }
+---------------------------------------------
+// Object with no quotes needed
+a = {
+  a: "a",
+  b: "b",
+};
+
+// Object with quotes preserved
+a = {
+  b: "b",
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: "c1",
+  c2: "c2",
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  "d1": "d1",
+  "d-2": "d2",
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: "value",
+    inner2: "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    "inner1": "value",
+    "inner-2": "value",
+  },
+  outer2: "value",
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  "outer1": {
+    inner1: "value",
+    inner2: "value",
+  },
+  "outer-2": "value",
+};
+
+// Nested object where both need quotes
+a = {
+  "outer1": {
+    "inner1": "value",
+    "inner-2": "value",
+  },
+  "outer-2": "value",
+};
+
+---------------------------------------------------------------
+{ printWidth: 80, quoteProps: "consistent", singleQuote: true }
+---------------------------------------------------------------
+// Object with no quotes needed
+a = {
+  a: 'a',
+  b: 'b',
+};
+
+// Object with quotes preserved
+a = {
+  b: 'b',
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: 'c1',
+  c2: 'c2',
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  'd1': 'd1',
+  'd-2': 'd2',
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: 'value',
+    inner2: 'value',
+  },
+  outer2: 'value',
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    'inner1': 'value',
+    'inner-2': 'value',
+  },
+  outer2: 'value',
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  'outer1': {
+    inner1: 'value',
+    inner2: 'value',
+  },
+  'outer-2': 'value',
+};
+
+// Nested object where both need quotes
+a = {
+  'outer1': {
+    'inner1': 'value',
+    'inner-2': 'value',
+  },
+  'outer-2': 'value',
+};
+
+----------------------------------------------------------------
+{ printWidth: 100, quoteProps: "consistent", singleQuote: true }
+----------------------------------------------------------------
+// Object with no quotes needed
+a = {
+  a: 'a',
+  b: 'b',
+};
+
+// Object with quotes preserved
+a = {
+  b: 'b',
+};
+
+// Object with mixed - consistent should quote all
+a = {
+  c1: 'c1',
+  c2: 'c2',
+};
+
+// Object with required quotes - consistent should quote all
+a = {
+  'd1': 'd1',
+  'd-2': 'd2',
+};
+
+// Nested objects - each object is handled independently
+a = {
+  outer1: {
+    inner1: 'value',
+    inner2: 'value',
+  },
+  outer2: 'value',
+};
+
+// Nested object where only inner needs quotes - outer keys stay unquoted
+a = {
+  outer1: {
+    'inner1': 'value',
+    'inner-2': 'value',
+  },
+  outer2: 'value',
+};
+
+// Nested object where only outer needs quotes - inner keys stay unquoted
+a = {
+  'outer1': {
+    inner1: 'value',
+    inner2: 'value',
+  },
+  'outer-2': 'value',
+};
+
+// Nested object where both need quotes
+a = {
+  'outer1': {
+    'inner1': 'value',
+    'inner-2': 'value',
+  },
+  'outer-2': 'value',
+};
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/options.json
@@ -1,0 +1,6 @@
+[
+  { "quoteProps": "as-needed" },
+  { "quoteProps": "preserve" },
+  { "quoteProps": "consistent" },
+  { "quoteProps": "consistent", "singleQuote": true }
+]

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/with-clause.js
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/with-clause.js
@@ -1,0 +1,17 @@
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b"
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8"
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other"
+};

--- a/crates/oxc_formatter/tests/fixtures/js/quote-props/with-clause.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/quote-props/with-clause.js.snap
@@ -1,0 +1,192 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b"
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8"
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other"
+};
+
+==================== Output ====================
+-------------------------------------------
+{ printWidth: 80, quoteProps: "as-needed" }
+-------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other",
+};
+
+--------------------------------------------
+{ printWidth: 100, quoteProps: "as-needed" }
+--------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other",
+};
+
+------------------------------------------
+{ printWidth: 80, quoteProps: "preserve" }
+------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other",
+};
+
+-------------------------------------------
+{ printWidth: 100, quoteProps: "preserve" }
+-------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  sd: "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  normal: "other",
+};
+
+--------------------------------------------
+{ printWidth: 80, quoteProps: "consistent" }
+--------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  "sd": "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  "normal": "other",
+};
+
+---------------------------------------------
+{ printWidth: 100, quoteProps: "consistent" }
+---------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from "test" with {
+  "tess-sdt": "a",
+  "sd": "b",
+};
+
+// Import with no quotes needed
+import B from "test2" with {
+  type: "json",
+  encoding: "utf8",
+};
+
+// Export with attributes
+export { foo } from "bar" with {
+  "x-y": "value",
+  "normal": "other",
+};
+
+---------------------------------------------------------------
+{ printWidth: 80, quoteProps: "consistent", singleQuote: true }
+---------------------------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from 'test' with {
+  'tess-sdt': 'a',
+  'sd': 'b',
+};
+
+// Import with no quotes needed
+import B from 'test2' with {
+  type: 'json',
+  encoding: 'utf8',
+};
+
+// Export with attributes
+export { foo } from 'bar' with {
+  'x-y': 'value',
+  'normal': 'other',
+};
+
+----------------------------------------------------------------
+{ printWidth: 100, quoteProps: "consistent", singleQuote: true }
+----------------------------------------------------------------
+// Import with attributes - consistent should quote all when one requires quotes
+import A from 'test' with {
+  'tess-sdt': 'a',
+  'sd': 'b',
+};
+
+// Import with no quotes needed
+import B from 'test2' with {
+  type: 'json',
+  encoding: 'utf8',
+};
+
+// Export with attributes
+export { foo } from 'bar' with {
+  'x-y': 'value',
+  'normal': 'other',
+};
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -3,7 +3,8 @@ use std::{env::current_dir, fs, path::Path};
 use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, FormatOptions, Formatter, IndentStyle,
-    IndentWidth, LineEnding, LineWidth, QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
+    IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
+    get_parse_options,
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -115,6 +116,16 @@ fn parse_format_options(json: &OptionSet) -> FormatOptions {
                         "crlf" => LineEnding::Crlf,
                         "cr" => LineEnding::Cr,
                         _ => LineEnding::default(),
+                    };
+                }
+            }
+            "quoteProps" => {
+                if let Some(s) = value.as_str() {
+                    options.quote_properties = match s {
+                        "as-needed" => QuoteProperties::AsNeeded,
+                        "preserve" => QuoteProperties::Preserve,
+                        "consistent" => QuoteProperties::Consistent,
+                        _ => QuoteProperties::default(),
                     };
                 }
             }

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/interfaces.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/interfaces.ts
@@ -1,0 +1,28 @@
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  'b': string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  'c2': number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  'd-2': number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  'e-2': boolean;
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/interfaces.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/interfaces.ts.snap
@@ -1,0 +1,291 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  'b': string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  'c2': number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  'd-2': number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  'e-2': boolean;
+}
+
+==================== Output ====================
+-------------------------------------------
+{ printWidth: 80, quoteProps: "as-needed" }
+-------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  "e-2": boolean;
+}
+
+--------------------------------------------
+{ printWidth: 100, quoteProps: "as-needed" }
+--------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  "e-2": boolean;
+}
+
+------------------------------------------
+{ printWidth: 80, quoteProps: "preserve" }
+------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  "b": string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  "c2": number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  "e-2": boolean;
+}
+
+-------------------------------------------
+{ printWidth: 100, quoteProps: "preserve" }
+-------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  "b": string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  "c2": number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  d1: string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  e1: string;
+  "e-2": boolean;
+}
+
+--------------------------------------------
+{ printWidth: 80, quoteProps: "consistent" }
+--------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  "d1": string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  "e1": string;
+  "e-2": boolean;
+}
+
+---------------------------------------------
+{ printWidth: 100, quoteProps: "consistent" }
+---------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  "d1": string;
+  "d-2": number;
+}
+
+// Interface extending another
+interface E extends D {
+  "e1": string;
+  "e-2": boolean;
+}
+
+---------------------------------------------------------------
+{ printWidth: 80, quoteProps: "consistent", singleQuote: true }
+---------------------------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  'd1': string;
+  'd-2': number;
+}
+
+// Interface extending another
+interface E extends D {
+  'e1': string;
+  'e-2': boolean;
+}
+
+----------------------------------------------------------------
+{ printWidth: 100, quoteProps: "consistent", singleQuote: true }
+----------------------------------------------------------------
+// Interface with no quotes needed
+interface A {
+  a: string;
+  b: number;
+}
+
+// Interface with quotes preserved
+interface B {
+  b: string;
+}
+
+// Interface with mixed - consistent should quote all
+interface C {
+  c1: string;
+  c2: number;
+}
+
+// Interface with required quotes - consistent should quote all
+interface D {
+  'd1': string;
+  'd-2': number;
+}
+
+// Interface extending another
+interface E extends D {
+  'e1': string;
+  'e-2': boolean;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/options.json
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/options.json
@@ -1,0 +1,6 @@
+[
+  { "quoteProps": "as-needed" },
+  { "quoteProps": "preserve" },
+  { "quoteProps": "consistent" },
+  { "quoteProps": "consistent", "singleQuote": true }
+]

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/type-literals.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/type-literals.ts
@@ -1,0 +1,31 @@
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  'b': string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  'c2': number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  'd-2': number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; 'y-z': number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  'method-2'(): string;
+};

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/type-literals.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/type-literals.ts.snap
@@ -1,0 +1,318 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  'b': string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  'c2': number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  'd-2': number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; 'y-z': number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  'method-2'(): string;
+};
+
+==================== Output ====================
+-------------------------------------------
+{ printWidth: 80, quoteProps: "as-needed" }
+-------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  "method-2"(): string;
+};
+
+--------------------------------------------
+{ printWidth: 100, quoteProps: "as-needed" }
+--------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  "method-2"(): string;
+};
+
+------------------------------------------
+{ printWidth: 80, quoteProps: "preserve" }
+------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  "b": string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  "c2": number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  "method-2"(): string;
+};
+
+-------------------------------------------
+{ printWidth: 100, quoteProps: "preserve" }
+-------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  "b": string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  "c2": number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  d1: string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { x: string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  method(): void;
+  "method-2"(): string;
+};
+
+--------------------------------------------
+{ printWidth: 80, quoteProps: "consistent" }
+--------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  "d1": string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { "x": string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  "method"(): void;
+  "method-2"(): string;
+};
+
+---------------------------------------------
+{ printWidth: 100, quoteProps: "consistent" }
+---------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  "d1": string;
+  "d-2": number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { "x": string; "y-z": number }): void {}
+
+// Type literal with method signature
+type E = {
+  "method"(): void;
+  "method-2"(): string;
+};
+
+---------------------------------------------------------------
+{ printWidth: 80, quoteProps: "consistent", singleQuote: true }
+---------------------------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  'd1': string;
+  'd-2': number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { 'x': string; 'y-z': number }): void {}
+
+// Type literal with method signature
+type E = {
+  'method'(): void;
+  'method-2'(): string;
+};
+
+----------------------------------------------------------------
+{ printWidth: 100, quoteProps: "consistent", singleQuote: true }
+----------------------------------------------------------------
+// Type literal with no quotes needed
+type A = {
+  a: string;
+  b: number;
+};
+
+// Type literal with quotes preserved
+type B = {
+  b: string;
+};
+
+// Type literal with mixed - consistent should quote all
+type C = {
+  c1: string;
+  c2: number;
+};
+
+// Type literal with required quotes - consistent should quote all
+type D = {
+  'd1': string;
+  'd-2': number;
+};
+
+// Inline type literal in function parameter
+function foo(param: { 'x': string; 'y-z': number }): void {}
+
+// Type literal with method signature
+type E = {
+  'method'(): void;
+  'method-2'(): string;
+};
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 737/761 (96.85%)
+js compatibility: 735/761 (96.58%)
 
 # Failed
 
@@ -20,6 +20,8 @@ js compatibility: 737/761 (96.85%)
 | js/identifier/parentheses/let.js | 💥💥 | 82.27% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/object-multiline/multiline.js | 💥✨ | 22.22% |
+| js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
+| js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -215,7 +215,6 @@ impl TestRunner {
                 // Skip all options that are not supported yet
                 !options.experimental_operator_position.is_start()
                     && !options.experimental_ternaries
-                    && !options.quote_properties.is_consistent()
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
### Summary 

close: https://github.com/oxc-project/oxc/issues/16247

The Prettier documentation is [Quote props](https://prettier.io/docs/next/options#quote-props).

Support `consistent` in all object-like nodes, including `ObjectExpression`, `Class`, `TSTypeLiteral`, `TSInterfaceDeclaration`, and `WithClause`. 

### Example:

```ts
// ============================================
// ObjectExpression - object literals
// ============================================
const obj = {
  normal: "value",
  "needs-quote": "value",  // triggers consistent quoting for all keys
};

// Nested objects are handled independently
const nested = {
  outer: {
    inner: "value",
    "inner-key": "value",  // only inner object gets quoted
  },
  outerKey: "value",       // outer stays unquoted
};

// ============================================
// Class - properties, methods, and accessors
// ============================================
class MyClass {
  prop1 = "value";
  "prop-2" = "value";      // triggers consistent quoting

  method1() {}
  "method-2"() {}          // triggers consistent quoting for methods too

  get getter1() { return 1; }
  get "getter-2"() { return 2; }  // triggers consistent quoting for accessors too
  set setter1(v) {}
  set "setter-2"(v) {}
}

// ============================================
// WithClause - import/export attributes
// ============================================
import data from "./data.json" with {
  type: "json",
  "custom-attr": "value",  // triggers consistent quoting
};

export { foo } from "./foo.js" with {
  key: "value",
  "x-y": "other",
};

// ============================================
// TSInterfaceDeclaration (TypeScript)
// ============================================
interface MyInterface {
  prop1: string;
  "prop-2": number;        // triggers consistent quoting

  method1(): void;
  "method-2"(): string;    // triggers consistent quoting for method signatures too
}

// ============================================
// TSTypeLiteral (TypeScript)
// ============================================
type MyType = {
  field1: string;
  "field-2": number;       // triggers consistent quoting

  method(): void;
  "method-2"(): string;    // triggers consistent quoting for method signatures too
};

// Inline type literal
function process(param: { x: string; "y-z": number }): void {}
```

NOTE: I've found a Prettier bug, that is, `TSMethodSignature` is not being wrapped in quotes! But it should be, see [Prettier Playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEMCeAHOACAtnGACwgBMBnbAXm2AB0ps8DiSAKASiWwDcIBLEgG56jAOT4ipALQAmURy68BwqAF8VIADQgIGGH2hlkoAIYAnMxADuABXMIjKEwBsrJtEe0AjMybABrAgBlE3wAGT4oOGQAMxcyOG0ILwArODAYAHVfDGQQDDM4BLNuaO9fAOCMP0iAc2QYMwBXRJAE3D4G5ta4AA8sMz58WBcAeQGTGAgzGwgyPn1oPIQSLRA+gaGEGBcAFTgzKHM+Itj41vmoWuc4AEUmiHgz5wTtFLJeoLqb+8fopDiL1aAEcHvAbJYMI5wIY+GR4IhtI0THxnHUAMIQXC4Ex5FzONaXa5wACCMEafC8TXBBwiUWerxAhBguGcmUICyK1TAcCCDgWfG4CzQeTAZE8IG4LQAklASNsgmBBnoSXKgugbgzWgU5nBsiZcigCkUDqU1itRjE6f8QM4YmtIsUYBCTLUcVrtNUzMU8l4TF44M4pDAJQVIlkBERkAAOAAM2kKoL4hRdbtxAPOSP9mUjhGQMm0TQSu39jkBjLguADJHlJDCJiuTVdcAAYtMceS6njqRAQKpVEA)

### Not implemented case

There are still two failed tests because NumericLiterals doesn't wrap in quotes in `consistent`, which is intended because Prettier only wraps them when the parser is `JavaScript` or `Flow`

For example:

Input:
```
const A = {
  "k-b": a,
  2: b,
}
```

Output:

With `babel` or `flow` parser
```ts
const A = {
  "k-b": a,
  "2": b,
};
```

With `babel-ts` or `typescript` parser

```ts
const A = {
  "k-b": a,
  2: b,
};
```

So, for simplicity, and since oxc includes parsing TS, we don't wrap `NumericLiteral` in quotes at all.

### Tests

All tests are generated by Claude with the proper prompt, covering all code in this PR.