### PR TITLE
feat(oxfmt): .editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 4
 
 [*.{js,mjs,cjs,jsx,ts,tsx,json,yml}]
 indent_size = 2
+
+[*.{md}]
+indent_size = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "editorconfig-parser"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf5c801bcfdbcf7a706b19b314daec914ef1f6054047adfd195fff9c38984f9"
+dependencies = [
+ "globset",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2536,7 @@ version = "0.17.0"
 dependencies = [
  "bpaf",
  "cow-utils",
+ "editorconfig-parser",
  "ignore",
  "json-strip-comments",
  "mimalloc-safe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ convert_case = "0.10.0" # Case conversion
 cow-utils = "0.1.3" # Copy-on-write utilities
 criterion2 = { version = "3.0.2", default-features = false } # Benchmarking
 dragonbox_ecma = "0.0.5" # Fast float formatting
+editorconfig-parser = "0.0.2" # .editorconfig parser
 encoding_rs = "0.8.35" # Character encoding
 encoding_rs_io = "0.1.7" # Encoding I/O
 env_logger = { version = "0.11.8", default-features = false } # Logging implementation
@@ -233,7 +234,6 @@ tracing-subscriber = "0.3.20" # Tracing implementation
 ureq = { version = "3.1.4", default-features = false } # HTTP client
 url = { version = "2.5.7" } # URL parsing
 walkdir = "2.5.0" # Directory traversal
-editorconfig-parser = "0.0.2" # .editorconfig parser
 
 [workspace.metadata.cargo-shear]
 ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ tracing-subscriber = "0.3.20" # Tracing implementation
 ureq = { version = "3.1.4", default-features = false } # HTTP client
 url = { version = "2.5.7" } # URL parsing
 walkdir = "2.5.0" # Directory traversal
+editorconfig-parser = "0.0.2" # .editorconfig parser
 
 [workspace.metadata.cargo-shear]
 ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi"]

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -47,6 +47,7 @@ sort-package-json = "0.0.2"
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
+editorconfig-parser = { workspace = true }
 
 # NAPI dependencies (conditional on napi feature)
 napi = { workspace = true, features = ["async"], optional = true }

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -36,6 +36,7 @@ oxc_span = { workspace = true }
 
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 cow-utils = { workspace = true }
+editorconfig-parser = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 json-strip-comments = { workspace = true }
 miette = { workspace = true }
@@ -47,7 +48,6 @@ sort-package-json = "0.0.2"
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
-editorconfig-parser = { workspace = true }
 
 # NAPI dependencies (conditional on napi feature)
 napi = { workspace = true, features = ["async"], optional = true }

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -18,7 +18,7 @@ use super::{
     service::{FormatService, SuccessResult},
     walk::Walk,
 };
-use crate::core::{SourceFormatter, utils};
+use crate::core::{SourceFormatter, editorconfig::find_root_editorconfig, utils};
 
 #[derive(Debug)]
 pub struct FormatRunner {
@@ -129,6 +129,8 @@ impl FormatRunner {
             }
         };
 
+        let editorconfig = find_root_editorconfig(&cwd);
+
         // Get the receiver for streaming entries
         let rx_entry = walker.stream_entries();
         // Collect format results (changed paths or unchanged count)
@@ -143,7 +145,7 @@ impl FormatRunner {
         }
 
         // Create `SourceFormatter` instance
-        let source_formatter = SourceFormatter::new(num_of_threads, format_options);
+        let source_formatter = SourceFormatter::new(num_of_threads, format_options, editorconfig);
         #[cfg(feature = "napi")]
         let source_formatter = source_formatter
             .with_external_formatter(self.external_formatter, oxfmt_options.is_sort_package_json);

--- a/apps/oxfmt/src/core/editorconfig.rs
+++ b/apps/oxfmt/src/core/editorconfig.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use editorconfig_parser::{EditorConfig, EditorConfigProperties};
+use oxc_formatter::FormatOptions;
+
+use crate::core::utils::read_to_string;
+
+/// Find root `.editorconfig`.
+/// <https://github.com/prettier/prettier/blob/v3.7/src/config/editorconfig/index.js>
+pub fn find_root_editorconfig(cwd: &Path) -> Option<EditorConfig> {
+    let root =
+        cwd.ancestors().find(|path| path.join(".git").exists() || path.join(".hg").exists())?;
+    let source = read_to_string(&root.join(".editorconfig")).ok()?;
+    Some(EditorConfig::parse(&source))
+}
+
+pub fn merge_editorconfig_and_format_options(
+    properties: EditorConfigProperties,
+    options: &FormatOptions,
+) -> FormatOptions {
+}

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod editorconfig;
 mod format;
 mod support;
 pub mod utils;

--- a/justfile
+++ b/justfile
@@ -183,7 +183,7 @@ oxfmt:
 
 # watch oxfmt, e.g. `just watch-oxfmt test.js`
 watch-oxfmt *args='':
-  just watch 'cargo run -p oxfmt -- {{args}}'
+  just watch 'cargo run -p oxfmt --no-default-features -- -c ./oxfmtrc.jsonc {{args}}'
 
 # Build oxfmt in release build
 oxfmt-node:


### PR DESCRIPTION
closes #15850

@leaysgur handing this over to you, because we need a bigger change to merge the options.

https://github.com/prettier/prettier/blob/1cc636785661d9c0b53a31845348ed0d5456211b/src/config/resolve-config.js#L74-L86

If you look at the TODO line, we need to create default options, then override it by editorconfig, then override by oxfmtrc.json

`.editorconfig` defines overrides already

```
[*]
charset = utf-8
trim_trailing_whitespace = true
end_of_line = lf
insert_final_newline = true
indent_style = space
indent_size = 4

[*.{js,mjs,cjs,jsx,ts,tsx,json,yml}]
indent_size = 2

```

So each path receives a different config. I think you may want to plan ahead for oxfmtrc override, which should behave exactly the same as editorconfig.