### PR TITLE
test(linter/plugins): exclude rules using CFG from conformance tests

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -1,6 +1,29 @@
-// Options to filter tests to a specific rule or specific code.
-// Useful for debugging a particular test case.
+/*
+ * Test filtering.
+ */
+
 type Filter = string | string[];
 
+// Options to filter tests to a specific rule or specific code.
+// Useful for debugging a particular test case.
 export const FILTER_ONLY_RULE: Filter | null = null;
 export const FILTER_ONLY_CODE: Filter | null = null;
+
+// Filter out rules which use CFG, which we don't support yet
+export const FILTER_EXCLUDE_RULE: Filter | null = [
+  "array-callback-return",
+  "complexity",
+  "consistent-return",
+  "constructor-super",
+  "getter-return",
+  "no-constructor-return",
+  "no-fallthrough",
+  "no-invalid-this",
+  "no-promise-executor-return",
+  "no-this-before-super",
+  "no-unreachable-loop",
+  "no-unreachable",
+  "no-useless-assignment",
+  "no-useless-return",
+  "require-atomic-updates",
+];

--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -7,7 +7,7 @@ import { join as pathJoin } from "node:path";
 import { fileURLToPath } from "node:url";
 import Module from "node:module";
 import { setCurrentRule, resetCurrentRule } from "./capture.ts";
-import { FILTER_ONLY_RULE } from "./filter.ts";
+import { FILTER_ONLY_RULE, FILTER_EXCLUDE_RULE } from "./filter.ts";
 
 import type { RuleResult } from "./capture.ts";
 
@@ -62,12 +62,16 @@ export function runAllTests(): RuleResult[] {
 function findTestFiles(): string[] {
   const filenames = fs.readdirSync(ESLINT_RULES_TESTS_DIR_PATH);
 
-  const ruleNameMatchesFilter =
-    FILTER_ONLY_RULE === null
-      ? null
-      : isArray(FILTER_ONLY_RULE)
-        ? (ruleName: string) => FILTER_ONLY_RULE!.includes(ruleName)
-        : (ruleName: string) => ruleName === FILTER_ONLY_RULE;
+  let ruleNameMatchesFilter = null;
+  if (FILTER_ONLY_RULE !== null) {
+    ruleNameMatchesFilter = isArray(FILTER_ONLY_RULE)
+      ? (ruleName: string) => FILTER_ONLY_RULE!.includes(ruleName)
+      : (ruleName: string) => ruleName === FILTER_ONLY_RULE;
+  } else if (FILTER_EXCLUDE_RULE !== null) {
+    ruleNameMatchesFilter = isArray(FILTER_EXCLUDE_RULE)
+      ? (ruleName: string) => !FILTER_EXCLUDE_RULE!.includes(ruleName)
+      : (ruleName: string) => ruleName !== FILTER_EXCLUDE_RULE;
+  }
 
   const ruleNames = [];
   for (const filename of filenames) {


### PR DESCRIPTION
We don't support CFG yet, so exclude rules which use it from conformance testing.