### PR TITLE
refactor(oxc_parser): `ParserConfig` for `Lexer` and `Parser`

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -6,21 +6,21 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    Context, ParserImpl, diagnostics,
+    Context, ParserConfig, ParserImpl, diagnostics,
     error_handler::FatalError,
     lexer::{Kind, LexerCheckpoint, LexerContext, Token},
 };
 
 #[derive(Clone)]
-pub struct ParserCheckpoint<'a> {
-    lexer: LexerCheckpoint<'a>,
+pub struct ParserCheckpoint<'a, C: ParserConfig> {
+    lexer: LexerCheckpoint<'a, C>,
     cur_token: Token,
     prev_span_end: u32,
     errors_pos: usize,
     fatal_error: Option<FatalError>,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     #[inline]
     pub(crate) fn start_span(&self) -> u32 {
         self.token.start()
@@ -300,7 +300,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn checkpoint(&mut self) -> ParserCheckpoint<'a> {
+    pub(crate) fn checkpoint(&mut self) -> ParserCheckpoint<'a, C> {
         ParserCheckpoint {
             lexer: self.lexer.checkpoint(),
             cur_token: self.token,
@@ -310,7 +310,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn checkpoint_with_error_recovery(&mut self) -> ParserCheckpoint<'a> {
+    pub(crate) fn checkpoint_with_error_recovery(&mut self) -> ParserCheckpoint<'a, C> {
         ParserCheckpoint {
             lexer: self.lexer.checkpoint_with_error_recovery(),
             cur_token: self.token,
@@ -320,7 +320,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn rewind(&mut self, checkpoint: ParserCheckpoint<'a>) {
+    pub(crate) fn rewind(&mut self, checkpoint: ParserCheckpoint<'a, C>) {
         let ParserCheckpoint { lexer, cur_token, prev_span_end, errors_pos, fatal_error } =
             checkpoint;
 
@@ -333,7 +333,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn try_parse<T>(
         &mut self,
-        func: impl FnOnce(&mut ParserImpl<'a>) -> T,
+        func: impl FnOnce(&mut ParserImpl<'a, C>) -> T,
     ) -> Option<T> {
         let checkpoint = self.checkpoint_with_error_recovery();
         let ctx = self.ctx;
@@ -347,7 +347,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn lookahead<U>(&mut self, predicate: impl Fn(&mut ParserImpl<'a>) -> U) -> U {
+    pub(crate) fn lookahead<U>(&mut self, predicate: impl Fn(&mut ParserImpl<'a, C>) -> U) -> U {
         let checkpoint = self.checkpoint();
         let answer = predicate(self);
         self.rewind(checkpoint);

--- a/crates/oxc_parser/src/error_handler.rs
+++ b/crates/oxc_parser/src/error_handler.rs
@@ -4,7 +4,7 @@ use oxc_allocator::Dummy;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
-use crate::{ParserImpl, diagnostics, lexer::Kind};
+use crate::{ParserConfig, ParserImpl, diagnostics, lexer::Kind};
 
 /// Fatal parsing error.
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub struct FatalError {
     pub errors_len: usize,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     #[cold]
     pub(crate) fn set_unexpected(&mut self) {
         // The lexer should have reported a more meaningful diagnostic
@@ -91,7 +91,7 @@ impl<'a> ParserImpl<'a> {
 // error, we detect these patterns and provide helpful guidance on how to resolve the conflict.
 //
 // Inspired by rust-lang/rust#106242
-impl ParserImpl<'_> {
+impl<C: ParserConfig> ParserImpl<'_, C> {
     /// Check if the current position looks like a merge conflict marker.
     ///
     /// Detects the following Git conflict markers:

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use oxc_syntax::precedence::Precedence;
 
 use super::{FunctionKind, Tristate};
-use crate::{ParserImpl, diagnostics, lexer::Kind};
+use crate::{ParserConfig, ParserImpl, diagnostics, lexer::Kind};
 
 struct ArrowFunctionHead<'a> {
     type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -14,7 +14,7 @@ struct ArrowFunctionHead<'a> {
     span: u32,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(super) fn try_parse_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -1,9 +1,9 @@
 use oxc_ast::{NONE, ast::*};
 use oxc_span::GetSpan;
 
-use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
+use crate::{Context, ParserConfig, ParserImpl, diagnostics, lexer::Kind};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     /// `BindingElement`
     ///     `SingleNameBinding`
     ///     `BindingPattern`[?Yield, ?Await] `Initializer`[+In, ?Yield, ?Await]opt

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -4,7 +4,7 @@ use oxc_ecmascript::PropName;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    Context, ParserImpl, StatementContext, diagnostics,
+    Context, ParserConfig, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
 };
@@ -15,7 +15,7 @@ type Extends<'a> =
     Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>;
 
 /// Section 15.7 Class Definitions
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     // `start_span` points at the start of all decoractors and `class` keyword.
     pub(crate) fn parse_class_statement(
         &mut self,

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -3,9 +3,9 @@ use oxc_ast::{NONE, ast::*};
 use oxc_span::GetSpan;
 
 use super::VariableDeclarationParent;
-use crate::{ParserImpl, StatementContext, diagnostics, lexer::Kind};
+use crate::{ParserConfig, ParserImpl, StatementContext, diagnostics, lexer::Kind};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let span = self.start_span();
 

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -17,12 +17,12 @@ use super::{
     },
 };
 use crate::{
-    Context, ParserImpl, diagnostics,
+    Context, ParserConfig, ParserImpl, diagnostics,
     lexer::{Kind, parse_big_int, parse_float, parse_int},
     modifiers::Modifiers,
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn parse_paren_expression(&mut self) -> Expression<'a> {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -4,7 +4,7 @@ use oxc_span::Span;
 
 use super::FunctionKind;
 use crate::{
-    Context, ParserImpl, StatementContext, diagnostics,
+    Context, ParserConfig, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
 };
@@ -19,7 +19,7 @@ impl FunctionKind {
     }
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn at_function_with_async(&mut self) -> bool {
         self.at(Kind::Function)
             || self.at(Kind::Async) && {

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -3,14 +3,14 @@
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use crate::{ParserImpl, diagnostics};
+use crate::{ParserConfig, ParserImpl, diagnostics};
 
-pub trait CoverGrammar<'a, T>: Sized {
-    fn cover(value: T, p: &mut ParserImpl<'a>) -> Self;
+pub trait CoverGrammar<'a, T, C: ParserConfig>: Sized {
+    fn cover(value: T, p: &mut ParserImpl<'a, C>) -> Self;
 }
 
-impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, Expression<'a>, C> for AssignmentTarget<'a> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         match expr {
             Expression::ArrayExpression(array_expr) => {
                 let pat = ArrayAssignmentTarget::cover(array_expr.unbox(), p);
@@ -25,8 +25,8 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
     }
 }
 
-impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, Expression<'a>, C> for SimpleAssignmentTarget<'a> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         match expr {
             Expression::Identifier(ident) => {
                 SimpleAssignmentTarget::AssignmentTargetIdentifier(ident)
@@ -90,8 +90,8 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
     }
 }
 
-impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
-    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignmentTarget<'a> {
+    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         let mut elements = p.ast.vec();
         let mut rest = None;
 
@@ -136,8 +136,8 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
     }
 }
 
-impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, Expression<'a>, C> for AssignmentTargetMaybeDefault<'a> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
                 if assignment_expr.operator != AssignmentOperator::Assign {
@@ -156,14 +156,16 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
     }
 }
 
-impl<'a> CoverGrammar<'a, AssignmentExpression<'a>> for AssignmentTargetWithDefault<'a> {
-    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, AssignmentExpression<'a>, C>
+    for AssignmentTargetWithDefault<'a>
+{
+    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         p.ast.assignment_target_with_default(expr.span, expr.left, expr.right)
     }
 }
 
-impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
-    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignmentTarget<'a> {
+    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         let mut properties = p.ast.vec();
         let mut rest = None;
 
@@ -203,8 +205,8 @@ impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
     }
 }
 
-impl<'a> CoverGrammar<'a, ObjectProperty<'a>> for AssignmentTargetProperty<'a> {
-    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Self {
+impl<'a, C: ParserConfig> CoverGrammar<'a, ObjectProperty<'a>, C> for AssignmentTargetProperty<'a> {
+    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         if property.shorthand {
             let binding = match property.key {
                 PropertyKey::StaticIdentifier(ident) => {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use super::FunctionKind;
 use crate::{
-    ParserImpl, StatementContext, diagnostics,
+    ParserConfig, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
     modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
 };
@@ -26,7 +26,7 @@ enum ImportOrExportSpecifier<'a> {
     Export(ExportSpecifier<'a>),
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     /// [Import Call](https://tc39.es/ecma262/#sec-import-calls)
     /// `ImportCall` : import ( `AssignmentExpression` )
     pub(crate) fn parse_import_expression(

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -3,14 +3,14 @@ use oxc_ast::ast::*;
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{
-    Context, ParserImpl, diagnostics,
+    Context, ParserConfig, ParserImpl, diagnostics,
     lexer::Kind,
     modifiers::{ModifierFlags, Modifiers},
 };
 
 use super::FunctionKind;
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     /// [Object Expression](https://tc39.es/ecma262/#sec-object-initializer)
     /// `ObjectLiteral`[Yield, Await] :
     ///     { }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -4,12 +4,12 @@ use oxc_span::{Atom, GetSpan, Span};
 
 use super::{VariableDeclarationParent, grammar::CoverGrammar};
 use crate::{
-    Context, ParserImpl, StatementContext, diagnostics,
+    Context, ParserConfig, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
     modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
 };
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     // Section 12
     // The InputElementHashbangOrRegExp goal is used at the start of a Script
     // or Module.

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -4,9 +4,9 @@ use oxc_allocator::{Box, Dummy, Vec};
 use oxc_ast::ast::*;
 use oxc_span::{Atom, GetSpan, Span};
 
-use crate::{ParserImpl, diagnostics, lexer::Kind};
+use crate::{ParserConfig, ParserImpl, diagnostics, lexer::Kind};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `<`

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -3,7 +3,7 @@ use memchr::memmem::Finder;
 use oxc_ast::CommentKind;
 use oxc_syntax::line_terminator::is_line_terminator;
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{
     Kind, Lexer, cold_branch,
@@ -22,7 +22,7 @@ static LINE_BREAK_TABLE: SafeByteMatchTable =
 static MULTILINE_COMMENT_START_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| matches!(b, b'*' | b'\r' | b'\n' | LS_OR_PS_FIRST));
 
-impl<'a> Lexer<'a> {
+impl<'a, C: ParserConfig> Lexer<'a, C> {
     /// Section 12.4 Single Line Comment
     pub(super) fn skip_single_line_comment(&mut self) -> Kind {
         byte_search! {

--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -6,7 +6,7 @@ use oxc_syntax::identifier::{
     is_identifier_part, is_identifier_part_unicode, is_identifier_start_unicode,
 };
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{
     Kind, Lexer, SourcePosition, cold_branch,
@@ -26,7 +26,7 @@ fn is_identifier_start_ascii_byte(byte: u8) -> bool {
     ASCII_ID_START_TABLE.matches(byte)
 }
 
-impl<'a> Lexer<'a> {
+impl<'a, C: ParserConfig> Lexer<'a, C> {
     /// Handle identifier with ASCII start character.
     /// Returns text of the identifier, minus its first char.
     ///

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -3,7 +3,7 @@ use memchr::memchr;
 use oxc_span::Span;
 use oxc_syntax::identifier::is_identifier_part;
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{
     Kind, Lexer, Token, cold_branch,
@@ -26,7 +26,7 @@ static JSX_CHILD_END_TABLE: SafeByteMatchTable =
 ///   `JSXStringCharacter` but not '
 /// `JSXStringCharacter` ::
 ///   `SourceCharacter` but not one of `HTMLCharacterReference`
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     /// Read JSX string literal.
     /// # SAFETY
     /// * `delimiter` must be an ASCII character.

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -1,10 +1,10 @@
 use oxc_syntax::identifier::{is_identifier_part_ascii, is_identifier_start};
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{Kind, Lexer, Span};
 
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     /// 12.9.3 Numeric Literals with `0` prefix
     pub(super) fn read_zero(&mut self) -> Kind {
         match self.peek_byte() {

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -1,6 +1,8 @@
+use crate::ParserConfig;
+
 use super::{Kind, Lexer, Token};
 
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     /// Section 12.8 Punctuators
     pub(super) fn read_dot(&mut self) -> Kind {
         if self.peek_2_bytes() == Some([b'.', b'.']) {

--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -2,9 +2,9 @@ use oxc_syntax::line_terminator::is_line_terminator;
 
 use crate::diagnostics;
 
-use super::{Kind, Lexer, RegExpFlags, Token};
+use super::{Kind, Lexer, ParserConfig, RegExpFlags, Token};
 
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     /// Re-tokenize the current `/` or `/=` and return `RegExp`
     /// See Section 12:
     ///   The `InputElementRegExp` goal symbol is used in all syntactic grammar contexts

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use oxc_allocator::StringBuilder;
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{
     Kind, Lexer, LexerContext, Span, Token, cold_branch,
@@ -202,7 +202,7 @@ macro_rules! handle_string_literal_escape {
 }
 
 /// 12.9.4 String Literals
-impl<'a> Lexer<'a> {
+impl<'a, C: ParserConfig> Lexer<'a, C> {
     /// Read string literal delimited with `"`.
     /// # SAFETY
     /// Next character must be `"`.

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -2,7 +2,7 @@ use std::{cmp::max, str};
 
 use oxc_allocator::StringBuilder;
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 
 use super::{
     Kind, Lexer, SourcePosition, Token, cold_branch,
@@ -33,7 +33,7 @@ static TEMPLATE_LITERAL_ESCAPED_MATCH_TABLE: SafeByteMatchTable = safe_byte_matc
 );
 
 /// 12.8.6 Template Literal Lexical Components
-impl<'a> Lexer<'a> {
+impl<'a, C: ParserConfig> Lexer<'a, C> {
     /// Read template literal component.
     ///
     /// This function handles the common case where template contains no escapes or `\r` characters
@@ -409,6 +409,8 @@ mod test {
     use oxc_allocator::Allocator;
     use oxc_span::SourceType;
 
+    use crate::StandardParserConfig;
+
     use super::super::{Kind, Lexer, UniquePromise};
 
     #[test]
@@ -442,7 +444,12 @@ mod test {
         fn run_test(source_text: String, expected_escaped: String, is_only_part: bool) {
             let allocator = Allocator::default();
             let unique = UniquePromise::new_for_tests_and_benchmarks();
-            let mut lexer = Lexer::new(&allocator, &source_text, SourceType::default(), unique);
+            let mut lexer = Lexer::<StandardParserConfig>::new(
+                &allocator,
+                &source_text,
+                SourceType::default(),
+                unique,
+            );
             let token = lexer.next_token();
             assert_eq!(
                 token.kind(),

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -1,6 +1,8 @@
+use crate::ParserConfig;
+
 use super::{Kind, Lexer, Token};
 
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     /// Re-tokenize '<<' or '<=' or '<<=' to '<'
     pub(crate) fn re_lex_as_typescript_l_angle(&mut self, offset: u32) -> Token {
         self.token.set_start(self.offset() - offset);

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Write};
 
 use cow_utils::CowUtils;
 
-use crate::diagnostics;
+use crate::{ParserConfig, diagnostics};
 use oxc_allocator::StringBuilder;
 use oxc_syntax::{
     identifier::{
@@ -29,7 +29,7 @@ enum UnicodeEscape {
     LoneSurrogate(u32),
 }
 
-impl<'a> Lexer<'a> {
+impl<'a, C: ParserConfig> Lexer<'a, C> {
     pub(super) fn unicode_char_handler(&mut self) -> Kind {
         let c = self.peek_char().unwrap();
         match c {

--- a/crates/oxc_parser/src/lexer/whitespace.rs
+++ b/crates/oxc_parser/src/lexer/whitespace.rs
@@ -1,3 +1,5 @@
+use crate::ParserConfig;
+
 use super::{
     Kind, Lexer,
     search::{SafeByteMatchTable, byte_search, safe_byte_match_table},
@@ -6,7 +8,7 @@ use super::{
 static NOT_REGULAR_WHITESPACE_OR_LINE_BREAK_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'));
 
-impl Lexer<'_> {
+impl<C: ParserConfig> Lexer<'_, C> {
     pub(super) fn line_break_handler(&mut self) -> Kind {
         self.token.set_is_on_new_line(true);
         self.trivia_builder.handle_newline();

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
 use crate::{
-    ParserImpl, diagnostics,
+    ParserConfig, ParserImpl, diagnostics,
     lexer::{Kind, Token},
 };
 
@@ -317,7 +317,7 @@ impl std::fmt::Display for ModifierKind {
     }
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers<'a> {
         if !self.at_modifier() {
             return Modifiers::empty();
@@ -522,8 +522,8 @@ impl<'a> ParserImpl<'a> {
             // Also `#[inline(never)]` to help `verify_modifiers` to get inlined.
             #[cold]
             #[inline(never)]
-            fn report<'a, F>(
-                parser: &mut ParserImpl<'a>,
+            fn report<'a, C: ParserConfig, F>(
+                parser: &mut ParserImpl<'a, C>,
                 modifiers: &Modifiers<'a>,
                 allowed: ModifierFlags,
                 strict: bool,

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    ParserImpl, diagnostics,
+    ParserConfig, ParserImpl, diagnostics,
     js::{FunctionKind, VariableDeclarationParent},
     lexer::Kind,
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
@@ -15,7 +15,7 @@ pub(super) enum CallOrConstructorSignature {
     Constructor,
 }
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     /* ------------------- Enum ------------------ */
     /// `https://www.typescriptlang.org/docs/handbook/enums.html`
     pub(crate) fn parse_ts_enum_declaration(

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -4,14 +4,14 @@ use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
 use crate::{
-    Context, ParserImpl, diagnostics,
+    Context, ParserConfig, ParserImpl, diagnostics,
     lexer::Kind,
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
 };
 
 use super::{super::js::FunctionKind, statement::CallOrConstructorSignature};
 
-impl<'a> ParserImpl<'a> {
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_type(&mut self) -> TSType<'a> {
         if self.is_start_of_function_type_or_constructor_type() {
             return self.parse_function_or_constructor_type();


### PR DESCRIPTION
Part of https://github.com/oxc-project/oxc/issues/16207. Preparation for the generic `ParserConfig` trait for `Lexer`, `Parser`, and `ParserImpl. This is a generic interface that concretely does nothing for most compilation targets and _will_ store tokens in an arena when compiled for oxlint.

Of particular note for reviewing is the `BYTE_HANDLERS` array. It had to be switched from a `static` array to a returned array from a `const` function to safely handle the generic. This seems to be the cause of a huge parsing performance downtick.

In future, this abstraction will also be used to conditionally compile UTF-8 to UTF-16 translation only in oxlint.

The oxlint-exclusive storage of tokens is _not_ implemented in this PR. At this point, the goal is to ensure there is no change in behavior or performance. 

- Uses the code snippets from https://github.com/oxc-project/oxc/issues/16207 as starting point.
- There are some review comments in https://github.com/lilnasy/oxc/pull/2.