### PR TITLE
feat(linter/plugins)!: do not export `NodeOrToken` type

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -55,7 +55,6 @@ export type {
   BeforeHook,
   Comment,
   Node,
-  NodeOrToken,
   Visitor,
   VisitorWithHooks,
 } from "./plugins/types.ts";


### PR DESCRIPTION
Unnecessary to export this type, as it's just an alias for `Node | Token | Comment`. Remove it.