### PR TITLE
feat(oxfmt): `oxfmt --migrate prettier`

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -8,7 +8,8 @@
  * 2. `setup_config_cb`: Callback to setup Prettier config
  * 3. `format_embedded_cb`: Callback to format embedded code in templates
  * 4. `format_file_cb`: Callback to format files
+ * 5. `get_prettier_config_cb`: Callback to get Prettier config for migration
  *
  * Returns `true` if formatting succeeded without errors, `false` otherwise.
  */
-export declare function format(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function format(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>, getPrettierConfigCb: (dirPath: string) => Promise<string | null>): Promise<boolean>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,10 +1,11 @@
 import { format } from "./bindings.js";
+import { getPrettierConfig } from "./prettier-migrate.js";
 import { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 
 const args = process.argv.slice(2);
 
-// Call the Rust formatter with our JS callback
-const success = await format(args, setupConfig, formatEmbeddedCode, formatFile);
+// Call the Rust formatter with our JS callbacks
+const success = await format(args, setupConfig, formatEmbeddedCode, formatFile, getPrettierConfig);
 
 // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxfmt/src-js/prettier-migrate.ts
+++ b/apps/oxfmt/src-js/prettier-migrate.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+
+/**
+ * Resolve Prettier configuration from a directory path.
+ * Uses a fake file path to trigger Prettier's config resolution.
+ *
+ * @param dirPath - Directory path to search from (current working directory)
+ * @returns Prettier config as JSON string, or null if not found
+ */
+export async function getPrettierConfig(dirPath: string): Promise<string | null> {
+  const prettier = await import("prettier");
+
+  try {
+    // Use a fake file path - Prettier will search upward from this directory
+    // The file doesn't need to exist; Prettier just uses it as a starting point
+    const fakePath = join(dirPath, "fake.js");
+    const config = await prettier.resolveConfig(fakePath);
+    return config ? JSON.stringify(config) : null;
+  } catch (error) {
+    console.error("Error resolving Prettier config:", error);
+    return null;
+  }
+}

--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -116,6 +116,9 @@ pub struct IgnoreOptions {
 /// Runtime Options
 #[derive(Debug, Clone, Bpaf)]
 pub struct RuntimeOptions {
+    /// Migrate from another formatter's configuration (currently supports: prettier)
+    #[bpaf(long, argument("SOURCE"), hide_usage)]
+    pub migrate: Option<String>,
     /// Do not exit with error when pattern is unmatched
     #[bpaf(switch, hide_usage)]
     pub no_error_on_unmatched_pattern: bool,

--- a/apps/oxfmt/src/cli/migrate.rs
+++ b/apps/oxfmt/src/cli/migrate.rs
@@ -1,0 +1,210 @@
+use std::fs;
+use std::io::BufWriter;
+use std::path::Path;
+
+use napi::bindgen_prelude::FnArgs;
+use serde_json::Value;
+
+use oxc_formatter::Oxfmtrc;
+
+use crate::cli::CliRunResult;
+use crate::core::{read_prettierignore, utils};
+
+#[cfg(feature = "napi")]
+use crate::core::JsGetPrettierConfigCb;
+
+/// Run the `--migrate` command for pure Rust builds (no NAPI)
+pub fn run_migrate(source: &str) -> CliRunResult {
+    let mut stderr = BufWriter::new(std::io::stderr());
+
+    if source != "prettier" {
+        utils::print_and_flush(
+            &mut stderr,
+            &format!("Error: Unknown migration source '{source}'\n"),
+        );
+        utils::print_and_flush(&mut stderr, "Supported sources: prettier\n");
+        return CliRunResult::MigrateFailed;
+    }
+
+    utils::print_and_flush(
+        &mut stderr,
+        "Error: Migration is only available in Node.js environment.\n",
+    );
+    utils::print_and_flush(&mut stderr, "Please use 'npx oxfmt --migrate prettier' instead.\n");
+    CliRunResult::MigrateFailed
+}
+
+/// Run the `--migrate` command with NAPI support
+#[cfg(feature = "napi")]
+pub async fn run_migrate_napi(
+    source: &str,
+    get_prettier_config_cb: JsGetPrettierConfigCb,
+) -> CliRunResult {
+    let mut stdout = BufWriter::new(std::io::stdout());
+    let mut stderr = BufWriter::new(std::io::stderr());
+
+    // Validate source
+    if source != "prettier" {
+        utils::print_and_flush(
+            &mut stderr,
+            &format!("Error: Unknown migration source '{source}'\n"),
+        );
+        utils::print_and_flush(&mut stderr, "Supported sources: prettier\n");
+        return CliRunResult::MigrateFailed;
+    }
+
+    // Check if config already exists
+    if Path::new(".oxfmtrc.json").exists() || Path::new(".oxfmtrc.jsonc").exists() {
+        utils::print_and_flush(&mut stderr, "Error: Configuration file already exists.\n");
+        utils::print_and_flush(
+            &mut stderr,
+            "Remove .oxfmtrc.json or .oxfmtrc.jsonc manually before migrating.\n",
+        );
+        return CliRunResult::MigrateAborted;
+    }
+
+    // Get current working directory
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(_) => {
+            utils::print_and_flush(&mut stderr, "Error: Could not determine current directory\n");
+            return CliRunResult::MigrateFailed;
+        }
+    };
+
+    // Call JS to get Prettier config
+    // Pass cwd path - Prettier will search upward from there
+    let config_json = {
+        let status =
+            get_prettier_config_cb.call_async(FnArgs::from((cwd.display().to_string(),))).await;
+        match status {
+            Ok(promise) => promise.await,
+            Err(err) => {
+                Err(napi::Error::from_reason(format!("Failed to get Prettier config: {err}")))
+            }
+        }
+    };
+
+    let config_json = match config_json {
+        Ok(Some(json)) => json,
+        Ok(None) => {
+            utils::print_and_flush(&mut stderr, "Error: No Prettier configuration found\n");
+            return CliRunResult::MigrateFailed;
+        }
+        Err(err) => {
+            utils::print_and_flush(&mut stderr, &format!("Error getting Prettier config: {err}\n"));
+            return CliRunResult::MigrateFailed;
+        }
+    };
+
+    // Parse Prettier config JSON
+    let prettier_config: Value = match serde_json::from_str(&config_json) {
+        Ok(v) => v,
+        Err(err) => {
+            utils::print_and_flush(&mut stderr, &format!("Error parsing Prettier config: {err}\n"));
+            return CliRunResult::MigrateFailed;
+        }
+    };
+
+    // Convert Prettier config to Oxfmt
+    let (mut oxfmtrc, unsupported) = match prettier_to_oxfmtrc(&prettier_config) {
+        Ok(result) => result,
+        Err(err) => {
+            utils::print_and_flush(&mut stderr, &format!("Error converting config: {err}\n"));
+            return CliRunResult::MigrateFailed;
+        }
+    };
+
+    // Read and parse .prettierignore from current directory
+    let ignore_patterns = read_prettierignore(&cwd);
+    // Always set ignore patterns (even if empty array)
+    oxfmtrc.ignore_patterns = Some(ignore_patterns);
+
+    // Write config file
+    if let Err(err) = write_migrated_config(&oxfmtrc) {
+        utils::print_and_flush(&mut stderr, &format!("{err}\n"));
+        return CliRunResult::MigrateFailed;
+    }
+
+    utils::print_and_flush(&mut stdout, "✓ Created .oxfmtrc.jsonc\n");
+
+    // Warn about unsupported options
+    if !unsupported.is_empty() {
+        utils::print_and_flush(
+            &mut stdout,
+            "\n⚠ Warning: The following Prettier options were not migrated:\n",
+        );
+        for item in &unsupported {
+            utils::print_and_flush(&mut stdout, &format!("  - {item}\n"));
+        }
+    }
+
+    CliRunResult::MigrateSucceeded
+}
+
+/// Convert Prettier config JSON to Oxfmtrc
+/// Returns (Oxfmtrc, unsupported_options)
+fn prettier_to_oxfmtrc(prettier_json: &Value) -> Result<(Oxfmtrc, Vec<String>), String> {
+    let mut unsupported = Vec::new();
+
+    let obj = prettier_json.as_object().ok_or("Invalid Prettier config: not an object")?;
+
+    // Track unsupported options before deserializing
+    let config_only_unsupported = [
+        ("experimentalOperatorPosition", "experimental feature not yet supported"),
+        ("experimentalTernaries", "experimental feature not yet supported"),
+        ("proseWrap", "markdown-specific option"),
+        ("htmlWhitespaceSensitivity", "HTML-specific option"),
+        ("vueIndentScriptAndStyle", "Vue-specific option"),
+    ];
+
+    for (key, reason) in &config_only_unsupported {
+        if let Some(value) = obj.get(*key) {
+            unsupported.push(format!("{key}: {value} ({reason})"));
+        }
+    }
+
+    // Deprecated option
+    if let Some(value) = obj.get("jsxBracketSameLine") {
+        unsupported
+            .push(format!("jsxBracketSameLine: {value} (deprecated, use bracketSameLine instead)"));
+    }
+
+    // Handle endOfLine: "auto" specially
+    if obj.get("endOfLine").and_then(|v| v.as_str()) == Some("auto") {
+        unsupported.push("endOfLine: \"auto\" (not supported, using default \"lf\")".to_string());
+    }
+
+    // Deserialize into Oxfmtrc - this handles all the field mapping
+    // Serde will skip invalid values and use defaults
+    let oxfmtrc: Oxfmtrc = serde_json::from_value(prettier_json.clone()).unwrap_or_default();
+
+    Ok((oxfmtrc, unsupported))
+}
+
+/// Write Oxfmtrc to .oxfmtrc.jsonc file
+fn write_migrated_config(oxfmtrc: &Oxfmtrc) -> Result<(), String> {
+    let mut json =
+        serde_json::to_value(oxfmtrc).map_err(|e| format!("Failed to serialize config: {e}"))?;
+
+    // Add $schema if available
+    let schema_path = "./node_modules/oxfmt/configuration_schema.json";
+    if Path::new(schema_path).is_file() {
+        if let Some(obj) = json.as_object_mut() {
+            let mut new_obj = serde_json::Map::new();
+            new_obj.insert("$schema".to_string(), Value::String(schema_path.to_string()));
+            for (k, v) in std::mem::take(obj) {
+                new_obj.insert(k, v);
+            }
+            json = Value::Object(new_obj);
+        }
+    }
+
+    let json_str =
+        serde_json::to_string_pretty(&json).map_err(|e| format!("Failed to format config: {e}"))?;
+
+    fs::write(".oxfmtrc.jsonc", format!("{json_str}\n"))
+        .map_err(|_| "Failed to write .oxfmtrc.jsonc".to_string())?;
+
+    Ok(())
+}

--- a/apps/oxfmt/src/cli/mod.rs
+++ b/apps/oxfmt/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod command;
 mod format;
 mod init;
+mod migrate;
 mod reporter;
 mod result;
 mod service;
@@ -9,4 +10,8 @@ mod walk;
 pub use command::{Mode, format_command};
 pub use format::FormatRunner;
 pub use init::{init_miette, init_rayon, init_tracing};
+pub use migrate::run_migrate;
 pub use result::CliRunResult;
+
+#[cfg(feature = "napi")]
+pub use migrate::run_migrate_napi;

--- a/apps/oxfmt/src/cli/result.rs
+++ b/apps/oxfmt/src/cli/result.rs
@@ -6,24 +6,32 @@ pub enum CliRunResult {
     None,
     FormatSucceeded,
     InitSucceeded,
+    MigrateSucceeded,
     // Warning error
     InvalidOptionConfig,
     FormatMismatch,
     InitAborted,
+    MigrateAborted,
     // Fatal error
     NoFilesFound,
     FormatFailed,
     InitFailed,
+    MigrateFailed,
 }
 
 impl Termination for CliRunResult {
     fn report(self) -> ExitCode {
         match self {
-            Self::None | Self::FormatSucceeded | Self::InitSucceeded => ExitCode::from(0),
-            Self::InvalidOptionConfig | Self::FormatMismatch | Self::InitAborted => {
-                ExitCode::from(1)
+            Self::None | Self::FormatSucceeded | Self::InitSucceeded | Self::MigrateSucceeded => {
+                ExitCode::from(0)
             }
-            Self::NoFilesFound | Self::FormatFailed | Self::InitFailed => ExitCode::from(2),
+            Self::InvalidOptionConfig
+            | Self::FormatMismatch
+            | Self::InitAborted
+            | Self::MigrateAborted => ExitCode::from(1),
+            Self::NoFilesFound | Self::FormatFailed | Self::InitFailed | Self::MigrateFailed => {
+                ExitCode::from(2)
+            }
         }
     }
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -54,6 +54,21 @@ pub type JsFormatFileCb = ThreadsafeFunction<
     false,
 >;
 
+/// Type alias for the get Prettier config callback function.
+/// Takes (directory_path) and returns Prettier config JSON or None.
+pub type JsGetPrettierConfigCb = ThreadsafeFunction<
+    // Input arguments
+    FnArgs<(String,)>, // (cwd path)
+    // Return type (what JS function returns)
+    Promise<Option<String>>, // config JSON or None
+    // Arguments (repeated)
+    FnArgs<(String,)>,
+    // Error status
+    Status,
+    // CalleeHandled
+    false,
+>;
+
 /// Callback function type for formatting files.
 /// Takes (parser_name, file_name, code) and returns formatted code or an error.
 type FormatFileCallback = Arc<dyn Fn(&str, &str, &str) -> Result<String, String> + Send + Sync>;

--- a/apps/oxfmt/src/core/migrate.rs
+++ b/apps/oxfmt/src/core/migrate.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+use crate::core::utils;
+
+/// Read and parse .prettierignore file from current directory
+/// Returns patterns with comments and empty lines filtered out
+pub fn read_prettierignore(cwd: &Path) -> Vec<String> {
+    let prettierignore_path = cwd.join(".prettierignore");
+
+    match utils::read_to_string(&prettierignore_path) {
+        Ok(content) => content
+            .lines()
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(|line| line.to_string())
+            .collect(),
+        Err(_) => {
+            // .prettierignore doesn't exist or can't be read
+            Vec::new()
+        }
+    }
+}

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod format;
+mod migrate;
 mod support;
 pub mod utils;
 
@@ -8,9 +9,10 @@ mod external_formatter;
 
 pub use config::{load_config, resolve_config_path};
 pub use format::{FormatResult, SourceFormatter};
+pub use migrate::read_prettierignore;
 pub use support::FormatFileStrategy;
 
 #[cfg(feature = "napi")]
 pub use external_formatter::{
-    ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsSetupConfigCb,
+    ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsGetPrettierConfigCb, JsSetupConfigCb,
 };

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,5 +1,6 @@
 use oxfmt::cli::{
     CliRunResult, FormatRunner, Mode, format_command, init_miette, init_rayon, init_tracing,
+    run_migrate,
 };
 use oxfmt::init::run_init;
 use oxfmt::lsp::run_lsp;
@@ -11,6 +12,11 @@ use oxfmt::lsp::run_lsp;
 async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = format_command().run();
+
+    // Handle --migrate mode (check before mode since it's independent)
+    if let Some(source) = &command.runtime_options.migrate {
+        return run_migrate(source);
+    }
 
     match command.mode {
         Mode::Init => run_init(),

--- a/apps/oxfmt/test/__snapshots__/migrate.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/migrate.test.ts.snap
@@ -1,0 +1,92 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`migrate > should error for unknown migration source 1`] = `
+"--------------------
+arguments: --migrate eslint
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 1
+--- STDOUT ---------
+
+--- STDERR ---------
+Error: Unknown migration source 'eslint'
+Supported sources: prettier
+--------------------"
+`;
+
+exports[`migrate > should error when .oxfmtrc.jsonc already exists 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 1
+--- STDOUT ---------
+
+--- STDERR ---------
+Error: Configuration file already exists.
+Remove .oxfmtrc.json or .oxfmtrc.jsonc manually before migrating.
+--------------------"
+`;
+
+exports[`migrate > should error when no prettier config found 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 1
+--- STDOUT ---------
+
+--- STDERR ---------
+Error: No Prettier configuration found
+--------------------"
+`;
+
+exports[`migrate > should handle package.json prettier config 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 0
+--- STDOUT ---------
+✓ Created .oxfmtrc.jsonc
+--- STDERR ---------
+
+--------------------"
+`;
+
+exports[`migrate > should migrate basic prettier config 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 0
+--- STDOUT ---------
+✓ Created .oxfmtrc.jsonc
+--- STDERR ---------
+
+--------------------"
+`;
+
+exports[`migrate > should migrate prettier config with .prettierignore 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 0
+--- STDOUT ---------
+✓ Created .oxfmtrc.jsonc
+--- STDERR ---------
+
+--------------------"
+`;
+
+exports[`migrate > should warn about unsupported options 1`] = `
+"--------------------
+arguments: --migrate prettier
+working directory: ../../../../../../../var/folders/nw/h<variable>msptn4x14x943x8vghxd00000gn/T/oxfmt-migrate-test-<random>
+exit code: 0
+--- STDOUT ---------
+✓ Created .oxfmtrc.jsonc
+
+⚠ Warning: The following Prettier options were not migrated:
+  - experimentalTernaries: true (experimental feature not yet supported)
+  - proseWrap: "always" (markdown-specific option)
+  - htmlWhitespaceSensitivity: "css" (HTML-specific option)
+--- STDERR ---------
+
+--------------------"
+`;

--- a/apps/oxfmt/test/migrate.test.ts
+++ b/apps/oxfmt/test/migrate.test.ts
@@ -134,10 +134,7 @@ node_modules/
 
   it("should error when .oxfmtrc.jsonc already exists", async () => {
     // Create .prettierrc
-    await fs.writeFile(
-      join(tempDir, ".prettierrc"),
-      JSON.stringify({ semi: false }),
-    );
+    await fs.writeFile(join(tempDir, ".prettierrc"), JSON.stringify({ semi: false }));
 
     // Create .oxfmtrc.jsonc
     await fs.writeFile(join(tempDir, ".oxfmtrc.jsonc"), "{}");
@@ -188,10 +185,7 @@ node_modules/
   });
 
   it("should handle empty .prettierignore", async () => {
-    await fs.writeFile(
-      join(tempDir, ".prettierrc"),
-      JSON.stringify({ semi: false }),
-    );
+    await fs.writeFile(join(tempDir, ".prettierrc"), JSON.stringify({ semi: false }));
 
     // Create empty .prettierignore
     await fs.writeFile(join(tempDir, ".prettierignore"), "");
@@ -203,10 +197,7 @@ node_modules/
   });
 
   it("should handle .prettierignore with only comments", async () => {
-    await fs.writeFile(
-      join(tempDir, ".prettierrc"),
-      JSON.stringify({ semi: false }),
-    );
+    await fs.writeFile(join(tempDir, ".prettierrc"), JSON.stringify({ semi: false }));
 
     await fs.writeFile(
       join(tempDir, ".prettierignore"),

--- a/apps/oxfmt/test/migrate.test.ts
+++ b/apps/oxfmt/test/migrate.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { runAndSnapshot } from "./utils";
+
+describe("migrate", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-migrate-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should migrate basic prettier config", async () => {
+    // Create .prettierrc
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({
+        semi: false,
+        singleQuote: true,
+        tabWidth: 4,
+        printWidth: 100,
+      }),
+    );
+
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    // Verify .oxfmtrc.jsonc was created
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"semi": false');
+    expect(configContent).toContain('"singleQuote": true');
+    expect(configContent).toContain('"tabWidth": 4');
+    expect(configContent).toContain('"printWidth": 100');
+  });
+
+  it("should migrate prettier config with .prettierignore", async () => {
+    // Create .prettierrc
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({
+        semi: false,
+      }),
+    );
+
+    // Create .prettierignore
+    await fs.writeFile(
+      join(tempDir, ".prettierignore"),
+      `# Comment line
+dist/
+build/
+
+node_modules/
+*.min.js
+`,
+    );
+
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    // Verify .oxfmtrc.jsonc contains ignore patterns
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"ignorePatterns"');
+    expect(configContent).toContain('"dist/"');
+    expect(configContent).toContain('"build/"');
+    expect(configContent).toContain('"node_modules/"');
+    expect(configContent).toContain('"*.min.js"');
+    expect(configContent).not.toContain("# Comment");
+  });
+
+  it("should migrate all supported prettier options", async () => {
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({
+        useTabs: true,
+        tabWidth: 2,
+        printWidth: 120,
+        semi: true,
+        singleQuote: false,
+        jsxSingleQuote: true,
+        trailingComma: "all",
+        bracketSpacing: false,
+        bracketSameLine: true,
+        arrowParens: "always",
+        endOfLine: "lf",
+        quoteProps: "consistent",
+        singleAttributePerLine: true,
+        embeddedLanguageFormatting: "off",
+      }),
+    );
+
+    await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"useTabs": true');
+    expect(configContent).toContain('"tabWidth": 2');
+    expect(configContent).toContain('"printWidth": 120');
+    expect(configContent).toContain('"semi": true');
+    expect(configContent).toContain('"singleQuote": false');
+    expect(configContent).toContain('"jsxSingleQuote": true');
+    expect(configContent).toContain('"trailingComma": "all"');
+    expect(configContent).toContain('"bracketSpacing": false');
+    expect(configContent).toContain('"bracketSameLine": true');
+    expect(configContent).toContain('"arrowParens": "always"');
+    expect(configContent).toContain('"endOfLine": "lf"');
+    expect(configContent).toContain('"quoteProps": "consistent"');
+    expect(configContent).toContain('"singleAttributePerLine": true');
+    expect(configContent).toContain('"embeddedLanguageFormatting": "off"');
+  });
+
+  it("should warn about unsupported options", async () => {
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({
+        semi: false,
+        experimentalTernaries: true,
+        proseWrap: "always",
+        htmlWhitespaceSensitivity: "css",
+      }),
+    );
+
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    // Check that stderr contains warnings
+    expect(snapshot).toContain("experimentalTernaries");
+    expect(snapshot).toContain("proseWrap");
+    expect(snapshot).toContain("htmlWhitespaceSensitivity");
+  });
+
+  it("should error when .oxfmtrc.jsonc already exists", async () => {
+    // Create .prettierrc
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({ semi: false }),
+    );
+
+    // Create .oxfmtrc.jsonc
+    await fs.writeFile(join(tempDir, ".oxfmtrc.jsonc"), "{}");
+
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    // Check that it's an error
+    expect(snapshot).toContain("Configuration file already exists");
+    expect(snapshot).toContain("exit code: 1");
+  });
+
+  it("should error when no prettier config found", async () => {
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    expect(snapshot).toContain("No Prettier configuration found");
+    expect(snapshot).toContain("exit code: 1");
+  });
+
+  it("should error for unknown migration source", async () => {
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "eslint"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    expect(snapshot).toContain("Unknown migration source");
+    expect(snapshot).toContain("exit code: 1");
+  });
+
+  it("should handle package.json prettier config", async () => {
+    // Create package.json with prettier config
+    await fs.writeFile(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        name: "test",
+        prettier: {
+          semi: false,
+          tabWidth: 8,
+        },
+      }),
+    );
+
+    const snapshot = await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+    expect(snapshot).toMatchSnapshot();
+
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"semi": false');
+    expect(configContent).toContain('"tabWidth": 8');
+  });
+
+  it("should handle empty .prettierignore", async () => {
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({ semi: false }),
+    );
+
+    // Create empty .prettierignore
+    await fs.writeFile(join(tempDir, ".prettierignore"), "");
+
+    await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"ignorePatterns": []');
+  });
+
+  it("should handle .prettierignore with only comments", async () => {
+    await fs.writeFile(
+      join(tempDir, ".prettierrc"),
+      JSON.stringify({ semi: false }),
+    );
+
+    await fs.writeFile(
+      join(tempDir, ".prettierignore"),
+      `# Just comments
+# No actual patterns
+`,
+    );
+
+    await runAndSnapshot(tempDir, [["--migrate", "prettier"]]);
+
+    const configContent = await fs.readFile(join(tempDir, ".oxfmtrc.jsonc"), "utf8");
+    expect(configContent).toContain('"ignorePatterns": []');
+  });
+});

--- a/apps/oxfmt/test/utils.ts
+++ b/apps/oxfmt/test/utils.ts
@@ -100,7 +100,10 @@ function normalizeOutput(output: string, cwd: string): string {
   const rootPath = repoRoot.replace(/\\/g, "/");
   normalized = normalized.replace(new RegExp(RegExp.escape(rootPath), "g"), "<cwd>");
   // Normalize temp directory paths (e.g., oxfmt-migrate-test-XXXXXX -> oxfmt-migrate-test-<random>)
-  normalized = normalized.replace(/oxfmt-migrate-test-[a-zA-Z0-9]{6}/g, "oxfmt-migrate-test-<random>");
+  normalized = normalized.replace(
+    /oxfmt-migrate-test-[a-zA-Z0-9]{6}/g,
+    "oxfmt-migrate-test-<random>",
+  );
   normalized = normalized.replace(/oxfmt-test-[a-zA-Z0-9]{6}/g, "oxfmt-test-<random>");
 
   return normalized;

--- a/apps/oxfmt/test/utils.ts
+++ b/apps/oxfmt/test/utils.ts
@@ -99,6 +99,9 @@ function normalizeOutput(output: string, cwd: string): string {
   const repoRoot = join(import.meta.dirname, "..", "..", "..");
   const rootPath = repoRoot.replace(/\\/g, "/");
   normalized = normalized.replace(new RegExp(RegExp.escape(rootPath), "g"), "<cwd>");
+  // Normalize temp directory paths (e.g., oxfmt-migrate-test-XXXXXX -> oxfmt-migrate-test-<random>)
+  normalized = normalized.replace(/oxfmt-migrate-test-[a-zA-Z0-9]{6}/g, "oxfmt-migrate-test-<random>");
+  normalized = normalized.replace(/oxfmt-test-[a-zA-Z0-9]{6}/g, "oxfmt-test-<random>");
 
   return normalized;
 }


### PR DESCRIPTION
For simplicity this PR only reads prettier config and .prettierignore from cwd.

closes #15849

Created by Claude, @leaysgur this over to you.