### PR TITLE
feat(linter/eslint-plugin-vitest): Add prefer-to-contain as vitest compatible jest rule

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -182,7 +182,7 @@ fn tests() {
     use crate::tester::Tester;
 
     #[expect(clippy::literal_string_with_formatting_args)]
-    let pass = vec![
+    let mut pass = vec![
         ("expect.hasAssertions", None),
         ("expect.hasAssertions()", None),
         ("expect.assertions(1)", None),
@@ -217,7 +217,7 @@ fn tests() {
     ];
 
     #[expect(clippy::literal_string_with_formatting_args)]
-    let fail = vec![
+    let mut fail = vec![
         ("expect(a.includes(b)).toEqual(true);", None),
         ("expect(a.includes(b,),).toEqual(true,)", None),
         ("expect(a['includes'](b)).toEqual(true);", None),
@@ -261,7 +261,7 @@ fn tests() {
     ];
 
     #[expect(clippy::literal_string_with_formatting_args)]
-    let fix = vec![
+    let mut fix = vec![
         ("expect(a.includes(b)).toEqual(true);", "expect(a).toContain(b);", None),
         ("expect(a.includes(b,),).toEqual(true,)", "expect(a).toContain(b)", None),
         ("expect(a['includes'](b)).toEqual(true);", "expect(a).toContain(b);", None),
@@ -352,8 +352,177 @@ fn tests() {
         ("expect(a.includes(b)).toEqual(false as boolean);", "expect(a).not.toContain(b);", None),
     ];
 
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let vitest_pass = vec![
+        ("expect.hasAssertions", None),
+        ("expect.hasAssertions()", None),
+        ("expect.assertions(1)", None),
+        ("expect().toBe(false);", None),
+        ("expect(a).toContain(b);", None),
+        ("expect(a.name).toBe('b');", None),
+        ("expect(a).toBe(true);", None),
+        ("expect(a).toEqual(b)", None),
+        ("expect(a.test(c)).toEqual(b)", None),
+        ("expect(a.includes(b)).toEqual()", None),
+        ("expect(a.includes(b)).toEqual('test')", None),
+        ("expect(a.includes(b)).toBe('test')", None),
+        ("expect(a.includes()).toEqual()", None),
+        ("expect(a.includes()).toEqual(true)", None),
+        ("expect(a.includes(b,c)).toBe(true)", None),
+        ("expect([{a:1}]).toContain({a:1})", None),
+        ("expect([1].includes(1)).toEqual", None),
+        ("expect([1].includes).toEqual", None),
+        ("expect([1].includes).not", None),
+        ("expect(a.test(b)).resolves.toEqual(true)", None),
+        ("expect(a.test(b)).resolves.not.toEqual(true)", None),
+        ("expect(a).not.toContain(b)", None),
+        ("expect(a.includes(...[])).toBe(true)", None),
+        ("expect(a.includes(b)).toBe(...true)", None),
+        ("expect(a);", None),
+    ];
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let vitest_fail = vec![
+        ("expect(a.includes(b)).toEqual(true);", None),
+        ("expect(a.includes(b,),).toEqual(true,);", None),
+        ("expect(a['includes'](b)).toEqual(true);", None),
+        ("expect(a['includes'](b))['toEqual'](true);", None),
+        ("expect(a['includes'](b)).toEqual(false);", None),
+        ("expect(a['includes'](b)).not.toEqual(false);", None),
+        ("expect(a['includes'](b))['not'].toEqual(false);", None),
+        ("expect(a['includes'](b))['not']['toEqual'](false);", None),
+        ("expect(a.includes(b)).toEqual(false);", None),
+        ("expect(a.includes(b)).not.toEqual(false);", None),
+        ("expect(a.includes(b)).not.toEqual(true);", None),
+        ("expect(a.includes(b)).toBe(true);", None),
+        ("expect(a.includes(b)).toBe(false);", None),
+        ("expect(a.includes(b)).not.toBe(false);", None),
+        ("expect(a.includes(b)).not.toBe(true);", None),
+        ("expect(a.includes(b)).toStrictEqual(true);", None),
+        ("expect(a.includes(b)).toStrictEqual(false);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(false);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(true);", None),
+        ("expect(a.test(t).includes(b.test(p))).toEqual(true);", None),
+        ("expect(a.test(t).includes(b.test(p))).toEqual(false);", None),
+        ("expect(a.test(t).includes(b.test(p))).not.toEqual(true);", None),
+        ("expect(a.test(t).includes(b.test(p))).not.toEqual(false);", None),
+        ("expect([{a:1}].includes({a:1})).toBe(true);", None),
+        ("expect([{a:1}].includes({a:1})).toBe(false);", None),
+        ("expect([{a:1}].includes({a:1})).not.toBe(true);", None),
+        ("expect([{a:1}].includes({a:1})).not.toBe(false);", None),
+        ("expect([{a:1}].includes({a:1})).toStrictEqual(true);", None),
+        ("expect([{a:1}].includes({a:1})).toStrictEqual(false);", None),
+        ("expect([{a:1}].includes({a:1})).not.toStrictEqual(true);", None),
+        ("expect([{a:1}].includes({a:1})).not.toStrictEqual(false);", None),
+        (
+            "
+                    import { expect as pleaseExpect } from 'vitest';
+                    pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false);
+                ",
+            None,
+        ),
+        // typescript
+        ("expect(a.includes(b)).toEqual(false as boolean);", None),
+    ];
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let vitest_fix = vec![
+        ("expect(a.includes(b)).toEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b,),).toEqual(true,);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b)).toEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['toEqual'](true);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b)).toEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a['includes'](b)).not.toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['not'].toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a['includes'](b))['not']['toEqual'](false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toEqual(true);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).toBe(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toBe(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toBe(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toBe(true);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).toStrictEqual(true);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).toStrictEqual(false);", "expect(a).not.toContain(b);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(false);", "expect(a).toContain(b);", None),
+        ("expect(a.includes(b)).not.toStrictEqual(true);", "expect(a).not.toContain(b);", None),
+        (
+            "expect(a.test(t).includes(b.test(p))).toEqual(true);",
+            "expect(a.test(t)).toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).toEqual(false);",
+            "expect(a.test(t)).not.toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).not.toEqual(true);",
+            "expect(a.test(t)).not.toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect(a.test(t).includes(b.test(p))).not.toEqual(false);",
+            "expect(a.test(t)).toContain(b.test(p));",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toBe(true);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toBe(false);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toBe(true);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toBe(false);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toStrictEqual(true);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).toStrictEqual(false);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toStrictEqual(true);",
+            "expect([{ a: 1 }]).not.toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "expect([{a:1}].includes({a:1})).not.toStrictEqual(false);",
+            "expect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        (
+            "import { expect as pleaseExpect } from 'vitest';
+                pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false);",
+            "import { expect as pleaseExpect } from 'vitest';
+                pleaseExpect([{ a: 1 }]).toContain({ a: 1 });",
+            None,
+        ),
+        ("expect(a.includes(b)).toEqual(false as boolean);", "expect(a).not.toContain(b);", None),
+    ];
+
+    pass.extend(vitest_pass);
+    fail.extend(vitest_fail);
+    fix.extend(vitest_fix);
+
     Tester::new(PreferToContain::NAME, PreferToContain::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_to_contain.snap
@@ -233,3 +233,236 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────
    ╰────
   help: Replace `expect(a.includes(b)).toEqual(false as boolean)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toEqual(true);
+   ·                       ───────
+   ╰────
+  help: Replace `expect(a.includes(b)).toEqual(true)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:25]
+ 1 │ expect(a.includes(b,),).toEqual(true,);
+   ·                         ───────
+   ╰────
+  help: Replace `expect(a.includes(b,),).toEqual(true,)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:26]
+ 1 │ expect(a['includes'](b)).toEqual(true);
+   ·                          ───────
+   ╰────
+  help: Replace `expect(a['includes'](b)).toEqual(true)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:26]
+ 1 │ expect(a['includes'](b))['toEqual'](true);
+   ·                          ─────────
+   ╰────
+  help: Replace `expect(a['includes'](b))['toEqual'](true)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:26]
+ 1 │ expect(a['includes'](b)).toEqual(false);
+   ·                          ───────
+   ╰────
+  help: Replace `expect(a['includes'](b)).toEqual(false)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:30]
+ 1 │ expect(a['includes'](b)).not.toEqual(false);
+   ·                              ───────
+   ╰────
+  help: Replace `expect(a['includes'](b)).not.toEqual(false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect(a['includes'](b))['not'].toEqual(false);
+   ·                                 ───────
+   ╰────
+  help: Replace `expect(a['includes'](b))['not'].toEqual(false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect(a['includes'](b))['not']['toEqual'](false);
+   ·                                 ─────────
+   ╰────
+  help: Replace `expect(a['includes'](b))['not']['toEqual'](false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toEqual(false);
+   ·                       ───────
+   ╰────
+  help: Replace `expect(a.includes(b)).toEqual(false)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toEqual(false);
+   ·                           ───────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toEqual(false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toEqual(true);
+   ·                           ───────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toEqual(true)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toBe(true);
+   ·                       ────
+   ╰────
+  help: Replace `expect(a.includes(b)).toBe(true)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toBe(false);
+   ·                       ────
+   ╰────
+  help: Replace `expect(a.includes(b)).toBe(false)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toBe(false);
+   ·                           ────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toBe(false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toBe(true);
+   ·                           ────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toBe(true)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toStrictEqual(true);
+   ·                       ─────────────
+   ╰────
+  help: Replace `expect(a.includes(b)).toStrictEqual(true)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toStrictEqual(false);
+   ·                       ─────────────
+   ╰────
+  help: Replace `expect(a.includes(b)).toStrictEqual(false)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toStrictEqual(false);
+   ·                           ─────────────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toStrictEqual(false)` with `expect(a).toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:27]
+ 1 │ expect(a.includes(b)).not.toStrictEqual(true);
+   ·                           ─────────────
+   ╰────
+  help: Replace `expect(a.includes(b)).not.toStrictEqual(true)` with `expect(a).not.toContain(b)`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:39]
+ 1 │ expect(a.test(t).includes(b.test(p))).toEqual(true);
+   ·                                       ───────
+   ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).toEqual(true)` with `expect(a.test(t)).toContain(b.test(p))`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:39]
+ 1 │ expect(a.test(t).includes(b.test(p))).toEqual(false);
+   ·                                       ───────
+   ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).toEqual(false)` with `expect(a.test(t)).not.toContain(b.test(p))`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:43]
+ 1 │ expect(a.test(t).includes(b.test(p))).not.toEqual(true);
+   ·                                           ───────
+   ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).not.toEqual(true)` with `expect(a.test(t)).not.toContain(b.test(p))`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:43]
+ 1 │ expect(a.test(t).includes(b.test(p))).not.toEqual(false);
+   ·                                           ───────
+   ╰────
+  help: Replace `expect(a.test(t).includes(b.test(p))).not.toEqual(false)` with `expect(a.test(t)).toContain(b.test(p))`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect([{a:1}].includes({a:1})).toBe(true);
+   ·                                 ────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toBe(true)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect([{a:1}].includes({a:1})).toBe(false);
+   ·                                 ────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toBe(false)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:37]
+ 1 │ expect([{a:1}].includes({a:1})).not.toBe(true);
+   ·                                     ────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toBe(true)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:37]
+ 1 │ expect([{a:1}].includes({a:1})).not.toBe(false);
+   ·                                     ────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toBe(false)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect([{a:1}].includes({a:1})).toStrictEqual(true);
+   ·                                 ─────────────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toStrictEqual(true)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:33]
+ 1 │ expect([{a:1}].includes({a:1})).toStrictEqual(false);
+   ·                                 ─────────────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).toStrictEqual(false)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:37]
+ 1 │ expect([{a:1}].includes({a:1})).not.toStrictEqual(true);
+   ·                                     ─────────────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toStrictEqual(true)` with `expect([{ a: 1 }]).not.toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:37]
+ 1 │ expect([{a:1}].includes({a:1})).not.toStrictEqual(false);
+   ·                                     ─────────────
+   ╰────
+  help: Replace `expect([{a:1}].includes({a:1})).not.toStrictEqual(false)` with `expect([{ a: 1 }]).toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:3:63]
+ 2 │                     import { expect as pleaseExpect } from 'vitest';
+ 3 │                     pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false);
+   ·                                                               ─────────────
+ 4 │                 
+   ╰────
+  help: Replace `pleaseExpect([{a:1}].includes({a:1})).not.toStrictEqual(false)` with `pleaseExpect([{ a: 1 }]).toContain({ a: 1 })`.
+
+  ⚠ eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.
+   ╭─[prefer_to_contain.tsx:1:23]
+ 1 │ expect(a.includes(b)).toEqual(false as boolean);
+   ·                       ───────
+   ╰────
+  help: Replace `expect(a.includes(b)).toEqual(false as boolean)` with `expect(a).not.toContain(b)`.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 36] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 37] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -64,6 +64,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 36] = [
     "prefer-mock-promise-shorthand",
     "prefer-strict-equal",
     "prefer-to-be",
+    "prefer-to-contain",
     "prefer-to-have-length",
     "prefer-todo",
     "require-to-throw-message",


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Add `prefer-to-contain` as a vitest compatible rule

Oxlint-migrate PR: https://github.com/oxc-project/oxlint-migrate/pull/280