### PR TITLE
chore(linter): Improve tests for no-abusive-eslint-disable rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
+    ///
     /// ```javascript
     /// /* eslint-disable */
     /// console.log(message);
@@ -38,7 +39,18 @@ declare_oxc_lint!(
     /// console.log(message);
     /// ```
     ///
+    /// ```javascript
+    /// /* oxlint-disable */
+    /// console.log(message);
+    ///
+    /// console.log(message); // oxlint-disable-line
+    ///
+    /// // oxlint-disable-next-line
+    /// console.log(message);
+    /// ```
+    ///
     /// Examples of **correct** code for this rule:
+    ///
     /// ```javascript
     /// /* eslint-disable no-console */
     /// console.log(message);
@@ -46,6 +58,16 @@ declare_oxc_lint!(
     /// console.log(message); // eslint-disable-line no-console
     ///
     /// // eslint-disable-next-line no-console
+    /// console.log(message);
+    /// ```
+    ///
+    /// ```javascript
+    /// /* oxlint-disable no-console */
+    /// console.log(message);
+    ///
+    /// console.log(message); // oxlint-disable-line no-console
+    ///
+    /// // oxlint-disable-next-line no-console
     /// console.log(message);
     /// ```
     NoAbusiveEslintDisable,
@@ -93,14 +115,19 @@ fn test() {
         "eval(); //     eslint-disable-line no-eval",
         "eval(); //	eslint-disable-line no-eval",
         "eval(); /* eslint-disable-line no-eval */",
+        "eval(); //	oxlint-disable-line no-eval",
+        "eval(); /* oxlint-disable-line no-eval */",
         "eval(); // eslint-disable-line plugin/rule",
         "eval(); // eslint-disable-line @scope/plugin/rule-name",
+        "eval(); // oxlint-disable-line plugin/rule",
+        "eval(); // oxlint-disable-line @scope/plugin/rule-name",
         "eval(); // eslint-disable-line no-eval, @scope/plugin/rule-name",
         "eval(); // eslint-disable-line @scope/rule-name",
         "eval(); // eslint-disable-line no-eval, @scope/rule-name",
         "eval(); // eslint-line-disable",
         "eval(); // some comment",
         "/* eslint-disable no-eval */",
+        "/* oxlint-disable no-eval */",
         r"
         /* eslint-disable no-abusive-eslint-disable */
         eval(); // eslint-disable-line
@@ -120,6 +147,11 @@ fn test() {
         /* eslint-disable-next-line no-eval */
         eval();
         ",
+        r"
+        foo();
+        /* oxlint-disable-next-line no-eval */
+        eval();
+        ",
     ];
 
     let fail = vec![
@@ -128,14 +160,21 @@ fn test() {
         eval();
         ",
         "eval(); // eslint-disable-line",
+        "eval(); // oxlint-disable-line",
         r"
         foo();
         eval(); // eslint-disable-line
         ",
         "/* eslint-disable */",
+        "/* oxlint-disable */",
         r"
         foo();
         /* eslint-disable */
+        eval();
+        ",
+        r"
+        foo();
+        /* oxlint-disable */
         eval();
         ",
         r"
@@ -145,6 +184,15 @@ fn test() {
         ",
         r"
         // eslint-disable-next-line
+        eval();
+        ",
+        r"
+        foo();
+        /* oxlint-disable-next-line */
+        eval();
+        ",
+        r"
+        // oxlint-disable-next-line
         eval();
         ",
     ];

--- a/crates/oxc_linter/src/snapshots/unicorn_no_abusive_eslint_disable.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_abusive_eslint_disable.snap
@@ -18,6 +18,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Specify the rules you want to disable.
 
   ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:1:11]
+ 1 │ eval(); // oxlint-disable-line
+   ·           ────────────────────
+   ╰────
+  help: Specify the rules you want to disable.
+
+  ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:3:19]
  2 │         foo();
  3 │         eval(); // eslint-disable-line
@@ -34,9 +41,25 @@ source: crates/oxc_linter/src/tester.rs
   help: Specify the rules you want to disable.
 
   ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:1:3]
+ 1 │ /* oxlint-disable */
+   ·   ────────────────
+   ╰────
+  help: Specify the rules you want to disable.
+
+  ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:3:11]
  2 │         foo();
  3 │         /* eslint-disable */
+   ·           ────────────────
+ 4 │         eval();
+   ╰────
+  help: Specify the rules you want to disable.
+
+  ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:3:11]
+ 2 │         foo();
+ 3 │         /* oxlint-disable */
    ·           ────────────────
  4 │         eval();
    ╰────
@@ -55,6 +78,24 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_abusive_eslint_disable.tsx:2:11]
  1 │ 
  2 │         // eslint-disable-next-line
+   ·           ─────────────────────────
+ 3 │         eval();
+   ╰────
+  help: Specify the rules you want to disable.
+
+  ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:3:11]
+ 2 │         foo();
+ 3 │         /* oxlint-disable-next-line */
+   ·           ──────────────────────────
+ 4 │         eval();
+   ╰────
+  help: Specify the rules you want to disable.
+
+  ⚠ eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:2:11]
+ 1 │ 
+ 2 │         // oxlint-disable-next-line
    ·           ─────────────────────────
  3 │         eval();
    ╰────


### PR DESCRIPTION
Previously this only tested eslint-disable comments.

Also improve the docs a bit to ensure that oxlint-disable is mentioned.