### PR TITLE
fix(linter/plugins): `RuleTester` sort diagnostics before comparing to errors

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -514,6 +514,9 @@ function assertInvalidTestCasePasses(test: InvalidTestCase, plugin: Plugin, conf
     // `errors` is an array of error objects
     assertErrorCountIsCorrect(diagnostics, errors.length);
 
+    // Sort diagnostics by line and column before comparing to expected errors. ESLint does the same.
+    diagnostics.sort((diag1, diag2) => diag1.line - diag2.line || diag1.column - diag2.column);
+
     const rule = Object.values(plugin.rules)[0],
       messages = rule.meta?.messages ?? null;
 


### PR DESCRIPTION
`RuleTester` sort diagnostics in source order before comparing to expected errors. This follows what ESLint does (and it makes sense).

Conformance tests now fully passing for 11 more rules.