### PR TITLE
test(linter/plugins): fix garbled output from assertions

### DIFF
--- a/apps/oxlint/conformance/src/main.ts
+++ b/apps/oxlint/conformance/src/main.ts
@@ -1,0 +1,48 @@
+/*
+ * Main logic.
+ */
+
+// oxlint-disable no-console
+
+import Module from "node:module";
+import { join as pathJoin } from "node:path";
+import fs from "node:fs";
+import { runAllTests, CONFORMANCE_DIR_PATH, ESLINT_ROOT_DIR_PATH } from "./run.ts";
+import { generateReport } from "./report.ts";
+import { RuleTester } from "./rule_tester.ts";
+
+// Patch NodeJS's CommonJS loader to substitute ESLint's `RuleTester` with our own
+const RULE_TESTER_PATH = pathJoin(ESLINT_ROOT_DIR_PATH, "lib/rule-tester/rule-tester.js");
+
+const jsLoaderOriginal = (Module as any)._extensions[".js"];
+(Module as any)._extensions[".js"] = function (module: Module, path: string, ...args: any[]) {
+  if (path === RULE_TESTER_PATH) {
+    module.exports = RuleTester;
+  } else {
+    return jsLoaderOriginal.call(this, module, path, ...args);
+  }
+};
+
+// Run tests
+const results = runAllTests();
+
+// Write results to markdown file
+const OUTPUT_FILE_PATH = pathJoin(CONFORMANCE_DIR_PATH, "snapshot.md");
+
+const report = generateReport(results);
+fs.writeFileSync(OUTPUT_FILE_PATH, report);
+console.log(`\nResults written to: ${OUTPUT_FILE_PATH}`);
+
+// Print summary
+const totalRuleCount = results.length;
+const fullyPassingCount = results.filter(
+  (r) => !r.isLoadError && r.tests.length > 0 && r.tests.every((t) => t.isPassed),
+).length;
+const loadErrorCount = results.filter((r) => r.isLoadError).length;
+
+console.log("\n=====================================");
+console.log("Summary:");
+console.log(`  Total rules: ${totalRuleCount}`);
+console.log(`  Fully passing: ${fullyPassingCount}`);
+console.log(`  Load errors: ${loadErrorCount}`);
+console.log(`  With failures: ${totalRuleCount - fullyPassingCount - loadErrorCount}`);

--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -218,9 +218,6 @@ function formatError(err: Error | null): string {
   for (; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (line.startsWith("    at ")) break;
-    // These "diff" lines appear to be produced by `AssertionError` non-deterministically.
-    // This appears to be a bug in NodeJS's `assert` module. Remove them, to avoid churn in snapshot.
-    if (line.trimStart() === "^") continue;
     out += `${cleanString(line)}\n`;
   }
 


### PR DESCRIPTION
Conformance tester has been suffering from non-deterministic output from NodeJS's `assert` module. Fix this by setting `process.env.FORCE_COLOR` before loading any code.

This also allows leaving the `     ^` diff marker lines in output which were removed in #16723, as they should now appear consistently.