### PR TITLE
refactor(linter/plugins): add TODO comments for `@ts-expect-error`s which need fixing

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -21,7 +21,7 @@ import { TOKEN } from '../../dist/src-js/raw-transfer/lazy-common.js';
 import { walkProgram } from '../generated/walk.js';
 */
 
-// @ts-expect-error we need to generate `.d.ts` file for this module
+// @ts-expect-error - TODO: We need to generate `.d.ts` file for this module
 import { walkProgram } from "../generated/walk.js";
 
 import type { AfterHook, BufferWithArrays } from "./types.ts";

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -115,7 +115,7 @@ function initTsScopeManager() {
   typeAssertIs<AnalyzeOptions>(analyzeOptions);
   // The effectiveness of this assertion depends on our alignment with ESTree.
   // It could eventually be removed as we align the remaining corner cases and the typegen.
-  // @ts-expect-error // TODO: Our types don't quite align yet
+  // @ts-expect-error - TODO: Our types don't quite align yet
   tsScopeManager = analyze(ast, analyzeOptions);
 }
 
@@ -146,7 +146,7 @@ export const SCOPE_MANAGER = Object.freeze({
    */
   get scopes(): Scope[] {
     if (tsScopeManager === null) initTsScopeManager();
-    // @ts-expect-error // TODO: Our types don't quite align yet
+    // @ts-expect-error - TODO: Our types don't quite align yet
     return tsScopeManager.scopes;
   },
 
@@ -155,7 +155,7 @@ export const SCOPE_MANAGER = Object.freeze({
    */
   get globalScope(): Scope | null {
     if (tsScopeManager === null) initTsScopeManager();
-    // @ts-expect-error // TODO: Our types don't quite align yet
+    // @ts-expect-error - TODO: Our types don't quite align yet
     return tsScopeManager.globalScope;
   },
 
@@ -167,7 +167,7 @@ export const SCOPE_MANAGER = Object.freeze({
    */
   getDeclaredVariables(node: ESTree.Node): Variable[] {
     if (tsScopeManager === null) initTsScopeManager();
-    // @ts-expect-error // TODO: Our types don't quite align yet
+    // @ts-expect-error - TODO: Our types don't quite align yet
     return tsScopeManager.getDeclaredVariables(node);
   },
 
@@ -182,7 +182,7 @@ export const SCOPE_MANAGER = Object.freeze({
    */
   acquire(node: ESTree.Node, inner?: boolean): Scope | null {
     if (tsScopeManager === null) initTsScopeManager();
-    // @ts-expect-error // TODO: Our types don't quite align yet
+    // @ts-expect-error - TODO: Our types don't quite align yet
     return tsScopeManager.acquire(node, inner);
   },
 });
@@ -233,7 +233,7 @@ export function getDeclaredVariables(node: ESTree.Node): Variable[] {
   if (tsScopeManager === null) initTsScopeManager();
   debugAssertIsNonNull(tsScopeManager);
 
-  // @ts-expect-error // TODO: Our types don't quite align yet
+  // @ts-expect-error - TODO: Our types don't quite align yet
   return tsScopeManager.getDeclaredVariables(node);
 }
 
@@ -253,7 +253,7 @@ export function getScope(node: ESTree.Node): Scope {
 
   // Traverse up the AST to find a `Node` whose scope can be acquired.
   do {
-    // @ts-expect-error // TODO: Our types don't quite align yet
+    // @ts-expect-error - TODO: Our types don't quite align yet
     const scope = tsScopeManager.acquire(node, inner) as Scope;
     if (scope !== null) {
       return scope.type === "function-expression-name" ? scope.childScopes[0] : scope;
@@ -264,7 +264,7 @@ export function getScope(node: ESTree.Node): Scope {
   } while (node !== null);
 
   // TODO: Is it possible to get here? Doesn't `Program` always have a scope?
-  // @ts-expect-error // TODO: Our types don't quite align yet
+  // @ts-expect-error - TODO: Our types don't quite align yet
   return tsScopeManager.scopes[0];
 }
 

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -1,7 +1,7 @@
 import esquery from "esquery";
 import visitorKeys from "../generated/keys.ts";
 import { FUNCTION_NODE_TYPE_IDS, NODE_TYPE_IDS_MAP } from "../generated/type_ids.ts";
-// @ts-expect-error we need to generate `.d.ts` file for this module
+// @ts-expect-error - TODO: We need to generate `.d.ts` file for this module
 import { ancestors } from "../generated/walk.js";
 
 import type { ESQueryOptions, Selector as EsquerySelector } from "esquery";

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -2,7 +2,7 @@ import { DATA_POINTER_POS_32, SOURCE_LEN_OFFSET } from "../generated/constants.t
 
 // We use the deserializer which removes `ParenthesizedExpression`s from AST,
 // and with `range`, `loc`, and `parent` properties on AST nodes, to match ESLint
-// @ts-expect-error we need to generate `.d.ts` file for this module
+// @ts-expect-error - TODO: We need to generate `.d.ts` file for this module
 import { deserializeProgramOnly, resetBuffer } from "../generated/deserialize.js";
 
 import visitorKeys from "../generated/keys.ts";
@@ -239,7 +239,7 @@ export const SOURCE_CODE = Object.freeze({
     const ancestors = [];
 
     while (true) {
-      // @ts-expect-error `parent` property should be present on `Node` type
+      // @ts-expect-error - TODO: `parent` property should be present on `Node` type
       node = node.parent;
       if (node === null) break;
       ancestors.push(node);

--- a/apps/oxlint/test/fixtures/parent/plugin.ts
+++ b/apps/oxlint/test/fixtures/parent/plugin.ts
@@ -14,7 +14,7 @@ const plugin: Plugin = {
               `parent: ${node.parent?.type}\n` +
               `ancestors: [ ${context.sourceCode
                 .getAncestors(node)
-                // @ts-expect-error - Shouldn't be an error. We need to fix our types.
+                // @ts-expect-error - TODO: Shouldn't be an error. We need to fix our types.
                 .map((node) => node.type)
                 .join(", ")} ]`,
             node,


### PR DESCRIPTION
Only alters comments.

* Make sure all `// @ts-expect-error` comments include "TODO" where it's an issue we need to fix.
* Format all the "TODO" comments consistently.