### PR TITLE
feat(oxfmt): Arrange cli mode and update help

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use bpaf::Bpaf;
+use bpaf::{Bpaf, Parser};
 
 const VERSION: &str = match option_env!("OXC_VERSION") {
     Some(v) => v,
@@ -21,14 +21,14 @@ const PATHS_ERROR_MESSAGE: &str = "PATH must not contain \"..\"";
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(options, version(VERSION))]
 pub struct FormatCommand {
-    #[bpaf(external, fallback(OutputOptions::Write), hide_usage)]
-    pub output_options: OutputOptions,
+    #[bpaf(external(mode))]
+    pub mode: Mode,
     #[bpaf(external)]
-    pub basic_options: BasicOptions,
+    pub config_options: ConfigOptions,
     #[bpaf(external)]
     pub ignore_options: IgnoreOptions,
     #[bpaf(external)]
-    pub misc_options: MiscOptions,
+    pub runtime_options: RuntimeOptions,
     /// Single file, single path or list of paths.
     /// If not provided, current working directory is used.
     /// Glob is supported only for exclude patterns like `'!**/fixtures/*.js'`.
@@ -38,23 +38,64 @@ pub struct FormatCommand {
     pub paths: Vec<PathBuf>,
 }
 
-/// Output Options
-#[derive(Debug, Clone, Bpaf)]
-pub enum OutputOptions {
+/// Operation Mode
+#[derive(Debug, Clone)]
+pub enum Mode {
+    /// Default CLI mode run against files and directories
+    Cli(OutputMode),
+    /// Initialize `.oxfmtrc.jsonc` with default values
+    Init,
+    /// Start language server protocol (LSP) server
+    Lsp,
+}
+
+fn mode() -> impl bpaf::Parser<Mode> {
+    let init = bpaf::long("init")
+        .help("Initialize `.oxfmtrc.jsonc` with default values")
+        .req_flag(Mode::Init)
+        .hide_usage();
+    let lsp = bpaf::long("lsp")
+        .help("Start language server protocol (LSP) server")
+        .req_flag(Mode::Lsp)
+        .hide_usage();
+    let mode_options = bpaf::construct!([init, lsp]).group_help("Mode Options:");
+
+    let output_mode_options = output_mode().map(Mode::Cli);
+
+    bpaf::construct!([mode_options, output_mode_options]).fallback(Mode::Cli(OutputMode::Write))
+}
+
+/// Format output mode
+#[derive(Debug, Clone)]
+pub enum OutputMode {
     /// Default - when no output option is specified, behaves like `--write` mode in Prettier
-    #[bpaf(hide)]
     Write,
     /// Check mode - check if files are formatted, also show statistics
-    #[bpaf(long)]
     Check,
     /// List mode - list files that would be changed
-    #[bpaf(long)]
     ListDifferent,
 }
 
-/// Basic Options
+fn output_mode() -> impl bpaf::Parser<OutputMode> {
+    let write = bpaf::long("write")
+        .help("Format and write files in place (default)")
+        .req_flag(OutputMode::Write)
+        .hide_usage();
+    let check = bpaf::long("check")
+        .help("Check if files are formatted, also show statistics")
+        .req_flag(OutputMode::Check)
+        .hide_usage();
+    let list_different = bpaf::long("list-different")
+        .help("List files that would be changed")
+        .req_flag(OutputMode::ListDifferent)
+        .hide_usage();
+
+    bpaf::construct!([write, check, list_different]).group_help("Output Options:")
+}
+
+/// Config Options
 #[derive(Debug, Clone, Bpaf)]
-pub struct BasicOptions {
+pub struct ConfigOptions {
     /// Path to the configuration file
     #[bpaf(short, long, argument("PATH"))]
     pub config: Option<PathBuf>,
@@ -72,15 +113,9 @@ pub struct IgnoreOptions {
     pub with_node_modules: bool,
 }
 
-/// Misc Options
+/// Runtime Options
 #[derive(Debug, Clone, Bpaf)]
-pub struct MiscOptions {
-    /// Initialize `.oxfmtrc.jsonc` with default values
-    #[bpaf(switch, hide_usage)]
-    pub init: bool,
-    /// Start language server protocol (LSP) server
-    #[bpaf(switch, hide_usage)]
-    pub lsp: bool,
+pub struct RuntimeOptions {
     /// Do not exit with error when pattern is unmatched
     #[bpaf(switch, hide_usage)]
     pub no_error_on_unmatched_pattern: bool,

--- a/apps/oxfmt/src/cli/mod.rs
+++ b/apps/oxfmt/src/cli/mod.rs
@@ -6,7 +6,7 @@ mod result;
 mod service;
 mod walk;
 
-pub use command::format_command;
+pub use command::{Mode, format_command};
 pub use format::FormatRunner;
 pub use init::{init_miette, init_rayon, init_tracing};
 pub use result::CliRunResult;

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,5 +1,5 @@
 use oxfmt::cli::{
-    CliRunResult, FormatRunner, format_command, init_miette, init_rayon, init_tracing,
+    CliRunResult, FormatRunner, Mode, format_command, init_miette, init_rayon, init_tracing,
 };
 use oxfmt::init::run_init;
 use oxfmt::lsp::run_lsp;
@@ -12,21 +12,17 @@ async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = format_command().run();
 
-    // Handle --init mode
-    if command.misc_options.init {
-        return run_init();
+    match command.mode {
+        Mode::Init => run_init(),
+        Mode::Lsp => {
+            run_lsp().await;
+            CliRunResult::None
+        }
+        Mode::Cli(_) => {
+            init_tracing();
+            init_miette();
+            init_rayon(command.runtime_options.threads);
+            FormatRunner::new(command).run()
+        }
     }
-
-    // Handle LSP mode
-    if command.misc_options.lsp {
-        run_lsp().await;
-        return CliRunResult::None;
-    }
-
-    // Otherwise, CLI mode
-    init_tracing();
-    init_miette();
-    init_rayon(command.misc_options.threads);
-
-    FormatRunner::new(command).run()
 }

--- a/tasks/website_formatter/src/snapshots/cli.snap
+++ b/tasks/website_formatter/src/snapshots/cli.snap
@@ -10,15 +10,25 @@ search: false
 ## Usage
  **`oxfmt`** \[**`-c`**=_`PATH`_\] \[_`PATH`_\]...
 
-## Output Options
+## Mode Options:
+- **`    --init`** &mdash; 
+  Initialize `.oxfmtrc.jsonc` with default values
+- **`    --lsp`** &mdash; 
+  Start language server protocol (LSP) server
+
+
+
+## Output Options:
+- **`    --write`** &mdash; 
+  Format and write files in place (default)
 - **`    --check`** &mdash; 
-  Check mode - check if files are formatted, also show statistics
+  Check if files are formatted, also show statistics
 - **`    --list-different`** &mdash; 
-  List mode - list files that would be changed
+  List files that would be changed
 
 
 
-## Basic Options
+## Config Options
 - **`-c`**, **`--config`**=_`PATH`_ &mdash; 
   Path to the configuration file
 
@@ -32,11 +42,7 @@ search: false
 
 
 
-## Misc Options
-- **`    --init`** &mdash; 
-  Initialize `.oxfmtrc.jsonc` with default values
-- **`    --lsp`** &mdash; 
-  Start language server protocol (LSP) server
+## Runtime Options
 - **`    --no-error-on-unmatched-pattern`** &mdash; 
   Do not exit with error when pattern is unmatched
 - **`    --threads`**=_`INT`_ &mdash; 

--- a/tasks/website_formatter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_formatter/src/snapshots/cli_terminal.snap
@@ -4,11 +4,16 @@ expression: snapshot
 ---
 Usage: [-c=PATH] [PATH]...
 
-Output Options
-        --check              Check mode - check if files are formatted, also show statistics
-        --list-different     List mode - list files that would be changed
+Mode Options:
+        --init               Initialize `.oxfmtrc.jsonc` with default values
+        --lsp                Start language server protocol (LSP) server
 
-Basic Options
+Output Options:
+        --write              Format and write files in place (default)
+        --check              Check if files are formatted, also show statistics
+        --list-different     List files that would be changed
+
+Config Options
     -c, --config=PATH        Path to the configuration file
 
 Ignore Options
@@ -17,9 +22,7 @@ Ignore Options
                              used.
         --with-node-modules  Format code in node_modules directory (skipped by default)
 
-Misc Options
-        --init               Initialize `.oxfmtrc.jsonc` with default values
-        --lsp                Start language server protocol (LSP) server
+Runtime Options
         --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
         --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core.
 


### PR DESCRIPTION
Updated to:

```
Usage: oxfmt [-c=PATH] [PATH]...

Mode Options:
        --init               Initialize `.oxfmtrc.jsonc` with default values
        --lsp                Start language server protocol (LSP) server

Output Options:
        --write              Format and write files in place (default)
        --check              Check if files are formatted, also show statistics
        --list-different     List files that would be changed

Config Options
    -c, --config=PATH        Path to the configuration file

Ignore Options
        --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not
                             specified, .gitignore and .prettierignore in the current directory are
                             used.
        --with-node-modules  Format code in node_modules directory (skipped by default)

Runtime Options
        --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
        --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core.

Available positional items:
    PATH                     Single file, single path or list of paths. If not provided, current
                             working directory is used. Glob is supported only for exclude patterns
                             like `'!**/fixtures/*.js'`.

Available options:
    -h, --help               Prints help information
    -V, --version            Prints version information

```