### PR TITLE
chore(linter): Remove one last reference to the regexp plugin.

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -521,7 +521,6 @@ fn plugin_name_to_prefix(plugin_name: &'static str) -> &'static str {
         "vitest" => "eslint-plugin-vitest",
         "node" => "eslint-plugin-node",
         "vue" => "eslint-plugin-vue",
-        "regexp" => "eslint-plugin-regexp",
         _ => plugin_name,
     }
 }


### PR DESCRIPTION
Eliminate one more reference that was still lingering.