### PR TITLE
test(linter/plugins): conformance tester include test cases in report

### DIFF
--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -2,6 +2,8 @@
  * `describe` and `it` functions for capturing test results.
  */
 
+import type { TestCase } from "./rule_tester.ts";
+
 /**
  * Result of running all tests in a rule file.
  */
@@ -20,6 +22,7 @@ export interface TestResult {
   code: string;
   isPassed: boolean;
   error: Error | null;
+  testCase: TestCase | null;
 }
 
 // Tracks what nested `describe` blocks currently in
@@ -70,6 +73,7 @@ export function it(code: string, fn: () => void): void {
     code,
     isPassed: false,
     error: null,
+    testCase: null,
   };
 
   try {
@@ -77,6 +81,7 @@ export function it(code: string, fn: () => void): void {
     testResult.isPassed = true;
   } catch (err) {
     testResult.error = err as Error;
+    testResult.testCase = err?.__testCase ?? null;
   }
 
   currentRule!.tests.push(testResult);

--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { CONFORMANCE_DIR_PATH } from "./run.ts";
 
 import type { RuleResult } from "./capture.ts";
+import type { TestCase } from "./rule_tester.ts";
 
 // Number of lines of stack trace to show in report for each error
 const STACK_TRACE_LINES = 4;
@@ -122,10 +123,20 @@ export function generateReport(results: RuleResult[]): string {
 
         lines.push(`#### ${test.groupName}`);
         lines.push("");
+
         lines.push("```js");
         lines.push(test.code);
         lines.push("```");
         lines.push("");
+
+        const testCaseStr = formatTestCase(test.testCase, test.code);
+        if (testCaseStr !== null) {
+          lines.push("```json");
+          lines.push(testCaseStr);
+          lines.push("```");
+          lines.push("");
+        }
+
         lines.push(formatError(test.error));
         lines.push("");
       }
@@ -249,4 +260,27 @@ function formatError(err: Error | null): string {
   }
 
   return out;
+}
+
+/**
+ * Format a test case as JSON.
+ * @param testCase - Test case to format
+ * @returns Test case formatted as JSON string, or `null` not present, or could not format
+ */
+function formatTestCase(testCase: TestCase | null, code: string): string | null {
+  if (!testCase) return null;
+
+  testCase = { ...testCase };
+
+  // Remove `eslintCompat` option - it's always `true`
+  testCase.eslintCompat = undefined;
+
+  // Remove `code` property if it's the same as the test case's code
+  if (testCase.code === code) (testCase as { code?: string }).code = undefined;
+
+  try {
+    return JSON.stringify(testCase, null, 2);
+  } catch {
+    return null;
+  }
 }

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -13,7 +13,7 @@ type ItFn = RuleTester.ItFn;
 type TestCases = RuleTester.TestCases;
 type ValidTestCase = RuleTester.ValidTestCase;
 type InvalidTestCase = RuleTester.InvalidTestCase;
-type TestCase = ValidTestCase | InvalidTestCase;
+export type TestCase = ValidTestCase | InvalidTestCase;
 
 const { isArray } = Array;
 

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -734,6 +734,32 @@ function getMessagePlaceholders(message: string): string[] {
   return Array.from(message.matchAll(PLACEHOLDER_REGEX), ([, name]) => name.trim());
 }
 
+// In debug builds, wrap `runValidTestCase` and `runInvalidTestCase` to add test case to error object.
+// This is used in conformance tests.
+type RunFunction<T> = (test: T, plugin: Plugin, config: Config, seenTestCases: Set<string>) => void;
+
+function wrapRunTestCaseFunction<T extends ValidTestCase | InvalidTestCase>(
+  run: RunFunction<T>,
+): RunFunction<T> {
+  return function (test, plugin, config, seenTestCases) {
+    try {
+      run(test, plugin, config, seenTestCases);
+    } catch (err) {
+      // oxlint-disable-next-line no-ex-assign
+      if (typeof err !== "object" || err === null) err = new Error("Unknown error");
+      err.__testCase = test;
+      throw err;
+    }
+  };
+}
+
+if (DEBUG) {
+  // oxlint-disable-next-line no-func-assign
+  (runValidTestCase as any) = wrapRunTestCaseFunction(runValidTestCase);
+  // oxlint-disable-next-line no-func-assign
+  (runInvalidTestCase as any) = wrapRunTestCaseFunction(runInvalidTestCase);
+}
+
 /**
  * Create config for a test run.
  * Merges config from `RuleTester` instance on top of shared config.


### PR DESCRIPTION
Include the details of failing test cases in report output by conformance tester, to make it easier to figure out why cases are failing.