### PR TITLE
feat(linter/plugins): support `parserOptions.ecmaFeatures.jsx` option in `RuleTester`

### DIFF
--- a/apps/oxlint/conformance/snapshot.md
+++ b/apps/oxlint/conformance/snapshot.md
@@ -7,9 +7,9 @@
 | Status            | Count |
 | ----------------- | ----- |
 | Total rules       |   292 |
-| Fully passing     |   158 |
-| Partially passing |   128 |
-| Fully failing     |     6 |
+| Fully passing     |   166 |
+| Partially passing |   121 |
+| Fully failing     |     5 |
 | Load errors       |     0 |
 | No tests run      |     0 |
 
@@ -18,8 +18,8 @@
 | Status      | Count |
 | ----------- | ----- |
 | Total tests | 33090 |
-| Passing     | 26548 |
-| Failing     |  6542 |
+| Passing     | 26802 |
+| Failing     |  6288 |
 
 ## Fully Passing Rules
 
@@ -28,6 +28,7 @@
 - `block-spacing` (101 tests)
 - `callback-return` (78 tests)
 - `capitalized-comments` (178 tests)
+- `comma-spacing` (173 tests)
 - `comma-style` (96 tests)
 - `curly` (216 tests)
 - `default-case-last` (37 tests)
@@ -43,12 +44,14 @@
 - `id-length` (181 tests)
 - `id-match` (98 tests)
 - `implicit-arrow-linebreak` (62 tests)
+- `jsx-quotes` (18 tests)
 - `key-spacing` (153 tests)
 - `line-comment-position` (38 tests)
 - `linebreak-style` (12 tests)
 - `lines-between-class-members` (112 tests)
 - `max-classes-per-file` (17 tests)
 - `max-depth` (25 tests)
+- `max-len` (108 tests)
 - `max-lines-per-function` (43 tests)
 - `max-lines` (47 tests)
 - `max-nested-callbacks` (14 tests)
@@ -95,6 +98,7 @@
 - `no-func-assign` (15 tests)
 - `no-implicit-coercion` (134 tests)
 - `no-import-assign` (116 tests)
+- `no-inline-comments` (49 tests)
 - `no-invalid-regexp` (108 tests)
 - `no-iterator` (9 tests)
 - `no-label-var` (5 tests)
@@ -104,6 +108,7 @@
 - `no-mixed-spaces-and-tabs` (61 tests)
 - `no-multi-assign` (31 tests)
 - `no-multi-spaces` (130 tests)
+- `no-multi-str` (7 tests)
 - `no-negated-condition` (19 tests)
 - `no-negated-in-lhs` (3 tests)
 - `no-nested-ternary` (4 tests)
@@ -125,6 +130,7 @@
 - `no-restricted-exports` (183 tests)
 - `no-restricted-modules` (44 tests)
 - `no-restricted-properties` (89 tests)
+- `no-restricted-syntax` (32 tests)
 - `no-return-assign` (30 tests)
 - `no-return-await` (71 tests)
 - `no-script-url` (10 tests)
@@ -144,6 +150,7 @@
 - `no-unused-private-class-members` (39 tests)
 - `no-useless-call` (44 tests)
 - `no-useless-catch` (16 tests)
+- `no-useless-escape` (288 tests)
 - `no-void` (12 tests)
 - `no-warning-comments` (61 tests)
 - `no-with` (2 tests)
@@ -161,6 +168,7 @@
 - `prefer-template` (78 tests)
 - `preserve-caught-error` (49 tests)
 - `quote-props` (104 tests)
+- `quotes` (113 tests)
 - `require-await` (38 tests)
 - `require-yield` (15 tests)
 - `rest-spread-spacing` (82 tests)
@@ -5000,63 +5008,6 @@ AssertionError [ERR_ASSERTION]: Should have 2 errors but had 1: [
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-### `comma-spacing`
-
-Pass: 169 / 173 (97.7%)
-Fail: 4 / 173 (2.3%)
-
-#### comma-spacing > valid
-
-```js
-<a>,</a>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### comma-spacing > valid
-
-```js
-<a>  ,  </a>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### comma-spacing > valid
-
-```js
-<a>Hello, world</a>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### comma-spacing > invalid
-
-```js
-<a>{foo(1 ,2)}</a>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `complexity`
@@ -13247,8 +13198,8 @@ TypeError: Expected `loc` to be an object with integer `line` and `column` prope
 
 ### `indent`
 
-Pass: 168 / 1090 (15.4%)
-Fail: 922 / 1090 (84.6%)
+Pass: 188 / 1090 (17.2%)
+Fail: 902 / 1090 (82.8%)
 
 #### indent > valid
 
@@ -34241,43 +34192,45 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
 #### indent > valid
 
 ```js
-<Foo a="b" c="d"/>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
 <Foo
     a="b"
     c="d"
 />;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-var foo = <Bar a="b" c="d"/>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34289,11 +34242,39 @@ var foo = <Bar
 />;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34305,11 +34286,39 @@ var foo = (<Bar
 />);
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34323,11 +34332,39 @@ var foo = (
 );
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34340,11 +34377,51 @@ Error: Parsing failed
 />;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34355,11 +34432,39 @@ Error: Parsing failed
     c="d"/>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34371,39 +34476,51 @@ Error: Parsing failed
     c="d"/>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<a href="foo">bar</a>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<a href="foo">
-    bar
-</a>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34416,11 +34533,27 @@ Error: Parsing failed
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34432,11 +34565,27 @@ Error: Parsing failed
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34449,11 +34598,39 @@ Error: Parsing failed
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34466,11 +34643,39 @@ Error: Parsing failed
     a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34483,26 +34688,27 @@ Error: Parsing failed
 >;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-var foo = <a href="bar">
-    baz
-</a>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34515,11 +34721,27 @@ var foo = <a
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34531,11 +34753,27 @@ var foo = <a
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34548,11 +34786,39 @@ var foo = <
 </a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34565,11 +34831,39 @@ var foo = <a
     a>;
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34582,11 +34876,27 @@ var foo = <a
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34598,43 +34908,27 @@ var foo = (<a
 </a>);
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-var foo = (
-    <a href="bar">baz</a>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-var foo = (
-    <a href="bar">
-        baz
-    </a>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34648,24 +34942,27 @@ var foo = (
 );
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-var foo = <a href="bar">baz</a>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34677,11 +34974,39 @@ Error: Parsing failed
 </a>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXEmptyExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34694,11 +35019,51 @@ Error: Parsing failed
 </a>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34720,38 +35085,159 @@ function foo() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 12: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 16.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 16,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 20.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 20,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 20.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 20,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 24.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'MemberExpression',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 24,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 24.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'MemberExpression',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 24,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 16.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 10,
+    column: 0,
+    endLine: 10,
+    endColumn: 16,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 11,
+    column: 0,
+    endLine: 11,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 12,
+    column: 0,
+    endLine: 12,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 13,
+    column: 0,
+    endLine: 13,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+12 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<App></App>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<App>
-</App>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34762,26 +35248,27 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<App>
-<Foo />
-</App>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34792,11 +35279,27 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34809,11 +35312,51 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34826,11 +35369,51 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34845,11 +35428,75 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34864,11 +35511,75 @@ it(
 )
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'CallExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'CallExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'CallExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34883,11 +35594,75 @@ it(
 )
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'CallExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34900,11 +35675,27 @@ Error: Parsing failed
 )
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34918,11 +35709,39 @@ Error: Parsing failed
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34936,11 +35755,39 @@ Error: Parsing failed
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34954,11 +35801,63 @@ Error: Parsing failed
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 4: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'LogicalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+4 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34973,11 +35872,75 @@ Error: Parsing failed
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'LogicalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'LogicalExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -34989,11 +35952,39 @@ Error: Parsing failed
 ]
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35009,11 +36000,87 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35029,29 +36096,63 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 4: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 8 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 8 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+4 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<div>
-bar <div>
-    bar
-    bar {foo}
-bar </div>
-</div>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35062,11 +36163,39 @@ foo ?
     <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35077,11 +36206,39 @@ foo ?
     : <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35093,11 +36250,51 @@ foo ?
     <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35116,11 +36313,123 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 9: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 10,
+    column: 0,
+    endLine: 10,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+9 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35136,11 +36445,87 @@ Error: Parsing failed
 </span>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35156,11 +36541,87 @@ Error: Parsing failed
 </span>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35178,25 +36639,111 @@ function foo() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 8: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+8 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<App foo
-/>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35207,26 +36754,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-<App
-foo
-/>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35237,11 +36785,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35252,11 +36816,27 @@ Error: Parsing failed
 ></App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35269,11 +36849,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35285,11 +36905,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35304,11 +36940,75 @@ var x = function() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35321,11 +37021,51 @@ var x = <App
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35342,11 +37082,87 @@ Error: Parsing failed
 </Provider>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35363,11 +37179,87 @@ Error: Parsing failed
 </Provider>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35378,11 +37270,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35393,11 +37301,27 @@ Error: Parsing failed
 ></App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35409,11 +37333,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35426,11 +37366,51 @@ var x = <App
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35440,11 +37420,27 @@ Error: Parsing failed
     foo />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35457,11 +37453,39 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35473,11 +37497,27 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35496,11 +37536,87 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingElement',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 10,
+    column: 0,
+    endLine: 10,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+6 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35513,11 +37629,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35530,11 +37686,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35547,30 +37743,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-foo ? (
-    <div>
-    </div>
-) : (
-    <span>
-    </span>
-)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35583,11 +37800,51 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXEmptyExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXEmptyExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35598,11 +37855,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35614,11 +37887,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35630,11 +37919,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35646,11 +37935,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35663,11 +37968,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35680,11 +38001,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35696,11 +38017,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35713,11 +38050,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35730,11 +38083,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35746,11 +38115,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35763,11 +38132,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35780,11 +38149,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35796,11 +38165,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35813,11 +38198,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35830,11 +38231,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35846,11 +38263,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35863,11 +38296,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35880,11 +38329,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35899,11 +38364,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35918,11 +38399,27 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -35934,11 +38431,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35950,11 +38447,11 @@ Error: Parsing failed
     /* Comment */ />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35966,11 +38463,11 @@ Error: Parsing failed
 /* Comment */ />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -35983,11 +38480,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -36000,11 +38497,11 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > valid
@@ -36016,11 +38513,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36032,11 +38545,27 @@ Error: Parsing failed
     /* Comment */ >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36048,11 +38577,27 @@ Error: Parsing failed
 /* Comment */ >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36065,11 +38610,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36082,11 +38643,27 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36101,11 +38678,75 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36125,11 +38766,135 @@ function A() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 10: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 16.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 16,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 8 spaces but found 20.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'LogicalExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 20,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 8 spaces but found 20.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 7,
+    column: 0,
+    endLine: 7,
+    endColumn: 20,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 16.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'LogicalExpression',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 16,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 12.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 12,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 10,
+    column: 0,
+    endLine: 10,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 11,
+    column: 0,
+    endLine: 11,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+10 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36140,11 +38905,27 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36155,11 +38936,27 @@ Error: Parsing failed
 </small>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36170,11 +38967,27 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36187,11 +39000,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXSpreadAttribute',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXSpreadAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > valid
@@ -36294,36 +39147,6 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
 #### indent > valid
 
 ```js
-<Foo
-            bar="1" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
-foo &&
-<Bar
->
-</Bar>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > valid
-
-```js
 (function($) {
 $(function() {
     foo;
@@ -36399,23 +39222,6 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-#### indent > valid
-
-```js
-<foo
-    prop='bar'
-    >
-    Text
-</foo>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
 
 
 #### indent > valid
@@ -50064,11 +52870,17 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 4 spaces but found 2." does not match "Expected indentation of 0 spaces but found 2."
++ actual - expected
+
++ 'Expected indentation of 0 spaces but found 2.'
+- 'Expected indentation of 4 spaces but found 2.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50079,11 +52891,17 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 2 spaces but found 4." does not match "Expected indentation of 0 spaces but found 4."
++ actual - expected
+
++ 'Expected indentation of 0 spaces but found 4.'
+- 'Expected indentation of 2 spaces but found 4.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50094,11 +52912,17 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 1 tab but found 4 spaces." does not match "Expected indentation of 0 tabs but found 4 spaces."
++ actual - expected
+
++ 'Expected indentation of 0 tabs but found 4 spaces.'
+- 'Expected indentation of 1 tab but found 4 spaces.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50111,11 +52935,51 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 9.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 9,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50128,11 +52992,51 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50147,11 +53051,63 @@ function App() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 3 errors but had 4: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 0.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 0,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 0.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 0,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+4 !== 3
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50162,11 +53118,17 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 4 spaces but found 1." does not match "Expected indentation of 0 spaces but found 1."
++ actual - expected
+
++ 'Expected indentation of 0 spaces but found 1.'
+- 'Expected indentation of 4 spaces but found 1.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50181,11 +53143,75 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrowFunctionExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 11.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 11,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrowFunctionExpression',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+5 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50197,11 +53223,39 @@ Error: Parsing failed
 ]
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ArrayExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50214,11 +53268,17 @@ Error: Parsing failed
 </App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 1 tab but found 1 space." does not match "Expected indentation of 0 tabs but found 1 space."
++ actual - expected
+
++ 'Expected indentation of 0 tabs but found 1 space.'
+- 'Expected indentation of 1 tab but found 1 space.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50229,11 +53289,17 @@ foo ?
 <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 4 spaces but found 0." does not match "Expected indentation of 0 spaces but found 4."
++ actual - expected
+
++ 'Expected indentation of 0 spaces but found 4.'
+- 'Expected indentation of 4 spaces but found 0.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50245,11 +53311,27 @@ foo ?
 <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 2 errors but had 1: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ConditionalExpression',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+1 !== 2
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50261,11 +53343,14 @@ foo ? (
 <Bar />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50276,11 +53361,17 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Hydrated message "Expected indentation of 4 spaces but found 2." does not match "Expected indentation of 0 spaces but found 2."
++ actual - expected
+
++ 'Expected indentation of 0 spaces but found 2.'
+- 'Expected indentation of 4 spaces but found 2.'
+                           ^
+
+    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50291,11 +53382,39 @@ Error: Parsing failed
   />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50306,11 +53425,39 @@ Error: Parsing failed
   ></App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50328,11 +53475,99 @@ const Button = function(props) {
 };
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 7: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 36.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 36,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 2 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'ReturnStatement',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 2,
+    suggestions: null
+  }
+]
+
+7 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50345,11 +53580,51 @@ var x = function() {
 }
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'BlockStatement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 9.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 9,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50360,27 +53635,39 @@ var x = <App
         />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 2.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 2,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 8,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > invalid
-
-```js
-var x = (
-  <Something
-    />
-)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50391,11 +53678,39 @@ Error: Parsing failed
 \u0009/>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50406,11 +53721,39 @@ Error: Parsing failed
 \u0009></App>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 1,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 tabs but found 1.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 1,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50429,11 +53772,87 @@ Error: Parsing failed
 >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 4 errors but had 6: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingElement',
+    line: 8,
+    column: 0,
+    endLine: 8,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 9,
+    column: 0,
+    endLine: 9,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXMemberExpression',
+    line: 10,
+    column: 0,
+    endLine: 10,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+6 !== 4
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50446,11 +53865,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50463,11 +53922,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50480,30 +53979,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### indent > invalid
-
-```js
-foo ? (
-    <div>
-    </div>
-) : (
-        <span>
-        </span>
-    )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50518,11 +54038,75 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 3 errors but had 5: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 4 spaces but found 8.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 8,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXExpressionContainer',
+    line: 6,
+    column: 0,
+    endLine: 6,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+5 !== 3
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50535,11 +54119,51 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXEmptyExpression',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXEmptyExpression',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50550,11 +54174,14 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50567,11 +54194,51 @@ Error: Parsing failed
 />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningElement',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 6.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXSpreadAttribute',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 6,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXSpreadAttribute',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50582,11 +54249,14 @@ Error: Parsing failed
 </div>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50597,11 +54267,14 @@ Error: Parsing failed
 </small>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50612,11 +54285,14 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50628,11 +54304,39 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningFragment',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50644,11 +54348,11 @@ Error: Parsing failed
     />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > invalid
@@ -50660,11 +54364,39 @@ Error: Parsing failed
     >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingFragment',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50677,11 +54409,51 @@ Error: Parsing failed
     >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 2 errors but had 3: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningFragment',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingFragment',
+    line: 5,
+    column: 0,
+    endLine: 5,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+3 !== 2
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50694,11 +54466,11 @@ Error: Parsing failed
     />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > invalid
@@ -50710,11 +54482,39 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningFragment',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50726,11 +54526,11 @@ Error: Parsing failed
     />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > invalid
@@ -50742,11 +54542,39 @@ Error: Parsing failed
     >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingFragment',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50758,11 +54586,39 @@ Error: Parsing failed
 </>
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXOpeningFragment',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 3,
+    column: 0,
+    endLine: 3,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -50774,11 +54630,11 @@ Error: Parsing failed
     />
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
+TSError: Identifier expected.
+    at B (apps/oxlint/dist/ts_eslint.cjs)
+    at d (apps/oxlint/dist/ts_eslint.cjs)
+    at a (apps/oxlint/dist/ts_eslint.cjs)
+    at C (apps/oxlint/dist/ts_eslint.cjs)
 
 
 #### indent > invalid
@@ -50790,11 +54646,39 @@ Error: Parsing failed
     >
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 2: [
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXText',
+    line: 2,
+    column: 0,
+    endLine: 2,
+    endColumn: 4,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/indent',
+    message: 'Expected indentation of 0 spaces but found 4.',
+    messageId: 'wrongIndentation',
+    severity: 1,
+    nodeType: 'JSXClosingFragment',
+    line: 4,
+    column: 0,
+    endLine: 4,
+    endColumn: 4,
+    suggestions: null
+  }
+]
+
+2 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### indent > invalid
@@ -55587,457 +59471,10 @@ Error: Parsing failed
     at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
-### `jsx-quotes`
-
-Pass: 0 / 18 (0.0%)
-Fail: 18 / 18 (100.0%)
-
-#### jsx-quotes > valid
-
-```js
-<foo bar="baz" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar='"' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar="'" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar='baz' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar="baz">"</foo>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar='baz'>'</foo>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar={'baz'} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar={"baz"} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar={baz} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar='&quot;' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar="&quot;" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar='&#39;' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > valid
-
-```js
-<foo bar="&#39;" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > invalid
-
-```js
-<foo bar='baz' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > invalid
-
-```js
-<foo bar="baz" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > invalid
-
-```js
-<foo bar="&quot;" />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### jsx-quotes > invalid
-
-```js
-<foo bar='&#39;' />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
 ### `keyword-spacing`
 
-Pass: 1046 / 1078 (97.0%)
-Fail: 32 / 1078 (3.0%)
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={async function foo() {}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ async function foo() {}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-async function wrap() { <Foo onClick={await a} /> }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-async function wrap() { <Foo onClick={ await a} /> }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={class {}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ class{}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={delete foo.a} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ delete foo.a} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={function() {}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ function() {}} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={new foo()} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ new foo()} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-function foo() { return <p/>; }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-function foo() { return<p/>; }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-class A extends B { constructor() { <Foo onClick={super()} /> } }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-class A extends B { constructor() { <Foo onClick={ super() } /> } }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 1072 / 1078 (99.4%)
+Fail: 6 / 1078 (0.6%)
 
 #### keyword-spacing > valid
 
@@ -56056,110 +59493,6 @@ Error: Parsing failed
 
 ```js
 <Thing>this.blah
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={this} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ this } />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={typeof foo} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ typeof foo} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={void foo} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-<Foo onClick={ void foo} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-function* foo() { <Foo onClick={yield} /> }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > valid
-
-```js
-function* foo() { <Foo onClick={ yield } /> }
 ```
 
 Error: Parsing failed
@@ -56193,32 +59526,6 @@ Error: Parsing failed
     at lint (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > invalid
-
-```js
-function foo() { return<p/>; }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### keyword-spacing > invalid
-
-```js
-function foo() { return <p/>; }
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 #### keyword-spacing > invalid
@@ -56990,599 +60297,6 @@ Error: Parsing failed
 
 ```js
 (a.b.c || (a.b.c = d)) as number
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-### `max-len`
-
-Pass: 70 / 108 (64.8%)
-Fail: 38 / 108 (35.2%)
-
-#### max-len > valid
-
-```js
-var foo = <div className="this is a very long string"></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  { /* this line has 38 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-\u0009\u0009{ /* this line has 40 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  <> text </>{ /* this line has 49 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line has 44 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line has 44 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = <Foo
-         attr = {a && b/* this line has 57 characters */}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = <Foo
-         attr = {/* this line has 57 characters */a && b}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = <Foo
-         attr = 
-          {a & b/* this line has 50 characters */}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  <> </> {/* this line with two separate comments */} {/* have 80 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have 80 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have 80 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/*
-       this line has 34 characters
-   */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {/*
-       this line has 34 characters
-   */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {a & b /* this line has 34 characters
-   */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > valid
-
-```js
-var jsx = (<>
-  {a & b /* this line has 34 characters
-   */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var foo = <div>this is a very very very long string</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  { /* this line has 38 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-\u0009\u0009{ /* this line has 40 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-{ 38/* this line has 38 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-{ 38/* this line has 38 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-{ 38/* this line has 38 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-   <> 50 </>{ 50/* this line has 50 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-         {/* this line has 44 characters */}
-  <> </> {/* this line has 44 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = <Foo
-         attr = {a && b/* this line has 57 characters */}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = <Foo
-         attr = {/* this line has 57 characters */a && b}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = <Foo
-         attr = {a & b/* this line has 56 characters */}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = <Foo
-         attr = 
-          {a & b /* this line has 51 characters */}
-></Foo>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have 80 characters */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  <> </> {/* this line with two separate comments */} {/* have 87 characters */} <> </>
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have 87 characters */} <> </>
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this is not treated as a comment */ a & b} {/* trailing */ /* comments */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-  {/* this line has 37 characters */}
-  <> </> {/* this is not treated as a comment */ a & b} {/* trailing */ /* comments */}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-12345678901234{/*
-*/}
-</>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### max-len > invalid
-
-```js
-var jsx = (<>
-{/*
-this line has 31 characters */}
-</>)
 ```
 
 Error: Parsing failed
@@ -58513,8 +61227,8 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 ### `no-array-constructor`
 
-Pass: 119 / 146 (81.5%)
-Fail: 27 / 146 (18.5%)
+Pass: 121 / 146 (82.9%)
+Fail: 25 / 146 (17.1%)
 
 #### no-array-constructor > valid
 
@@ -58543,38 +61257,6 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-#### no-array-constructor > invalid
-
-```js
-
-                <foo />
-                Array()
-                
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-array-constructor > invalid
-
-```js
-
-                <foo></foo>
-                Array()
-                
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 #### no-array-constructor > valid
@@ -59044,60 +61726,8 @@ TypeError: Cannot convert object to primitive value
 
 ### `no-constant-binary-expression`
 
-Pass: 221 / 260 (85.0%)
-Fail: 39 / 260 (15.0%)
-
-#### no-constant-binary-expression > valid
-
-```js
-<p /> && foo
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-constant-binary-expression > valid
-
-```js
-<></> && foo
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-constant-binary-expression > valid
-
-```js
-<p /> ?? foo
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-constant-binary-expression > valid
-
-```js
-<></> ?? foo
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 225 / 260 (86.5%)
+Fail: 35 / 260 (13.5%)
 
 #### no-constant-binary-expression > invalid
 
@@ -77492,8 +80122,8 @@ Error: Parsing failed
 
 ### `no-extra-parens`
 
-Pass: 1030 / 1072 (96.1%)
-Fail: 42 / 1072 (3.9%)
+Pass: 1060 / 1072 (98.9%)
+Fail: 12 / 1072 (1.1%)
 
 #### no-extra-parens > valid
 
@@ -77574,275 +80204,6 @@ TSError: Decimals with leading zeros are not allowed.
     at d (apps/oxlint/dist/ts_eslint.cjs)
     at a (apps/oxlint/dist/ts_eslint.cjs)
     at C (apps/oxlint/dist/ts_eslint.cjs)
-
-
-#### no-extra-parens > valid
-
-```js
-function a() {
-    return (
-        <JSX />
-    );
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-function a() {
-    return (
-        <></>
-    );
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<div />)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = ((<div />))
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<>
-  <p />
-</>);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = ((<>
-  <p />
-</>));
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<div>
-  <p />
-</div>);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (
-  <div />
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component =
-  (<div />)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<div />);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = ((<div />));
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (
-  <div />
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component =
-(<div />)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (
-<div>
-  <p />
-</div>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = ((
-<div>
-  <p />
-</div>
-));
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<div>
-  <p />
-</div>);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component =
-(<div>
-  <p />
-</div>);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > valid
-
-```js
-const Component = (<div
-  prop={true}
-/>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
 
 
 #### no-extra-parens > valid
@@ -77983,189 +80344,6 @@ TSError: Decimals with leading zeros are not allowed.
     at d (apps/oxlint/dist/ts_eslint.cjs)
     at a (apps/oxlint/dist/ts_eslint.cjs)
     at C (apps/oxlint/dist/ts_eslint.cjs)
-
-
-#### no-extra-parens > invalid
-
-```js
-function a() {
-    return (<JSX />);
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-function a() {
-    return
-    (<JSX />);
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-function a() {
-    return ((
-       <JSX />
-    ));
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-function a() {
-    return ((
-       <></>
-    ));
-}
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (<div />);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (
-  <div />
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (
-  <></>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (
-<div>
-  <p />
-</div>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (<div>
-  <p />
-</div>);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (<div
-  prop={true}
-/>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (<div />);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-extra-parens > invalid
-
-```js
-const Component = (<div>
-<p />
-</div>)
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `no-fallthrough`
@@ -82339,587 +84517,6 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-### `no-inline-comments`
-
-Pass: 18 / 49 (36.7%)
-Fail: 31 / 49 (63.3%)
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            {/*comment*/}
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            { /* comment */ }
-            <h1>Some heading</h1>
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            {// comment
-            }
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            { // comment
-            }
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            {/* comment 1 */
-            /* comment 2 */}
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            {/*
-              * comment 1
-              */
-             /*
-              * comment 2
-              */}
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > valid
-
-```js
-var a = (
-            <div>
-            {/*
-               multi
-               line
-               comment
-            */}
-            </div>
-        )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{/* comment */}</div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{// comment
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{/* comment */
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{/*
-                       * comment
-                       */
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{/*
-                       * comment
-                       */}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>{/*
-                       * comment
-                       */}</div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {/*
-                  * comment
-                  */}</div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                 /*
-                  * comment
-                  */}</div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                /* comment */}</div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {b/* comment */}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {/* comment */b}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {// comment
-                    b
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {/* comment */
-                    b
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {/*
-                  * comment
-                  */
-                    b
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    b// comment
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    /* comment */b
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    b/* comment */
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    b
-                /*
-                 * comment
-                 */}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    b
-                /* comment */}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    { /* this is an empty object literal, not braces for js code! */ }
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    {// comment
-                    }
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    {
-                    /* comment */}
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-inline-comments > invalid
-
-```js
-var a = (
-                <div>
-                {
-                    /* overlapping
-                    */ /*
-                       lines */
-                }
-                </div>
-            )
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `no-inner-declarations`
@@ -90819,281 +92416,8 @@ TypeError: Cannot read properties of undefined (reading 'init')
 
 ### `no-irregular-whitespace`
 
-Pass: 236 / 280 (84.3%)
-Fail: 44 / 280 (15.7%)
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>\u000b</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>\u000c</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>᠎</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>﻿</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>​</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > valid
-
-```js
-<div>　</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 278 / 280 (99.3%)
+Fail: 2 / 280 (0.7%)
 
 #### no-irregular-whitespace > valid
 
@@ -91147,279 +92471,6 @@ AssertionError [ERR_ASSERTION]: Actual error location does not match expected er
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>\u000b</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>\u000c</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>᠎</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>﻿</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>​</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div> </div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-irregular-whitespace > invalid
-
-```js
-<div>　</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `no-labels`
@@ -92043,47 +93094,8 @@ Error: Parsing failed
 
 ### `no-magic-numbers`
 
-Pass: 123 / 205 (60.0%)
-Fail: 82 / 205 (40.0%)
-
-#### no-magic-numbers > valid
-
-```js
-var a = <input maxLength={10} />;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-magic-numbers > valid
-
-```js
-var a = <div objectProp={{ test: 1}}></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-magic-numbers > invalid
-
-```js
-var a = <div arrayProp={[1,2,3]}></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 126 / 205 (61.5%)
+Fail: 79 / 205 (38.5%)
 
 #### no-magic-numbers > valid
 
@@ -93366,26 +94378,6 @@ AssertionError [ERR_ASSERTION]: Hydrated message "Unexpected mix of '-' and '/'.
     at apps/oxlint/dist/index.js
 
 
-### `no-multi-str`
-
-Pass: 6 / 7 (85.7%)
-Fail: 1 / 7 (14.3%)
-
-#### no-multi-str > valid
-
-```js
-var a = <div>
-<h1>Wat</h1>
-</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
 ### `no-multiple-empty-lines`
 
 Pass: 45 / 46 (97.8%)
@@ -94377,8 +95369,8 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 ### `no-object-constructor`
 
-Pass: 53 / 56 (94.6%)
-Fail: 3 / 56 (5.4%)
+Pass: 55 / 56 (98.2%)
+Fail: 1 / 56 (1.8%)
 
 #### no-object-constructor > valid
 
@@ -94407,38 +95399,6 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-#### no-object-constructor > invalid
-
-```js
-
-                <foo />
-                Object()
-                
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-object-constructor > invalid
-
-```js
-
-                <foo></foo>
-                Object()
-                
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `no-promise-executor-return`
@@ -97997,24 +98957,6 @@ Error: Parsing failed
     at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
-### `no-restricted-syntax`
-
-Pass: 31 / 32 (96.9%)
-Fail: 1 / 32 (3.1%)
-
-#### no-restricted-syntax > invalid
-
-```js
-const foo = [<div/>, <div/>]
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
 ### `no-self-assign`
 
 Pass: 84 / 85 (98.8%)
@@ -101488,11 +102430,75 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
 var React, App, a=1; React.render(<App attr={a} />);
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have no errors but had 5: [
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'a' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 16,
+    endLine: 1,
+    endColumn: 17,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 21,
+    endLine: 1,
+    endColumn: 26,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 4,
+    endLine: 1,
+    endColumn: 9,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'App' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'JSXIdentifier',
+    line: 1,
+    column: 35,
+    endLine: 1,
+    endColumn: 38,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'a' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 45,
+    endLine: 1,
+    endColumn: 46,
+    suggestions: null
+  }
+]
+
+5 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### no-undef > valid
@@ -102200,11 +103206,51 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 var React; React.render(<img attr={a} />);
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 3: [
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 11,
+    endLine: 1,
+    endColumn: 16,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 4,
+    endLine: 1,
+    endColumn: 9,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'a' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 35,
+    endLine: 1,
+    endColumn: 36,
+    suggestions: null
+  }
+]
+
+3 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 #### no-undef > invalid
@@ -102213,11 +103259,63 @@ Error: Parsing failed
 var React, App; React.render(<App attr={a} />);
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 4: [
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 16,
+    endLine: 1,
+    endColumn: 21,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'React' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 4,
+    endLine: 1,
+    endColumn: 9,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'App' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'JSXIdentifier',
+    line: 1,
+    column: 30,
+    endLine: 1,
+    endColumn: 33,
+    suggestions: null
+  },
+  {
+    ruleId: 'rule-to-test/no-undef',
+    message: "'a' is not defined.",
+    messageId: 'undef',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 40,
+    endLine: 1,
+    endColumn: 41,
+    suggestions: null
+  }
+]
+
+4 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
+    at apps/oxlint/dist/index.js
 
 
 ### `no-undefined`
@@ -117195,99 +118293,8 @@ AssertionError [ERR_ASSERTION]: Should have 2 errors but had 1: [
 
 ### `no-unused-expressions`
 
-Pass: 98 / 124 (79.0%)
-Fail: 26 / 124 (21.0%)
-
-#### no-unused-expressions > valid
-
-```js
-<div />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > valid
-
-```js
-<></>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > valid
-
-```js
-var partial = <div />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > valid
-
-```js
-var partial = <div />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > valid
-
-```js
-var partial = <></>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > invalid
-
-```js
-<div />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-unused-expressions > invalid
-
-```js
-<></>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 105 / 124 (84.7%)
+Fail: 19 / 124 (15.3%)
 
 #### no-unused-expressions > invalid
 
@@ -120310,8 +121317,8 @@ AssertionError [ERR_ASSERTION]: Hydrated message "'b' is defined but never used.
 
 ### `no-use-before-define`
 
-Pass: 280 / 347 (80.7%)
-Fail: 67 / 347 (19.3%)
+Pass: 284 / 347 (81.8%)
+Fail: 63 / 347 (18.2%)
 
 #### no-use-before-define > invalid
 
@@ -121063,74 +122070,6 @@ Error: Parsing failed
 \u0009
 \u0009let baz: Enum;
 \u0009enum Enum {}
-\u0009\u0009  
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-use-before-define > valid
-
-```js
-
-\u0009import * as React from 'react';
-\u0009
-\u0009<div />;
-\u0009\u0009  
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-use-before-define > valid
-
-```js
-
-\u0009import React from 'react';
-\u0009
-\u0009<div />;
-\u0009\u0009  
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-use-before-define > valid
-
-```js
-
-\u0009import { h } from 'preact';
-\u0009
-\u0009<div />;
-\u0009\u0009  
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-use-before-define > valid
-
-```js
-
-\u0009const React = require('react');
-\u0009
-\u0009<div />;
 \u0009\u0009  
 ```
 
@@ -122452,11 +123391,11 @@ TypeError: Cannot read properties of null (reading 'currentSegments')
             
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TypeError: Cannot read properties of null (reading 'currentSegments')
+    at Identifier (apps/oxlint/conformance/submodules/eslint/lib/rules/no-useless-assignment.js:533:38)
+    at walkIdentifier (apps/oxlint/dist/lint.js)
+    at walkNode (apps/oxlint/dist/lint.js)
+    at walkFunctionDeclaration (apps/oxlint/dist/lint.js)
 
 
 #### no-useless-assignment > valid
@@ -122472,11 +123411,11 @@ Error: Parsing failed
             
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TypeError: Cannot read properties of null (reading 'currentSegments')
+    at Identifier (apps/oxlint/conformance/submodules/eslint/lib/rules/no-useless-assignment.js:533:38)
+    at walkIdentifier (apps/oxlint/dist/lint.js)
+    at walkNode (apps/oxlint/dist/lint.js)
+    at walkFunctionDeclaration (apps/oxlint/dist/lint.js)
 
 
 #### no-useless-assignment > valid
@@ -122493,11 +123432,11 @@ Error: Parsing failed
             
 ```
 
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
+TypeError: Cannot read properties of null (reading 'currentSegments')
+    at Identifier (apps/oxlint/conformance/submodules/eslint/lib/rules/no-useless-assignment.js:533:38)
+    at walkIdentifier (apps/oxlint/dist/lint.js)
+    at walkNode (apps/oxlint/dist/lint.js)
+    at walkFunctionDeclaration (apps/oxlint/dist/lint.js)
 
 
 #### no-useless-assignment > invalid
@@ -123490,102 +124429,6 @@ Error: Parsing failed
     at lint (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
     at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-### `no-useless-escape`
-
-Pass: 281 / 288 (97.6%)
-Fail: 7 / 288 (2.4%)
-
-#### no-useless-escape > valid
-
-```js
-<foo attr="\d"/>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > valid
-
-```js
-<div> Testing: \ </div>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > valid
-
-```js
-<div> Testing: &#x5C </div>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > valid
-
-```js
-<foo attr='\d'></foo>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > valid
-
-```js
-<> Testing: \ </>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > valid
-
-```js
-<> Testing: &#x5C </>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### no-useless-escape > invalid
-
-```js
-<foo attr={"\d"}/>
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `no-useless-rename`
@@ -124987,28 +125830,8 @@ AssertionError [ERR_ASSERTION]: Actual error location does not match expected er
 
 ### `padding-line-between-statements`
 
-Pass: 363 / 624 (58.2%)
-Fail: 261 / 624 (41.8%)
-
-#### padding-line-between-statements > valid
-
-```js
-var foo = (
-<div
-ref={function() {
-}}
->
-foo
-</div>
-);
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
+Pass: 364 / 624 (58.3%)
+Fail: 260 / 624 (41.7%)
 
 #### padding-line-between-statements > invalid
 
@@ -130663,180 +131486,6 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
     at runInvalidTestCase (apps/oxlint/dist/index.js)
     at apps/oxlint/dist/index.js
-
-
-### `quotes`
-
-Pass: 100 / 113 (88.5%)
-Fail: 13 / 113 (11.5%)
-
-#### quotes > valid
-
-```js
-var foo = <>Hello world</>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <>Hello world</>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <>Hello world</>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <>Hello world</>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div>Hello world</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div id="foo"></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div>Hello world</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div>Hello world</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div id="foo"></div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > valid
-
-```js
-var foo = <div>Hello world</div>;
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > invalid
-
-```js
-<div blah={"blah"} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > invalid
-
-```js
-<div blah={'blah'} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-
-
-#### quotes > invalid
-
-```js
-<div blah={'blah'} />
-```
-
-Error: Parsing failed
-    at parse (apps/oxlint/dist/index.js)
-    at lint (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
 
 
 ### `radix`

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -2229,6 +2229,333 @@ describe("RuleTester", () => {
       });
     });
 
+    describe("ecmaFeatures.jsx", () => {
+      it("default (false)", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: ["let x;", "<div/>"],
+          invalid: [],
+        });
+
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            null,
+            [Error: Parsing failed],
+          ]
+        `);
+      });
+
+      describe("false", () => {
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in `RuleTester` options, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+          });
+
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases, overriding global setting", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases, overriding `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+      });
+
+      describe("true", () => {
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null, null]);
+        });
+
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null, null]);
+        });
+
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toEqual([null, null]);
+        });
+      });
+
+      it("mixed across test cases", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [
+            "let x;",
+            "<div/>",
+            {
+              code: "let x;",
+              languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+            },
+            {
+              code: "<div/>",
+              languageOptions: { parserOptions: { ecmaFeatures: { jsx: false } } },
+            },
+            {
+              code: "let x;",
+              languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+            },
+            {
+              code: "<div/>",
+              languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+            },
+          ],
+          invalid: [],
+        });
+
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            null,
+            [Error: Parsing failed],
+            null,
+            [Error: Parsing failed],
+            null,
+            null,
+          ]
+        `);
+      });
+
+      describe("does not take priority over `lang` option", () => {
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { parserOptions: { lang: "js", ecmaFeatures: { jsx: true } } },
+          });
+
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { lang: "js", ecmaFeatures: { jsx: true } } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["let x;", "<div/>"],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { lang: "js", ecmaFeatures: { jsx: true } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { lang: "js", ecmaFeatures: { jsx: true } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+
+        it("set in individual test cases with `lang` defined in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { parserOptions: { lang: "js" } },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "let x;",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+              },
+              {
+                code: "<div/>",
+                languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+              },
+            ],
+            invalid: [],
+          });
+
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
+      });
+    });
+
     describe("ignoreNonFatalErrors", () => {
       it("default (off)", () => {
         const tester = new RuleTester();


### PR DESCRIPTION
Add `parserOptions.ecmaFeatures.jsx` to `RuleTester`, for compatibility with ESLint's `RuleTester`.

```js
const tester = new RuleTester({
  languageOptions: {
    parserOptions: {
      ecmaFeatures: {
        jsx: true
      },
    },
  },
});

tester.run("my-rule", rule, {
  valid: [
    // No parsing error
    "<div />",
  ],
  invalid: [],
});
```

This fixes another ~250 conformance tests.
