### PR TITLE
test(linter/plugins): conformance tester error on test cases with custom parsers

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -15,7 +15,10 @@ type ItFn = RuleTester.ItFn;
 type TestCases = RuleTester.TestCases;
 type ValidTestCase = RuleTester.ValidTestCase;
 type InvalidTestCase = RuleTester.InvalidTestCase;
+type LanguageOptions = RuleTester.LanguageOptions;
 export type TestCase = ValidTestCase | InvalidTestCase;
+
+type LanguageOptionsWithParser = LanguageOptions & { parser?: unknown };
 
 const { isArray } = Array;
 
@@ -90,7 +93,7 @@ function modifyTestCase(test: TestCase): void {
   test.eslintCompat = true;
 
   // If test case uses `@typescript-eslint/parser` as parser, set `parserOptions.lang = "ts"`
-  let { languageOptions } = test;
+  let languageOptions = test.languageOptions as LanguageOptionsWithParser | undefined;
   if (languageOptions?.parser === tsEslintParser) {
     languageOptions = { ...languageOptions };
     test.languageOptions = languageOptions;

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -131,11 +131,18 @@ interface LanguageOptions {
     string,
     boolean | "true" | "writable" | "writeable" | "false" | "readonly" | "readable" | "off" | null
   >;
+  parserOptions?: ParserOptions;
+}
+
+/**
+ * Language options config, with parser.
+ * For internal use only.
+ */
+interface LanguageOptionsWithParser extends LanguageOptions {
   parser?: {
     parse?: (code: string, options?: Record<string, unknown>) => unknown;
     parseForESLint?: (code: string, options?: Record<string, unknown>) => unknown;
   };
-  parserOptions?: ParserOptions;
 }
 
 /**
@@ -966,8 +973,11 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
 function getParseOptions(test: TestCase): ParseOptions {
   const parseOptions: ParseOptions = {};
 
-  const { languageOptions } = test;
+  const languageOptions = test.languageOptions as LanguageOptionsWithParser | undefined;
   if (languageOptions != null) {
+    // Throw error if custom parser is provided
+    if (languageOptions.parser != null) throw new Error("Custom parsers are not supported");
+
     // Handle `languageOptions.sourceType`
     let { sourceType } = languageOptions;
     if (sourceType != null) {


### PR DESCRIPTION
Some ESLint test cases provide a custom parser. We cannot easily support that, so just throw an error if a custom parser is provided.

Some of these cases were previously passing (Oxc managed to parse them), but some were not. It's hard when debugging to figure out for each test case whether it should be failing or not due to absence of custom parser, so simpler to just error for them all at this stage.