### PR TITLE
test(linter/plugins): conformance tests ignore parsing errors

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -92,17 +92,18 @@ function modifyTestCase(test: TestCase): void {
   // and enables `sourceType: "commonjs"`.
   test.eslintCompat = true;
 
+  // Ignore parsing errors. ESLint's test cases include invalid code.
+  const languageOptions = { ...test.languageOptions } as LanguageOptionsWithParser;
+  test.languageOptions = languageOptions;
+
+  const parserOptions = { ...languageOptions.parserOptions };
+  languageOptions.parserOptions = parserOptions;
+
+  parserOptions.ignoreNonFatalErrors = true;
+
   // If test case uses `@typescript-eslint/parser` as parser, set `parserOptions.lang = "ts"`
-  let languageOptions = test.languageOptions as LanguageOptionsWithParser | undefined;
-  if (languageOptions?.parser === tsEslintParser) {
-    languageOptions = { ...languageOptions };
-    test.languageOptions = languageOptions;
-
+  if (languageOptions.parser === tsEslintParser) {
     delete languageOptions.parser;
-
-    const parserOptions = { ...languageOptions.parserOptions };
-    languageOptions.parserOptions = parserOptions;
-
     parserOptions.lang = parserOptions.ecmaFeatures?.jsx === true ? "tsx" : "ts";
   }
 }


### PR DESCRIPTION
ESLint's has many test cases with invalid code. Loosen parsing in conformance test, so parsing only errors if there's a fatal error, and allow any other error where parser can produce a valid AST.