### PR TITLE
docs(linter): Added in the missing jest rules that are compatible with vitest.

### DIFF
--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -66,6 +66,17 @@ declare_oxc_lint!(
     ///     expect(true).toBeDefined();
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/max-expects": "error"
+    ///   }
+    /// }
+    /// ```
     MaxExpects,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -120,6 +120,17 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/max-nested-describe": "error"
+    ///   }
+    /// }
+    /// ```
     MaxNestedDescribe,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -93,6 +93,17 @@ declare_oxc_lint!(
     ///   await expect(foo).rejects.toThrow(Error);
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-conditional-expect": "error"
+    ///   }
+    /// }
+    /// ```
     NoConditionalExpect,
     jest,
     correctness

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -92,6 +92,17 @@ declare_oxc_lint!(
     ///   await expect(promiseValue()).resolves.toBe(1);
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-conditional-in-test": "error"
+    ///   }
+    /// }
+    /// ```
     NoConditionalInTest,
     jest,
     pedantic,

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -100,6 +100,17 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-duplicate-hooks": "error"
+    ///   }
+    /// }
+    /// ```
     NoDuplicateHooks,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -83,6 +83,17 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-hooks": "error"
+    ///   }
+    /// }
+    /// ```
     NoHooks,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -51,6 +51,17 @@ declare_oxc_lint!(
     ///   `${interpolated}`,
     /// );
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-interpolation-in-snapshots": "error"
+    ///   }
+    /// }
+    /// ```
     NoInterpolationInSnapshots,
     jest,
     style

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -68,6 +68,17 @@ declare_oxc_lint!(
     ///   // ...
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-restricted-vi-methods": "error"
+    ///   }
+    /// }
+    /// ```
     NoRestrictedJestMethods,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -105,6 +105,17 @@ declare_oxc_lint!(
     ///   });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-restricted-matchers": "error"
+    ///   }
+    /// }
+    /// ```
     NoRestrictedMatchers,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -70,6 +70,17 @@ declare_oxc_lint!(
     ///     expect(1).toBe(1);
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-standalone-expect": "error"
+    ///   }
+    /// }
+    /// ```
     NoStandaloneExpect,
     jest,
     correctness,

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -47,6 +47,17 @@ declare_oxc_lint!(
     ///    expect(1).toBe(1);
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-return-statement.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/no-test-return-statement": "error"
+    ///   }
+    /// }
+    /// ```
     NoTestReturnStatement,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -60,6 +60,17 @@ declare_oxc_lint!(
     /// // special case - see below
     /// expect(x < 'Carl').toBe(true);
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-comparison-matcher.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-comparison-matchers": "error"
+    ///   }
+    /// }
+    /// ```
     PreferComparisonMatcher,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -67,7 +67,7 @@ declare_oxc_lint!(
     /// ```json
     /// {
     ///   "rules": {
-    ///      "vitest/prefer-comparison-matchers": "error"
+    ///      "vitest/prefer-comparison-matcher": "error"
     ///   }
     /// }
     /// ```

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -63,6 +63,17 @@ declare_oxc_lint!(
     /// 	expect(item).toBe('foo')
     /// })
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-each": "error"
+    ///   }
+    /// }
+    /// ```
     PreferEach,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -51,6 +51,17 @@ declare_oxc_lint!(
     /// expect(name).not.toEqual('Carl');
     /// expect(myObj).toStrictEqual(thatObj);
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-equality-matchers": "error"
+    ///   }
+    /// }
+    /// ```
     PreferEqualityMatcher,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -58,7 +58,7 @@ declare_oxc_lint!(
     /// ```json
     /// {
     ///   "rules": {
-    ///      "vitest/prefer-equality-matchers": "error"
+    ///      "vitest/prefer-equality-matcher": "error"
     ///   }
     /// }
     /// ```

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -72,6 +72,17 @@ declare_oxc_lint!(
     ///     );
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-expect-resolves": "error"
+    ///   }
+    /// }
+    /// ```
     PreferExpectResolves,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -144,6 +144,17 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-hooks-on-top": "error"
+    ///   }
+    /// }
+    /// ```
     PreferHooksOnTop,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -151,6 +151,17 @@ declare_oxc_lint!(
     ///     expect(sum(1, 2)).toBe(3);
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-lowercase-title.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-lowercase-title": "error"
+    ///   }
+    /// }
+    /// ```
     PreferLowercaseTitle,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -57,6 +57,17 @@ declare_oxc_lint!(
     ///   .mockResolvedValueOnce(42)
     ///   .mockRejectedValue(new Error('too many calls!'));
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-mock-promise-shorthand": "error"
+    ///   }
+    /// }
+    /// ```
     PreferMockPromiseShorthand,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -40,6 +40,17 @@ declare_oxc_lint!(
     /// ```javascript
     /// expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-equal.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-strict-equal": "error"
+    ///   }
+    /// }
+    /// ```
     PreferStrictEqual,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -82,6 +82,17 @@ declare_oxc_lint!(
     /// expect(didError).not.toBe(true);
     /// expect(catchError()).toStrictEqual({ message: 'oh noes!' });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-to-be": "error"
+    ///   }
+    /// }
+    /// ```
     PreferToBe,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -43,6 +43,17 @@ declare_oxc_lint!(
     /// ```javascript
     /// expect(files).toHaveLength(1);
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-to-have-length": "error"
+    ///   }
+    /// }
+    /// ```
     PreferToHaveLength,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -42,6 +42,17 @@ declare_oxc_lint!(
     /// ```javascript
     /// test.todo('i need to write this test');
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-todo": "error"
+    ///   }
+    /// }
+    /// ```
     PreferTodo,
     jest,
     style,

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -52,6 +52,17 @@ declare_oxc_lint!(
     ///   await expect(a()).rejects.toThrowError('a');
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/require-to-throw-message": "error"
+    ///   }
+    /// }
+    /// ```
     RequireToThrowMessage,
     jest,
     correctness

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -99,6 +99,17 @@ declare_oxc_lint!(
     ///     });
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/require-top-level-describe": "error"
+    ///   }
+    /// }
+    /// ```
     RequireTopLevelDescribe,
     jest,
     style,


### PR DESCRIPTION
After the review @connorshea did in https://github.com/oxc-project/oxc/pull/16540#pullrequestreview-3548500490, suggested to me add a missing part of documentation in the linter rule. I hadn't added it because the reference rule I used lack of it.

So this PR aims to add it in all jest rules stated as compatible.

## Before this PR

The following Jest linter only had this documentation part:

- consistent-test-it
- expect-expect
- no-alias-methods
- no-commented-out-tests
- no-disabled-tests
- no-focused-tests
- no-identical-title
- no-test-prefixes
- prefer-hooks-in-order
- valid-describe-callback
- valid-expect

## Adding in this PR

- max-expects
- max-nested-describe
- no-conditional-expect
- no-conditional-in-test
- no-duplicate-hooks
- no-hooks
- no-interpolation-in-snapshots
- no-restricted-jest-methods: I have doubts here see my comment in the [vitest-eslint-plugin issue](https://github.com/oxc-project/oxc/issues/4656#issuecomment-3616755697)
- no-restricted-matchers
- no-standalone-expect
- no-test-return-statement
- prefer-comparison-matcher
- prefer-each
- prefer-equality-matcher
- prefer-expect-resolves
- prefer-hooks-on-top
- prefer-lowercase-title
- prefer-mock-promise-shorthand
- prefer-strict-equal
- prefer-to-be
- prefer-to-have-length
- prefer-todo
- require-to-throw-message
- require-top-level-describe