### PR TITLE
fix(linter/plugins): correct punctuation in error message

### DIFF
--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -234,9 +234,7 @@ export function getOffsetFromLineColumn(loc: LineColumn): number {
     }
   }
 
-  throw new TypeError(
-    "Expected `loc` to be an object with integer `line` and `column` properties.",
-  );
+  throw new TypeError("Expected `loc` to be an object with integer `line` and `column` properties");
 }
 
 /**


### PR DESCRIPTION
Tiny change. Our convention is not to have full stops on end of error messages, unless they have multiple sentences. Alter this one to make it consistent with that style.