### PR TITLE
feat(formatter): support more expressions in embedded template tags

### DIFF
--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -53,8 +53,10 @@ export async function formatEmbeddedCode({
   tagName,
   options,
 }: FormatEmbeddedCodeParam): Promise<string> {
-  // TODO: This should be resolved in Rust side
-  const parserName = TAG_TO_PARSER[tagName];
+  // Extract the base tag name from member expressions
+  // e.g., "styled" from "styled.div"
+  const baseTag = tagName.split(".")[0];
+  const parserName = TAG_TO_PARSER[baseTag];
 
   // Unknown tag, return original code
   if (!parserName) return code;

--- a/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
@@ -24,6 +24,8 @@ const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radiu
 
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
+const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -185,6 +187,12 @@ const styledHeader = styled["h1"]\`
   font-size: 24px;
   color: #333;
   margin-bottom: 16px;
+\`;
+
+const styledFooter = styled.footer\`
+  background-color: #f8f8f8;
+  padding: 20px;
+  text-align: center;
 \`;
 
 // ============================================================================
@@ -379,6 +387,8 @@ const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radiu
 
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
+const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -507,6 +517,8 @@ const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;borde
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
 
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
+
+const styledFooter = styled.footer\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
@@ -643,6 +655,8 @@ const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radiu
 
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
+const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -771,6 +785,8 @@ const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;borde
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
 
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
+
+const styledFooter = styled.footer\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags

--- a/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
@@ -22,6 +22,8 @@ const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;borde
 
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
 
+const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -176,6 +178,13 @@ const styledInput = styled.input\`
   padding: 8px;
   border-radius: 2px;
   font-size: 14px;
+\`;
+
+const styledHeader = styled["h1"]\`
+  font-weight: bold;
+  font-size: 24px;
+  color: #333;
+  margin-bottom: 16px;
 \`;
 
 // ============================================================================
@@ -368,6 +377,8 @@ const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;borde
 
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
 
+const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -494,6 +505,8 @@ const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:
 const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
 
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
@@ -628,6 +641,8 @@ const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;borde
 
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
 
+const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -754,6 +769,8 @@ const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:
 const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
 
 const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags

--- a/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
@@ -26,6 +26,8 @@ const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;ma
 
 const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
 
+const styledWrapper = styled(styledButton)\`display:inline-block;margin:10px;position:relative;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -193,6 +195,12 @@ const styledFooter = styled.footer\`
   background-color: #f8f8f8;
   padding: 20px;
   text-align: center;
+\`;
+
+const styledWrapper = styled(styledButton)\`
+  display: inline-block;
+  margin: 10px;
+  position: relative;
 \`;
 
 // ============================================================================
@@ -389,6 +397,8 @@ const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;ma
 
 const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
 
+const styledWrapper = styled(styledButton)\`display:inline-block;margin:10px;position:relative;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -519,6 +529,8 @@ const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radiu
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
 const styledFooter = styled.footer\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
+
+const styledWrapper = styled(styledButton)\`display:inline-block;margin:10px;position:relative;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
@@ -657,6 +669,8 @@ const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;ma
 
 const styledFooter = (styled.footer)\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
 
+const styledWrapper = styled(styledButton)\`display:inline-block;margin:10px;position:relative;\`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
@@ -787,6 +801,8 @@ const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radiu
 const styledHeader = styled["h1"]\`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;\`;
 
 const styledFooter = styled.footer\`background-color:#f8f8f8;padding:20px;text-align:center;\`;
+
+const styledWrapper = styled(styledButton)\`display:inline-block;margin:10px;position:relative;\`;
 
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags

--- a/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/embedded_languages.test.ts.snap
@@ -13,6 +13,16 @@ const styles = css\`.button{color:red;background:blue;padding:10px 20px;}.contai
 const styledComponent = styled\`background-color:#ffffff;border-radius:4px;padding:8px;\`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:#f0f0f0;\`;
+
+const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
+
+const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -47,6 +57,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css\`.button{color:red;}\`;
+
+const mixedStyled = styled.span\`color:green;font-weight:bold;\`;
 
 const mixedQuery = gql\`query{users{name}}\`;
 
@@ -142,6 +154,31 @@ const styledComponent = styled\`
 \`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`
+  color: blue;
+  font-size: 16px;
+  padding: 12px;
+  background: #f0f0f0;
+\`;
+
+const styledButton = styled.button\`
+  border: 1px solid #ccc;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+\`;
+
+const styledInput = styled.input\`
+  border: 1px solid #ddd;
+  padding: 8px;
+  border-radius: 2px;
+  font-size: 14px;
+\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -207,6 +244,11 @@ const mixedStyles = css\`
   .button {
     color: red;
   }
+\`;
+
+const mixedStyled = styled.span\`
+  color: green;
+  font-weight: bold;
 \`;
 
 const mixedQuery = gql\`
@@ -317,6 +359,16 @@ const styles = css\`.button{color:red;background:blue;padding:10px 20px;}.contai
 const styledComponent = styled\`background-color:#ffffff;border-radius:4px;padding:8px;\`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:#f0f0f0;\`;
+
+const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
+
+const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -351,6 +403,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css\`.button{color:red;}\`;
+
+const mixedStyled = styled.span\`color:green;font-weight:bold;\`;
 
 const mixedQuery = gql\`query{users{name}}\`;
 
@@ -432,6 +486,16 @@ const styles = css\`.button{color:red;background:blue;padding:10px 20px;}.contai
 const styledComponent = styled\`background-color:#ffffff;border-radius:4px;padding:8px;\`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:#f0f0f0;\`;
+
+const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
+
+const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -466,6 +530,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css\`.button{color:red;}\`;
+
+const mixedStyled = styled.span\`color:green;font-weight:bold;\`;
 
 const mixedQuery = gql\`query{users{name}}\`;
 
@@ -553,6 +619,16 @@ const styles = css\`.button{color:red;background:blue;padding:10px 20px;}.contai
 const styledComponent = styled\`background-color:#ffffff;border-radius:4px;padding:8px;\`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:#f0f0f0;\`;
+
+const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
+
+const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -587,6 +663,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css\`.button{color:red;}\`;
+
+const mixedStyled = styled.span\`color:green;font-weight:bold;\`;
 
 const mixedQuery = gql\`query{users{name}}\`;
 
@@ -668,6 +746,16 @@ const styles = css\`.button{color:red;background:blue;padding:10px 20px;}.contai
 const styledComponent = styled\`background-color:#ffffff;border-radius:4px;padding:8px;\`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div\`color:blue;font-size:16px;padding:12px;background:#f0f0f0;\`;
+
+const styledButton = styled.button\`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;\`;
+
+const styledInput = styled.input\`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;\`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -702,6 +790,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css\`.button{color:red;}\`;
+
+const mixedStyled = styled.span\`color:green;font-weight:bold;\`;
 
 const mixedQuery = gql\`query{users{name}}\`;
 

--- a/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
+++ b/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
@@ -20,6 +20,8 @@ const styledHeader = styled["h1"]`font-weight:bold;font-size:24px;color:#333;mar
 
 const styledFooter = (styled.footer)`background-color:#f8f8f8;padding:20px;text-align:center;`;
 
+const styledWrapper = styled(styledButton)`display:inline-block;margin:10px;position:relative;`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================

--- a/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
+++ b/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
@@ -18,6 +18,8 @@ const styledInput = styled.input`border:1px solid #ddd;padding:8px;border-radius
 
 const styledHeader = styled["h1"]`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;`;
 
+const styledFooter = (styled.footer)`background-color:#f8f8f8;padding:20px;text-align:center;`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================

--- a/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
+++ b/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
@@ -7,6 +7,16 @@ const styles = css`.button{color:red;background:blue;padding:10px 20px;}.contain
 const styledComponent = styled`background-color:#ffffff;border-radius:4px;padding:8px;`;
 
 // ============================================================================
+// Member Expression Tags - styled.div, styled.button, etc.
+// ============================================================================
+
+const styledDiv = styled.div`color:blue;font-size:16px;padding:12px;background:#f0f0f0;`;
+
+const styledButton = styled.button`border:1px solid #ccc;padding:8px 16px;border-radius:4px;cursor:pointer;`;
+
+const styledInput = styled.input`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;`;
+
+// ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================
 
@@ -41,6 +51,8 @@ npm install package
 // ============================================================================
 
 const mixedStyles = css`.button{color:red;}`;
+
+const mixedStyled = styled.span`color:green;font-weight:bold;`;
 
 const mixedQuery = gql`query{users{name}}`;
 

--- a/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
+++ b/apps/oxfmt/test/fixtures/embedded_languages/embedded_languages.js
@@ -16,6 +16,8 @@ const styledButton = styled.button`border:1px solid #ccc;padding:8px 16px;border
 
 const styledInput = styled.input`border:1px solid #ddd;padding:8px;border-radius:2px;font-size:14px;`;
 
+const styledHeader = styled["h1"]`font-weight:bold;font-size:24px;color:#333;margin-bottom:16px;`;
+
 // ============================================================================
 // GraphQL - Tagged template literals with gql and graphql tags
 // ============================================================================

--- a/crates/oxc_formatter/src/embedded_formatter.rs
+++ b/crates/oxc_formatter/src/embedded_formatter.rs
@@ -26,8 +26,12 @@ impl EmbeddedFormatter {
     }
 
     /// Check if the given tag name is supported for embedded formatting.
+    /// Supports both simple identifiers (css) and member expressions (styled.div).
     pub fn is_supported_tag(tag_name: &str) -> bool {
-        SUPPORTED_TAGS.contains(&tag_name)
+        // For member expressions, check if the base identifier is supported
+        // e.g., "styled" from "styled.div"
+        let base_tag = tag_name.split('.').next().unwrap_or(tag_name);
+        SUPPORTED_TAGS.contains(&base_tag)
     }
 
     /// Format embedded code with the given tag name.

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -699,6 +699,10 @@ fn get_tag_name(expr: &Expression<'_>) -> Option<String> {
             // this may produce a string that isn't a valid JS expression like `styled.foo-bar`.
             Some(format!("{}.{}", base, property.as_str()))
         }
+        Expression::CallExpression(call) => {
+            // Handle cases like styled(Button)
+            get_tag_name(&call.callee)
+        }
         _ => None,
     }
 }

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -689,6 +689,15 @@ fn get_tag_name(expr: &Expression<'_>) -> Option<String> {
             let base = get_tag_name(&member.object)?;
             Some(format!("{}.{}", base, member.property.name.as_str()))
         }
+        Expression::ComputedMemberExpression(exp) => {
+            let property = exp.static_property_name()?;
+            let base = get_tag_name(&exp.object)?;
+
+            // NOTE: This string is only a "notion" used for embedded-formatter tag matching.
+            // For computed properties that aren't valid identifiers (e.g. `styled["foo-bar"]`),
+            // this may produce a string that isn't a valid JS expression like `styled.foo-bar`.
+            Some(format!("{}.{}", base, property.as_str()))
+        }
         _ => None,
     }
 }

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -682,6 +682,7 @@ impl<'a> Format<'a> for EachTemplateTable<'a> {
 /// Extract the full tag name from an expression
 /// Handles both simple identifiers (css) and member expressions (styled.div)
 fn get_tag_name(expr: &Expression<'_>) -> Option<String> {
+    let expr = expr.get_inner_expression();
     match expr {
         Expression::Identifier(ident) => Some(ident.name.as_str().to_string()),
         Expression::StaticMemberExpression(member) => {


### PR DESCRIPTION
Allow formatting of tagged templates with member expressions like `styled.div`, enabling better support for styled-components and similar libraries.