### PR TITLE
feat(eslint-plugin-jest): Add fix capabilities to prefer to contain rule

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -154,10 +154,10 @@ impl PreferToContain {
             };
 
             let argument_trailing_comma = {
-                let has_traling_comma = fixer.source_text()
+                let has_trailing_comma = fixer.source_text()
                     [(property_span.end as usize)..(includes_call_expr.span.end as usize)]
                     .contains(',');
-                if has_traling_comma { "," } else { "" }
+                if has_trailing_comma { "," } else { "" }
             }
             .to_string();
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -140,8 +140,8 @@ impl PreferToContain {
                     .unwrap_or(false);
                 let has_not = jest_expect_fn_call
                     .modifiers()
-                    .first()
-                    .is_some_and(|value| value.name().is_some_and(|modifier| modifier.eq("not")));
+                    .iter()
+                    .any(|modifier| modifier.is_name_equal("not"));
 
                 match (boolean_value, has_not) {
                     (false, true) | (true, false) => "",

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -371,6 +371,5 @@ fn tests() {
     Tester::new(PreferToContain::NAME, PreferToContain::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_jest_plugin(true)
-        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -3,6 +3,7 @@ use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
 };
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
@@ -52,6 +53,7 @@ declare_oxc_lint!(
     PreferToContain,
     jest,
     style,
+    fix
 );
 
 impl Rule for PreferToContain {
@@ -122,7 +124,58 @@ impl PreferToContain {
             return;
         }
 
-        ctx.diagnostic(use_to_contain(matcher.span));
+        ctx.diagnostic_with_fix(use_to_contain(matcher.span), |fixer| {
+            let Some(mem_expr) = includes_call_expr.callee.as_member_expression() else {
+                return fixer.noop();
+            };
+
+            let Some(argument) = includes_call_expr.arguments.first() else {
+                return fixer.noop();
+            };
+
+            let Some((property_span, _)) = mem_expr.static_property_info() else {
+                return fixer.noop();
+            };
+
+            let negation = {
+                let boolean_value = jest_expect_first_arg
+                    .get_inner_expression()
+                    .to_boolean(&WithoutGlobalReferenceInformation {})
+                    .unwrap_or(false);
+                let has_not = jest_expect_fn_call
+                    .modifiers()
+                    .first()
+                    .is_some_and(|value| value.name().is_some_and(|modifier| modifier.eq("not")));
+
+                match (boolean_value, has_not) {
+                    (false, true) | (true, false) => "",
+                    (true, true) | (false, false) => ".not",
+                }
+            };
+
+            let argument_trailing_comma = {
+                let has_traling_comma = fixer.source_text()
+                    [(property_span.end as usize)..(includes_call_expr.span.end as usize)]
+                    .contains(',');
+                if has_traling_comma { "," } else { "" }
+            }
+            .to_string();
+
+            let trailing_property = fixer.source_text()
+                [(includes_call_expr.span.end as usize)..(expect_call_expr.span.end as usize)]
+                .to_string();
+
+            let mut formatter = fixer.codegen();
+
+            formatter.print_expression(&expect_call_expr.callee);
+            formatter.print_str("(");
+            formatter.print_expression(mem_expr.object());
+            formatter.print_str(format!("{trailing_property}{negation}.toContain(").as_str());
+            formatter.print_expression(argument.to_expression());
+            formatter.print_str(format!("{argument_trailing_comma})").as_str());
+
+            fixer.replace(call_expr.span, formatter.into_source_text())
+        });
     }
 
     fn is_fixable_includes_call_expression(call_expr: &CallExpression) -> bool {
@@ -223,7 +276,101 @@ fn tests() {
         ("expect(a.includes(b)).toEqual(false as boolean);", None),
     ];
 
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let fix = vec![
+        ("expect(a.includes(b)).toEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b,),).toEqual(true,);", "expect(a,).toContain(b,);", None),
+        ("expect(a['includes'](b)).toEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['toEqual'](true);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b)).toEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a['includes'](b)).not.toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['not'].toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['not']['toEqual'](false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toEqual(true);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).toBe(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toBe(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toBe(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toBe(true);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).toStrictEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toStrictEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(true);", "expect(a).not.toContain(b);", None),
+        (
+            "expect(a.test(t).includes(b.test(p))).toEqual(true);",
+            "expect(a.test(t)).toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).toEqual(false);",
+            "expect(a.test(t)).not.toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).not.toEqual(true);",
+            "expect(a.test(t)).not.toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).not.toEqual(false);",
+            "expect(a.test(t)).toContain(b.test(p));",
+            None,
+        ),
+        // Diff with eslint: The default print_expression add a space between key and value, and before and after curly braces, values
+        (
+            "expect([{a:1}].includes({a:1})).toBe(true);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toBe(false);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toBe(true);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toBe(false);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toStrictEqual(true);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toStrictEqual(false);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toStrictEqual(true);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toStrictEqual(false);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "import { expect as pleaseExpect } from '@jest/globals';
+			pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false);",
+            "import { expect as pleaseExpect } from '@jest/globals';
+			pleaseExpect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        ("expect(a.includes(b)).toEqual(false as boolean);", "expect(a).not.toContain(b);", None),
+    ];
+
     Tester::new(PreferToContain::NAME, PreferToContain::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
@@ -13,7 +13,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(a.includes(b,),).toEqual(true,)
    ·                         ───────
    ╰────
-  help: Replace `expect(a.includes(b,),).toEqual(true,)` with `expect(a,).toContain(b,)`.
+  help: Replace `expect(a.includes(b,),).toEqual(true,)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:26]

--- a/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
@@ -6,186 +6,217 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(a.includes(b)).toEqual(true);
    ·                       ───────
    ╰────
+  help: Replace `expect(a.includes(b)).toEqual(true)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:25]
  1 │ expect(a.includes(b,),).toEqual(true,)
    ·                         ───────
    ╰────
+  help: Replace `expect(a.includes(b,),).toEqual(true,)` with `expect(a,).toContain(b,)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:26]
  1 │ expect(a['includes'](b)).toEqual(true);
    ·                          ───────
    ╰────
+  help: Replace `expect(a['includes'](b)).toEqual(true)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:26]
  1 │ expect(a['includes'](b))['toEqual'](true);
    ·                          ─────────
    ╰────
+  help: Replace `expect(a['includes'](b))['toEqual'](true)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:26]
  1 │ expect(a['includes'](b)).toEqual(false);
    ·                          ───────
    ╰────
+  help: Replace `expect(a['includes'](b)).toEqual(false)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:30]
  1 │ expect(a['includes'](b)).not.toEqual(false);
    ·                              ───────
    ╰────
+  help: Replace `expect(a['includes'](b)).not.toEqual(false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect(a['includes'](b))['not'].toEqual(false);
    ·                                 ───────
    ╰────
+  help: Replace `expect(a['includes'](b))['not'].toEqual(false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect(a['includes'](b))['not']['toEqual'](false);
    ·                                 ─────────
    ╰────
+  help: Replace `expect(a['includes'](b))['not']['toEqual'](false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toEqual(false);
    ·                       ───────
    ╰────
+  help: Replace `expect(a.includes(b)).toEqual(false)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toEqual(false);
    ·                           ───────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toEqual(false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toEqual(true);
    ·                           ───────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toEqual(true)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toBe(true);
    ·                       ────
    ╰────
+  help: Replace `expect(a.includes(b)).toBe(true)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toBe(false);
    ·                       ────
    ╰────
+  help: Replace `expect(a.includes(b)).toBe(false)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toBe(false);
    ·                           ────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toBe(false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toBe(true);
    ·                           ────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toBe(true)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toStrictEqual(true);
    ·                       ─────────────
    ╰────
+  help: Replace `expect(a.includes(b)).toStrictEqual(true)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toStrictEqual(false);
    ·                       ─────────────
    ╰────
+  help: Replace `expect(a.includes(b)).toStrictEqual(false)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toStrictEqual(false);
    ·                           ─────────────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toStrictEqual(false)` with `expect(a).toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:27]
  1 │ expect(a.includes(b)).not.toStrictEqual(true);
    ·                           ─────────────
    ╰────
+  help: Replace `expect(a.includes(b)).not.toStrictEqual(true)` with `expect(a).not.toContain(b)`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:39]
  1 │ expect(a.test(t).includes(b.test(p))).toEqual(true);
    ·                                       ───────
    ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).toEqual(true)` with `expect(a.test(t)).toContain(b.test(p))`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:39]
  1 │ expect(a.test(t).includes(b.test(p))).toEqual(false);
    ·                                       ───────
    ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).toEqual(false)` with `expect(a.test(t)).not.toContain(b.test(p))`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:43]
  1 │ expect(a.test(t).includes(b.test(p))).not.toEqual(true);
    ·                                           ───────
    ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).not.toEqual(true)` with `expect(a.test(t)).not.toContain(b.test(p))`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:43]
  1 │ expect(a.test(t).includes(b.test(p))).not.toEqual(false);
    ·                                           ───────
    ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).not.toEqual(false)` with `expect(a.test(t)).toContain(b.test(p))`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect([{a:1}].includes({b:1})).toBe(true);
    ·                                 ────
    ╰────
+  help: Replace `expect([{a:1}].includes({b:1})).toBe(true)` with `expect([{ a: 1 }]).toContain({ b: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect([{a:1}].includes({a:1})).toBe(false);
    ·                                 ────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toBe(false)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:37]
  1 │ expect([{a:1}].includes({a:1})).not.toBe(true);
    ·                                     ────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toBe(true)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:37]
  1 │ expect([{a:1}].includes({a:1})).not.toBe(false);
    ·                                     ────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toBe(false)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect([{a:1}].includes({a:1})).toStrictEqual(true);
    ·                                 ─────────────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toStrictEqual(true)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:33]
  1 │ expect([{a:1}].includes({a:1})).toStrictEqual(false);
    ·                                 ─────────────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toStrictEqual(false)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:37]
  1 │ expect([{a:1}].includes({a:1})).not.toStrictEqual(true);
    ·                                     ─────────────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toStrictEqual(true)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:37]
  1 │ expect([{a:1}].includes({a:1})).not.toStrictEqual(false);
    ·                                     ─────────────
    ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toStrictEqual(false)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:3:59]
@@ -194,9 +225,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                           ─────────────
  4 │             
    ╰────
+  help: Replace `pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false)` with `pleaseExpect([{ a: 1 }]).toContain({ a: 1 })`.
 
   ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
    ╭─[prefer_to_contain.tsx:1:23]
  1 │ expect(a.includes(b)).toEqual(false as boolean);
    ·                       ───────
    ╰────
+  help: Replace `expect(a.includes(b)).toEqual(false as boolean)` with `expect(a).not.toContain(b)`.


### PR DESCRIPTION
Currently oxclint can't fix any `prefer-to-contain` error, but the [jest eslint rule can](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-contain.md), also this will be helpful to vitest.

Any alternative for the trailing comma check are welcome. None of my global searched in the codebase lead to an example, only to check if a trailing comma exists.