### PR TITLE
refactor(lsp): tools can report diagnostics for other uris too

### DIFF
--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@debugger.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@debugger.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/cross_module/debugger.ts
+Linted file: fixtures/linter/cross_module/debugger.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/cross_module/debugger.ts
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module@dep-a.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/cross_module/dep-a.ts
+Linted file: fixtures/linter/cross_module/dep-a.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/cross_module/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-cycle for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config@dep-a.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/cross_module_extended_config/dep-a.ts
+Linted file: fixtures/linter/cross_module_extended_config/dep-a.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/cross_module_extended_config/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-cycle for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -2,16 +2,18 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/cross_module_nested_config/dep-a.ts
+Linted file: fixtures/linter/cross_module_nested_config/dep-a.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/cross_module_nested_config/dep-a.ts
 
 ########### Code Actions/Commands
 
 ########## 
-file: fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
+Linted file: fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
@@ -23,6 +25,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-cycle for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_deny_no_console@hello_world.js.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/deny_no_console/hello_world.js
+Linted file: fixtures/linter/deny_no_console/hello_world.js
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/deny_no_console/hello_world.js
 
 code: "eslint(no-console)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-console for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/frameworks/astro/debugger.astro
+Linted file: fixtures/linter/frameworks/astro/debugger.astro
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/frameworks/astro/debugger.astro
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -49,6 +50,7 @@ related_information[0].location.range: Range { start: Position { line: 18, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement
@@ -267,9 +269,10 @@ TextEdit: TextEdit {
 
 
 ########## 
-file: fixtures/linter/frameworks/vue/debugger.vue
+Linted file: fixtures/linter/frameworks/vue/debugger.vue
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/frameworks/vue/debugger.vue
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -292,6 +295,7 @@ related_information[0].location.range: Range { start: Position { line: 8, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement
@@ -402,9 +406,10 @@ TextEdit: TextEdit {
 
 
 ########## 
-file: fixtures/linter/frameworks/svelte/debugger.svelte
+Linted file: fixtures/linter/frameworks/svelte/debugger.svelte
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/frameworks/svelte/debugger.svelte
 
 code: "eslint(no-unassigned-vars)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html"
@@ -438,6 +443,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-unassigned-vars for this line
@@ -566,9 +572,10 @@ TextEdit: TextEdit {
 
 
 ########## 
-file: fixtures/linter/frameworks/nextjs/[[..rest]]/debugger.ts
+Linted file: fixtures/linter/frameworks/nextjs/[[..rest]]/debugger.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/frameworks/nextjs/%5B%5B..rest%5D%5D/debugger.ts
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -580,6 +587,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -2,13 +2,14 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/ignore_patterns/ignored-file.ts
+Linted file: fixtures/linter/ignore_patterns/ignored-file.ts
 ----------
-File is ignored
+No diagnostics / Files are ignored
 ########## 
-file: fixtures/linter/ignore_patterns/another_config/not-ignored-file.ts
+Linted file: fixtures/linter/ignore_patterns/another_config/not-ignored-file.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/ignore_patterns/another_config/not-ignored-file.ts
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -20,6 +21,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_invalid_syntax@debugger.ts_invalid.vue.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_invalid_syntax@debugger.ts_invalid.vue.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/invalid_syntax/debugger.ts
+Linted file: fixtures/linter/invalid_syntax/debugger.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/invalid_syntax/debugger.ts
 
 code: ""
 code_description.href: "None"
@@ -16,12 +17,14 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 
 ########## 
-file: fixtures/linter/invalid_syntax/invalid.vue
+Linted file: fixtures/linter/invalid_syntax/invalid.vue
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/invalid_syntax/invalid.vue
 
 code: ""
 code_description.href: "None"
@@ -33,4 +36,5 @@ related_information[0].location.range: Range { start: Position { line: 2, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_14565@foo-bar.astro.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_14565@foo-bar.astro.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/issue_14565/foo-bar.astro
+Linted file: fixtures/linter/issue_14565/foo-bar.astro
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/issue_14565/foo-bar.astro
 
 code: "eslint-plugin-unicorn(filename-case)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/filename-case.html"
@@ -16,4 +17,5 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958@issue.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958@issue.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/issue_9958/issue.ts
+Linted file: fixtures/linter/issue_9958/issue.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/issue_9958/issue.ts
 
 code: "eslint(no-extra-boolean-cast)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast.html"
@@ -41,6 +42,7 @@ related_information[0].location.range: Range { start: Position { line: 11, chara
 severity: Some(Hint)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-extra-boolean-cast for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_js_plugins@index.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_js_plugins@index.js.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/js_plugins/index.js
+Linted file: fixtures/linter/js_plugins/index.js
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/js_plugins/index.js
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_multiple_suggestions@forward_ref.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/multiple_suggestions/forward_ref.ts
+Linted file: fixtures/linter/multiple_suggestions/forward_ref.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/multiple_suggestions/forward_ref.ts
 
 code: "eslint-plugin-react(forward-ref-uses-ref)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/react/forward-ref-uses-ref.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: remove `forwardRef` wrapper

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_no_errors@hello_world.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_no_errors@hello_world.js.snap
@@ -2,8 +2,9 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/no_errors/hello_world.js
+Linted file: fixtures/linter/no_errors/hello_world.js
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/no_errors/hello_world.js
 
 ########### Code Actions/Commands

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature@index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature@index.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/regexp_feature/index.ts
+Linted file: fixtures/linter/regexp_feature/index.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/regexp_feature/index.ts
 
 code: "eslint(no-control-regex)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex.html"
@@ -27,6 +28,7 @@ related_information[0].location.range: Range { start: Position { line: 0, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-control-regex for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_ts_path_alias@deep__src__dep-a.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/ts_path_alias/deep/src/dep-a.ts
+Linted file: fixtures/linter/ts_path_alias/deep/src/dep-a.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/ts_path_alias/deep/src/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
@@ -16,6 +17,7 @@ related_information[0].location.range: Range { start: Position { line: 1, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-cycle for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint@no-floating-promises__index.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/tsgolint/no-floating-promises/index.ts
+Linted file: fixtures/linter/tsgolint/no-floating-promises/index.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/tsgolint/no-floating-promises/index.ts
 
 code: "eslint(no-unused-expressions)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html"
@@ -71,6 +72,7 @@ related_information[0].location.range: Range { start: Position { line: 13, chara
 severity: Some(Warning)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-unused-expressions for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_tsgolint_unused_disabled_directives@test.ts.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/tsgolint/unused_disabled_directives/test.ts
+Linted file: fixtures/linter/tsgolint/unused_disabled_directives/test.ts
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/tsgolint/unused_disabled_directives/test.ts
 
 code: "typescript-eslint(no-floating-promises)"
 code_description.href: "None"
@@ -27,6 +28,7 @@ related_information[0].location.range: Range { start: Position { line: 38, chara
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-floating-promises for this line

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_unused_disabled_directives@test.js.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 ########## 
-file: fixtures/linter/unused_disabled_directives/test.js
+Linted file: fixtures/linter/unused_disabled_directives/test.js
 ----------
 ########## Diagnostic Reports
+File URI: file://<variable>/fixtures/linter/unused_disabled_directives/test.js
 
 code: "eslint(no-console)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
@@ -60,6 +61,7 @@ related_information[0].location.range: Range { start: Position { line: 8, charac
 severity: Some(Error)
 source: Some("oxc")
 tags: None
+
 ########### Code Actions/Commands
 CodeAction: 
 Title: Disable no-console for this line

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -8,7 +8,7 @@ use tower_lsp_server::{
     ls_types::*,
 };
 
-use crate::{Tool, ToolBuilder, ToolRestartChanges, backend::Backend};
+use crate::{Tool, ToolBuilder, ToolRestartChanges, backend::Backend, tool::DiagnosticResult};
 
 pub struct FakeToolBuilder;
 
@@ -124,29 +124,28 @@ impl Tool for FakeTool {
         vec![]
     }
 
-    fn run_diagnostic(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         if uri.as_str().ends_with("diagnostics.config") {
-            return Some(vec![Diagnostic {
-                message: format!(
-                    "Fake diagnostic for content: {}",
-                    content.unwrap_or("<no content>")
-                ),
-                ..Default::default()
-            }]);
+            return vec![(
+                uri.clone(),
+                vec![Diagnostic {
+                    message: format!(
+                        "Fake diagnostic for content: {}",
+                        content.unwrap_or("<no content>")
+                    ),
+                    ..Default::default()
+                }],
+            )];
         }
-        None
+        vec![]
     }
 
-    fn run_diagnostic_on_change(
-        &self,
-        uri: &Uri,
-        content: Option<&str>,
-    ) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic_on_change(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         // For this fake tool, we use the same logic as run_diagnostic
         self.run_diagnostic(uri, content)
     }
 
-    fn run_diagnostic_on_save(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<Diagnostic>> {
+    fn run_diagnostic_on_save(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         // For this fake tool, we use the same logic as run_diagnostic
         self.run_diagnostic(uri, content)
     }

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -14,6 +14,8 @@ pub trait ToolBuilder: Send + Sync {
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;
 }
 
+pub type DiagnosticResult = Vec<(Uri, Vec<Diagnostic>)>;
+
 pub trait Tool: Send + Sync {
     /// Get the name of the tool.
     fn name(&self) -> &'static str;
@@ -84,34 +86,25 @@ pub trait Tool: Send + Sync {
 
     /// Run diagnostics on the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
-    /// Returns a vector of `Diagnostic` representing the diagnostic results.
-    /// Not all tools will implement diagnostics, so the default implementation returns `None`.
-    fn run_diagnostic(&self, _uri: &Uri, _content: Option<&str>) -> Option<Vec<Diagnostic>> {
-        None
+    /// Not all tools will implement diagnostics, so the default implementation returns an empty vector.
+    fn run_diagnostic(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
+        Vec::new()
     }
 
     /// Run diagnostics on save for the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
-    /// Returns a vector of `Diagnostic` representing the diagnostic results.
-    /// Not all tools will implement diagnostics on save, so the default implementation returns `None`.
-    fn run_diagnostic_on_save(
-        &self,
-        _uri: &Uri,
-        _content: Option<&str>,
-    ) -> Option<Vec<Diagnostic>> {
-        None
+    /// Returns a vector of a Uri-Diagnostic tuple representing the diagnostic results.
+    /// Not all tools will implement diagnostics on save, so the default implementation returns an empty vector.
+    fn run_diagnostic_on_save(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
+        Vec::new()
     }
 
     /// Run diagnostics on change for the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
-    /// Returns a vector of `Diagnostic` representing the diagnostic results.
-    /// Not all tools will implement diagnostics on change, so the default implementation returns `None`.
-    fn run_diagnostic_on_change(
-        &self,
-        _uri: &Uri,
-        _content: Option<&str>,
-    ) -> Option<Vec<Diagnostic>> {
-        None
+    /// Returns a vector of a Uri-Diagnostic tuple representing the diagnostic results.
+    /// Not all tools will implement diagnostics on change, so the default implementation returns an empty vector.
+    fn run_diagnostic_on_change(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
+        Vec::new()
     }
 
     /// Remove internal cache for the given URI, if any.


### PR DESCRIPTION
> This PR refactors the LSP tool diagnostic API to allow tools to report diagnostics for multiple URIs, not just the file being analyzed. This enables cross-file analysis features like ts config deprecation detection.