### PR TITLE
chore(linter): Remove "Options" sections in rule docs.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -40,10 +40,6 @@ declare_oxc_lint!(
     /// This can lead to hard-to-find bugs.
     /// By enforcing block scoping, this rule helps avoid hoisting issues and aligns more closely with how other languages treat block variables.
     ///
-    /// ### Options
-    ///
-    /// No options available for this rule.
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -24,9 +24,6 @@ declare_oxc_lint!(
     /// While it is legal to place it before or between `case` clauses, doing so is confusing and may
     /// lead to unexpected "fall-through" behavior.
     ///
-    /// ### Options
-    /// No options available for this rule
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -25,10 +25,6 @@ declare_oxc_lint!(
     /// which improves readability and consistency. This rule applies equally to JavaScript and
     /// TypeScript functions.
     ///
-    /// ### Options
-    ///
-    /// No options available for this rule
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
@@ -189,7 +185,7 @@ fn test() {
                 public a: number,
                 protected b = 10,
                 private c?: number,
-            ) {} 
+            ) {}
         }",
         "
         class Foo {
@@ -264,7 +260,7 @@ fn test() {
             constructor(
                 public a?: number,
                 private b: number,
-            ) {} 
+            ) {}
         }",
         "
         class Foo {

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -18,7 +18,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn for_direction_diagnostic(test_span: Span, update_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The update clause in this loop moves the variable in the wrong direction")
-        .with_help("Use while loop for intended infinite loop")
+        .with_help("Use `while` loop for intended infinite loop")
         .with_labels([
             test_span.label("This test moves in the wrong direction"),
             update_span.label("with this update"),
@@ -40,16 +40,12 @@ declare_oxc_lint!(
     /// infinitely. While infinite loops can be intentional, they are usually written
     /// as `while` loops. More often, an infinite `for` loop is a bug.
     ///
-    /// ### Options
-    ///
-    /// No options available for this rule.
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     ///
     /// ```js
-    /// /* eslint for-direction: "error" */
+    /// /* for-direction: "error" */
     ///
     /// for (var i = 0; i < 10; i--) {
     /// }
@@ -71,7 +67,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     ///
     /// ```js
-    /// /* eslint for-direction: "error" */
+    /// /* for-direction: "error" */
     ///
     /// for (var i = 0; i < 10; i++) {
     /// }

--- a/crates/oxc_linter/src/snapshots/eslint_for_direction.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_for_direction.snap
@@ -8,7 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │     ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │     ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │     ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │     ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │      ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │     ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │     ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │      ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │       ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -98,7 +98,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -107,7 +107,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -116,7 +116,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │      ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -125,7 +125,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │       ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -134,7 +134,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:17]
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
    ╭─[for_direction.tsx:1:16]
@@ -152,4 +152,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                   │      ╰── with this update
    ·                   ╰── This test moves in the wrong direction
    ╰────
-  help: Use while loop for intended infinite loop
+  help: Use `while` loop for intended infinite loop


### PR DESCRIPTION
If we want to do these for rules that have no config options, we should auto-generate them.