### PR TITLE
test(linter/plugins): conformance tester add summary of failing tests to report

### DIFF
--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -123,6 +123,18 @@ export function generateReport(results: RuleResult[]): string {
   if (failingRules.length === 0) {
     lines.push("No rules with failures");
   } else {
+    // Summary
+    for (const rule of failingRules) {
+      const { testCount } = rule,
+        passedCount = testCount - rule.failingTests.length;
+      lines.push(`- \`${rule.ruleName}\` - ${formatProportion(passedCount, testCount)}`);
+    }
+    lines.push("");
+
+    // Details
+    lines.push("## Rules with Failures Detail");
+    lines.push("");
+
     for (const rule of failingRules) {
       const { testCount, failingTests } = rule,
         failedCount = failingTests.length,


### PR DESCRIPTION
Add a summary of rules with failing tests to the snapshot report, so can easily see which rules have the most failures.