### PR TITLE
fix(linter): Fix incorrect `allowNames` config option name in `typescript/no-this-alias` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -39,12 +39,14 @@ pub struct NoThisAliasConfig {
     /// Whether to allow destructuring of `this` to local variables.
     allow_destructuring: bool,
     /// An array of variable names that are allowed to alias `this`.
-    allow_names: FxHashSet<CompactStr>,
+    #[serde(alias = "allowNames")]
+    // Note: allowedNames is the config option used in the original ESLint rule, we typo'd it as allowNames.
+    allowed_names: FxHashSet<CompactStr>,
 }
 
 impl Default for NoThisAliasConfig {
     fn default() -> Self {
-        Self { allow_destructuring: true, allow_names: FxHashSet::default() }
+        Self { allow_destructuring: true, allowed_names: FxHashSet::default() }
     }
 }
 
@@ -58,7 +60,7 @@ impl std::ops::Deref for NoThisAlias {
 
 impl NoThisAlias {
     fn is_allowed(&self, name: &str) -> bool {
-        self.allow_names.contains(name)
+        self.allowed_names.contains(name)
     }
 }
 
@@ -79,9 +81,8 @@ declare_oxc_lint!(
 impl Rule for NoThisAlias {
     fn from_configuration(value: serde_json::Value) -> Self {
         let obj = value.get(0);
-        let allowed_names: FxHashSet<CompactStr> = value
-            .get(0)
-            .and_then(|v| v.get("allowNames"))
+        let allowed_names: FxHashSet<CompactStr> = obj
+            .and_then(|v| v.get("allowedNames").or_else(|| v.get("allowNames")))
             .and_then(Value::as_array)
             .unwrap_or(&vec![])
             .iter()
@@ -94,7 +95,7 @@ impl Rule for NoThisAlias {
                 .and_then(|v| v.get("allowDestructuring"))
                 .and_then(Value::as_bool)
                 .unwrap_or(true),
-            allow_names: allowed_names,
+            allowed_names,
         }))
     }
 
@@ -185,6 +186,8 @@ fn test() {
         ("const [foo] = this;", Some(serde_json::json!([{ "allowDestructuring": true }]))),
         ("const [foo, bar] = this;", Some(serde_json::json!([{ "allowDestructuring": true }]))),
         // allow list
+        ("const self = this;", Some(serde_json::json!([{ "allowedNames": vec!["self"] }]))),
+        // alternative key for backwards compatibility
         ("const self = this;", Some(serde_json::json!([{ "allowNames": vec!["self"] }]))),
     ];
 
@@ -234,6 +237,10 @@ fn test() {
           }",
             Some(serde_json::json!([{ "allowDestructuring": false }])),
         ),
+        // allow something else but not self
+        ("const self = this;", Some(serde_json::json!([{ "allowedNames": vec!["bar"] }]))),
+        // alternative key for backwards compatibility
+        ("const self = this;", Some(serde_json::json!([{ "allowNames": vec!["bar"] }]))),
     ];
 
     Tester::new(NoThisAlias::NAME, NoThisAlias::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/typescript_no_this_alias.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_this_alias.snap
@@ -117,3 +117,17 @@ source: crates/oxc_linter/src/tester.rs
  17 │             }
     ╰────
   help: Disabling destructuring of this is not a default, consider allowing destructuring
+
+  ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:7]
+ 1 │ const self = this;
+   ·       ────
+   ╰────
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
+
+  ⚠ typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:7]
+ 1 │ const self = this;
+   ·       ────
+   ╰────
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.


### PR DESCRIPTION
This change corrects the configuration option name from `allowNames` to `allowedNames` in the `no-this-alias` rule of the linter. The previous name was seemingly a mistake, the original typescript-eslint rule uses allowedNames.

I've retained allowNames as an alias for backwards compatibility with existing configurations that set up their config based on the config docs we previously had.

See https://typescript-eslint.io/rules/no-this-alias/

Generated docs after this PR:

```md
## Configuration

This rule accepts a configuration object with the following properties:

### allowDestructuring

type: `boolean`

default: `true`

Whether to allow destructuring of `this` to local variables.


### allowedNames

type: `string[]`

default: `[]`

An array of variable names that are allowed to alias `this`.
```