### PR TITLE
feat(semantic): add TS1038 "declare modifier cannot be used in an already ambient context"

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -76,8 +76,11 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
             }
             ts::check_class(class, ctx);
         }
-        AstKind::Function(func) if !ctx.source_type.is_typescript() => {
-            js::check_function_redeclaration(func, ctx);
+        AstKind::Function(func) => {
+            if !ctx.source_type.is_typescript() {
+                js::check_function_redeclaration(func, ctx);
+            }
+            ts::check_function(func, ctx);
         }
         AstKind::MethodDefinition(method) => {
             ts::check_method_definition(method, ctx);
@@ -100,6 +103,9 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::ObjectExpression(expr) => js::check_object_expression(expr, ctx),
         AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, ctx),
         AstKind::YieldExpression(expr) => js::check_yield_expression(expr, ctx),
+        AstKind::VariableDeclaration(decl) => {
+            ts::check_variable_declaration(decl, ctx);
+        }
         AstKind::VariableDeclarator(decl) => {
             if !ctx.source_type.is_typescript() {
                 js::check_variable_declarator_redeclaration(decl, ctx);

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: c21f73fd
 parser_typescript Summary:
 AST Parsed     : 9832/9833 (99.99%)
 Positive Passed: 9823/9833 (99.90%)
-Negative Passed: 1486/2547 (58.34%)
+Negative Passed: 1495/2547 (58.70%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -205,10 +205,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/corrupted.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/crashRegressionTest.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
 
@@ -763,8 +759,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidat
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidation5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelAmbientExternalModuleImportWithExport.ts
 
@@ -1752,8 +1746,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration18.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
@@ -1761,8 +1753,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.d.ts
 
@@ -1783,8 +1773,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment9.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts
 
@@ -1826,11 +1814,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration2.d.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration3.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration4.d.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList14.ts
 
@@ -1899,8 +1883,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 
@@ -4856,6 +4838,70 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ var na=new number[];
    ·                   ─
  2 │ 
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts:2:5]
+ 1 │ declare namespace M {
+ 2 │     declare var x;
+   ·     ──────────────
+ 3 │     declare function f();
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts:3:5]
+ 2 │     declare var x;
+ 3 │     declare function f();
+   ·     ─────────────────────
+ 4 │ 
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts:5:5]
+ 4 │ 
+ 5 │     declare namespace N { }
+   ·     ───────────────────────
+ 6 │ 
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFile.ts:7:5]
+ 6 │ 
+ 7 │     declare class C { }
+   ·     ───────────────────
+ 8 │ }
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts:2:5]
+ 1 │ declare namespace M {
+ 2 │     declare var x;
+   ·     ──────────────
+ 3 │     declare function f();
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts:3:5]
+ 2 │     declare var x;
+ 3 │     declare function f();
+   ·     ─────────────────────
+ 4 │ 
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts:5:5]
+ 4 │ 
+ 5 │     declare namespace N { }
+   ·     ───────────────────────
+ 6 │ 
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/compiler/declFileWithErrorsInInputDeclarationFileWithOut.ts:7:5]
+ 6 │ 
+ 7 │     declare class C { }
+   ·     ───────────────────
+ 8 │ }
    ╰────
 
   × Identifier `a` has already been declared
@@ -9713,6 +9759,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·           ──────
    ╰────
 
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:133:9]
+ 132 │         namespace m2 {
+ 133 │ ╭─▶         declare module "abc" {
+ 134 │ ╰─▶         }
+ 135 │         }
+     ╰────
+
   × TS(1029): 'export' modifier must precede 'declare' modifier.
      ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:326:9]
  325 │ 
@@ -9729,6 +9783,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  327 │     namespace m2 {
      ╰────
   help: Only 'declare' modifier is allowed here.
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:314:9]
+ 313 │         namespace m2 {
+ 314 │ ╭─▶         declare module "abc" {
+ 315 │ ╰─▶         }
+ 316 │         }
+     ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:328:9]
+ 327 │         namespace m2 {
+ 328 │ ╭─▶         declare module "abc" {
+ 329 │ ╰─▶         }
+ 330 │         }
+     ╰────
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/privateNameJsx.tsx:4:22]
@@ -21183,6 +21253,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Remove the extra base class or use interfaces for multiple inheritance
 
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.ts:2:3]
+ 1 │     declare namespace M {
+ 2 │ ╭─▶   declare class C {
+ 3 │ ╰─▶   }
+ 4 │     }
+   ╰────
+
   × TS(2390): Constructor implementation is missing.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration8.ts:2:3]
  1 │ class C {
@@ -21292,6 +21370,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  2 │   1, 2, 3
    ·   ─
  3 │ }
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration2.ts:2:3]
+ 1 │     declare namespace M {
+ 2 │ ╭─▶   declare enum E {
+ 3 │ ╰─▶   }
+ 4 │     }
    ╰────
 
   × Identifier expected. 'void' is a reserved word that cannot be used here.
@@ -21977,6 +22063,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·    ─────────
    ╰────
 
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts:2:3]
+ 1 │ declare namespace M {
+ 2 │   declare function F();
+   ·   ─────────────────────
+ 3 │ }
+   ╰────
+
   × TS(1183): An implementation cannot be declared in ambient contexts.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.ts:1:24]
  1 │ declare function Foo() {
@@ -22488,6 +22582,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MissingTokens/parserMissingToken2.ts:1:1]
  1 │ / b;
    · ────
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration3.ts:2:3]
+ 1 │     declare namespace M {
+ 2 │ ╭─▶   declare namespace M2 {
+ 3 │ ╰─▶   }
+ 4 │     }
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration5.ts:3:5]
+ 2 │       declare namespace M2 {
+ 3 │ ╭─▶     declare namespace M3 {
+ 4 │ ╰─▶     }
+ 5 │       }
    ╰────
 
   × Expected `(` but found `;`
@@ -23487,6 +23597,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts:1:7]
  1 │ var a,;
    ·       ─
+   ╰────
+
+  × TS(1038): A 'declare' modifier cannot be used in an already ambient context.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.ts:2:4]
+ 1 │ declare namespace M {
+ 2 │    declare var v;
+   ·    ──────────────
+ 3 │ }
    ╰────
 
   × Unexpected token


### PR DESCRIPTION
Implement TypeScript error TS1038 which reports when the `declare` modifier is used inside a `declare namespace` or `declare module` block.

This correctly allows `declare` at the top level of `.d.ts` files, but errors when `declare` is nested inside another `declare` block.

🤖 generated with help from Claude Opus 4.5