### PR TITLE
fix(oxfmt): Report `exitCode` correctly

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -9,6 +9,8 @@
  * 3. `format_embedded_cb`: Callback to format embedded code in templates
  * 4. `format_file_cb`: Callback to format files
  *
- * Returns `true` if formatting succeeded without errors, `false` otherwise.
+ * Returns a tuple of `[mode, exitCode]`:
+ * - `mode`: "cli" | "lsp" | "init"
+ * - `exitCode`: exit code (0, 1, 2) for "cli" mode, `undefined` for other modes
  */
-export declare function format(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<boolean>
+export declare function runCli(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/bindings.js
+++ b/apps/oxfmt/src-js/bindings.js
@@ -575,5 +575,5 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { format } = nativeBinding
-export { format }
+const { runCli } = nativeBinding
+export { runCli }

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,20 +1,27 @@
-import { format } from "./bindings.js";
+import { runCli } from "./bindings.js";
 import { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 import { runInit } from "./migration/init.js";
 
 void (async () => {
   const args = process.argv.slice(2);
 
-  // Handle `--init` command in JS
-  if (args.includes("--init")) {
-    return await runInit();
+  // Call the Rust CLI to parse args and determine mode
+  const [mode, exitCode] = await runCli(args, setupConfig, formatEmbeddedCode, formatFile);
+
+  switch (mode) {
+    // Handle `--init` command in JS
+    case "init":
+      await runInit();
+      break;
+    // LSP mode is handled by Rust, nothing to do here
+    case "lsp":
+      break;
+    // CLI mode also handled by Rust, just need to set exit code
+    case "cli":
+      // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
+      // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
+      // https://nodejs.org/api/process.html#processexitcode
+      if (exitCode) process.exitCode = exitCode;
+      break;
   }
-
-  // Call the Rust formatter with our JS callback
-  const success = await format(args, setupConfig, formatEmbeddedCode, formatFile);
-
-  // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
-  // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
-  // https://nodejs.org/api/process.html#processexitcode
-  if (!success) process.exitCode = 1;
 })();

--- a/apps/oxfmt/src/cli/result.rs
+++ b/apps/oxfmt/src/cli/result.rs
@@ -13,12 +13,18 @@ pub enum CliRunResult {
     FormatFailed,
 }
 
+impl CliRunResult {
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            Self::None | Self::FormatSucceeded => 0,
+            Self::InvalidOptionConfig | Self::FormatMismatch => 1,
+            Self::NoFilesFound | Self::FormatFailed => 2,
+        }
+    }
+}
+
 impl Termination for CliRunResult {
     fn report(self) -> ExitCode {
-        match self {
-            Self::None | Self::FormatSucceeded => ExitCode::from(0),
-            Self::InvalidOptionConfig | Self::FormatMismatch => ExitCode::from(1),
-            Self::NoFilesFound | Self::FormatFailed => ExitCode::from(2),
-        }
+        ExitCode::from(self.exit_code())
     }
 }

--- a/apps/oxfmt/src/main.rs
+++ b/apps/oxfmt/src/main.rs
@@ -4,7 +4,7 @@ use oxfmt::cli::{
 
 // Pure Rust CLI entry point.
 // This CLI only supports the basic `Cli` mode.
-// For full featured JS CLI entry point, see `format()` exported by `main_napi.rs`.
+// For full featured JS CLI entry point, see `run_cli()` exported by `main_napi.rs`.
 
 #[tokio::main]
 async fn main() -> CliRunResult {

--- a/apps/oxfmt/test/__snapshots__/ignore_and_override.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/ignore_and_override.test.ts.snap
@@ -18,7 +18,7 @@ Finished in <variable>ms on 1 files using 1 threads.
 --------------------
 arguments: --check --ignore-path ignore1
 working directory: fixtures/ignore_and_override
-exit code: 1
+exit code: 2
 --- STDOUT ---------
 Checking formatting...
 
@@ -28,7 +28,7 @@ Expected at least one target file
 --------------------
 arguments: --check --ignore-path ignore1 should_format/ok.js
 working directory: fixtures/ignore_and_override
-exit code: 1
+exit code: 2
 --- STDOUT ---------
 
 --- STDERR ---------

--- a/apps/oxfmt/test/__snapshots__/no_error_on_unmatched_pattern.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/no_error_on_unmatched_pattern.test.ts.snap
@@ -15,7 +15,7 @@ No files found matching the given patterns.
 --------------------
 arguments: --check __non__existent__file.js
 working directory: fixtures
-exit code: 1
+exit code: 2
 --- STDOUT ---------
 Checking formatting...
 


### PR DESCRIPTION
Previously,

- `oxfmt(napi) not-exists.js` returns `exitCode: 1`
- `oxfmt(rust) not-exists.js` returns `exitCode: 2` = Expected

To fix this, I updated napi callback return value from `bool`.

Additionally, I realized that by returning the processing `Mode` simultaneously, Rust can handle the CLI arguments in better way. Like `--init --help`, which now shows help.

And finally changed napi binding name from `format()` to `runCli()` for the future Node API.