### PR TITLE
chore(lint): enable ban-ts-comment rule and fix ts-ignore usages

### DIFF
--- a/napi/parser/test/lazy-deserialization.test.ts
+++ b/napi/parser/test/lazy-deserialization.test.ts
@@ -1,5 +1,6 @@
 // Tests for lazy deserialization.
 
+// oxlint-disable-next-line typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
 import { describe, expect, it } from "vitest";

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -474,7 +474,7 @@ describe("parse", () => {
             const ret = parseSync("test.js", 'import.defer("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
-            // @ts-ignore
+            // @ts-expect-error - ignore
             expect(ret.program.body[0].expression).toEqual({
               type: "ImportExpression",
               start: 0,
@@ -491,7 +491,7 @@ describe("parse", () => {
             const ret = parseSync("test.ts", 'import.defer("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
-            // @ts-ignore
+            // @ts-expect-error - ignore
             expect(ret.program.body[0].expression).toEqual({
               type: "ImportExpression",
               start: 0,
@@ -508,7 +508,7 @@ describe("parse", () => {
             const ret = parseSync("test.js", 'import.source("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
-            // @ts-ignore
+            // @ts-expect-error - ignore
             expect(ret.program.body[0].expression).toEqual({
               type: "ImportExpression",
               start: 0,
@@ -525,7 +525,7 @@ describe("parse", () => {
             const ret = parseSync("test.ts", 'import.source("x");');
             expect(ret.errors.length).toBe(0);
             expect(ret.program.body.length).toBe(1);
-            // @ts-ignore
+            // @ts-expect-error - ignore
             expect(ret.program.body[0].expression).toEqual({
               type: "ImportExpression",
               start: 0,
@@ -704,22 +704,16 @@ describe("parse", () => {
     it("should include range when true", () => {
       const ret = parseSync("test.js", "(x)", { range: true });
       expect(ret.program.body[0].start).toBe(0);
-      // TODO: Remove `@ts-ignore` comment once we've corrected TS type definitions
-      // @ts-ignore
       expect(ret.program.body[0].range).toEqual([0, 3]);
     });
 
     it("should not include range when false", () => {
       const ret = parseSync("test.js", "(x)", { range: false });
-      // TODO: Remove `@ts-ignore` comment once we've corrected TS type definitions
-      // @ts-ignore
       expect(ret.program.body[0].range).toBeUndefined();
     });
 
     it("should not include range by default", () => {
       const ret = parseSync("test.js", "(x)");
-      // TODO: Remove `@ts-ignore` comment once we've corrected TS type definitions
-      // @ts-ignore
       expect(ret.program.body[0].range).toBeUndefined();
     });
   });

--- a/napi/parser/test/visit.test.ts
+++ b/napi/parser/test/visit.test.ts
@@ -13,8 +13,7 @@ describe("visit", () => {
 
   describe("invalid visitor", () => {
     it("undefined visitor object", () => {
-      // @ts-ignore
-      expect(() => new Visitor()).toThrow(new TypeError("Visitor must be an object"));
+      expect(() => new Visitor(undefined!)).toThrow(new TypeError("Visitor must be an object"));
     });
 
     it("null visitor object", () => {

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -24,6 +24,7 @@
       "VariableDeclarator": { "array": false, "object": true }
     }],
     "typescript/consistent-indexed-object-style": ["error", "record"],
+    "typescript/ban-ts-comment": ["error", { "ts-expect-error": "allow-with-description" }],
     "eslint-js/prefer-const": ["error", { "destructuring": "all" }]
   },
   "overrides": [

--- a/tasks/e2e/test/utils.ts
+++ b/tasks/e2e/test/utils.ts
@@ -61,11 +61,10 @@ async function fsRequire(code: string, format: "cjs" | "esm" | "iife") {
   const fsRequire = createFsRequire(vol);
 
   if (format === "iife") {
-    const mockedWindow = {};
-    // @ts-expect-error
+    const mockedWindow = {} as (typeof globalThis)["window"];
     globalThis.window = mockedWindow;
     fsRequire("/index.js");
-    // @ts-expect-error
+    // @ts-expect-error - ignore
     delete globalThis.window;
     return mockedWindow;
   }


### PR DESCRIPTION
follow on from https://github.com/oxc-project/oxc/pull/16796