### PR TITLE
refactor(vscode)!: use `node_module/.bin/oxlint` by default, fallback to internal language server

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -1,5 +1,6 @@
 import { commands, ExtensionContext, window, workspace } from "vscode";
 
+import { join } from "node:path";
 import { OxcCommands } from "./commands";
 import { ConfigService } from "./ConfigService";
 import StatusBarItemHandler from "./StatusBarItemHandler";
@@ -74,6 +75,15 @@ export async function activate(context: ExtensionContext) {
       ),
     ),
   );
+
+  // when no oxlint binary path are provided, fallback to internal oxc_language_server
+  if (!binaryPaths[0]) {
+    const ext = process.platform === "win32" ? ".exe" : "";
+    // NOTE: The `./target/release` path is aligned with the path defined in .github/workflows/release_vscode.yml
+    binaryPaths[0] =
+      process.env.SERVER_PATH_DEV ??
+      join(context.extensionPath, `./target/release/oxc_language_server${ext}`);
+  }
 
   // remove this block, when `oxfmt` binary is always required. This will be a breaking change.
   if (

--- a/editors/vscode/client/tools/formatter.ts
+++ b/editors/vscode/client/tools/formatter.ts
@@ -7,7 +7,6 @@ import {
   LogOutputChannel,
   Uri,
   window,
-  workspace,
 } from "vscode";
 
 import { ConfigurationParams, ShowMessageNotification } from "vscode-languageclient";
@@ -37,7 +36,7 @@ export default class FormatterTool implements ToolInterface {
     configService: ConfigService,
   ): Promise<string | undefined> {
     const bin = await configService.getOxfmtServerBinPath();
-    if (workspace.isTrusted && bin) {
+    if (bin) {
       try {
         await fsPromises.access(bin);
         return bin;

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -24,7 +24,6 @@ import {
   ServerOptions,
 } from "vscode-languageclient/node";
 
-import { join } from "node:path";
 import { OxcCommands } from "../commands";
 import { ConfigService } from "../ConfigService";
 import StatusBarItemHandler from "../StatusBarItemHandler";
@@ -61,8 +60,8 @@ export default class LinterTool implements ToolInterface {
     outputChannel: LogOutputChannel,
     configService: ConfigService,
   ): Promise<string | undefined> {
-    const bin = configService.getUserServerBinPath();
-    if (workspace.isTrusted && bin) {
+    const bin = await configService.getOxlintServerBinPath();
+    if (bin) {
       try {
         await fsPromises.access(bin);
         return bin;
@@ -70,12 +69,7 @@ export default class LinterTool implements ToolInterface {
         outputChannel.error(`Invalid bin path: ${bin}`, e);
       }
     }
-    const ext = process.platform === "win32" ? ".exe" : "";
-    // NOTE: The `./target/release` path is aligned with the path defined in .github/workflows/release_vscode.yml
-    return (
-      process.env.SERVER_PATH_DEV ??
-      join(context.extensionPath, `./target/release/oxc_language_server${ext}`)
-    );
+    return process.env.SERVER_PATH_DEV;
   }
 
   async activate(

--- a/editors/vscode/tests/ConfigService.spec.ts
+++ b/editors/vscode/tests/ConfigService.spec.ts
@@ -70,20 +70,20 @@ suite('ConfigService', () => {
     });
   });
 
-  suite('getUserServerBinPath', () => {
+  suite('getOxlintServerBinPath', () => {
     testSingleFolderMode('resolves relative server path with workspace folder', async () => {
       const service = new ConfigService();
-      const nonDefinedServerPath = service.getUserServerBinPath();
+      const nonDefinedServerPath = await service.getOxlintServerBinPath();
 
       strictEqual(nonDefinedServerPath, undefined);
 
       await conf.update('path.oxlint', '/absolute/oxlint');
-      const absoluteServerPath = service.getUserServerBinPath();
+      const absoluteServerPath = await service.getOxlintServerBinPath();
 
       strictEqual(absoluteServerPath, '/absolute/oxlint');
 
       await conf.update('path.oxlint', './relative/oxlint');
-      const relativeServerPath = service.getUserServerBinPath();
+      const relativeServerPath = await service.getOxlintServerBinPath();
 
       const workspace_path = getWorkspaceFolderPlatformSafe();
       strictEqual(relativeServerPath, `${workspace_path}/relative/oxlint`);
@@ -92,7 +92,7 @@ suite('ConfigService', () => {
     testSingleFolderMode('returns undefined for unsafe server path', async () => {
       const service = new ConfigService();
       await conf.update('path.oxlint', '../unsafe/oxlint');
-      const unsafeServerPath = service.getUserServerBinPath();
+      const unsafeServerPath = await service.getOxlintServerBinPath();
 
       strictEqual(unsafeServerPath, undefined);
     });
@@ -103,7 +103,7 @@ suite('ConfigService', () => {
       }
       const service = new ConfigService();
       await conf.update('path.oxlint', './relative/oxlint');
-      const relativeServerPath = service.getUserServerBinPath();
+      const relativeServerPath = await service.getOxlintServerBinPath();
       const workspace_path = getWorkspaceFolderPlatformSafe();
 
       strictEqual(workspace_path[1], ':', 'The test workspace folder must be an absolute path with a drive letter on Windows');


### PR DESCRIPTION
This PR refactors the VSCode extension to prefer using oxlint and oxfmt binaries from node_modules/.bin by default, with a fallback to the internal oxc_language_server when no binaries are found.