### PR TITLE
feat(oxfmt): Support `oxfmt --init`

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -75,6 +75,9 @@ pub struct IgnoreOptions {
 /// Misc Options
 #[derive(Debug, Clone, Bpaf)]
 pub struct MiscOptions {
+    /// Initialize `.oxfmtrc.jsonc` with default values
+    #[bpaf(switch, hide_usage)]
+    pub init: bool,
     /// Start language server protocol (LSP) server
     #[bpaf(switch, hide_usage)]
     pub lsp: bool,

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -74,7 +74,7 @@ impl FormatRunner {
             match load_config(config_path.as_deref()) {
                 Ok(c) => c,
                 Err(err) => {
-                    print_and_flush(
+                    utils::print_and_flush(
                         stderr,
                         &format!("Failed to load configuration file.\n{err}\n"),
                     );
@@ -93,7 +93,7 @@ impl FormatRunner {
             .expect("External formatter must be set when `napi` feature is enabled")
             .setup_config(&external_config.to_string(), num_of_threads)
         {
-            print_and_flush(
+            utils::print_and_flush(
                 stderr,
                 &format!("Failed to setup external formatter config.\n{err}\n"),
             );
@@ -114,14 +114,14 @@ impl FormatRunner {
             // All target paths are ignored
             Ok(None) => {
                 if misc_options.no_error_on_unmatched_pattern {
-                    print_and_flush(stderr, "No files found matching the given patterns.\n");
+                    utils::print_and_flush(stderr, "No files found matching the given patterns.\n");
                     return CliRunResult::None;
                 }
-                print_and_flush(stderr, "Expected at least one target file\n");
+                utils::print_and_flush(stderr, "Expected at least one target file\n");
                 return CliRunResult::NoFilesFound;
             }
             Err(err) => {
-                print_and_flush(
+                utils::print_and_flush(
                     stderr,
                     &format!("Failed to parse target paths or ignore settings.\n{err}\n"),
                 );
@@ -138,8 +138,8 @@ impl FormatRunner {
             DiagnosticService::new(Box::new(DefaultReporter::default()));
 
         if matches!(output_options, OutputOptions::Check) {
-            print_and_flush(stdout, "Checking formatting...\n");
-            print_and_flush(stdout, "\n");
+            utils::print_and_flush(stdout, "Checking formatting...\n");
+            utils::print_and_flush(stdout, "\n");
         }
 
         // Create `SourceFormatter` instance
@@ -169,7 +169,7 @@ impl FormatRunner {
         // Print sorted changed file paths to stdout
         if !changed_paths.is_empty() {
             changed_paths.sort_unstable();
-            print_and_flush(stdout, &changed_paths.join("\n"));
+            utils::print_and_flush(stdout, &changed_paths.join("\n"));
         }
 
         // Then, output diagnostics errors to stderr
@@ -182,7 +182,7 @@ impl FormatRunner {
         let total_target_files_count = changed_paths.len() + unchanged_count + error_count;
         let print_stats = |stdout| {
             let elapsed_ms = start_time.elapsed().as_millis();
-            print_and_flush(
+            utils::print_and_flush(
                 stdout,
                 &format!(
                     "Finished in {elapsed_ms}ms on {total_target_files_count} files using {num_of_threads} threads.\n",
@@ -193,18 +193,18 @@ impl FormatRunner {
         // Check if no files were found
         if total_target_files_count == 0 {
             if misc_options.no_error_on_unmatched_pattern {
-                print_and_flush(stderr, "No files found matching the given patterns.\n");
+                utils::print_and_flush(stderr, "No files found matching the given patterns.\n");
                 print_stats(stdout);
                 return CliRunResult::None;
             }
 
-            print_and_flush(stderr, "Expected at least one target file\n");
+            utils::print_and_flush(stderr, "Expected at least one target file\n");
             return CliRunResult::NoFilesFound;
         }
 
         if 0 < error_count {
             // Each error is already printed in reporter
-            print_and_flush(
+            utils::print_and_flush(
                 stderr,
                 "Error occurred when checking code style in the above files.\n",
             );
@@ -217,13 +217,13 @@ impl FormatRunner {
             (OutputOptions::ListDifferent, _) => CliRunResult::FormatMismatch,
             // `--check` outputs friendly summary
             (OutputOptions::Check, 0) => {
-                print_and_flush(stdout, "All matched files use the correct format.\n");
+                utils::print_and_flush(stdout, "All matched files use the correct format.\n");
                 print_stats(stdout);
                 CliRunResult::FormatSucceeded
             }
             (OutputOptions::Check, changed_count) => {
-                print_and_flush(stdout, "\n\n");
-                print_and_flush(
+                utils::print_and_flush(stdout, "\n\n");
+                utils::print_and_flush(
                     stdout,
                     &format!(
                         "Format issues found in above {changed_count} files. Run without `--check` to fix.\n",
@@ -307,19 +307,4 @@ fn load_config(config_path: Option<&Path>) -> Result<(FormatOptions, OxfmtOption
     Oxfmtrc::populate_prettier_config(&format_options, &mut raw_config);
 
     Ok((format_options, oxfmt_options, raw_config))
-}
-
-fn print_and_flush(writer: &mut dyn Write, message: &str) {
-    use std::io::{Error, ErrorKind};
-    fn check_for_writer_error(error: Error) -> Result<(), Error> {
-        // Do not panic when the process is killed (e.g. piping into `less`).
-        if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
-            Ok(())
-        } else {
-            Err(error)
-        }
-    }
-
-    writer.write_all(message.as_bytes()).or_else(check_for_writer_error).unwrap();
-    writer.flush().unwrap();
 }

--- a/apps/oxfmt/src/cli/result.rs
+++ b/apps/oxfmt/src/cli/result.rs
@@ -5,20 +5,25 @@ pub enum CliRunResult {
     // Success
     None,
     FormatSucceeded,
+    InitSucceeded,
     // Warning error
     InvalidOptionConfig,
     FormatMismatch,
+    InitAborted,
     // Fatal error
     NoFilesFound,
     FormatFailed,
+    InitFailed,
 }
 
 impl Termination for CliRunResult {
     fn report(self) -> ExitCode {
         match self {
-            Self::None | Self::FormatSucceeded => ExitCode::from(0),
-            Self::InvalidOptionConfig | Self::FormatMismatch => ExitCode::from(1),
-            Self::NoFilesFound | Self::FormatFailed => ExitCode::from(2),
+            Self::None | Self::FormatSucceeded | Self::InitSucceeded => ExitCode::from(0),
+            Self::InvalidOptionConfig | Self::FormatMismatch | Self::InitAborted => {
+                ExitCode::from(1)
+            }
+            Self::NoFilesFound | Self::FormatFailed | Self::InitFailed => ExitCode::from(2),
         }
     }
 }

--- a/apps/oxfmt/src/init/mod.rs
+++ b/apps/oxfmt/src/init/mod.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::io::BufWriter;
+use std::path::Path;
+
+use oxc_formatter::Oxfmtrc;
+
+use crate::cli::CliRunResult;
+use crate::core::utils;
+
+/// Run the `--init` command to scaffold a default configuration file.
+pub fn run_init() -> CliRunResult {
+    let mut stdout = BufWriter::new(std::io::stdout());
+    let mut stderr = BufWriter::new(std::io::stderr());
+
+    // Check if config file already exists
+    if Path::new(".oxfmtrc.json").exists() || Path::new(".oxfmtrc.jsonc").exists() {
+        utils::print_and_flush(&mut stderr, "Configuration file already exists.\n");
+        return CliRunResult::InitAborted;
+    }
+
+    // NOTE: Use `Oxfmtrc` struct to prevent typos and ensure field consistency
+    // All other fields are default `None` = not set
+    let config = Oxfmtrc {
+        // To make visible that this field exists
+        ignore_patterns: Some(vec![]),
+        ..Oxfmtrc::default()
+    };
+    let Ok(mut json) = serde_json::to_value(&config) else {
+        utils::print_and_flush(&mut stderr, "Failed to generate configuration.\n");
+        return CliRunResult::InitFailed;
+    };
+
+    // NOTE: `serde_json::Map` does not support inserting at the beginning,
+    // so we rebuild the object to place `$schema` at the top.
+    let schema_path = "./node_modules/oxfmt/configuration_schema.json";
+    if Path::new(schema_path).is_file()
+        && let Some(obj) = json.as_object_mut()
+    {
+        let mut new_obj = serde_json::Map::new();
+        new_obj.insert("$schema".to_string(), serde_json::Value::String(schema_path.to_string()));
+        for (k, v) in std::mem::take(obj) {
+            new_obj.insert(k, v);
+        }
+        json = serde_json::Value::Object(new_obj);
+    }
+
+    let Ok(json_str) = serde_json::to_string_pretty(&json) else {
+        utils::print_and_flush(&mut stderr, "Failed to serialize configuration.\n");
+        return CliRunResult::InitFailed;
+    };
+
+    if fs::write(".oxfmtrc.jsonc", format!("{json_str}\n")).is_ok() {
+        utils::print_and_flush(&mut stdout, "Created `.oxfmtrc.jsonc`.\n");
+        CliRunResult::InitSucceeded
+    } else {
+        utils::print_and_flush(&mut stderr, "Failed to write `.oxfmtrc.jsonc`.\n");
+        CliRunResult::InitFailed
+    }
+}

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 mod core;
+pub mod init;
 pub mod lsp;
 
 // Only include code to run formatter when the `napi` feature is enabled.

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::BufWriter;
 
 use oxfmt::cli::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing};
+use oxfmt::init::run_init;
 use oxfmt::lsp::run_lsp;
 
 // Pure Rust CLI entry point.
@@ -10,6 +11,11 @@ use oxfmt::lsp::run_lsp;
 async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = format_command().run();
+
+    // Handle --init mode
+    if command.misc_options.init {
+        return run_init();
+    }
 
     // Handle LSP mode
     if command.misc_options.lsp {

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -9,6 +9,7 @@ use napi_derive::napi;
 use crate::{
     cli::{CliRunResult, FormatRunner, format_command, init_miette, init_tracing},
     core::{ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsSetupConfigCb},
+    init::run_init,
     lsp::run_lsp,
 };
 
@@ -64,6 +65,11 @@ async fn format_impl(
             };
         }
     };
+
+    // Handle --init mode
+    if command.misc_options.init {
+        return run_init();
+    }
 
     // Handle LSP mode
     if command.misc_options.lsp {

--- a/tasks/website_formatter/src/snapshots/cli.snap
+++ b/tasks/website_formatter/src/snapshots/cli.snap
@@ -33,6 +33,8 @@ search: false
 
 
 ## Misc Options
+- **`    --init`** &mdash; 
+  Initialize `.oxfmtrc.jsonc` with default values
 - **`    --lsp`** &mdash; 
   Start language server protocol (LSP) server
 - **`    --no-error-on-unmatched-pattern`** &mdash; 

--- a/tasks/website_formatter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_formatter/src/snapshots/cli_terminal.snap
@@ -18,6 +18,7 @@ Ignore Options
         --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Misc Options
+        --init               Initialize `.oxfmtrc.jsonc` with default values
         --lsp                Start language server protocol (LSP) server
         --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
         --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core.


### PR DESCRIPTION
Follow up #16703, fixes #16622

I will add test for `--init` and also `--lsp` later.