### PR TITLE
fix(linter/plugins)!: use TypeScript parser directly for getting tokens

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -27,7 +27,6 @@
     "@types/estree": "^1.0.8",
     "@types/json-stable-stringify-without-jsonify": "^1.0.2",
     "@typescript-eslint/scope-manager": "8.48.1",
-    "@typescript-eslint/typescript-estree": "^8.47.0",
     "cross-env": "catalog:",
     "eslint": "^9.36.0",
     "esquery": "^1.6.0",

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -28,7 +28,6 @@ export type {
   RangeOptions,
   SkipOptions,
   Token,
-  CommentToken,
   BooleanToken,
   IdentifierToken,
   JSXIdentifierToken,

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -26,8 +26,8 @@ import { debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Program } from "../generated/types.d.ts";
 import type { Ranged } from "./location.ts";
-import type { Token, CommentToken } from "./tokens.ts";
-import type { BufferWithArrays, Node } from "./types.ts";
+import type { Token } from "./tokens.ts";
+import type { BufferWithArrays, Comment, Node } from "./types.ts";
 import type { ScopeManager } from "./scope.ts";
 
 const { max } = Math;
@@ -194,7 +194,7 @@ export const SOURCE_CODE = Object.freeze({
    * Array of all tokens and comments in the file, in source order.
    */
   // This property is present in ESLint's `SourceCode`, but is undocumented
-  get tokensAndComments(): (Token | CommentToken)[] {
+  get tokensAndComments(): (Token | Comment)[] {
     if (tokensAndComments === null) {
       if (tokens === null) {
         if (sourceText === null) initSourceText();

--- a/apps/oxlint/src-js/plugins/tokens_parse.ts
+++ b/apps/oxlint/src-js/plugins/tokens_parse.ts
@@ -1,0 +1,268 @@
+/*
+ * Use TypeScript parser to get tokens from source text.
+ */
+
+import { createRequire } from "node:module";
+import { filePath } from "./context.ts";
+import { getNodeLoc } from "./location.ts";
+import { sourceText } from "./source_code.ts";
+import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
+
+import type * as ts from "typescript";
+import type { Token } from "./tokens.ts";
+
+// `typescript` package is lazy-loaded only when needed, as it's a lot of code.
+//
+// `tsSyntaxKind` is `null` originally.
+// Using hack of `null as any` to avoid having to assert that `tsSyntaxKind` is not `null` all over the place.
+// `initTokens` initializes `tsSyntaxKind`, before any of the functions that access `tsSyntaxKind` are called.
+let tsModule: typeof import("typescript") | null = null;
+let tsSyntaxKind: typeof import("typescript").SyntaxKind = null as any;
+
+// Prototype for `Token` objects, which calculates `loc` property lazily.
+// This is the same as `NodeProto` used for AST nodes (in `generated/deserialize.js`).
+// TODO: De-duplicate this code between here and `generated/deserialize.js`.
+const TokenProto = Object.create(null, {
+  loc: {
+    get() {
+      return getNodeLoc(this);
+    },
+    enumerable: true,
+  },
+});
+
+/**
+ * Initialize TS-ESLint tokens for current file.
+ *
+ * Caller must ensure `filePath` and `sourceText` are initialized before calling this function.
+ */
+export function parseTokens(): Token[] {
+  debugAssertIsNonNull(filePath);
+  debugAssertIsNonNull(sourceText);
+
+  // Lazy-load TypeScript.
+  // `./typescript.cjs` is path to the bundle in `dist` directory, as well as relative path in `src-js`,
+  // so is valid both in bundled `dist` output, and in unit tests.
+  if (tsModule === null) {
+    const require = createRequire(import.meta.url);
+    tsModule = require("./typescript.cjs");
+    debugAssertIsNonNull(tsModule);
+    tsSyntaxKind = tsModule.SyntaxKind;
+  }
+
+  // Parse source text into TypeScript AST
+  const tsAst = tsModule.createSourceFile(
+    filePath,
+    sourceText,
+    // These options are the same as in TS-ESLint's `parse` function
+    {
+      jsDocParsingMode: tsModule.JSDocParsingMode.ParseNone,
+      languageVersion: tsModule.ScriptTarget.Latest,
+      setExternalModuleIndicator: undefined,
+    },
+    true, // `setParentNodes`
+    // TODO: Use `TS` or `TSX` depending on source type
+    tsModule.ScriptKind.TSX,
+  );
+
+  // Check that TypeScript hasn't altered source text.
+  // If it had, token ranges would be incorrect.
+  debugAssert(tsAst.text === sourceText);
+
+  // Extract tokens from TypeScript AST
+  return convertTokens(tsAst);
+}
+
+/**
+ * Convert all tokens for the given AST.
+ *
+ * Adapted from:
+ * https://github.com/typescript-eslint/typescript-eslint/blob/5bd78cab52569a5e9e14a8e4588a672ca933a0be/packages/typescript-estree/src/node-utils.ts#L617-L637
+ *
+ * This function and all functions below in this file are copied from TS-ESLint's implementation,
+ * and refactored to reduce function calls and duplicated property lookups.
+ *
+ * Only substantive differences are:
+ * 1. `Token`s we produce have `start` and `end` properties, whereas TS-ESLint's `Token`s do not.
+ * 2. We lazily calculate `loc`, whereas TS-ESLint does it eagerly.
+ * 3. Added workaround for TypeScript not being able to parse JSX closing fragment containing a line break.
+ *
+ * @param tsAst - TypeScript AST
+ * @returns Array of `Token`s
+ */
+function convertTokens(tsAst: ts.SourceFile): Token[] {
+  const tokens: Token[] = [];
+  walk(tsAst);
+  return tokens;
+
+  function walk(node: ts.Node): void {
+    const { kind } = node;
+
+    // TypeScript generates tokens for types in JSDoc blocks.
+    // Comment tokens and their children should not be walked or added to the resulting tokens list.
+    if (
+      kind === tsSyntaxKind.SingleLineCommentTrivia ||
+      kind === tsSyntaxKind.MultiLineCommentTrivia ||
+      kind === tsSyntaxKind.JSDoc
+    ) {
+      return;
+    }
+
+    if (
+      kind >= tsSyntaxKind.FirstToken &&
+      kind <= tsSyntaxKind.LastToken &&
+      kind !== tsSyntaxKind.EndOfFileToken
+    ) {
+      // Token
+      convertToken(node as ts.Token<ts.TokenSyntaxKind>, tsAst, tokens);
+    } else {
+      // Node
+      node.getChildren(tsAst).forEach(walk);
+    }
+  }
+}
+
+/**
+ * Convert TS token to TS-ESLint-style token.
+ * @param token - TS token
+ * @param tsAst - TypeScript AST
+ * @param tokens - Array of tokens to push converted token to
+ */
+function convertToken(token: ts.Token<ts.TokenSyntaxKind>, tsAst: ts.SourceFile, tokens: Token[]) {
+  const { kind } = token;
+
+  const start = kind === tsSyntaxKind.JsxText ? token.getFullStart() : token.getStart(tsAst);
+  const end = token.getEnd();
+
+  // TypeScript cannot parse JSX closing fragment containing a line break. e.g. `<><\n/>`
+  // It produces an `Identifier` token with 0-length range. Skip these invalid tokens.
+  if (start === end) return;
+
+  let value = sourceText!.slice(start, end);
+
+  if (kind === tsSyntaxKind.RegularExpressionLiteral) {
+    tokens.push({
+      // `TokenProto` provides getter for `loc`
+      // @ts-expect-error - TS doesn't understand `__proto__`
+      __proto__: TokenProto,
+      type: "RegularExpression",
+      value,
+      regex: {
+        flags: value.slice(value.lastIndexOf("/") + 1),
+        pattern: value.slice(1, value.lastIndexOf("/")),
+      },
+      start,
+      end,
+      range: [start, end],
+    });
+  } else {
+    const tokenType = getTokenType(token);
+
+    // TODO: `kind === tsSyntaxKind.PrivateIdentifier` would be a faster check, but TS doesn't like it
+    if (tokenType === "PrivateIdentifier") value = value.slice(1);
+
+    tokens.push({
+      // `TokenProto` provides getter for `loc`
+      // @ts-expect-error - TS doesn't understand `__proto__`
+      __proto__: TokenProto,
+      type: tokenType,
+      value,
+      start,
+      end,
+      range: [start, end],
+    });
+  }
+}
+
+/**
+ * Returns the type of a given `ts.Token`.
+ */
+function getTokenType(token: ts.Identifier | ts.Token<ts.SyntaxKind>): Token["type"] {
+  const { kind } = token;
+
+  if (kind === tsSyntaxKind.NullKeyword) return "Null";
+
+  if (kind >= tsSyntaxKind.FirstKeyword && kind <= tsSyntaxKind.LastFutureReservedWord) {
+    return kind === tsSyntaxKind.FalseKeyword || kind === tsSyntaxKind.TrueKeyword
+      ? "Boolean"
+      : "Keyword";
+  }
+
+  if (kind >= tsSyntaxKind.FirstPunctuation && kind <= tsSyntaxKind.LastPunctuation) {
+    return "Punctuator";
+  }
+
+  if (kind >= tsSyntaxKind.NoSubstitutionTemplateLiteral && kind <= tsSyntaxKind.TemplateTail) {
+    return "Template";
+  }
+
+  switch (kind) {
+    case tsSyntaxKind.NumericLiteral:
+    case tsSyntaxKind.BigIntLiteral:
+      return "Numeric";
+
+    case tsSyntaxKind.PrivateIdentifier:
+      return "PrivateIdentifier";
+
+    case tsSyntaxKind.JsxText:
+      return "JSXText";
+
+    case tsSyntaxKind.StringLiteral: {
+      // A TypeScript `StringLiteral` token with a `JsxAttribute` or `JsxElement` parent,
+      // must actually be an ESTree `JSXText` token
+      const parentKind = token.parent.kind;
+      return parentKind === tsSyntaxKind.JsxAttribute || parentKind === tsSyntaxKind.JsxElement
+        ? "JSXText"
+        : "String";
+    }
+
+    case tsSyntaxKind.RegularExpressionLiteral:
+      return "RegularExpression";
+
+    case tsSyntaxKind.Identifier: {
+      // Some JSX tokens have to be determined based on their parent
+      const { parent } = token,
+        parentKind = parent.kind;
+      if (
+        isJSXTokenKind(parentKind) ||
+        (parentKind === tsSyntaxKind.PropertyAccessExpression && hasJSXAncestor(parent.parent))
+      ) {
+        return "JSXIdentifier";
+      }
+    }
+
+    /*
+    case tsSyntaxKind.ConstructorKeyword:
+    case tsSyntaxKind.GetKeyword:
+    case tsSyntaxKind.SetKeyword:
+
+    // Intentional fallthrough
+    default:
+    */
+  }
+
+  return "Identifier";
+}
+
+/**
+ * Check if `node` is a JSX token, or has a JSX token within its ancestry.
+ * @param node - TS AST node
+ * @returns `true` if `node` has a JSX token within its ancestry
+ */
+function hasJSXAncestor(node: ts.Node | undefined): boolean {
+  while (node !== undefined) {
+    if (isJSXTokenKind(node.kind)) return true;
+    node = node.parent;
+  }
+
+  return false;
+}
+
+/**
+ * Check if `kind` is a JSX token kind.
+ * @param kind - TS AST token kind
+ * @returns `true` if `kind` is a JSX token kind
+ */
+function isJSXTokenKind(kind: ts.SyntaxKind): boolean {
+  return kind >= tsSyntaxKind.JsxElement && kind <= tsSyntaxKind.JsxAttribute;
+}

--- a/apps/oxlint/src-js/plugins/ts_eslint.cjs
+++ b/apps/oxlint/src-js/plugins/ts_eslint.cjs
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = require("@typescript-eslint/typescript-estree");

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -7,7 +7,7 @@ export interface Visitor {
 */
 
 import type { Span } from "./location.ts";
-import type { Token, CommentToken } from "./tokens.ts";
+import type { Token } from "./tokens.ts";
 
 import type { VisitorObject as Visitor } from "../generated/visitor.d.ts";
 export type { Visitor };
@@ -31,7 +31,7 @@ export type VisitFn = (node: Node) => void;
 // AST node type.
 export interface Node extends Span {}
 
-export type NodeOrToken = Node | Token | CommentToken;
+export type NodeOrToken = Node | Token | Comment;
 
 // Comment.
 export interface Comment extends Span {

--- a/apps/oxlint/src-js/plugins/typescript.cjs
+++ b/apps/oxlint/src-js/plugins/typescript.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("typescript");

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+
 import type { Plugin, Rule } from "#oxlint";
 
 const rule: Rule = {
@@ -14,15 +16,20 @@ const rule: Rule = {
       message:
         `Tokens:\n` +
         ast.tokens
-          .map(
-            ({ type, loc, range, value }) =>
-              `${type.padEnd(17)} ` +
-              `loc=${loc.start.line}:${loc.start.column}-${loc.end.line}:${loc.end.column} `.padEnd(
-                16,
-              ) +
+          .map((token) => {
+            const { range } = token;
+            assert(token.start === range[0]);
+            assert(token.end === range[1]);
+
+            const { start, end } = token.loc;
+
+            return (
+              `${token.type.padEnd(17)} ` +
+              `loc=${start.line}:${start.column}-${end.line}:${end.column} `.padEnd(16) +
               `range=${range[0]}-${range[1]} `.padEnd(10) +
-              `"${value}"`,
-          )
+              `"${token.value}"`
+            );
+          })
           .join("\n"),
       node: { range: [0, sourceCode.text.length] },
     });
@@ -32,15 +39,20 @@ const rule: Rule = {
       message:
         `Tokens and comments:\n` +
         tokensAndComments
-          .map(
-            ({ type, loc, range, value }) =>
-              `${type.padEnd(17)} ` +
-              `loc=${loc.start.line}:${loc.start.column}-${loc.end.line}:${loc.end.column} `.padEnd(
-                16,
-              ) +
+          .map((token) => {
+            const { range } = token;
+            assert(token.start === range[0]);
+            assert(token.end === range[1]);
+
+            const { start, end } = token.loc;
+
+            return (
+              `${token.type.padEnd(17)} ` +
+              `loc=${start.line}:${start.column}-${end.line}:${end.column} `.padEnd(16) +
               `range=${range[0]}-${range[1]} `.padEnd(10) +
-              `"${value}"`,
-          )
+              `"${token.value}"`
+            );
+          })
           .join("\n"),
       node: { range: [0, sourceCode.text.length] },
     });

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -56,12 +56,12 @@ export default defineConfig([
       experimental: { nativeMagicString: true },
     },
   },
-  // TS-ESLint parser.
+  // TypeScript.
   // Bundled separately and lazy-loaded, as it's a lot of code.
-  // Bundle contains both `@typescript-eslint/typescript-estree` and `typescript`.
+  // Only used for tokens APIs.
   {
     ...commonConfig,
-    entry: "src-js/plugins/ts_eslint.cjs",
+    entry: "src-js/plugins/typescript.cjs",
     format: "commonjs",
     // Minify as this bundle is just dependencies. We don't need to be able to debug it.
     // Minification halves the size of the bundle.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,21 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@napi-rs/cli':
-      specifier: 3.5.0
-      version: 3.5.0
-    '@napi-rs/wasm-runtime':
-      specifier: 1.1.0
-      version: 1.1.0
-    '@types/node':
-      specifier: ^24.0.0
-      version: 24.10.1
     cross-env:
       specifier: ^10.1.0
       version: 10.1.0
-    publint:
-      specifier: 0.3.15
-      version: 0.3.15
     rolldown:
       specifier: 1.0.0-beta.54
       version: 1.0.0-beta.54
@@ -113,9 +101,6 @@ importers:
       '@typescript-eslint/scope-manager':
         specifier: 8.48.1
         version: 8.48.1(patch_hash=08ab34b5f27480602bc518186b717a8915aa4d6b2b5df1adc747320ba25b1f8b)
-      '@typescript-eslint/typescript-estree':
-        specifier: ^8.47.0
-        version: 8.48.1(typescript@5.9.3)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -2247,31 +2232,13 @@ packages:
   '@types/vscode@1.93.0':
     resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
 
-  '@typescript-eslint/project-service@8.48.1':
-    resolution: {integrity: sha512-HQWSicah4s9z2/HifRPQ6b6R7G+SBx64JlFQpgSSHWPKdvCZX57XCbszg/bapbRsOEv42q5tayTYcEFpACcX1w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/scope-manager@8.48.1':
     resolution: {integrity: sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.48.1':
-    resolution: {integrity: sha512-k0Jhs4CpEffIBm6wPaCXBAD7jxBtrHjrSgtfCjUvPp9AZ78lXKdTR8fxyZO5y4vWNlOvYXRtngSZNSn+H53Jkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/types@8.48.1':
     resolution: {integrity: sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.48.1':
-    resolution: {integrity: sha512-/9wQ4PqaefTK6POVTjJaYS0bynCgzh6ClJHGSBj06XEHjkfylzB+A3qvyaXnErEZSaxhIo4YdyBgq6j4RysxDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/visitor-keys@8.48.1':
     resolution: {integrity: sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==}
@@ -4127,12 +4094,6 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   tsdown@0.17.3:
     resolution: {integrity: sha512-bgLgTog+oyadDTr9SZ57jZtb+A4aglCjo3xgJrkCDxbzcQl2l2iDDr4b06XHSQHwyDNIhYFDgPRhuu1wL3pNsw==}
     engines: {node: '>=20.19.0'}
@@ -5053,7 +5014,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5069,7 +5030,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -6071,40 +6032,12 @@ snapshots:
 
   '@types/vscode@1.93.0': {}
 
-  '@typescript-eslint/project-service@8.48.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
-      debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.48.1(patch_hash=08ab34b5f27480602bc518186b717a8915aa4d6b2b5df1adc747320ba25b1f8b)':
     dependencies:
       '@typescript-eslint/types': 8.48.1
       '@typescript-eslint/visitor-keys': 8.48.1
 
-  '@typescript-eslint/tsconfig-utils@8.48.1(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
   '@typescript-eslint/types@8.48.1': {}
-
-  '@typescript-eslint/typescript-estree@8.48.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/visitor-keys@8.48.1':
     dependencies:
@@ -6573,6 +6506,10 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -6799,7 +6736,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -8165,10 +8102,6 @@ snapshots:
   totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
-
-  ts-api-utils@2.1.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
 
   tsdown@0.17.3(@arethetypeswrong/core@0.18.2)(publint@0.3.15)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Previously we used `@typescript-eslint/typescript-estree` parser to tokenize a source text. `@typescript-eslint/typescript-estree` uses TypeScript parser internally, and then builds the tokens array by traversing TypeScript's AST.

Instead, use TypeScript parser directly, and copy the code from TS-ESLint for converting tokens from TypeScript's format to TS-ESTree format.

### Why?

This has a few advantages:

1. Remove a dependency.
2. TS-ESLint's tokens did not have `start` or `end` properties, which we want for consistency with our AST. By reimplementing ourselves, we can add those properties to tokens.
3. TS-ESLint does a bunch of other work besides compiling the tokens array - it converts the AST too. We discard the AST that TS-ESLint produces, so this work is pointless. By cutting out TS-ESLint, we also cut out that unnecessary work, and do only what we need to - tokenizing.
4. TS-ESLint would throw an error if TypeScript produces any errors (even non-fatal ones), and there is no option to tell TS-ESLint not to do that. This caused a bunch of conformance tests to fail, because ESLint's tests include invalid code.
5. Can add workarounds for TypeScript bugs - e.g. not being able to parse JSX closing fragments containing line breaks (`<>hello<\n/>`).

### Implementation detail

We no longer need to get comments from TypeScript. We use the comments produced by Oxc parser instead.

### `CommentToken` type

A side effect is that there's no longer any need for separate `Comment` and `CommentToken` types - as we use our own comments now. So this PR removes `CommentToken` type.

Have marked this as a breaking change due to removal of this type.