### PR TITLE
test(linter/plugins): conformance tests parse as TSX where specified

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -96,7 +96,10 @@ function modifyTestCase(test: TestCase): void {
 
     delete languageOptions.parser;
 
-    languageOptions.parserOptions = { ...languageOptions.parserOptions, lang: "ts" };
+    const parserOptions = { ...languageOptions.parserOptions };
+    languageOptions.parserOptions = parserOptions;
+
+    parserOptions.lang = parserOptions.ecmaFeatures?.jsx === true ? "tsx" : "ts";
   }
 }
 


### PR DESCRIPTION
Parse test cases as TSX where parser is specified as `@typescript-eslint/parser`, and `parserOptions.ecmaFeatures.jsx === true`.