### PR TITLE
docs(linter): Update various rules to note that they can be disabled for TS code.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -50,6 +50,9 @@ declare_oxc_lint!(
     /// Requires `super()` calls in constructors of derived classes and disallows `super()` calls
     /// in constructors of non-derived classes.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
     /// In JavaScript, calling `super()` in the constructor of a derived class (a class that extends

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -21,6 +21,9 @@ declare_oxc_lint!(
     ///
     /// Disallow reassigning class variables.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
     /// `ClassDeclaration` creates a variable that can be re-assigned, but the re-assignment is a

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -24,7 +24,10 @@ pub struct NoDupeClassMembers;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow duplicate class members
+    /// Disallow duplicate class members.
+    ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -24,15 +24,15 @@ pub struct NoDupeKeys;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow duplicate keys in object literals
+    /// Disallow duplicate keys in object literals.
+    ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
     ///
     /// ### Why is this bad?
     ///
     /// Multiple properties with the same key in object literals can cause
     /// unexpected behavior in your application.
-    ///
-    /// It is safe to disable this rule when using TypeScript because
-    /// TypeScript's compiler enforces this check.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -17,7 +17,10 @@ pub struct NoFuncAssign;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow reassigning `function` declarations
+    /// Disallow reassigning `function` declarations.
+    ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -11,8 +11,8 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_import_assign_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("do not assign to imported bindings")
-        .with_help("imported bindings are readonly")
+    OxcDiagnostic::warn("Do not assign to imported bindings")
+        .with_help("Imported bindings are readonly")
         .with_label(span)
 }
 
@@ -22,11 +22,16 @@ pub struct NoImportAssign;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow assigning to imported bindings
+    /// Disallow assigning to imported bindings.
     ///
     /// ### Why is this bad?
     ///
     /// The updates of imported bindings by ES Modules cause runtime errors.
+    ///
+    /// The TypeScript compiler generally enforces this check already. Although
+    /// it should be noted that there are some cases TypeScript does not catch, such
+    /// as assignments via `Object.assign`. So this rule is still useful for
+    /// TypeScript code in those cases.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -15,7 +15,10 @@ pub struct NoNewNativeNonconstructor;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `new` operators with global non-constructor functions (`Symbol`, `BigInt`)
+    /// Disallow `new` operators with global non-constructor functions (`Symbol`, `BigInt`).
+    ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -26,8 +26,8 @@ declare_oxc_lint!(
     ///
     /// Disallow calling some global objects as functions.
     ///
-    /// It is safe to disable this rule when using TypeScript, because
-    /// TypeScript's compiler enforces this check.
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -17,6 +17,9 @@ declare_oxc_lint!(
     ///
     /// Setters cannot return values.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
     /// While returning a value from a setter does not produce an error, the returned value is

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -28,10 +28,13 @@ declare_oxc_lint!(
     ///
     /// Requires calling `super()` before using `this` or `super`.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
     /// In the constructor of derived classes, if `this`/`super` are used before `super()` calls,
-    /// it raises a ReferenceError.
+    /// it raises a `ReferenceError`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -30,9 +30,13 @@ declare_oxc_lint!(
     ///
     /// Disallow the use of undeclared variables.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
-    /// It is most likely a potential ReferenceError caused by a misspelling of a variable or parameter name.
+    /// It is most likely a potential ReferenceError caused by a misspelling
+    /// of a variable or parameter name.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -24,7 +24,10 @@ pub struct NoUnreachable;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unreachable code after `return`, `throw`, `continue`, and `break` statements
+    /// Disallow unreachable code after `return`, `throw`, `continue`, and `break` statements.
+    ///
+    /// This rule can be disabled for TypeScript code if `allowUnreachableCode: false` is configured
+    /// in the `tsconfig.json`, as the TypeScript compiler enforces this check.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -40,6 +40,9 @@ declare_oxc_lint!(
     /// Disallows negating the left operand of relational operators to prevent logical errors
     /// caused by misunderstanding operator precedence or accidental use of negation.
     ///
+    /// This rule can be disabled for TypeScript code, as the TypeScript compiler
+    /// enforces this check.
+    ///
     /// ### Why is this bad?
     ///
     /// Negating the left operand of relational operators can result in unexpected behavior due to

--- a/crates/oxc_linter/src/snapshots/eslint_no_import_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_import_assign.snap
@@ -1,415 +1,415 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:25]
  1 │ import mod1 from 'mod'; mod1 = 0
    ·                         ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:25]
  1 │ import mod2 from 'mod'; mod2 += 0
    ·                         ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:25]
  1 │ import mod3 from 'mod'; mod3++
    ·                         ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import mod4 from 'mod'; for (mod4 in foo);
    ·                              ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import mod5 from 'mod'; for (mod5 of foo);
    ·                              ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:26]
  1 │ import mod6 from 'mod'; [mod6] = foo
    ·                          ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:26]
  1 │ import mod7 from 'mod'; [mod7 = 0] = foo
    ·                          ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:29]
  1 │ import mod8 from 'mod'; [...mod8] = foo
    ·                             ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:33]
  1 │ import mod9 from 'mod'; ({ bar: mod9 } = foo)
    ·                                 ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:34]
  1 │ import mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)
    ·                                  ─────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:32]
  1 │ import mod11 from 'mod'; ({ ...mod11 } = foo)
    ·                                ─────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:29]
  1 │ import {named1} from 'mod'; named1 = 0
    ·                             ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:29]
  1 │ import {named2} from 'mod'; named2 += 0
    ·                             ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:29]
  1 │ import {named3} from 'mod'; named3++
    ·                             ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:34]
  1 │ import {named4} from 'mod'; for (named4 in foo);
    ·                                  ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:34]
  1 │ import {named5} from 'mod'; for (named5 of foo);
    ·                                  ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import {named6} from 'mod'; [named6] = foo
    ·                              ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import {named7} from 'mod'; [named7 = 0] = foo
    ·                              ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:33]
  1 │ import {named8} from 'mod'; [...named8] = foo
    ·                                 ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:37]
  1 │ import {named9} from 'mod'; ({ bar: named9 } = foo)
    ·                                     ──────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:38]
  1 │ import {named10} from 'mod'; ({ bar: named10 = 0 } = foo)
    ·                                      ───────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:36]
  1 │ import {named11} from 'mod'; ({ ...named11 } = foo)
    ·                                    ───────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:37]
  1 │ import {named12 as foo} from 'mod'; foo = 0; named12 = 0
    ·                                     ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod1 from 'mod'; mod1 = 0
    ·                              ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod2 from 'mod'; mod2 += 0
    ·                              ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod3 from 'mod'; mod3++
    ·                              ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:35]
  1 │ import * as mod4 from 'mod'; for (mod4 in foo);
    ·                                   ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:35]
  1 │ import * as mod5 from 'mod'; for (mod5 of foo);
    ·                                   ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:31]
  1 │ import * as mod6 from 'mod'; [mod6] = foo
    ·                               ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:31]
  1 │ import * as mod7 from 'mod'; [mod7 = 0] = foo
    ·                               ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:34]
  1 │ import * as mod8 from 'mod'; [...mod8] = foo
    ·                                  ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:38]
  1 │ import * as mod9 from 'mod'; ({ bar: mod9 } = foo)
    ·                                      ────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:39]
  1 │ import * as mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)
    ·                                       ─────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:37]
  1 │ import * as mod11 from 'mod'; ({ ...mod11 } = foo)
    ·                                     ─────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod1 from 'mod'; mod1.named = 0
    ·                              ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod2 from 'mod'; mod2.named += 0
    ·                              ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:30]
  1 │ import * as mod3 from 'mod'; mod3.named++
    ·                              ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:35]
  1 │ import * as mod4 from 'mod'; for (mod4.named in foo);
    ·                                   ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:35]
  1 │ import * as mod5 from 'mod'; for (mod5.named of foo);
    ·                                   ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:31]
  1 │ import * as mod6 from 'mod'; [mod6.named] = foo
    ·                               ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:31]
  1 │ import * as mod7 from 'mod'; [mod7.named = 0] = foo
    ·                               ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:34]
  1 │ import * as mod8 from 'mod'; [...mod8.named] = foo
    ·                                  ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:38]
  1 │ import * as mod9 from 'mod'; ({ bar: mod9.named } = foo)
    ·                                      ──────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:39]
  1 │ import * as mod10 from 'mod'; ({ bar: mod10.named = 0 } = foo)
    ·                                       ───────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:37]
  1 │ import * as mod11 from 'mod'; ({ ...mod11.named } = foo)
    ·                                     ───────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:38]
  1 │ import * as mod12 from 'mod'; delete mod12.named
    ·                                      ───────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:43]
  1 │ import * as mod from 'mod'; Object.assign(mod, obj)
    ·                                           ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:51]
  1 │ import * as mod from 'mod'; Object.defineProperty(mod, key, d)
    ·                                                   ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:53]
  1 │ import * as mod from 'mod'; Object.defineProperties(mod, d)
    ·                                                     ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:51]
  1 │ import * as mod from 'mod'; Object.setPrototypeOf(mod, proto)
    ·                                                   ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:43]
  1 │ import * as mod from 'mod'; Object.freeze(mod)
    ·                                           ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:52]
  1 │ import * as mod from 'mod'; Reflect.defineProperty(mod, key, d)
    ·                                                    ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:52]
  1 │ import * as mod from 'mod'; Reflect.deleteProperty(mod, key)
    ·                                                    ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:41]
  1 │ import * as mod from 'mod'; Reflect.set(mod, key, value)
    ·                                         ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:52]
  1 │ import * as mod from 'mod'; Reflect.setPrototypeOf(mod, proto)
    ·                                                    ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:51]
  1 │ import mod, * as mod_ns from 'mod'; mod.prop = 0; mod_ns.prop = 0
    ·                                                   ───────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:52]
  1 │ import * as mod from 'mod'; Object?.defineProperty(mod, key, d)
    ·                                                    ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:54]
  1 │ import * as mod from 'mod'; (Object?.defineProperty)(mod, key, d)
    ·                                                      ───
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly
 
-  ⚠ eslint(no-import-assign): do not assign to imported bindings
+  ⚠ eslint(no-import-assign): Do not assign to imported bindings
    ╭─[no_import_assign.tsx:1:36]
  1 │ import * as mod from 'mod'; delete mod?.prop
    ·                                    ─────────
    ╰────
-  help: imported bindings are readonly
+  help: Imported bindings are readonly


### PR DESCRIPTION
This is generally based on the `handled_by_typescript` flag in the original ESLint rule definitions. All of these are flagged in the original rules as being "handled by TypeScript", and so I deferred to that when determining which rules to note this on.