### PR TITLE
test(linter/plugins): remove non-deterministic error output in conformance tester

### DIFF
--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -218,6 +218,9 @@ function formatError(err: Error | null): string {
   for (; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (line.startsWith("    at ")) break;
+    // These "diff" lines appear to be produced by `AssertionError` non-determinatically.
+    // This appears to be a bug in NodeJS's `assert` module. Remove them, to avoid churn in snapshot.
+    if (line.trimStart() === "^") continue;
     out += `${cleanString(line)}\n`;
   }
 


### PR DESCRIPTION
Report snapshot for conformance test results contains the errors thrown during linting. In the case of `AssertionError`s generated by `assert`, they sometimes contain diff markers e.g.:

```
+ 'missingClosingLinebreak'
- 'missingOpeningLinebreak'
          ^
```

However, these `^` only appear sometimes, and seem to do so non-deterministically. They appear and disappear randomly from run to run in some places. Looks like this is a bug in NodeJS.

Remove all such lines from the report to avoid meaningless churn in the snapshot.