### PR TITLE
refactor(linter): Simplify from_configuration for several tsgolint rules.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -46,7 +46,7 @@ pub struct JsxPropsNoSpreadingConfig {
     exceptions: Vec<CompactStr>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct JsxPropsNoSpreading(Box<JsxPropsNoSpreadingConfig>);
 
 impl std::ops::Deref for JsxPropsNoSpreading {
@@ -91,11 +91,9 @@ declare_oxc_lint!(
 
 impl Rule for JsxPropsNoSpreading {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<JsxPropsNoSpreadingConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<JsxPropsNoSpreading>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::TypeOrValueSpecifier,
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoFloatingPromises(Box<NoFloatingPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -112,11 +112,9 @@ declare_oxc_lint!(
 
 impl Rule for NoFloatingPromises {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoFloatingPromisesConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoFloatingPromises>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     rule::{DefaultRuleConfig, Rule},
-    utils::{TypeOrValueSpecifier, default_true},
+    utils::TypeOrValueSpecifier,
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct OnlyThrowError(Box<OnlyThrowErrorConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -17,10 +17,8 @@ pub struct OnlyThrowErrorConfig {
     /// Use this to allow throwing custom error types.
     pub allow: Vec<TypeOrValueSpecifier>,
     /// Whether to allow throwing values typed as `any`.
-    #[serde(default = "default_true")]
     pub allow_throwing_any: bool,
     /// Whether to allow throwing values typed as `unknown`.
-    #[serde(default = "default_true")]
     pub allow_throwing_unknown: bool,
 }
 
@@ -89,11 +87,9 @@ declare_oxc_lint!(
 
 impl Rule for OnlyThrowError {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<OnlyThrowErrorConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<OnlyThrowError>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
@@ -2,12 +2,9 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct PreferNullishCoalescing(Box<PreferNullishCoalescingConfig>);
 
 /// Options for ignoring specific primitive types.
@@ -55,7 +52,6 @@ pub struct PreferNullishCoalescingConfig {
     /// Whether to ignore arguments to the `Boolean` constructor.
     pub ignore_boolean_coercion: bool,
     /// Whether to ignore cases that are located within a conditional test.
-    #[serde(default = "default_true")]
     pub ignore_conditional_tests: bool,
     /// Whether to ignore any if statements that could be simplified by using
     /// the nullish coalescing operator.
@@ -144,11 +140,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferNullishCoalescing {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<PreferNullishCoalescingConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<PreferNullishCoalescing>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     rule::{DefaultRuleConfig, Rule},
-    utils::{LibFrom, LibSpecifier, NameSpecifier, TypeOrValueSpecifier, default_true},
+    utils::{LibFrom, LibSpecifier, NameSpecifier, TypeOrValueSpecifier},
 };
 
 fn default_restrict_template_allow() -> Vec<TypeOrValueSpecifier> {
@@ -18,28 +18,23 @@ fn default_restrict_template_allow() -> Vec<TypeOrValueSpecifier> {
     })]
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct RestrictTemplateExpressions(Box<RestrictTemplateExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct RestrictTemplateExpressionsConfig {
     /// Whether to allow `any` typed values in template expressions.
-    #[serde(default = "default_true")]
     pub allow_any: bool,
     /// Whether to allow array types in template expressions.
     pub allow_array: bool,
     /// Whether to allow boolean types in template expressions.
-    #[serde(default = "default_true")]
     pub allow_boolean: bool,
     /// Whether to allow nullish types (`null` or `undefined`) in template expressions.
-    #[serde(default = "default_true")]
     pub allow_nullish: bool,
     /// Whether to allow number and bigint types in template expressions.
-    #[serde(default = "default_true")]
     pub allow_number: bool,
     /// Whether to allow RegExp values in template expressions.
-    #[serde(default = "default_true")]
     pub allow_reg_exp: bool,
     /// Whether to allow `never` type in template expressions.
     pub allow_never: bool,
@@ -133,11 +128,9 @@ declare_oxc_lint!(
 
 impl Rule for RestrictTemplateExpressions {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<RestrictTemplateExpressionsConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<RestrictTemplateExpressions>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -2,12 +2,9 @@ use oxc_macros::declare_oxc_lint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    rule::{DefaultRuleConfig, Rule},
-    utils::default_true,
-};
+use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct StrictBooleanExpressions(Box<StrictBooleanExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -24,13 +21,10 @@ pub struct StrictBooleanExpressionsConfig {
     /// Whether to allow nullable enum types in boolean contexts.
     pub allow_nullable_enum: bool,
     /// Whether to allow nullable object types in boolean contexts.
-    #[serde(default = "default_true")]
     pub allow_nullable_object: bool,
     /// Whether to allow string types in boolean contexts (checks for non-empty strings).
-    #[serde(default = "default_true")]
     pub allow_string: bool,
     /// Whether to allow number types in boolean contexts (checks for non-zero numbers).
-    #[serde(default = "default_true")]
     pub allow_number: bool,
     /// Whether to allow this rule to run without `strictNullChecks` enabled.
     /// This is not recommended as the rule may produce incorrect results.
@@ -134,11 +128,9 @@ declare_oxc_lint!(
 
 impl Rule for StrictBooleanExpressions {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<StrictBooleanExpressionsConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<StrictBooleanExpressions>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/unbound_method.rs
+++ b/crates/oxc_linter/src/rules/typescript/unbound_method.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule::{DefaultRuleConfig, Rule};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct UnboundMethod(Box<UnboundMethodConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -102,11 +102,9 @@ declare_oxc_lint!(
 
 impl Rule for UnboundMethod {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<UnboundMethodConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<UnboundMethod>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {


### PR DESCRIPTION
This updates all the tsgolint rules that were using a box wrapper + `DefaultRuleConfig<RuleNameConfig>`. And also one react rule.

The default_true utility is also unneeded, as the defaults will work fine without it. The `impl Default` sets the defaults for the relevant fields on each of these rules.

Basically the same kind of change as #16818.