### PR TITLE
fix(formatter): should not insert a semicolon for non-property signatures when no semicolon is set

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1477,12 +1477,11 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
                 }
             }
             Semicolons::AsNeeded => {
-                let [is_computed, has_no_type_annotation] = match self.signature.as_ref() {
-                    TSSignature::TSPropertySignature(property) => {
-                        [property.computed, property.type_annotation.is_none()]
-                    }
-                    _ => [false, false],
+                let TSSignature::TSPropertySignature(property) = self.signature.as_ref() else {
+                    return;
                 };
+
+                let has_no_type_annotation = property.type_annotation.is_none();
 
                 // Needs semicolon anyway when:
                 // 1. It's a non-computed property signature with type annotation followed by
@@ -1491,7 +1490,7 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
                 // 2. It's a non-computed property signature without type annotation followed by
                 //    a call signature or method signature
                 //    e.g for: `a; () => void` or `a; method(): void`
-                let needs_semicolon = !is_computed
+                let needs_semicolon = !property.computed
                     && self.next_signature.is_some_and(|signature| match signature.as_ref() {
                         TSSignature::TSCallSignatureDeclaration(call) => {
                             has_no_type_annotation || call.type_parameters.is_some()

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts
@@ -1,0 +1,4 @@
+export interface MethodSignatures {
+  (arg: string): void;
+  (arg: number): null;
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+export interface MethodSignatures {
+  (arg: string): void;
+  (arg: number): null;
+}
+
+==================== Output ====================
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+export interface MethodSignatures {
+  (arg: string): void
+  (arg: number): null
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+export interface MethodSignatures {
+  (arg: string): void
+  (arg: number): null
+}
+
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+export interface MethodSignatures {
+  (arg: string): void;
+  (arg: number): null;
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+export interface MethodSignatures {
+  (arg: string): void;
+  (arg: number): null;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/options.json
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "semi": false
+  },
+  {
+    "semi": true
+  }
+]


### PR DESCRIPTION
Prettier issue: https://github.com/prettier/prettier/issues/14040

Only property signatures would conflict with the following signatures in some situations, so return early if the current signature is not a property when `no-semi` is set.