### PR TITLE
test(linter/plugins): conformance tester avoid repeated loops creating report

### DIFF
--- a/apps/oxlint/conformance/src/main.ts
+++ b/apps/oxlint/conformance/src/main.ts
@@ -35,10 +35,19 @@ console.log(`\nResults written to: ${OUTPUT_FILE_PATH}`);
 
 // Print summary
 const totalRuleCount = results.length;
-const fullyPassingCount = results.filter(
-  (r) => !r.isLoadError && r.tests.length > 0 && r.tests.every((t) => t.isPassed),
-).length;
-const loadErrorCount = results.filter((r) => r.isLoadError).length;
+let loadErrorCount = 0,
+  fullyPassingCount = 0;
+
+for (const rule of results) {
+  if (rule.isLoadError) {
+    loadErrorCount++;
+  } else {
+    const { tests } = rule;
+    if (tests.length > 0 && tests.every((test) => test.isPassed)) {
+      fullyPassingCount++;
+    }
+  }
+}
 
 console.log("\n=====================================");
 console.log("Summary:");

--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -44,10 +44,11 @@ export function runAllTests(): RuleResult[] {
     if (result.isLoadError) {
       console.log(" LOAD ERROR");
     } else {
-      const passed = result.tests.filter((t) => t.isPassed).length;
-      const total = result.tests.length;
-      const status = passed === total ? "PASS" : "FAIL";
-      console.log(` ${status} (${passed}/${total})`);
+      const { tests } = result,
+        totalCount = tests.length,
+        passedCount = tests.reduce((total, test) => total + (test.isPassed ? 1 : 0), 0),
+        status = passedCount === totalCount ? "PASS" : "FAIL";
+      console.log(` ${status} (${passedCount}/${totalCount})`);
     }
   }
 


### PR DESCRIPTION
Pure refactor to conformance tester. The code written by Claude looped over the same arrays 10+ times, and was hard to read. Instead, categorize rule results once at the start of preparing the report. Ditto for summary stats output to `stdout`.