### PR TITLE
fix(oxfmt): Remove `jsonc` parser override for `(j|t)sconfig(.*)?.json`

### DIFF
--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -143,14 +143,12 @@ impl SourceFormatter {
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
 
-        // NOTE: To call Prettier, we need to either infer the parser from `filepath` or specify the `parser`.
+        // NOTE: To call Prettier, we need to either:
+        // - let Prettier infer the parser from `filepath`
+        // - or specify the `parser`
         //
-        // We are specifying the `parser`, so `filepath` is not actually necessary,
+        // We are specifying the `parser` for perf, so `filepath` is not actually necessary,
         // but since some plugins might depend on `filepath`, we pass the actual file name as well.
-        //
-        // In that sense, it might be OK to just pass `filepath` without specifying `parser`,
-        // but considering cases like treating `tsconfig.json` as `jsonc`, we need to specify `parser` as well.
-        // (without supporting `overrides` in config file)
         let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
 
         external_formatter.format_file(parser_name, file_name, source_text).map_err(|err| {

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -78,12 +78,6 @@ fn get_external_format_source(path: PathBuf) -> Option<FormatFileStrategy> {
     if JSON_FILENAMES.contains(file_name) {
         return Some(FormatFileStrategy::ExternalFormatter { path, parser_name: "json" });
     }
-    // Must be checked before generic JSON/JSONC
-    if (file_name.starts_with("tsconfig.") || file_name.starts_with("jsconfig."))
-        && extension == Some("json")
-    {
-        return Some(FormatFileStrategy::ExternalFormatter { path, parser_name: "jsonc" });
-    }
     if let Some(ext) = extension
         && JSON_EXTENSIONS.contains(ext)
     {
@@ -340,8 +334,6 @@ mod tests {
             // JSON
             ("package.json", Some("json-stringify")),
             ("config.importmap", Some("json-stringify")),
-            ("tsconfig.json", Some("jsonc")),
-            ("jsconfig.dev.json", Some("jsonc")),
             ("data.json", Some("json")),
             ("schema.avsc", Some("json")),
             ("config.code-workspace", Some("jsonc")),

--- a/apps/oxfmt/test/__snapshots__/external_formatter.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/external_formatter.test.ts.snap
@@ -76,8 +76,8 @@ tsconfig.dummy.json
   // Allow comments!
   "compilerOptions": {
     "module": "commonjs",
-    "strict": true,
-  },
+    "strict": true
+  }
 }
 
 --------------------"


### PR DESCRIPTION
Fixes #16637