### PR TITLE
feat(linter/eslint-plugin-vitest): Add no-large-snapshot as vitest compatible jest rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_large_snapshots.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -15,7 +15,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -23,7 +23,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected Jest snapshot to be no longer than 50 lines but it was 51 lines long
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
 
   ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
    ╭─[no_large_snapshots.tsx:1:19]
@@ -31,4 +31,36 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──────────────────────────────────
  2 │ line
    ╰────
-  help: Expected to not encounter a Jest snapshot but one was found that is 51 lines long
+  help: Expected to not encounter a Jest or Vitest snapshot but one was found that is 51 lines long
+
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toMatchInlineSnapshot(`
+   ·                   ─────────────────────
+ 2 │ line
+   ╰────
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
+
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
+
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
+  help: Expected Jest or Vitest snapshot to be no longer than 50 lines but it was 51 lines long
+
+  ⚠ eslint-plugin-jest(no-large-snapshots): Snapshot is too long.
+   ╭─[no_large_snapshots.tsx:1:19]
+ 1 │ expect(something).toThrowErrorMatchingInlineSnapshot(`
+   ·                   ──────────────────────────────────
+ 2 │ line
+   ╰────
+  help: Expected to not encounter a Jest or Vitest snapshot but one was found that is 51 lines long

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 37] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 38] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -48,6 +48,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 37] = [
     "no-hooks",
     "no-identical-title",
     "no-interpolation-in-snapshots",
+    "no-large-snapshots",
     "no-mocks-import",
     "no-restricted-jest-methods",
     "no-restricted-matchers",


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Add `no-large-snapshot` as a vitest compatible rule

Oxlint-migrate PR: https://github.com/oxc-project/oxlint-migrate/pull/281