### PR TITLE
perf(linter/plugins): remove unnecessary check

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -185,10 +185,6 @@ const LANGUAGE_OPTIONS = freeze({
    * Globals defined for the file being linted.
    */
   get globals(): Readonly<Globals> | null {
-    if (filePath === null) {
-      throw new Error("Cannot access `context.languageOptions.globals` in `createOnce`");
-    }
-
     if (globals === null) initGlobals();
     debugAssertIsNonNull(globals);
 


### PR DESCRIPTION
This check is unnecessary as in order to obtain `languageOptions`, you have to go through `context.languageOptions` getter which already does the check.

If user hold onto the returned `languageOptions` object and accesses `globals` on it in a tick in between linting files, they'll just get `null` anyway.