### PR TITLE
feat(oxfmt): Support `oxfmt --migrate [prettier]` (Rust side)

### DIFF
--- a/apps/oxfmt/src/cli/mod.rs
+++ b/apps/oxfmt/src/cli/mod.rs
@@ -6,6 +6,8 @@ mod result;
 mod service;
 mod walk;
 
+#[cfg(feature = "napi")]
+pub use command::MigrateSource;
 pub use command::{Mode, format_command};
 pub use format::FormatRunner;
 pub use init::{init_miette, init_rayon, init_tracing};

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -52,6 +52,7 @@ pub async fn run_cli(
 
     match command.mode {
         Mode::Init => ("init".to_string(), None),
+        Mode::Migrate(_) => ("migrate:prettier".to_string(), None),
         Mode::Lsp => {
             run_lsp().await;
             ("lsp".to_string(), None)

--- a/tasks/website_formatter/src/snapshots/cli.snap
+++ b/tasks/website_formatter/src/snapshots/cli.snap
@@ -15,6 +15,8 @@ search: false
   Initialize `.oxfmtrc.json` with default values
 - **`    --lsp`** &mdash; 
   Start language server protocol (LSP) server
+- **`    --migrate`**=_`SOURCE`_ &mdash; 
+  Migrate configuration to `.oxfmtrc.json` from specified source Available sources: prettier
 
 
 

--- a/tasks/website_formatter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_formatter/src/snapshots/cli_terminal.snap
@@ -7,6 +7,8 @@ Usage: [-c=PATH] [PATH]...
 Mode Options:
         --init               Initialize `.oxfmtrc.json` with default values
         --lsp                Start language server protocol (LSP) server
+        --migrate=SOURCE     Migrate configuration to `.oxfmtrc.json` from specified source
+                             Available sources: prettier
 
 Output Options:
         --write              Format and write files in place (default)


### PR DESCRIPTION
Part of #15849 

```
Usage: [-c=PATH] [PATH]...

Mode Options:
        --init               Initialize `.oxfmtrc.json` with default values
        --lsp                Start language server protocol (LSP) server
        --migrate=SOURCE     Migrate configuration to `.oxfmtrc.json` from specified source
                             Available sources: prettier

...
```

At this point, do nothing and just exit. The JS side will be in the next PR.