### PR TITLE
refactor(linter): Update various rules to use DefaultRuleConfig and fix some minor issues.

### DIFF
--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -79,6 +79,12 @@ declare_oxc_lint!(
 );
 
 impl Rule for ButtonHasType {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        serde_json::from_value::<DefaultRuleConfig<ButtonHasType>>(value)
+            .unwrap_or_default()
+            .into_inner()
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
@@ -151,12 +157,6 @@ impl Rule for ButtonHasType {
             }
             _ => {}
         }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ButtonHasType>>(value)
-            .unwrap_or_default()
-            .into_inner()
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {

--- a/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_handler_names.rs
@@ -26,7 +26,7 @@ fn bad_handler_name_diagnostic(
         } else {
             "Bad handler name".to_string()
         },
-)
+    )
         .with_help(format!(
             "Handler function for {prop_key} prop key must be a camelCase name beginning with \'{handler_prefix}\' only"
         ))

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn no_render_return_value_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not depend on the return value from ReactDOM.render.")
+    OxcDiagnostic::warn("Do not depend on the return value from `ReactDOM.render`.")
         .with_help("Using the return value is a legacy feature.")
         .with_label(span)
 }
@@ -21,11 +21,11 @@ pub struct NoRenderReturnValue;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule will warn you if you try to use the ReactDOM.render() return value.
+    /// This rule will warn you if you try to use the `ReactDOM.render()` return value.
     ///
     /// ### Why is this bad?
     ///
-    /// Using the return value from ReactDOM.render() is a legacy feature and should not be used.
+    /// Using the return value from `ReactDOM.render()` is a legacy feature and should not be used.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use setState").with_label(span)
+    OxcDiagnostic::warn("Do not use `setState`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
@@ -9,7 +9,7 @@ use crate::{
     AstNode,
     context::{ContextHost, LintContext},
     frameworks::FrameworkOptions,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
 };
 
 fn prefer_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
@@ -25,15 +25,19 @@ fn avoid_with_defaults_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[schemars(untagged, rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 enum Destructure {
+    /// Requires destructuring when using `defineProps` and warns against using `withDefaults` with destructuring
     #[default]
     Always,
+    /// Requires using a variable to store props and prohibits destructuring
     Never,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct DefinePropsDestructuring {
+    /// Require or prohibit destructuring.
     destructure: Destructure,
 }
 
@@ -70,18 +74,6 @@ declare_oxc_lint!(
     ///   const { bar = 'default' } = defineProps<{ bar?: string }>()
     /// </script>
     /// ```
-    ///
-    /// ### Options
-    /// ```json
-    /// {
-    ///   "vue/define-props-destructuring": ["error", {
-    ///     "destructure": "always" | "never"
-    ///   }]
-    /// }
-    /// ```
-    /// `destructure` - Sets the destructuring preference for props
-    /// - `"always"` (default) - Requires destructuring when using `defineProps` and warns against using `withDefaults` with destructuring
-    /// - `"never"` - Requires using a variable to store props and prohibits destructuring
     DefinePropsDestructuring,
     vue,
     style,
@@ -90,16 +82,9 @@ declare_oxc_lint!(
 
 impl Rule for DefinePropsDestructuring {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let val = value
-            .get(0)
-            .and_then(|v| v.as_object())
-            .and_then(|obj| obj.get("destructure").and_then(|v| v.as_str()));
-        Self {
-            destructure: match val {
-                Some("never") => Destructure::Never,
-                _ => Destructure::Always,
-            },
-        }
+        serde_json::from_value::<DefaultRuleConfig<DefinePropsDestructuring>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -167,60 +152,60 @@ fn test() {
     let pass = vec![
         (
             "
-			      <script setup>
-			      const props = defineProps()
-			      </script>
-			      ",
+                  <script setup>
+                  const props = defineProps()
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			      const { foo = 'default' } = defineProps(['foo'])
-			      </script>
-			      ",
+                  <script setup>
+                  const { foo = 'default' } = defineProps(['foo'])
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			      const { foo = 'default' } = defineProps<{ foo?: string }>()
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                  const { foo = 'default' } = defineProps<{ foo?: string }>()
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") }      },
         (
             "
-			      <script setup>
-			      const props = defineProps(['foo'])
-			      </script>
-			      ",
+                  <script setup>
+                  const props = defineProps(['foo'])
+                  </script>
+                  ",
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			      const props = withDefaults(defineProps(['foo']), { foo: 'default' })
-			      </script>
-			      ",
+                  <script setup>
+                  const props = withDefaults(defineProps(['foo']), { foo: 'default' })
+                  </script>
+                  ",
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			      const props = defineProps<{ foo?: string }>()
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                  const props = defineProps<{ foo?: string }>()
+                  </script>
+                  "#,
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),
@@ -230,80 +215,80 @@ fn test() {
     let fail = vec![
         (
             "
-			      <script setup>
-			      const props = defineProps(['foo'])
-			      </script>
-			      ",
+                  <script setup>
+                  const props = defineProps(['foo'])
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			      const props = withDefaults(defineProps(['foo']), { foo: 'default' })
-			      </script>
-			      ",
+                  <script setup>
+                  const props = withDefaults(defineProps(['foo']), { foo: 'default' })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			      const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
-			      </script>
-			      ",
+                  <script setup>
+                  const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			      const props = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                  const props = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") }      },
         (
             r#"
-			      <script setup lang="ts">
-			      const { foo } = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                  const { foo } = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") }      },
         (
             "
-			      <script setup>
-			      const { foo } = defineProps(['foo'])
-			      </script>
-			      ",
+                  <script setup>
+                  const { foo } = defineProps(['foo'])
+                  </script>
+                  ",
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			      const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
-			      </script>
-			      ",
+                  <script setup>
+                  const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
+                  </script>
+                  ",
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			      const { foo } = defineProps<{ foo?: string }>()
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                  const { foo } = defineProps<{ foo?: string }>()
+                  </script>
+                  "#,
             Some(serde_json::json!([{ "destructure": "never" }])),
             None,
             Some(PathBuf::from("test.vue")),

--- a/crates/oxc_linter/src/snapshots/react_no_render_return_value.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_render_return_value.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:1:13]
  1 │ var Hello = ReactDOM.render(<div />, document.body);
    ·             ───────────────
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:3:26]
  2 │                     var o = {
  3 │                       inst: ReactDOM.render(<div />, document.body)
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:3:27]
  2 │                     function render () {
  3 │                       return ReactDOM.render(<div />, document.body)
@@ -26,28 +26,28 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:1:24]
  1 │ var render = (a, b) => ReactDOM.render(a, b)
    ·                        ───────────────
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:1:10]
  1 │ this.o = ReactDOM.render(<div />, document.body);
    ·          ───────────────
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:1:12]
  1 │ var v; v = ReactDOM.render(<div />, document.body);
    ·            ───────────────
    ╰────
   help: Using the return value is a legacy feature.
 
-  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.
+  ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
    ╭─[no_render_return_value.tsx:1:12]
  1 │ var inst = ReactDOM.render(<div />, document.body);
    ·            ───────────────

--- a/crates/oxc_linter/src/snapshots/react_no_set_state.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_set_state.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(no-set-state): Do not use setState
+  ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
  3 │                       componentDidUpdate: function() {
  4 │                         this.setState({
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                           name: this.props.name.toUpperCase()
    ╰────
 
-  ⚠ eslint-plugin-react(no-set-state): Do not use setState
+  ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
  3 │                       someMethod: function() {
  4 │                         this.setState({
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                           name: this.props.name.toUpperCase()
    ╰────
 
-  ⚠ eslint-plugin-react(no-set-state): Do not use setState
+  ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
  3 │                       someMethod() {
  4 │                         this.setState({
@@ -25,7 +25,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                           name: this.props.name.toUpperCase()
    ╰────
 
-  ⚠ eslint-plugin-react(no-set-state): Do not use setState
+  ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
  3 │                       someMethod = () => {
  4 │                         this.setState({
@@ -33,7 +33,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                           name: this.props.name.toUpperCase()
    ╰────
 
-  ⚠ eslint-plugin-react(no-set-state): Do not use setState
+  ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:48]
  3 │                       render() {
  4 │                         return <div onMouseEnter={() => this.setState({dropdownIndex: index})} />;

--- a/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
+++ b/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
@@ -1,25 +1,25 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:12]
  1 │ <div style="color: 'red'" />
    ·            ──────────────
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:14]
  1 │ <Hello style="color: 'green'" />
    ·              ────────────────
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:12]
  1 │ <div style={true} />
    ·            ──────
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
  3 │               function redDiv2() {
  4 │                 return <div style={styles} />;
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │               }
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
  3 │               function redDiv2() {
  4 │                 return <div style={styles} />;
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │               }
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:37]
  3 │               function redDiv2() {
  4 │                 return <Hello style={styles} />;
@@ -43,7 +43,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │               }
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
  3 │               function redDiv() {
  4 │                 return <div style={styles} />;
@@ -51,19 +51,19 @@ source: crates/oxc_linter/src/tester.rs
  5 │               }
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:20]
  1 │ <MyComponent style="myStyle" />
    ·                    ─────────
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:44]
  1 │ React.createElement(MyComponent2, { style: "mySpecialStyle" })
    ·                                            ────────────────
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
  2 │             let styles: string | undefined
  3 │             return <div style={styles} />
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │           
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
  2 │             let styles: number | undefined
  3 │             return <div style={styles} />
@@ -79,7 +79,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │           
    ╰────
 
-  ⚠ eslint-plugin-react(style-prop-object): Style prop value must be an object
+  ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
  2 │             let styles: boolean | undefined
  3 │             return <div style={styles} />

--- a/crates/oxc_linter/src/snapshots/vue_define_props_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/vue_define_props_destructuring.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-vue(define-props-destructuring): Prefer destructuring from `defineProps` directly.
-   ╭─[define_props_destructuring.tsx:3:24]
+   ╭─[define_props_destructuring.tsx:3:33]
  2 │                   <script setup>
  3 │                   const props = defineProps(['foo'])
    ·                                 ────────────────────
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Prefer destructuring from `defineProps` directly.
-   ╭─[define_props_destructuring.tsx:3:37]
+   ╭─[define_props_destructuring.tsx:3:46]
  2 │                   <script setup>
  3 │                   const props = withDefaults(defineProps(['foo']), { foo: 'default' })
    ·                                              ────────────────────
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid using `withDefaults` with destructuring.
-   ╭─[define_props_destructuring.tsx:3:26]
+   ╭─[define_props_destructuring.tsx:3:35]
  2 │                   <script setup>
  3 │                   const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
    ·                                   ────────────
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Prefer destructuring from `defineProps` directly.
-   ╭─[define_props_destructuring.tsx:3:37]
+   ╭─[define_props_destructuring.tsx:3:46]
  2 │                   <script setup lang="ts">
  3 │                   const props = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
    ·                                              ───────────────────────────────
@@ -34,7 +34,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid using `withDefaults` with destructuring.
-   ╭─[define_props_destructuring.tsx:3:26]
+   ╭─[define_props_destructuring.tsx:3:35]
  2 │                   <script setup lang="ts">
  3 │                   const { foo } = withDefaults(defineProps<{ foo?: string }>(), { foo: 'default' })
    ·                                   ────────────
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
-   ╭─[define_props_destructuring.tsx:3:26]
+   ╭─[define_props_destructuring.tsx:3:35]
  2 │                   <script setup>
  3 │                   const { foo } = defineProps(['foo'])
    ·                                   ────────────────────
@@ -50,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
-   ╭─[define_props_destructuring.tsx:3:39]
+   ╭─[define_props_destructuring.tsx:3:48]
  2 │                   <script setup>
  3 │                   const { foo } = withDefaults(defineProps(['foo']), { foo: 'default' })
    ·                                                ────────────────────
@@ -58,7 +58,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
-   ╭─[define_props_destructuring.tsx:3:26]
+   ╭─[define_props_destructuring.tsx:3:35]
  2 │                   <script setup lang="ts">
  3 │                   const { foo } = defineProps<{ foo?: string }>()
    ·                                   ───────────────────────────────


### PR DESCRIPTION
Update a handful of rules to use the DefaultRuleConfig pattern.


- `react/button-has-type`
- `react/jsx-no-target-blank`
- `react/style-prop-object`
- `vue/define-props-destructuring`


For `react/style-prop-object`, this _was_ sorting the `allow` vector to enable binary search, but I'd be surprised if the performance of this matters enough to warrant it. And it wasn't being done consistently anyway, the most common case (JSX elements) wasn't even using a binary search.

This also fixes the rule docs for `vue/define-props-destructuring`, which were previously broken.

Now they look like this:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### destructure

type: `"always" | "never"`

default: `"always"`

Require or prohibit destructuring.

#### `"always"`

Requires destructuring when using `defineProps` and warns against using `withDefaults` with destructuring

#### `"never"`

Requires using a variable to store props and prohibits destructuring
```