### PR TITLE
test(linter/plugins): fix type in comment

### DIFF
--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -218,7 +218,7 @@ function formatError(err: Error | null): string {
   for (; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (line.startsWith("    at ")) break;
-    // These "diff" lines appear to be produced by `AssertionError` non-determinatically.
+    // These "diff" lines appear to be produced by `AssertionError` non-deterministically.
     // This appears to be a bug in NodeJS's `assert` module. Remove them, to avoid churn in snapshot.
     if (line.trimStart() === "^") continue;
     out += `${cleanString(line)}\n`;


### PR DESCRIPTION
Just fix a typo.