### PR TITLE
feat(minifier): remove empty `[]` and `{}` declaration

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -18,16 +18,21 @@ impl<'a> PeepholeOptimizations {
         if !Self::can_remove_unused_declarators(ctx) {
             return false;
         }
-        if let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind {
-            // Unsafe to remove `using`, unable to statically determine usage of [Symbol.dispose].
-            if decl.kind.is_using() {
-                return false;
-            }
-            if let Some(symbol_id) = ident.symbol_id.get() {
-                return ctx.scoping().symbol_is_unused(symbol_id);
-            }
+        // Unsafe to remove `using`, unable to statically determine usage of [Symbol.dispose].
+        if decl.kind.is_using() {
+            return false;
         }
-        false
+        match &decl.id.kind {
+            BindingPatternKind::BindingIdentifier(ident) => {
+                if let Some(symbol_id) = ident.symbol_id.get() {
+                    return ctx.scoping().symbol_is_unused(symbol_id);
+                }
+                false
+            }
+            BindingPatternKind::ArrayPattern(ident) => ident.is_empty(),
+            BindingPatternKind::ObjectPattern(ident) => ident.is_empty(),
+            BindingPatternKind::AssignmentPattern(_) => false,
+        }
     }
 
     pub fn remove_unused_variable_declaration(
@@ -117,6 +122,13 @@ mod test {
         test_options("var x", "", &options);
         test_options("var x = 1", "", &options);
         test_options("var x = foo", "foo", &options);
+        test_options("var [] = []", "", &options);
+        test_options("var [] = [1]", "", &options);
+        test_options("var [] = [foo]", "foo", &options);
+        test_options("var {} = {}", "", &options);
+        test_options("var {} = { a: 1 }", "", &options);
+        test_options("var {} = { foo }", "foo", &options);
+        test_options("var {} = { foo: { a } }", "a", &options);
         test_same_options("var x; foo(x)", &options);
         test_same_options("export var x", &options);
         test_same_options("using x = foo", &options);


### PR DESCRIPTION
Expands check for `should_remove_unused_declarator` to include empty array and object pattern