### PR TITLE
refactor(linter): Use DefaultRuleConfig for config options on three jest rules.

### DIFF
--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 
 use crate::{
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{PossibleJestNode, collect_possible_jest_call_node},
 };
 
@@ -35,14 +35,13 @@ impl Default for MaxExpects {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// As more assertions are made, there is a possible tendency for the test to be
-    /// more likely to mix multiple objectives. To avoid this, this rule reports when
-    /// the maximum number of assertions is exceeded.
+    /// This rule enforces a maximum number of `expect()` calls in a single test.
     ///
     /// ### Why is this bad?
     ///
-    /// This rule enforces a maximum number of `expect()` calls.
-    /// The following patterns are considered warnings (with the default max of 5):
+    /// Tests with many different assertions are likely mixing multiple objectives.
+    /// It is generally better to have a single objective per test to ensure that when a test fails,
+    /// the problem is easy to identify.
     ///
     /// ### Examples
     ///
@@ -85,11 +84,9 @@ declare_oxc_lint!(
 
 impl Rule for MaxExpects {
     fn from_configuration(value: serde_json::Value) -> Self {
-        value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
+        serde_json::from_value::<DefaultRuleConfig<MaxExpects>>(value)
             .unwrap_or_default()
+            .into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_commented_out_tests_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Some tests seem to be commented")
-        .with_help("Remove or uncomment this comment")
+    OxcDiagnostic::warn("Some tests appear to be inside comments.")
+        .with_help("Remove or uncomment this test.")
         .with_label(span)
 }
 
@@ -17,13 +17,14 @@ pub struct NoCommentedOutTests;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule raises a warning about commented out tests. It's similar to
-    /// no-disabled-tests rule.
+    /// This rule raises a warning about commented out tests. It's similar to the
+    /// `no-disabled-tests` rule.
     ///
     /// ### Why is this bad?
     ///
-    /// You may forget to uncomment some tests. This rule raises a warning about commented out tests. It's similar to
-    /// no-disabled-tests rule.
+    /// You may forget to uncomment some tests. This rule raises a warning about commented-out tests.
+    ///
+    /// It is generally better to skip a test if it's flaky, or remove it if it's no longer needed.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -12,8 +12,8 @@ use crate::{
     },
 };
 
-fn no_test_prefixes_diagnostic(x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use {x1:?} instead.")).with_label(span2)
+fn no_test_prefixes_diagnostic(preferred_node_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `{preferred_node_name}` instead.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
@@ -1,114 +1,114 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fdescribe('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe['skip']('foo', function () {})
    ·   ────────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe['skip']('foo', function () {})
    ·   ────────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.skip('foo', function () {})
    ·   ───────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.only('foo', function () {})
    ·   ───────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.concurrent('foo', function () {})
    ·   ─────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it['skip']('foo', function () {})
    ·   ──────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.skip('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.concurrent('foo', function () {})
    ·   ───────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test['skip']('foo', function () {})
    ·   ────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xdescribe('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xit('foo', function () {})
    ·   ───────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fit('foo', function () {})
    ·   ───────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xtest('foo', function () {})
    ·   ─────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:2:17]
  1 │ 
  2 │               // test(
    ·                 ──────
  3 │               //   "foo", function () {}
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:2:17]
  1 │     
  2 │ ╭─▶               /* test
@@ -118,44 +118,44 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶               */
  7 │                 
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it('has title but no callback')
    ·   ────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it()
    ·   ─────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.someNewMethodThatMightBeAddedInTheFuture()
    ·   ────────────────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test['someNewMethodThatMightBeAddedInTheFuture']()
    ·   ───────────────────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test('has title but no callback')
    ·   ──────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:3:17]
  2 │                   foo()
  3 │ ╭─▶               /*
@@ -163,55 +163,55 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶               */
  6 │                   bar()
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe(\'foo\', function () {})\'
    ·   ────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.concurrent("foo", function () {})
    ·   ───────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test["skip"]("foo", function () {})
    ·   ────────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xdescribe("foo", function () {})
    ·   ─────────────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xit("foo", function () {})
    ·   ───────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fit("foo", function () {})
    ·   ───────────────────────────
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.
 
-  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:2:15]
  1 │ 
  2 │             // test(
    ·               ──────
  3 │             //   "foo", function () {}
    ╰────
-  help: Remove or uncomment this comment
+  help: Remove or uncomment this test.

--- a/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
@@ -1,28 +1,28 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:29]
  1 │ (() => {})('testing', () => expect(true).toBe(false))
    ·                             ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:1]
  1 │ expect.hasAssertions()
    · ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:1]
  1 │ expect().hasAssertions()
    · ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:4:40]
  3 │                     const t = Math.random() ? it.only : it;
  4 │                     t('testing', () => expect(true).toBe(false));
@@ -31,7 +31,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:4:40]
  3 │                     const t = Math.random() ? it.only : it;
  4 │                     t('testing', () => expect(true).toBe(false));
@@ -40,7 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:7:21]
  6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
  7 │                     expect(a + b).toBe(expected);
@@ -49,7 +49,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:7:21]
  6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
  7 │                     expect(a + b).toBe(expected);
@@ -58,7 +58,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:7:21]
  6 │                 ]).test('returns the result of adding %d to %d', (a, b, expected) => {
  7 │                     expect(a + b).toBe(expected);
@@ -67,63 +67,63 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:28]
  1 │ describe('a test', () => { expect(1).toBe(1); });
    ·                            ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:26]
  1 │ describe('a test', () => expect(1).toBe(1));
    ·                          ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:71]
  1 │ describe('a test', () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });
    ·                                                                       ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:63]
  1 │ describe('a test', () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });
    ·                                                               ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:1]
  1 │ expect(1).toBe(1);
    · ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:2]
  1 │ {expect(1).toBe(1)}
    ·  ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:70]
  1 │ it.each([1, true])('trues', value => { expect(value).toBe(true); }); expect(1).toBe(1);
    ·                                                                      ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:46]
  1 │ describe.each([1, true])('trues', value => { expect(value).toBe(true); });
    ·                                              ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:3:44]
  2 │                 import { expect as pleaseExpect } from '@jest/globals';
  3 │                 describe('a test', () => { pleaseExpect(1).toBe(1); });
@@ -132,7 +132,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:3:34]
  2 │                 import { expect as pleaseExpect } from '@jest/globals';
  3 │                 beforeEach(() => pleaseExpect.hasAssertions());

--- a/crates/oxc_linter/src/snapshots/jest_no_standalone_expect@vitest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_standalone_expect@vitest.snap
@@ -1,21 +1,21 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:29]
  1 │ (() => {})('testing', () => expect(true).toBe(false))
    ·                             ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:1]
  1 │ expect.hasAssertions()
    · ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:4:29]
  3 │                   const t = Math.random() ? it.only : it;
  4 │                   t('testing', () => expect(true).toBe(false));
@@ -24,7 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:3:29]
  2 │                   const t = Math.random() ? it.only : it;
  3 │                   t('testing', () => expect(true).toBe(false));
@@ -33,49 +33,49 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:28]
  1 │ describe("a test", () => { expect(1).toBe(1); });
    ·                            ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:26]
  1 │ describe("a test", () => expect(1).toBe(1));
    ·                          ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:71]
  1 │ describe("a test", () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });
    ·                                                                       ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:63]
  1 │ describe("a test", () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });
    ·                                                               ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:1]
  1 │ expect(1).toBe(1);
    · ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:2]
  1 │ {expect(1).toBe(1)}
    ·  ──────
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
 
-  ⚠ eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.
+  ⚠ eslint-plugin-jest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:7:11]
  6 │                  ]).test('returns the result of adding %d to %d', (a, b, expected) => {
  7 │                    expect(a + b).toBe(expected);

--- a/crates/oxc_linter/src/snapshots/jest_no_test_prefixes.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_test_prefixes.snap
@@ -1,77 +1,77 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.only` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])('foo', function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.only` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit('foo', function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit('foo', function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest('foo', function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip` instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit } from '@jest/globals';
  3 │                 xit('foo', function () {})
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip` instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit as skipThis } from '@jest/globals';
  3 │                 skipThis('foo', function () {})
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `skipThis` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.only` instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { fit as onlyThis } from '@jest/globals';
  3 │                 onlyThis('foo', function () {})
@@ -98,70 +98,70 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `onlyThis` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.only` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])("foo", function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.only` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit("foo", function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `describe.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit("foo", function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest("foo", function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``("foo", function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `it.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use `test.skip.each` instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])("foo", function () {})
    · ──────────


### PR DESCRIPTION
Just a simple refactor to get three more rules using the `DefaultRuleConfig` pattern. This also includes some documentation and diagnostics improvements.