### PR TITLE
build(linter/plugins): add conformance build

### DIFF
--- a/apps/oxlint/conformance/README.md
+++ b/apps/oxlint/conformance/README.md
@@ -9,11 +9,11 @@ The results are saved in `conformance/snapshot.md`.
 
 ## Setup
 
-Build Oxlint in debug mode:
+Build Oxlint in conformance mode:
 
 ```sh
 cd apps/oxlint
-pnpm run build-test
+pnpm run build-conformance
 ```
 
 Initialize ESLint submodule:

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm run build-napi-release && pnpm run build-js",
     "build-dev": "pnpm run build-napi && cross-env DEBUG=true pnpm run build-js",
     "build-test": "pnpm run build-napi-test && cross-env DEBUG=true pnpm run build-js",
+    "build-conformance": "pnpm run build-napi-test && cross-env CONFORMANCE=true pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
     "build-napi-test": "pnpm run build-napi --features force_test_reporter",
     "build-napi-release": "pnpm run build-napi --release --features allocator",

--- a/apps/oxlint/src-js/globals.d.ts
+++ b/apps/oxlint/src-js/globals.d.ts
@@ -1,2 +1,7 @@
-// Global constant defined at build time by TSDown
+// Global constants defined at build time by TSDown
+
+// `true` if is debug build
 declare const DEBUG: boolean;
+
+// `true` if is build for conformance testing
+declare const CONFORMANCE: boolean;

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -427,7 +427,7 @@ export class RuleTester {
 // This is used in conformance tester.
 let modifyTestCase: ((test: TestCase) => void) | null = null;
 
-if (DEBUG) {
+if (CONFORMANCE) {
   (RuleTester as any).registerModifyTestCaseHook = (alter: (test: TestCase) => void) => {
     modifyTestCase = alter;
   };
@@ -744,7 +744,7 @@ function getMessagePlaceholders(message: string): string[] {
   return Array.from(message.matchAll(PLACEHOLDER_REGEX), ([, name]) => name.trim());
 }
 
-// In debug builds, wrap `runValidTestCase` and `runInvalidTestCase` to add test case to error object.
+// In conformance build, wrap `runValidTestCase` and `runInvalidTestCase` to add test case to error object.
 // This is used in conformance tests.
 type RunFunction<T> = (test: T, plugin: Plugin, config: Config, seenTestCases: Set<string>) => void;
 
@@ -763,7 +763,7 @@ function wrapRunTestCaseFunction<T extends ValidTestCase | InvalidTestCase>(
   };
 }
 
-if (DEBUG) {
+if (CONFORMANCE) {
   // oxlint-disable-next-line no-func-assign
   (runValidTestCase as any) = wrapRunTestCaseFunction(runValidTestCase);
   // oxlint-disable-next-line no-func-assign
@@ -819,8 +819,8 @@ function mergeConfigIntoTestCase<T extends ValidTestCase | InvalidTestCase>(
   };
 
   // Call hook to modify test case before it is run.
-  // `modifyTestCase` is only available in debug builds - it's only for conformance testing.
-  if (DEBUG && modifyTestCase !== null) modifyTestCase(merged);
+  // `modifyTestCase` is only available in conformance build - it's only for conformance testing.
+  if (CONFORMANCE && modifyTestCase !== null) modifyTestCase(merged);
 
   return merged;
 }

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -4,9 +4,17 @@ import { parseSync, Visitor } from "oxc-parser";
 
 import type { Plugin } from "rolldown";
 
+const { env } = process;
+const isEnabled = (env: string | undefined) => env === "true" || env === "1";
+
+// When run with `CONFORMANCE=true pnpm run build-js`, generate a conformance build with alterations to behavior.
+// Also enables debug assertions.
+// This is the build used in conformance tests.
+const CONFORMANCE = isEnabled(env.CONFORMANCE);
+
 // When run with `DEBUG=true pnpm run build-js`, generate a debug build with extra assertions.
 // This is the build used in tests.
-const DEBUG = process.env.DEBUG === "true" || process.env.DEBUG === "1";
+const DEBUG = CONFORMANCE || isEnabled(env.DEBUG);
 
 const commonConfig = defineConfig({
   platform: "node",
@@ -38,7 +46,10 @@ export default defineConfig([
     },
     dts: { resolve: true },
     attw: { profile: "esm-only" },
-    define: { DEBUG: DEBUG ? "true" : "false" },
+    define: {
+      DEBUG: DEBUG ? "true" : "false",
+      CONFORMANCE: CONFORMANCE ? "true" : "false",
+    },
     plugins: DEBUG ? [] : [createReplaceAssertsPlugin()],
     inputOptions: {
       // For `replaceAssertsPlugin`

--- a/apps/oxlint/vitest.config.ts
+++ b/apps/oxlint/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   },
   define: {
     DEBUG: "true",
+    CONFORMANCE: "false",
   },
 });


### PR DESCRIPTION
Supporting conformance testing is requiring adding extra code paths to `RuleTester` and main JS plugins code.

Previously, these paths were guarded by `if (DEBUG)` branches, so the extra code is not in release build. But ideally we don't want this code in debug build either, so the tests are testing a build that's identical to release build, except for enabling debug assertions.

Introduce a new build specifically for conformance testing, and gate code specific to conformance testing with `if (CONFORMANCE)` instead of `if (DEBUG)`.
