### PR TITLE
feat(oxfmt): override all js formatting in prettier POC

### DIFF
--- a/apps/oxfmt/src-js/prettier-worker.ts
+++ b/apps/oxfmt/src-js/prettier-worker.ts
@@ -57,5 +57,61 @@ export async function formatFile({ parserName, fileName, code }: FormatFileArgs)
     ...prettierConfig,
     parser: parserName,
     filepath: fileName,
+    // TODO remove this, enabling for test
+    embeddedLanguageFormatting: "auto",
+    // TODO: cache this
+    plugins: await getPlugins(prettierCache),
   });
+}
+
+async function getPlugins(prettier) {
+  const { languages } = await prettier.getSupportInfo();
+
+  const programParser = {
+    astFormat: "oxfmt",
+    parse: (text) => ({
+      type: "Program",
+      body: [],
+      sourceType: "module",
+      __oxfmtFormatted: "formatted by oxfmt",
+    }),
+  };
+
+  const expressionParser = {
+    astFormat: "oxfmt",
+    parse: (text) => ({
+      type: "Program",
+      body: [],
+      sourceType: "module",
+      __oxfmtFormatted: "formatted by oxfmt expr",
+    }),
+  };
+
+  return [
+    {
+      // TODO: double check whether we need this
+      languages: languages
+        .filter((l) => ["JavaScript", "JSX", "TypeScript", "TSX"].includes(l.name))
+        .map((l) => ({ ...l, parsers: ["oxc"] })),
+
+      parsers: {
+        oxc: programParser,
+        babel: programParser,
+        "babel-ts": programParser,
+        typescript: programParser,
+        __vue_expression: expressionParser,
+        __vue_ts_expression: expressionParser,
+        __vue_event_binding: expressionParser,
+        __vue_ts_event_binding: expressionParser,
+        __js_expression: expressionParser,
+        __ts_expression: expressionParser,
+      },
+
+      printers: {
+        oxfmt: {
+          print: (path) => path.node.__oxfmtFormatted || "/* ERROR */",
+        },
+      },
+    },
+  ];
 }

--- a/test.vue
+++ b/test.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="wrapper">
+    <header class="header">
+      <h1>{{ formatted by oxfmt expr }}</h1>
+      <p v-if="formatted by oxfmt expr">{{ formatted by oxfmt expr }}</p>
+
+      <!-- Slots -->
+      <slot name="actions" />
+
+      <!-- v-for with key + destructuring -->
+      <ul>
+        <li v-for="formatted by oxfmt in formatted by oxfmt expr" :key="formatted by oxfmt expr">
+          {{ formatted by oxfmt expr }}. {{ formatted by oxfmt expr }}
+        </li>
+      </ul>
+    </header>
+  </div>
+</template>
+
+<script lang="ts" setup>
+formatted by oxfmt
+</script>


### PR DESCRIPTION
`pnpm --filter oxfmt-app build-dev && node ./apps/oxfmt/dist/cli.js -c oxfmtrc.jsonc test.vue`

part of https://github.com/oxc-project/oxc/issues/16608