### PR TITLE
refactor(linter): Use DefaultRuleConfig more and simplify from_configuration for tsgolint rules

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoConfusingVoidExpression(Box<NoConfusingVoidExpressionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -74,11 +74,9 @@ declare_oxc_lint!(
 
 impl Rule for NoConfusingVoidExpression {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoConfusingVoidExpressionConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoConfusingVoidExpression>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoDuplicateTypeConstituents(Box<NoDuplicateTypeConstituentsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -69,11 +69,9 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateTypeConstituents {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoDuplicateTypeConstituentsConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoDuplicateTypeConstituents>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -2,16 +2,13 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
 fn default_checks_void_return() -> ChecksVoidReturn {
     ChecksVoidReturn::Boolean(true)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoMisusedPromises(Box<NoMisusedPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -20,11 +17,9 @@ pub struct NoMisusedPromises(Box<NoMisusedPromisesConfig>);
 pub struct NoMisusedPromisesConfig {
     /// Whether to check if Promises are used in conditionals.
     /// When true, disallows using Promises in conditions where a boolean is expected.
-    #[serde(default = "default_true")]
     pub checks_conditionals: bool,
     /// Whether to check if Promises are used in spread syntax.
     /// When true, disallows spreading Promise values.
-    #[serde(default = "default_true")]
     pub checks_spreads: bool,
     /// Configuration for checking if Promises are returned in contexts expecting void.
     /// Can be a boolean to enable/disable all checks, or an object for granular control.
@@ -53,22 +48,16 @@ pub enum ChecksVoidReturn {
 #[serde(rename_all = "camelCase", default)]
 pub struct ChecksVoidReturnOptions {
     /// Whether to check Promise-returning functions passed as arguments to void-returning functions.
-    #[serde(default = "default_true")]
     pub arguments: bool,
     /// Whether to check Promise-returning functions in JSX attributes expecting void.
-    #[serde(default = "default_true")]
     pub attributes: bool,
     /// Whether to check Promise-returning methods that override void-returning inherited methods.
-    #[serde(default = "default_true")]
     pub inherited_methods: bool,
     /// Whether to check Promise-returning functions assigned to object properties expecting void.
-    #[serde(default = "default_true")]
     pub properties: bool,
     /// Whether to check Promise values returned from void-returning functions.
-    #[serde(default = "default_true")]
     pub returns: bool,
     /// Whether to check Promise-returning functions assigned to variables typed as void-returning.
-    #[serde(default = "default_true")]
     pub variables: bool,
 }
 
@@ -88,7 +77,9 @@ impl Default for ChecksVoidReturnOptions {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule forbids providing Promises to logical locations such as if statements in places where the TypeScript compiler allows them but they are not handled properly. These situations can often arise due to a missing await keyword or just a misunderstanding of the way async functions are handled/awaited.
+    /// This rule forbids providing Promises to logical locations such as if statements in places where the TypeScript
+    /// compiler allows them but they are not handled properly. These situations can often arise due to a missing
+    /// `await` keyword or just a misunderstanding of the way async functions are handled/awaited.
     ///
     /// ### Why is this bad?
     ///
@@ -140,11 +131,9 @@ declare_oxc_lint!(
 
 impl Rule for NoMisusedPromises {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoMisusedPromisesConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoMisusedPromises>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -10,6 +10,12 @@ use crate::{
     rule::Rule,
 };
 
+fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("'Disallow non-null assertions in the left operand of a nullish coalescing operator")
+        .with_help("The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.")
+        .with_label(span)
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertedNullishCoalescing;
 
@@ -61,12 +67,6 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("'Disallow non-null assertions in the left operand of a nullish coalescing operator")
-        .with_help("The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.")
-        .with_label(span)
-}
-
 impl Rule for NoNonNullAssertedNullishCoalescing {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
@@ -85,6 +85,7 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
         ctx.source_type().is_typescript()
     }
 }
+
 fn has_assignment_before_node(
     symbol_id: SymbolId,
     ctx: &LintContext,

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -2,12 +2,9 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoUnnecessaryBooleanLiteralCompare(Box<NoUnnecessaryBooleanLiteralCompareConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -15,11 +12,9 @@ pub struct NoUnnecessaryBooleanLiteralCompare(Box<NoUnnecessaryBooleanLiteralCom
 pub struct NoUnnecessaryBooleanLiteralCompareConfig {
     /// Whether to allow comparing nullable boolean expressions to `false`.
     /// When false, `x === false` where x is `boolean | null` will be flagged.
-    #[serde(default = "default_true")]
     pub allow_comparing_nullable_booleans_to_false: bool,
     /// Whether to allow comparing nullable boolean expressions to `true`.
     /// When false, `x === true` where x is `boolean | null` will be flagged.
-    #[serde(default = "default_true")]
     pub allow_comparing_nullable_booleans_to_true: bool,
     /// Whether to allow this rule to run without `strictNullChecks` enabled.
     /// This is not recommended as the rule may produce incorrect results.
@@ -97,13 +92,9 @@ declare_oxc_lint!(
 
 impl Rule for NoUnnecessaryBooleanLiteralCompare {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryBooleanLiteralCompareConfig>>(
-                value,
-            )
+        serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryBooleanLiteralCompare>>(value)
             .unwrap_or_default()
-            .into_inner(),
-        ))
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoUnnecessaryTypeAssertion(Box<NoUnnecessaryTypeAssertionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -67,11 +67,9 @@ declare_oxc_lint!(
 
 impl Rule for NoUnnecessaryTypeAssertion {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryTypeAssertionConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryTypeAssertion>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct PreferPromiseRejectErrors(Box<PreferPromiseRejectErrorsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -77,11 +77,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferPromiseRejectErrors {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<PreferPromiseRejectErrorsConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<PreferPromiseRejectErrors>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
+++ b/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
@@ -2,34 +2,26 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct PromiseFunctionAsync(Box<PromiseFunctionAsyncConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PromiseFunctionAsyncConfig {
     /// Whether to allow functions returning `any` type without requiring `async`.
-    #[serde(default = "default_true")]
     pub allow_any: bool,
     /// A list of Promise type names that are allowed without requiring `async`.
     /// Example: `["SpecialPromise"]` to allow functions returning `SpecialPromise` without `async`.
     pub allowed_promise_names: Vec<String>,
     /// Whether to check arrow functions for missing `async` keyword.
-    #[serde(default = "default_true")]
     pub check_arrow_functions: bool,
     /// Whether to check function declarations for missing `async` keyword.
-    #[serde(default = "default_true")]
     pub check_function_declarations: bool,
     /// Whether to check function expressions for missing `async` keyword.
-    #[serde(default = "default_true")]
     pub check_function_expressions: bool,
     /// Whether to check method declarations for missing `async` keyword.
-    #[serde(default = "default_true")]
     pub check_method_declarations: bool,
 }
 
@@ -117,11 +109,9 @@ declare_oxc_lint!(
 
 impl Rule for PromiseFunctionAsync {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<PromiseFunctionAsyncConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<PromiseFunctionAsync>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
@@ -2,31 +2,23 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct RestrictPlusOperands(Box<RestrictPlusOperandsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct RestrictPlusOperandsConfig {
     /// Whether to allow `any` type in plus operations.
-    #[serde(default = "default_true")]
     pub allow_any: bool,
     /// Whether to allow `boolean` types in plus operations.
-    #[serde(default = "default_true")]
     pub allow_boolean: bool,
     /// Whether to allow nullish types (`null` or `undefined`) in plus operations.
-    #[serde(default = "default_true")]
     pub allow_nullish: bool,
     /// Whether to allow mixed number and string operands in plus operations.
-    #[serde(default = "default_true")]
     pub allow_number_and_string: bool,
     /// Whether to allow `RegExp` types in plus operations.
-    #[serde(default = "default_true")]
     pub allow_reg_exp: bool,
     /// Whether to skip compound assignments (e.g., `a += b`).
     pub skip_compound_assignments: bool,
@@ -106,11 +98,9 @@ declare_oxc_lint!(
 
 impl Rule for RestrictPlusOperands {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<RestrictPlusOperandsConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<RestrictPlusOperands>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/return_await.rs
+++ b/crates/oxc_linter/src/rules/typescript/return_await.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ReturnAwait(Box<ReturnAwaitOption>);
 
 impl Default for ReturnAwait {
@@ -38,7 +38,10 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// There are different patterns for returning awaited values from async functions. Sometimes you want to await before returning (to handle errors in the current function), and sometimes you want to return the Promise directly (for better performance). This rule helps enforce consistency.
+    /// There are different patterns for returning awaited values from async functions.
+    /// Sometimes you want to await before returning (to handle errors in the current
+    /// function), and sometimes you want to return the Promise directly (for better
+    /// performance). This rule helps enforce consistency.
     ///
     /// ### Examples
     ///
@@ -102,11 +105,9 @@ declare_oxc_lint!(
 
 impl Rule for ReturnAwait {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<ReturnAwaitOption>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<ReturnAwait>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {


### PR DESCRIPTION
This removes the `Self(Box::new())` wrapper for various tsgolint-based rules in order to simplify the implementation of the `from_configuration` method for those rules. If I understand correctly, the box wrapping is still used, it's just not referenced explicitly in the `from_configuration` method for these rules anymore, as we've moved the `DefaultRuleConfig<>` from taking the config object over to taking the rule itself.

This PR also removes various uses of `#[serde(default = "default_true")]`, as it's unnecessary when Default is defined.

Will wait to merge this until cam (either of them 😛) can review this and confirm that I'm not about to break anything here. But I'm fairly confident this should not cause any problems.