### PR TITLE
test(linter/plugins): conformance tester allow filter array

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -1,4 +1,6 @@
 // Options to filter tests to a specific rule or specific code.
 // Useful for debugging a particular test case.
-export const FILTER_ONLY_RULE: string | null = null;
-export const FILTER_ONLY_CODE: string | null = null;
+type Filter = string | string[];
+
+export const FILTER_ONLY_RULE: Filter | null = null;
+export const FILTER_ONLY_CODE: Filter | null = null;

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -15,6 +15,8 @@ type ValidTestCase = RuleTester.ValidTestCase;
 type InvalidTestCase = RuleTester.InvalidTestCase;
 type TestCase = ValidTestCase | InvalidTestCase;
 
+const { isArray } = Array;
+
 // Set up `RuleTester` to use our hooks
 RuleTester.describe = describe;
 RuleTester.it = it;
@@ -53,12 +55,16 @@ class RuleTesterShim extends RuleTester {
   // Apply filter to test cases.
   run(ruleName: string, rule: Rule, tests: TestCases): void {
     if (FILTER_ONLY_CODE !== null) {
+      const codeMatchesFilter = isArray(FILTER_ONLY_CODE)
+        ? (code: string) => FILTER_ONLY_CODE!.includes(code)
+        : (code: string) => code === FILTER_ONLY_CODE;
+
       tests = {
         valid: tests.valid.filter((test) => {
           const code = typeof test === "string" ? test : test.code;
-          return code === FILTER_ONLY_CODE;
+          return codeMatchesFilter(code);
         }),
-        invalid: tests.invalid.filter((test) => test.code === FILTER_ONLY_CODE),
+        invalid: tests.invalid.filter((test) => codeMatchesFilter(test.code)),
       };
     }
 

--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -11,6 +11,8 @@ import { FILTER_ONLY_RULE } from "./filter.ts";
 
 import type { RuleResult } from "./capture.ts";
 
+const { isArray } = Array;
+
 // Paths
 export const CONFORMANCE_DIR_PATH = pathJoin(fileURLToPath(import.meta.url), "../..");
 export const ESLINT_ROOT_DIR_PATH = pathJoin(CONFORMANCE_DIR_PATH, "submodules/eslint");
@@ -60,11 +62,18 @@ export function runAllTests(): RuleResult[] {
 function findTestFiles(): string[] {
   const filenames = fs.readdirSync(ESLINT_RULES_TESTS_DIR_PATH);
 
+  const ruleNameMatchesFilter =
+    FILTER_ONLY_RULE === null
+      ? null
+      : isArray(FILTER_ONLY_RULE)
+        ? (ruleName: string) => FILTER_ONLY_RULE!.includes(ruleName)
+        : (ruleName: string) => ruleName === FILTER_ONLY_RULE;
+
   const ruleNames = [];
   for (const filename of filenames) {
     if (!filename.endsWith(".js")) continue;
     const ruleName = filename.slice(0, -3);
-    if (FILTER_ONLY_RULE !== null && ruleName !== FILTER_ONLY_RULE) continue;
+    if (ruleNameMatchesFilter !== null && !ruleNameMatchesFilter(ruleName)) continue;
     ruleNames.push(ruleName);
   }
   return ruleNames;


### PR DESCRIPTION
#16659 added filtering to the conformance tester. Make the filters more flexible by accepting an array of strings, as well as a single string.