### PR TITLE
fix(semantic): add TS1016 error code to required parameter after optional diagnostic

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -104,8 +104,7 @@ pub fn check_ts_type_alias_declaration<'a>(
 }
 
 fn required_parameter_after_optional_parameter(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A required parameter cannot follow an optional parameter.")
-        .with_label(span)
+    ts_error("1016", "A required parameter cannot follow an optional parameter.").with_label(span)
 }
 
 pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -464,7 +464,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties/input.ts
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties/input.ts:7:9]
  6 │         private pi?: number,
  7 │         public readonly pur,
@@ -556,7 +556,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts:1:25]
  1 │ declare function f([]?, {})
    ·                         ──
@@ -13171,7 +13171,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ╰────
   help: No modifiers are allowed here.
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:7:9]
  6 │         private pi?: number,
  7 │         public readonly pur,
@@ -13447,7 +13447,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: No modifiers are allowed here.
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:6:3]
  5 │   private pi?: number,
  6 │   public readonly pur,
@@ -13455,13 +13455,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  7 │   readonly x = 0,
    ╰────
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/pattern-optional-parameters/input.ts:1:17]
  1 │ function f([]?, {}) {}
    ·                 ──
    ╰────
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/pattern-optional-parameters-arrow/input.ts:1:7]
  1 │ ([]?, {}) => {}
    ·       ──

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6419,7 +6419,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  5 │ 
    ╰────
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts:1:9]
  1 │ (arg1?, arg2) => 101;
    ·         ────
@@ -22534,7 +22534,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: No modifiers are allowed here.
 
-  × A required parameter cannot follow an optional parameter.
+  × TS(1016): A required parameter cannot follow an optional parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList3.ts:2:9]
  1 │ class C {
  2 │   F(A?, B) { }


### PR DESCRIPTION
I noticed this while looking at https://discord.com/channels/1079625926024900739/1448256490904354931
