### PR TITLE
fix(oxfmt): Make Rust CLI as just formatting CLI

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -43,26 +43,35 @@ pub struct FormatCommand {
 pub enum Mode {
     /// Default CLI mode run against files and directories
     Cli(OutputMode),
+    #[cfg(feature = "napi")]
     /// Initialize `.oxfmtrc.jsonc` with default values
     Init,
+    #[cfg(feature = "napi")]
     /// Start language server protocol (LSP) server
     Lsp,
 }
 
 fn mode() -> impl bpaf::Parser<Mode> {
-    let init = bpaf::long("init")
-        .help("Initialize `.oxfmtrc.jsonc` with default values")
-        .req_flag(Mode::Init)
-        .hide_usage();
-    let lsp = bpaf::long("lsp")
-        .help("Start language server protocol (LSP) server")
-        .req_flag(Mode::Lsp)
-        .hide_usage();
-    let mode_options = bpaf::construct!([init, lsp]).group_help("Mode Options:");
-
     let output_mode_options = output_mode().map(Mode::Cli);
 
-    bpaf::construct!([mode_options, output_mode_options]).fallback(Mode::Cli(OutputMode::Write))
+    #[cfg(feature = "napi")]
+    {
+        let init = bpaf::long("init")
+            .help("Initialize `.oxfmtrc.jsonc` with default values")
+            .req_flag(Mode::Init)
+            .hide_usage();
+        let lsp = bpaf::long("lsp")
+            .help("Start language server protocol (LSP) server")
+            .req_flag(Mode::Lsp)
+            .hide_usage();
+        let mode_options = bpaf::construct!([init, lsp]).group_help("Mode Options:");
+
+        bpaf::construct!([mode_options, output_mode_options]).fallback(Mode::Cli(OutputMode::Write))
+    }
+    #[cfg(not(feature = "napi"))]
+    {
+        output_mode_options.fallback(Mode::Cli(OutputMode::Write))
+    }
 }
 
 /// Format output mode

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -56,6 +56,8 @@ impl FormatRunner {
         let cwd = self.cwd;
         let FormatCommand { paths, mode, config_options, ignore_options, runtime_options } =
             self.options;
+        // If `napi` feature is disabled, there is no other mode.
+        #[cfg_attr(not(feature = "napi"), expect(irrefutable_let_patterns))]
         let Mode::Cli(format_mode) = mode else {
             unreachable!("`FormatRunner` should only be called with Mode::Cli");
         };

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -1,28 +1,18 @@
 use oxfmt::cli::{
-    CliRunResult, FormatRunner, Mode, format_command, init_miette, init_rayon, init_tracing,
+    CliRunResult, FormatRunner, format_command, init_miette, init_rayon, init_tracing,
 };
-use oxfmt::init::run_init;
-use oxfmt::lsp::run_lsp;
 
 // Pure Rust CLI entry point.
-// For JS CLI entry point, see `format()` exported by `main_napi.rs`.
+// This CLI only supports the basic `Cli` mode.
+// For full featured JS CLI entry point, see `format()` exported by `main_napi.rs`.
 
 #[tokio::main]
 async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = format_command().run();
 
-    match command.mode {
-        Mode::Init => run_init(),
-        Mode::Lsp => {
-            run_lsp().await;
-            CliRunResult::None
-        }
-        Mode::Cli(_) => {
-            init_tracing();
-            init_miette();
-            init_rayon(command.runtime_options.threads);
-            FormatRunner::new(command).run()
-        }
-    }
+    init_tracing();
+    init_miette();
+    init_rayon(command.runtime_options.threads);
+    FormatRunner::new(command).run()
 }

--- a/tasks/website_formatter/Cargo.toml
+++ b/tasks/website_formatter/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 bpaf = { workspace = true, features = ["docgen"] }
 oxc_formatter = { path = "../../crates/oxc_formatter" }
-oxfmt = { path = "../../apps/oxfmt", default-features = false }
+oxfmt = { path = "../../apps/oxfmt" }
 pico-args = { workspace = true }
 schemars = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
When adding new features primarily using JS via napi, to reduce future maintenance burdens such as missed implementations.