### PR TITLE
feat(oxfmt): Support `--stdin-filepath`

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -84,6 +84,11 @@ pub struct MiscOptions {
     /// Number of threads to use. Set to 1 for using only 1 CPU core.
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,
+    /// Read code from stdin and use this path to determine the parser.
+    /// The path does not need to exist.
+    /// Output is always written to stdout in this mode.
+    #[bpaf(long, argument("PATH"))]
+    pub stdin_filepath: Option<PathBuf>,
 }
 
 impl FormatCommand {

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -1,0 +1,73 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use oxc_formatter::{FormatOptions, OxfmtOptions, Oxfmtrc};
+
+use super::utils;
+
+/// Resolve config file path from cwd and optional explicit path.
+pub fn resolve_config_path(cwd: &Path, config_path: Option<&Path>) -> Option<PathBuf> {
+    // If `--config` is explicitly specified, use that path
+    if let Some(config_path) = config_path {
+        return Some(if config_path.is_absolute() {
+            config_path.to_path_buf()
+        } else {
+            cwd.join(config_path)
+        });
+    }
+
+    // If `--config` is not specified, search the nearest config file from cwd upwards
+    // Support both `.json` and `.jsonc`, but prefer `.json` if both exist
+    cwd.ancestors().find_map(|dir| {
+        for filename in [".oxfmtrc.json", ".oxfmtrc.jsonc"] {
+            let config_path = dir.join(filename);
+            if config_path.exists() {
+                return Some(config_path);
+            }
+        }
+        None
+    })
+}
+
+/// Load and parse config file.
+///
+/// # Errors
+/// Returns error if:
+/// - Config file is specified but not found or invalid
+/// - Config file parsing fails
+pub fn load_config(
+    config_path: Option<&Path>,
+) -> Result<(FormatOptions, OxfmtOptions, Value), String> {
+    // Read and parse config file, or use empty JSON if not found
+    let json_string = match config_path {
+        Some(path) => {
+            let mut json_string = utils::read_to_string(path)
+                // Do not include OS error, it differs between platforms
+                .map_err(|_| format!("Failed to read config {}: File not found", path.display()))?;
+            // Strip comments (JSONC support)
+            json_strip_comments::strip(&mut json_string).map_err(|err| {
+                format!("Failed to strip comments from {}: {err}", path.display())
+            })?;
+            json_string
+        }
+        None => "{}".to_string(),
+    };
+
+    // Parse as raw JSON value (to pass to external formatter)
+    let mut raw_config: Value = serde_json::from_str(&json_string)
+        .map_err(|err| format!("Failed to parse config: {err}"))?;
+
+    // NOTE: Field validation for `enum` are done here
+    let oxfmtrc: Oxfmtrc = serde_json::from_str(&json_string)
+        .map_err(|err| format!("Failed to deserialize config: {err}"))?;
+
+    // NOTE: Other validation based on it's field values are done here
+    let (format_options, oxfmt_options) =
+        oxfmtrc.into_options().map_err(|err| format!("Failed to parse configuration.\n{err}"))?;
+
+    // Populate `raw_config` with resolved options to apply our defaults
+    Oxfmtrc::populate_prettier_config(&format_options, &mut raw_config);
+
+    Ok((format_options, oxfmt_options, raw_config))
+}

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -1,3 +1,4 @@
+mod config;
 mod format;
 mod support;
 pub mod utils;
@@ -5,6 +6,7 @@ pub mod utils;
 #[cfg(feature = "napi")]
 mod external_formatter;
 
+pub use config::{load_config, resolve_config_path};
 pub use format::{FormatResult, SourceFormatter};
 pub use support::FormatFileStrategy;
 

--- a/apps/oxfmt/src/core/utils.rs
+++ b/apps/oxfmt/src/core/utils.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::Path};
+use std::{fs, io, io::Write, path::Path};
 
 pub fn read_to_string(path: &Path) -> io::Result<String> {
     // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
@@ -12,4 +12,21 @@ pub fn read_to_string(path: &Path) -> io::Result<String> {
     }
     // SAFETY: `simdutf8` has ensured it's a valid UTF-8 string
     Ok(unsafe { String::from_utf8_unchecked(bytes) })
+}
+
+// ---
+
+pub fn print_and_flush(writer: &mut dyn Write, message: &str) {
+    use std::io::{Error, ErrorKind};
+    fn check_for_writer_error(error: Error) -> Result<(), Error> {
+        // Do not panic when the process is killed (e.g. piping into `less`).
+        if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+
+    writer.write_all(message.as_bytes()).or_else(check_for_writer_error).unwrap();
+    writer.flush().unwrap();
 }

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 mod core;
 pub mod lsp;
+pub mod stdin;
 
 // Only include code to run formatter when the `napi` feature is enabled.
 #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -2,6 +2,7 @@ use std::io::BufWriter;
 
 use oxfmt::cli::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing};
 use oxfmt::lsp::run_lsp;
+use oxfmt::stdin::StdinRunner;
 
 // Pure Rust CLI entry point.
 // For JS CLI entry point, see `format()` exported by `main_napi.rs`.
@@ -15,6 +16,21 @@ async fn main() -> CliRunResult {
     if command.misc_options.lsp {
         run_lsp().await;
         return CliRunResult::None;
+    }
+
+    // Handle Stdin mode
+    if let Some(stdin_filepath) = command.misc_options.stdin_filepath {
+        init_tracing();
+        init_miette();
+
+        let mut stdin = std::io::stdin();
+        let mut stdout = BufWriter::new(std::io::stdout());
+        let mut stderr = BufWriter::new(std::io::stderr());
+        return StdinRunner::new(stdin_filepath, command.basic_options.config).run(
+            &mut stdin,
+            &mut stdout,
+            &mut stderr,
+        );
     }
 
     // Otherwise, CLI mode

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -1,0 +1,123 @@
+use std::{
+    env,
+    io::{Read, Write},
+    path::PathBuf,
+};
+
+use crate::cli::CliRunResult;
+use crate::core::{
+    FormatFileStrategy, FormatResult, SourceFormatter, load_config, resolve_config_path, utils,
+};
+
+pub struct StdinRunner {
+    cwd: PathBuf,
+    stdin_file_path: PathBuf,
+    config_path: Option<PathBuf>,
+    #[cfg(feature = "napi")]
+    external_formatter: Option<crate::core::ExternalFormatter>,
+}
+
+impl StdinRunner {
+    /// Creates a new `StdinRunner` instance.
+    ///
+    /// # Panics
+    /// Panics if the current working directory cannot be determined.
+    pub fn new(stdin_file_path: PathBuf, config_path: Option<PathBuf>) -> Self {
+        Self {
+            cwd: env::current_dir().expect("Failed to get current working directory"),
+            stdin_file_path,
+            config_path,
+            #[cfg(feature = "napi")]
+            external_formatter: None,
+        }
+    }
+
+    #[cfg(feature = "napi")]
+    #[must_use]
+    pub fn with_external_formatter(
+        mut self,
+        external_formatter: Option<crate::core::ExternalFormatter>,
+    ) -> Self {
+        self.external_formatter = external_formatter;
+        self
+    }
+
+    /// # Panics
+    /// Panics if `napi` feature is enabled but external_formatter is not set.
+    pub fn run(
+        self,
+        stdin: &mut dyn Read,
+        stdout: &mut dyn Write,
+        stderr: &mut dyn Write,
+    ) -> CliRunResult {
+        // Load config
+        let config_path = resolve_config_path(&self.cwd, self.config_path.as_deref());
+        let (format_options, oxfmt_options, external_config) =
+            match load_config(config_path.as_deref()) {
+                Ok(config) => config,
+                Err(err) => {
+                    utils::print_and_flush(
+                        stderr,
+                        &format!("Failed to load configuration file.\n{err}\n"),
+                    );
+                    return CliRunResult::InvalidOptionConfig;
+                }
+            };
+        #[cfg(not(feature = "napi"))]
+        let _ = (external_config, oxfmt_options.sort_package_json);
+
+        // TODO: Plugins support
+        #[cfg(feature = "napi")]
+        if let Err(err) = self
+            .external_formatter
+            .as_ref()
+            .expect("External formatter must be set when `napi` feature is enabled")
+            .setup_config(&external_config.to_string(), 1)
+        {
+            utils::print_and_flush(
+                stderr,
+                &format!("Failed to setup external formatter config.\n{err}\n"),
+            );
+            return CliRunResult::InvalidOptionConfig;
+        }
+
+        // Formatter (single-threaded)
+        let source_formatter = SourceFormatter::new(1, format_options);
+        #[cfg(feature = "napi")]
+        let source_formatter = source_formatter
+            .with_external_formatter(self.external_formatter, oxfmt_options.sort_package_json);
+
+        let entry = match FormatFileStrategy::try_from(self.stdin_file_path.clone()) {
+            Ok(entry @ FormatFileStrategy::OxcFormatter { .. }) => entry,
+            #[cfg(feature = "napi")]
+            Ok(entry) => entry,
+            _ => {
+                utils::print_and_flush(
+                    stderr,
+                    &format!("Unsupported file type: {}\n", self.stdin_file_path.display()),
+                );
+                return CliRunResult::InvalidOptionConfig;
+            }
+        };
+
+        // Read source from stdin
+        let mut source_text = String::new();
+        if let Err(err) = stdin.read_to_string(&mut source_text) {
+            utils::print_and_flush(stderr, &format!("Failed to read from stdin: {err}\n"));
+            return CliRunResult::FormatFailed;
+        }
+
+        match source_formatter.format(&entry, &source_text) {
+            FormatResult::Success { code, .. } => {
+                let _ = stdout.write_all(code.as_bytes());
+                CliRunResult::FormatSucceeded
+            }
+            FormatResult::Error(diagnostics) => {
+                for diagnostic in diagnostics {
+                    utils::print_and_flush(stderr, &format!("{diagnostic}\n"));
+                }
+                CliRunResult::FormatFailed
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14720 

- [x] In addition to `cli`, add a new mode called `stdin`, similar to `lsp`
- [x] Therefore, extract shared code into `core/utils` and `core/config`
- [x] Implementation lives in `stdin/mod.rs`
- [ ] Update CLI doc snapshot
- [ ] Self review, add tests