### PR TITLE
feat(semantic): add TS2670 error for global scope augmentation without declare modifier

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -159,8 +159,20 @@ pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &Sem
     check_ts_export_assignment_in_module_decl(decl, ctx);
 }
 
+fn global_scope_augmentation_should_have_declare_modifier(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "2670",
+        "Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context.",
+    )
+    .with_label(span)
+}
+
 pub fn check_ts_global_declaration<'a>(decl: &TSGlobalDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
     check_ts_module_or_global_declaration(decl.span, ctx);
+
+    if !decl.declare && !ctx.in_declare_scope() {
+        ctx.error(global_scope_augmentation_should_have_declare_modifier(decl.global_span));
+    }
 }
 
 fn check_ts_module_or_global_declaration(span: Span, ctx: &SemanticBuilder<'_>) {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: c21f73fd
 parser_typescript Summary:
 AST Parsed     : 9832/9833 (99.99%)
 Positive Passed: 9823/9833 (99.90%)
-Negative Passed: 1485/2547 (58.30%)
+Negative Passed: 1486/2547 (58.34%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -653,8 +653,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmen
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationEnumClassMergeOfReexportIsError.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal6.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal6_1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal7.ts
 
@@ -8165,6 +8163,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
   help: Only 'readonly' modifier is allowed here.
+
+  × TS(2670): Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context.
+   ╭─[typescript/tests/cases/compiler/moduleAugmentationGlobal6_1.ts:1:1]
+ 1 │ global {
+   · ──────
+ 2 │     interface Array<T> { x }
+   ╰────
 
   × Identifier `Kettle` has already been declared
     ╭─[typescript/tests/cases/compiler/moduleDuplicateIdentifiers.ts:20:14]


### PR DESCRIPTION
Report error when `global { }` is used without `declare` modifier and not in an already ambient context (like .d.ts files or inside `declare module` blocks).

Discovered while working on https://github.com/oxc-project/oxc/issues/16743

🤖 generated with help from Claude Opus 4.5