### PR TITLE
test(linter/plugins): conformance tests parse as TS where tests use TS-ESLint parser

### DIFF
--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -16,7 +16,7 @@ const { isArray } = Array;
 // Paths
 export const CONFORMANCE_DIR_PATH = pathJoin(fileURLToPath(import.meta.url), "../..");
 export const ESLINT_ROOT_DIR_PATH = pathJoin(CONFORMANCE_DIR_PATH, "submodules/eslint");
-const ESLINT_RULES_TESTS_DIR_PATH = pathJoin(ESLINT_ROOT_DIR_PATH, "tests/lib/rules");
+export const ESLINT_RULES_TESTS_DIR_PATH = pathJoin(ESLINT_ROOT_DIR_PATH, "tests/lib/rules");
 
 // Create require function for loading CommonJS modules
 const require = Module.createRequire(import.meta.url);


### PR DESCRIPTION
Conformance tester intercept test cases where parser is set to `@typescript-eslint/parser`. Instead, set `parserOptions.lang` to `"ts"`, to enable TS parsing.

This fixes ~2000 test cases.