### PR TITLE
refactor(linter/plugins): move type defs into `visitor.ts`

### DIFF
--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -6,7 +6,8 @@ import { ancestors } from "../generated/walk.js";
 
 import type { ESQueryOptions, Selector as EsquerySelector } from "esquery";
 import type { Node as EsqueryNode } from "estree";
-import type { Node, VisitFn } from "./types.ts";
+import type { Node } from "./types.ts";
+import type { VisitFn } from "./visitor.ts";
 
 const ObjectKeys = Object.keys;
 

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -25,9 +25,6 @@ export type VisitorWithHooks = Visitor & {
   after?: AfterHook;
 };
 
-// Visit function for a specific AST node type.
-export type VisitFn = (node: Node) => void;
-
 // AST node type.
 export interface Node extends Span {}
 
@@ -37,17 +34,6 @@ export type NodeOrToken = Node | Token | Comment;
 export interface Comment extends Span {
   type: "Line" | "Block";
   value: string;
-}
-
-// Element of compiled visitor array.
-// * `VisitFn | null` for leaf nodes.
-// * `EnterExit | null` for non-leaf nodes.
-export type CompiledVisitorEntry = VisitFn | EnterExit | null;
-
-// Enter+exit pair, for non-leaf nodes in compiled visitor.
-export interface EnterExit {
-  enter: VisitFn | null;
-  exit: VisitFn | null;
 }
 
 // Buffer with typed array views of itself stored as properties.

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -80,10 +80,24 @@ import {
 import { parseSelector, wrapVisitFnWithSelectorMatch } from "./selector.ts";
 import { typeAssertIs, debugAssertIsNonNull } from "../utils/asserts.ts";
 
-import type { CompiledVisitorEntry, EnterExit, Node, VisitFn, Visitor } from "./types.ts";
+import type { Node, Visitor } from "./types.ts";
 
 const ObjectKeys = Object.keys,
   { isArray } = Array;
+
+// Visit function for a specific AST node type.
+export type VisitFn = (node: Node) => void;
+
+// Enter+exit pair, for non-leaf nodes in compiled visitor.
+export interface EnterExit {
+  enter: VisitFn | null;
+  exit: VisitFn | null;
+}
+
+// Element of compiled visitor array.
+// * `VisitFn | null` for leaf nodes.
+// * `EnterExit | null` for non-leaf nodes.
+type CompiledVisitorEntry = VisitFn | EnterExit | null;
 
 // Types for temporary state of entries of `compiledVisitor`
 // between calling `initCompiledVisitor` and `finalizeCompiledVisitor`.

--- a/apps/oxlint/test/compile_visitor.test.ts
+++ b/apps/oxlint/test/compile_visitor.test.ts
@@ -9,7 +9,8 @@ import {
   initCompiledVisitor,
 } from "../src-js/plugins/visitor.ts";
 
-import type { EnterExit, Node, VisitFn } from "../src-js/plugins/types.ts";
+import type { Node } from "../src-js/plugins/types.ts";
+import type { EnterExit, VisitFn } from "../src-js/plugins/visitor.ts";
 
 const PROGRAM_TYPE_ID = NODE_TYPE_IDS_MAP.get("Program")!,
   EMPTY_STMT_TYPE_ID = NODE_TYPE_IDS_MAP.get("EmptyStatement")!,


### PR DESCRIPTION
Pure refactor. Move TS type defs related to visitor compilation from `types.ts` into `visitor.ts`. Does not change the types in any way, only moves them.