### PR TITLE
test(linter/plugins): remove non-deterministic error output in conformance tester

### DIFF
--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -243,6 +243,9 @@ function formatError(err: Error | null): string {
   for (; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (line.startsWith("    at ")) break;
+    // These `      ^` diff marker lines appear to be produced by `AssertionError` non-deterministically.
+    // This appears to be a bug in NodeJS's `assert` module. Remove them, to avoid churn in snapshot.
+    if (line.trimStart() === "^") continue;
     out += `${cleanString(line)}\n`;
   }
 


### PR DESCRIPTION
Repeat of #16723. `^` diff marker lines still appear and disappear non-deterministically. It seems #16738 didn't fix it after all. Grrr.