### PR TITLE
test(linter/plugins): conformance tests skip rules where all fails are due to custom parsers

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -9,8 +9,9 @@ type Filter = string | string[];
 export const FILTER_ONLY_RULE: Filter | null = null;
 export const FILTER_ONLY_CODE: Filter | null = null;
 
-// Filter out rules which use CFG, which we don't support yet
+// Filter out rules where test failures are expected
 export const FILTER_EXCLUDE_RULE: Filter | null = [
+  // Rules which use CFG - which we don't support yet
   "array-callback-return",
   "complexity",
   "consistent-return",
@@ -26,4 +27,23 @@ export const FILTER_EXCLUDE_RULE: Filter | null = [
   "no-useless-assignment",
   "no-useless-return",
   "require-atomic-updates",
+  // Rules where only test failures are due to using a custom parser
+  "array-bracket-spacing",
+  "arrow-parens",
+  "function-paren-newline",
+  "keyword-spacing",
+  "new-parens",
+  "no-extra-boolean-cast",
+  "no-unexpected-multiline",
+  "no-unneeded-ternary",
+  "no-useless-constructor",
+  "no-useless-rename",
+  "no-var",
+  "object-curly-newline",
+  "object-curly-spacing",
+  "object-shorthand",
+  "require-await",
+  "space-before-blocks",
+  "space-before-function-paren",
+  "space-infix-ops",
 ];


### PR DESCRIPTION
For some rules, the only failing tests are due to test cases specifying custom parsers, which we don't support. Skip testing these rules, since the test failures are expected.