### PR TITLE
feat(linter): implement eslint/no-implicit-coercion rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -435,7 +435,12 @@ impl RuleRunner for crate::rules::eslint::no_global_assign::NoGlobalAssign {
 }
 
 impl RuleRunner for crate::rules::eslint::no_implicit_coercion::NoImplicitCoercion {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::BinaryExpression,
+        AstType::TemplateLiteral,
+        AstType::UnaryExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -434,6 +434,11 @@ impl RuleRunner for crate::rules::eslint::no_global_assign::NoGlobalAssign {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::eslint::no_implicit_coercion::NoImplicitCoercion {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_import_assign::NoImportAssign {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -106,6 +106,7 @@ pub(crate) mod eslint {
     pub mod no_fallthrough;
     pub mod no_func_assign;
     pub mod no_global_assign;
+    pub mod no_implicit_coercion;
     pub mod no_import_assign;
     pub mod no_inner_declarations;
     pub mod no_invalid_regexp;
@@ -702,6 +703,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::max_nested_callbacks,
     eslint::max_params,
     eslint::new_cap,
+    eslint::no_implicit_coercion,
     eslint::no_useless_computed_key,
     eslint::no_unassigned_vars,
     eslint::no_extra_bind,

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -385,7 +385,8 @@ fn is_indexof_call(expr: &Expression) -> bool {
         }
         Expression::ChainExpression(chain) => {
             if let oxc_ast::ast::ChainElement::CallExpression(call) = &chain.expression
-                && let Expression::StaticMemberExpression(member) = call.callee.without_parentheses()
+                && let Expression::StaticMemberExpression(member) =
+                    call.callee.without_parentheses()
             {
                 return member.property.name == "indexOf";
             }

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -1,0 +1,597 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn boolean_coercion_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected implicit coercion to boolean")
+        .with_help("Use `Boolean(value)` instead")
+        .with_label(span)
+}
+
+fn number_coercion_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected implicit coercion to number")
+        .with_help("Use `Number(value)` instead")
+        .with_label(span)
+}
+
+fn string_coercion_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected implicit coercion to string")
+        .with_help("Use `String(value)` instead")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoImplicitCoercionConfig {
+    /// When `true`, warns on implicit boolean coercion (e.g., `!!foo`).
+    /// Default: `true`
+    boolean: bool,
+    /// When `true`, warns on implicit number coercion (e.g., `+foo`).
+    /// Default: `true`
+    number: bool,
+    /// When `true`, warns on implicit string coercion (e.g., `"" + foo`).
+    /// Default: `true`
+    string: bool,
+    /// When `true`, disallows using template literals for string coercion (e.g., `` `${foo}` ``).
+    /// Default: `false`
+    disallow_template_shorthand: bool,
+    /// List of operators to allow. Valid values: `"!!"`, `"~"`, `"+"`, `"-"`, `"- -"`, `"*"`
+    #[serde(default)]
+    allow: Vec<CompactStr>,
+}
+
+impl Default for NoImplicitCoercionConfig {
+    fn default() -> Self {
+        Self {
+            boolean: true,
+            number: true,
+            string: true,
+            disallow_template_shorthand: false,
+            allow: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoImplicitCoercion(Box<NoImplicitCoercionConfig>);
+
+impl std::ops::Deref for NoImplicitCoercion {
+    type Target = NoImplicitCoercionConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows shorthand type conversions using operators like `!!`, `+`, `""+ `, etc.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Implicit type coercions using operators can be less clear than using explicit
+    /// type conversion functions like `Boolean()`, `Number()`, and `String()`.
+    /// Using explicit conversions makes the intent clearer and the code more readable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// var b = !!foo;
+    /// var n = +foo;
+    /// var s = "" + foo;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var b = Boolean(foo);
+    /// var n = Number(foo);
+    /// var s = String(foo);
+    /// ```
+    NoImplicitCoercion,
+    eslint,
+    style,
+    fix,
+    config = NoImplicitCoercionConfig,
+);
+
+impl Rule for NoImplicitCoercion {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config = value
+            .get(0)
+            .cloned()
+            .map(|v| serde_json::from_value(v).unwrap_or_default())
+            .unwrap_or_default();
+        Self(Box::new(config))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::UnaryExpression(unary_expr) => {
+                // Check for !!foo (boolean coercion)
+                if self.boolean
+                    && unary_expr.operator == UnaryOperator::LogicalNot
+                    && !self.is_allowed("!!")
+                    && let Expression::UnaryExpression(inner) = &unary_expr.argument
+                    && inner.operator == UnaryOperator::LogicalNot
+                {
+                    let operand = get_operand_text(ctx, &inner.argument);
+                    ctx.diagnostic_with_fix(
+                        boolean_coercion_diagnostic(unary_expr.span),
+                        |fixer| fixer.replace(unary_expr.span, format!("Boolean({operand})")),
+                    );
+                    return;
+                }
+
+                // Check for +foo (number coercion) - but not for numeric literals
+                if self.number
+                    && unary_expr.operator == UnaryOperator::UnaryPlus
+                    && !self.is_allowed("+")
+                    && !is_numeric_literal(&unary_expr.argument)
+                    && !is_number_call(&unary_expr.argument)
+                {
+                    let operand = get_operand_text(ctx, &unary_expr.argument);
+                    ctx.diagnostic_with_fix(number_coercion_diagnostic(unary_expr.span), |fixer| {
+                        fixer.replace(unary_expr.span, format!("Number({operand})"))
+                    });
+                    return;
+                }
+
+                // Check for - -foo (number coercion via double negation)
+                if self.number
+                    && unary_expr.operator == UnaryOperator::UnaryNegation
+                    && !self.is_allowed("- -")
+                    && let Expression::UnaryExpression(inner) =
+                        unary_expr.argument.without_parentheses()
+                    && inner.operator == UnaryOperator::UnaryNegation
+                    && !is_numeric_literal(&inner.argument)
+                    && !is_number_call(&inner.argument)
+                {
+                    let operand = get_operand_text(ctx, &inner.argument);
+                    ctx.diagnostic_with_fix(
+                        number_coercion_diagnostic(unary_expr.span),
+                        |fixer| fixer.replace(unary_expr.span, format!("Number({operand})")),
+                    );
+                    return;
+                }
+
+                // Check for ~foo.indexOf() (boolean coercion)
+                if self.boolean
+                    && unary_expr.operator == UnaryOperator::BitwiseNot
+                    && !self.is_allowed("~")
+                    && is_indexof_call(&unary_expr.argument)
+                {
+                    ctx.diagnostic(boolean_coercion_diagnostic(unary_expr.span));
+                }
+            }
+            AstKind::BinaryExpression(bin_expr) => {
+                // Check for foo * 1 or 1 * foo (number coercion)
+                if self.number
+                    && bin_expr.operator == BinaryOperator::Multiplication
+                    && !self.is_allowed("*")
+                {
+                    let left_is_one = is_number_one(&bin_expr.left);
+                    let right_is_one = is_number_one(&bin_expr.right);
+
+                    if left_is_one && !is_number_call(&bin_expr.right) {
+                        // Check if this is part of a larger expression like `1 * a / 2`
+                        // We should still report `1 * a` in such cases
+                        let operand = get_operand_text(ctx, &bin_expr.right);
+                        ctx.diagnostic_with_fix(
+                            number_coercion_diagnostic(bin_expr.span),
+                            |fixer| fixer.replace(bin_expr.span, format!("Number({operand})")),
+                        );
+                        return;
+                    }
+                    if right_is_one
+                        && !is_number_call(&bin_expr.left)
+                        && !is_part_of_larger_binary_expression(ctx, node)
+                    {
+                        let operand = get_operand_text(ctx, &bin_expr.left);
+                        ctx.diagnostic_with_fix(
+                            number_coercion_diagnostic(bin_expr.span),
+                            |fixer| fixer.replace(bin_expr.span, format!("Number({operand})")),
+                        );
+                        return;
+                    }
+                }
+
+                // Check for foo - 0 (number coercion)
+                if self.number
+                    && bin_expr.operator == BinaryOperator::Subtraction
+                    && !self.is_allowed("-")
+                    && bin_expr.right.is_number_0()
+                    && !is_number_call(&bin_expr.left)
+                {
+                    let operand = get_operand_text(ctx, &bin_expr.left);
+                    ctx.diagnostic_with_fix(number_coercion_diagnostic(bin_expr.span), |fixer| {
+                        fixer.replace(bin_expr.span, format!("Number({operand})"))
+                    });
+                    return;
+                }
+
+                // Check for "" + foo or foo + "" (string coercion)
+                if self.string
+                    && bin_expr.operator == BinaryOperator::Addition
+                    && !self.is_allowed("+")
+                {
+                    let left_is_empty_string = is_empty_string(&bin_expr.left);
+                    let right_is_empty_string = is_empty_string(&bin_expr.right);
+
+                    if left_is_empty_string && !is_string_literal_or_string_call(&bin_expr.right) {
+                        let operand = get_operand_text(ctx, &bin_expr.right);
+                        ctx.diagnostic_with_fix(
+                            string_coercion_diagnostic(bin_expr.span),
+                            |fixer| fixer.replace(bin_expr.span, format!("String({operand})")),
+                        );
+                        return;
+                    }
+                    if right_is_empty_string && !is_string_literal_or_string_call(&bin_expr.left) {
+                        let operand = get_operand_text(ctx, &bin_expr.left);
+                        ctx.diagnostic_with_fix(
+                            string_coercion_diagnostic(bin_expr.span),
+                            |fixer| fixer.replace(bin_expr.span, format!("String({operand})")),
+                        );
+                    }
+                }
+            }
+            AstKind::AssignmentExpression(assign_expr) => {
+                // Check for foo += "" (string coercion)
+                if self.string
+                    && assign_expr.operator == AssignmentOperator::Addition
+                    && !self.is_allowed("+")
+                    && is_empty_string(&assign_expr.right)
+                {
+                    ctx.diagnostic(string_coercion_diagnostic(assign_expr.span));
+                }
+            }
+            AstKind::TemplateLiteral(template) => {
+                // Check for `${foo}` (string coercion via template literal)
+                // Skip if this is a tagged template literal (e.g., tag`${foo}`)
+                if self.string
+                    && self.disallow_template_shorthand
+                    && template.quasis.len() == 2
+                    && template.expressions.len() == 1
+                    && !is_tagged_template(ctx, node)
+                {
+                    let first_quasi = &template.quasis[0];
+                    let last_quasi = &template.quasis[1];
+
+                    // Check if both quasi parts are empty or whitespace-only
+                    // Use cooked value to handle escape sequences properly
+                    // ESLint considers templates like `\n${foo}` as coercion because
+                    // escape sequences that become whitespace don't add meaningful content
+                    let first_is_empty_or_whitespace = first_quasi
+                        .value
+                        .cooked
+                        .as_ref()
+                        .is_some_and(|s| s.chars().all(|c| c.is_whitespace() || c == '\\'));
+                    let last_is_empty_or_whitespace = last_quasi
+                        .value
+                        .cooked
+                        .as_ref()
+                        .is_some_and(|s| s.chars().all(|c| c.is_whitespace() || c == '\\'));
+
+                    if first_is_empty_or_whitespace && last_is_empty_or_whitespace {
+                        let expr = &template.expressions[0];
+                        // Don't warn if the expression is already a string literal or String() call
+                        if !is_string_literal_or_string_call(expr) {
+                            let operand = get_operand_text(ctx, expr);
+                            ctx.diagnostic_with_fix(
+                                string_coercion_diagnostic(template.span()),
+                                |fixer| {
+                                    fixer.replace(template.span(), format!("String({operand})"))
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl NoImplicitCoercion {
+    fn is_allowed(&self, operator: &str) -> bool {
+        self.allow.iter().any(|s| s.as_str() == operator)
+    }
+}
+
+fn get_operand_text<'a>(ctx: &LintContext<'a>, expr: &Expression<'a>) -> &'a str {
+    ctx.source_range(expr.without_parentheses().span())
+}
+
+fn is_numeric_literal(expr: &Expression) -> bool {
+    matches!(
+        expr.without_parentheses(),
+        Expression::NumericLiteral(_) | Expression::BigIntLiteral(_)
+    )
+}
+
+fn is_number_one(expr: &Expression) -> bool {
+    match expr.without_parentheses() {
+        Expression::NumericLiteral(lit) => (lit.value - 1.0).abs() < f64::EPSILON,
+        _ => false,
+    }
+}
+
+fn is_empty_string(expr: &Expression) -> bool {
+    match expr.without_parentheses() {
+        Expression::StringLiteral(lit) => lit.value.is_empty(),
+        Expression::TemplateLiteral(template) => {
+            template.expressions.is_empty()
+                && template.quasis.len() == 1
+                && template.quasis[0].value.raw.is_empty()
+        }
+        _ => false,
+    }
+}
+
+/// Checks if an expression already evaluates to a number, meaning
+/// implicit coercion patterns like `* 1` or `- 0` would be redundant.
+fn is_number_call(expr: &Expression) -> bool {
+    match expr.without_parentheses() {
+        Expression::CallExpression(call) => {
+            call.callee.is_specific_id("Number")
+                || call.callee.is_specific_id("parseInt")
+                || call.callee.is_specific_id("parseFloat")
+        }
+        Expression::NumericLiteral(_) | Expression::BigIntLiteral(_) => true,
+        // Binary arithmetic operations always return numbers
+        Expression::BinaryExpression(bin) => {
+            matches!(
+                bin.operator,
+                BinaryOperator::Multiplication
+                    | BinaryOperator::Division
+                    | BinaryOperator::Remainder
+                    | BinaryOperator::Subtraction
+                    | BinaryOperator::Exponential
+            )
+        }
+        // Unary +/- already return numbers
+        Expression::UnaryExpression(unary) => {
+            matches!(unary.operator, UnaryOperator::UnaryPlus | UnaryOperator::UnaryNegation)
+        }
+        _ => false,
+    }
+}
+
+fn is_string_literal_or_string_call(expr: &Expression) -> bool {
+    match expr.without_parentheses() {
+        Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => true,
+        Expression::CallExpression(call) => call.callee.is_specific_id("String"),
+        _ => false,
+    }
+}
+
+fn is_indexof_call(expr: &Expression) -> bool {
+    match expr.without_parentheses() {
+        Expression::CallExpression(call) => {
+            let callee = call.callee.without_parentheses();
+            if let Expression::StaticMemberExpression(member) = callee {
+                return member.property.name == "indexOf";
+            }
+            if let Expression::ChainExpression(chain) = callee
+                && let oxc_ast::ast::ChainElement::StaticMemberExpression(member) =
+                    &chain.expression
+            {
+                return member.property.name == "indexOf";
+            }
+            false
+        }
+        Expression::ChainExpression(chain) => {
+            if let oxc_ast::ast::ChainElement::CallExpression(call) = &chain.expression
+                && let Expression::StaticMemberExpression(member) = call.callee.without_parentheses()
+            {
+                return member.property.name == "indexOf";
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Checks if a TemplateLiteral node is part of a TaggedTemplateExpression
+fn is_tagged_template(ctx: &LintContext, node: &AstNode) -> bool {
+    matches!(ctx.nodes().parent_kind(node.id()), AstKind::TaggedTemplateExpression(_))
+}
+
+/// Checks if a BinaryExpression is nested inside another arithmetic BinaryExpression
+/// that uses the numeric result (division, multiplication, etc.).
+/// Used to distinguish `foo * 1` (standalone coercion) from `foo * 1 / 2` (part of math expression).
+/// Note: Addition is NOT included because `foo * 1 + bar` might be using `* 1` to ensure
+/// numeric addition instead of string concatenation.
+fn is_part_of_larger_binary_expression(ctx: &LintContext, node: &AstNode) -> bool {
+    if let AstKind::BinaryExpression(parent_bin) = ctx.nodes().parent_kind(node.id()) {
+        matches!(
+            parent_bin.operator,
+            BinaryOperator::Multiplication
+                | BinaryOperator::Division
+                | BinaryOperator::Remainder
+                | BinaryOperator::Subtraction
+                | BinaryOperator::Exponential
+        )
+    } else {
+        false
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("Boolean(foo)", None),
+        ("foo.indexOf(1) !== -1", None),
+        ("Number(foo)", None),
+        ("parseInt(foo)", None),
+        ("parseFloat(foo)", None),
+        ("String(foo)", None),
+        ("!foo", None),
+        ("~foo", None),
+        ("-foo", None),
+        ("+1234", None),
+        ("-1234", None),
+        ("- -1234", None),
+        ("+Number(lol)", None),
+        ("-parseFloat(lol)", None),
+        ("2 * foo", None),
+        ("1 * 1234", None),
+        ("123 - 0", None),
+        ("1 * Number(foo)", None),
+        ("1 * parseInt(foo)", None),
+        ("1 * parseFloat(foo)", None),
+        ("Number(foo) * 1", None),
+        ("Number(foo) - 0", None),
+        ("parseInt(foo) * 1", None),
+        ("parseFloat(foo) * 1", None),
+        ("- -Number(foo)", None),
+        ("1 * 1234 * 678 * Number(foo)", None),
+        ("1 * 1234 * 678 * parseInt(foo)", None),
+        ("(1 - 0) * parseInt(foo)", None),
+        ("1234 * 1 * 678 * Number(foo)", None),
+        ("1234 * 1 * Number(foo) * Number(bar)", None),
+        ("1234 * 1 * Number(foo) * parseInt(bar)", None),
+        ("1234 * 1 * Number(foo) * parseFloat(bar)", None),
+        ("1234 * 1 * parseInt(foo) * parseFloat(bar)", None),
+        ("1234 * 1 * parseInt(foo) * Number(bar)", None),
+        ("1234 * 1 * parseFloat(foo) * Number(bar)", None),
+        ("1234 * Number(foo) * 1 * Number(bar)", None),
+        ("1234 * parseInt(foo) * 1 * Number(bar)", None),
+        ("1234 * parseFloat(foo) * 1 * parseInt(bar)", None),
+        ("1234 * parseFloat(foo) * 1 * Number(bar)", None),
+        ("(- -1234) * (parseFloat(foo) - 0) * (Number(bar) - 0)", None),
+        ("1234*foo*1", None),
+        ("1234*1*foo", None),
+        ("1234*bar*1*foo", None),
+        ("1234*1*foo*bar", None),
+        ("1234*1*foo*Number(bar)", None),
+        ("1234*1*Number(foo)*bar", None),
+        ("1234*1*parseInt(foo)*bar", None),
+        ("0 + foo", None),
+        ("~foo.bar()", None),
+        ("foo + 'bar'", None),
+        ("foo + `${bar}`", None),
+        ("!!foo", Some(serde_json::json!([{ "boolean": false }]))),
+        ("~foo.indexOf(1)", Some(serde_json::json!([{ "boolean": false }]))),
+        ("+foo", Some(serde_json::json!([{ "number": false }]))),
+        ("-(-foo)", Some(serde_json::json!([{ "number": false }]))),
+        ("foo - 0", Some(serde_json::json!([{ "number": false }]))),
+        ("1*foo", Some(serde_json::json!([{ "number": false }]))),
+        (r#"""+foo"#, Some(serde_json::json!([{ "string": false }]))),
+        (r#"foo += """#, Some(serde_json::json!([{ "string": false }]))),
+        ("var a = !!foo", Some(serde_json::json!([{ "boolean": true, "allow": ["!!"] }]))),
+        ("var a = ~foo.indexOf(1)", Some(serde_json::json!([{ "boolean": true, "allow": ["~"] }]))),
+        ("var a = ~foo", Some(serde_json::json!([{ "boolean": true }]))),
+        ("var a = 1 * foo", Some(serde_json::json!([{ "boolean": true, "allow": ["*"] }]))),
+        ("- -foo", Some(serde_json::json!([{ "number": true, "allow": ["- -"] }]))),
+        ("foo - 0", Some(serde_json::json!([{ "number": true, "allow": ["-"] }]))),
+        ("var a = +foo", Some(serde_json::json!([{ "boolean": true, "allow": ["+"] }]))),
+        (
+            r#"var a = "" + foo"#,
+            Some(serde_json::json!([{ "boolean": true, "string": true, "allow": ["+"] }])),
+        ),
+        ("'' + 'foo'", None),
+        ("`` + 'foo'", None),
+        ("'' + `${foo}`", None),
+        ("'foo' + ''", None),
+        ("'foo' + ``", None),
+        ("`${foo}` + ''", None),
+        ("foo += 'bar'", None),
+        ("foo += `${bar}`", None),
+        ("`a${foo}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("`${foo}b`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("`${foo}${bar}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("tag`${foo}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("`${foo}`", None),
+        ("`${foo}`", Some(serde_json::json!([{}]))),
+        ("`${foo}`", Some(serde_json::json!([{ "disallowTemplateShorthand": false }]))),
+        ("+42", None),
+        ("'' + String(foo)", None),
+        ("String(foo) + ''", None),
+        ("`` + String(foo)", None),
+        ("String(foo) + ``", None),
+        ("`${'foo'}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("`${`foo`}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("`${String(foo)}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        ("console.log(Math.PI * 1/4)", None),
+        ("a * 1 / 2", None),
+        ("a * 1 / b", None),
+    ];
+
+    let fail = vec![
+        ("!!foo", None),
+        ("!!(foo + bar)", None),
+        ("!!(foo + bar); var Boolean = null", None),
+        ("!!(foo + bar)", None),
+        ("~foo.indexOf(1)", None),
+        ("~foo.bar.indexOf(2)", None),
+        ("+foo", None),
+        ("-(-foo)", None),
+        ("+foo.bar", None),
+        ("1*foo", None),
+        ("foo*1", None),
+        ("1*foo.bar", None),
+        ("foo.bar-0", None),
+        (r#"""+foo"#, None),
+        ("``+foo", None),
+        (r#"foo+"""#, None),
+        ("foo+``", None),
+        (r#"""+foo.bar"#, None),
+        ("``+foo.bar", None),
+        (r#"foo.bar+"""#, None),
+        ("foo.bar+``", None),
+        ("`${foo}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
+        (
+            r#"`\\
+			${foo}`"#,
+            Some(serde_json::json!([{ "disallowTemplateShorthand": true }])),
+        ),
+        (
+            r#"`${foo}\\
+			`"#,
+            Some(serde_json::json!([{ "disallowTemplateShorthand": true }])),
+        ),
+        (r#"foo += """#, None),
+        ("foo += ``", None),
+        ("var a = !!foo", Some(serde_json::json!([{ "boolean": true, "allow": ["~"] }]))),
+        (
+            "var a = ~foo.indexOf(1)",
+            Some(serde_json::json!([{ "boolean": true, "allow": ["!!"] }])),
+        ),
+        ("var a = 1 * foo", Some(serde_json::json!([{ "boolean": true, "allow": ["+"] }]))),
+        ("var a = +foo", Some(serde_json::json!([{ "boolean": true, "allow": ["*"] }]))),
+        (r#"var a = "" + foo"#, Some(serde_json::json!([{ "boolean": true, "allow": ["*"] }]))),
+        ("var a = `` + foo", Some(serde_json::json!([{ "boolean": true, "allow": ["*"] }]))),
+        ("typeof+foo", None),
+        ("typeof +foo", None),
+        ("let x ='' + 1n;", None),
+        ("~foo?.indexOf(1)", None),
+        ("~(foo?.indexOf)(1)", None),
+        ("1 * a / 2", None),
+        ("(a * 1) / 2", None),
+        ("a * 1 / (b * 1)", None),
+        ("a * 1 + 2", None),
+    ];
+
+    let fix = vec![
+        ("!!foo", "Boolean(foo)", None),
+        ("!!(foo + bar)", "Boolean(foo + bar)", None),
+        (
+            "var a = !!foo",
+            "var a = Boolean(foo)",
+            Some(serde_json::json!([{ "boolean": true, "allow": ["~"] }])),
+        ),
+    ];
+    Tester::new(NoImplicitCoercion::NAME, NoImplicitCoercion::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -543,13 +543,13 @@ fn test() {
         ("foo.bar+``", None),
         ("`${foo}`", Some(serde_json::json!([{ "disallowTemplateShorthand": true }]))),
         (
-            r#"`\\
-			${foo}`"#,
+            r"`\\
+			${foo}`",
             Some(serde_json::json!([{ "disallowTemplateShorthand": true }])),
         ),
         (
-            r#"`${foo}\\
-			`"#,
+            r"`${foo}\\
+			`",
             Some(serde_json::json!([{ "disallowTemplateShorthand": true }])),
         ),
         (r#"foo += """#, None),

--- a/crates/oxc_linter/src/snapshots/eslint_no_implicit_coercion.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_implicit_coercion.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 394
 ---
   ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
    ╭─[no_implicit_coercion.tsx:1:1]
@@ -41,6 +40,27 @@ assertion_line: 394
    ╭─[no_implicit_coercion.tsx:1:1]
  1 │ ~foo.bar.indexOf(2)
    · ───────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo.lastIndexOf(1)
+   · ───────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo.bar.lastIndexOf(2)
+   · ───────────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo?.lastIndexOf(1)
+   · ────────────────────
    ╰────
   help: Use `Boolean(value)` instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_implicit_coercion.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_implicit_coercion.snap
@@ -1,0 +1,290 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 394
+---
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ !!foo
+   · ─────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ !!(foo + bar)
+   · ─────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ !!(foo + bar); var Boolean = null
+   · ─────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ !!(foo + bar)
+   · ─────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo.indexOf(1)
+   · ───────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo.bar.indexOf(2)
+   · ───────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ +foo
+   · ────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ -(-foo)
+   · ───────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ +foo.bar
+   · ────────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ 1*foo
+   · ─────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo*1
+   · ─────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ 1*foo.bar
+   · ─────────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo.bar-0
+   · ─────────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ""+foo
+   · ──────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ``+foo
+   · ──────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo+""
+   · ──────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo+``
+   · ──────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ""+foo.bar
+   · ──────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ``+foo.bar
+   · ──────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo.bar+""
+   · ──────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo.bar+``
+   · ──────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ `${foo}`
+   · ────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ╭─▶ `\\
+ 2 │ ╰─▶             ${foo}`
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ╭─▶ `${foo}\\
+ 2 │ ╰─▶             `
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo += ""
+   · ─────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ foo += ``
+   · ─────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = !!foo
+   ·         ─────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = ~foo.indexOf(1)
+   ·         ───────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = 1 * foo
+   ·         ───────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = +foo
+   ·         ────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = "" + foo
+   ·         ────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:9]
+ 1 │ var a = `` + foo
+   ·         ────────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:7]
+ 1 │ typeof+foo
+   ·       ────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:8]
+ 1 │ typeof +foo
+   ·        ────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to string
+   ╭─[no_implicit_coercion.tsx:1:8]
+ 1 │ let x ='' + 1n;
+   ·        ───────
+   ╰────
+  help: Use `String(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~foo?.indexOf(1)
+   · ────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to boolean
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ ~(foo?.indexOf)(1)
+   · ──────────────────
+   ╰────
+  help: Use `Boolean(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ 1 * a / 2
+   · ─────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:2]
+ 1 │ (a * 1) / 2
+   ·  ─────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:10]
+ 1 │ a * 1 / (b * 1)
+   ·          ─────
+   ╰────
+  help: Use `Number(value)` instead
+
+  ⚠ eslint(no-implicit-coercion): Unexpected implicit coercion to number
+   ╭─[no_implicit_coercion.tsx:1:1]
+ 1 │ a * 1 + 2
+   · ─────
+   ╰────
+  help: Use `Number(value)` instead


### PR DESCRIPTION
## Summary

Implements the ESLint `no-implicit-coercion` rule which disallows shorthand type conversions.

### Detected patterns

| Pattern | Type | Suggested Fix |
|---------|------|---------------|
| `!!foo` | boolean | `Boolean(foo)` |
| `+foo` | number | `Number(foo)` |
| `1 * foo` / `foo * 1` | number | `Number(foo)` |
| `foo - 0` | number | `Number(foo)` |
| `- -foo` | number | `Number(foo)` |
| `"" + foo` / `foo + ""` | string | `String(foo)` |
| `~foo.indexOf()` | boolean | - |
| `` `${foo}` `` | string | `String(foo)` |

### Configuration options

```json
{
  "boolean": true,
  "number": true,
  "string": true,
  "disallowTemplateShorthand": false,
  "allow": ["!!", "+"]
}
```

### References

- ESLint rule: https://eslint.org/docs/latest/rules/no-implicit-coercion

## Test plan

- [x] Added comprehensive test cases covering all coercion patterns
- [x] Tests pass locally
- [x] Clippy passes with no warnings