### PR TITLE
test(linter): Add more tests for deserializing globals in Oxlintrc.

### DIFF
--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -155,6 +155,10 @@ mod test {
         assert!(globals.is_enabled("foo"));
         assert!(globals.is_enabled("bar"));
         assert!(!globals.is_enabled("baz"));
+
+        assert_eq!(globals.get("foo"), Some(&GlobalValue::Readonly));
+        assert_eq!(globals.get("bar"), Some(&GlobalValue::Writable));
+        assert_eq!(globals.get("baz"), Some(&GlobalValue::Off));
     }
 
     #[test]
@@ -165,6 +169,9 @@ mod test {
         });
         assert!(globals.is_enabled("foo"));
         assert!(globals.is_enabled("bar"));
+        // Ensure they map to the correct variants
+        assert_eq!(globals.get("foo"), Some(&GlobalValue::Readonly));
+        assert_eq!(globals.get("bar"), Some(&GlobalValue::Writable));
     }
 
     #[test]
@@ -175,6 +182,9 @@ mod test {
         });
         assert!(globals.is_enabled("foo"));
         assert!(globals.is_enabled("bar"));
+
+        assert_eq!(globals.get("foo"), Some(&GlobalValue::Writable));
+        assert_eq!(globals.get("bar"), Some(&GlobalValue::Readonly));
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -105,6 +105,35 @@ mod test {
         );
         assert_eq!(env.iter().count(), 1);
         assert!(globals.is_enabled("foo"));
+        assert_eq!(globals.get("foo"), Some(&super::GlobalValue::Readonly));
+    }
+
+    #[test]
+    fn test_deserialize_globals() {
+        let config = Oxlintrc::deserialize(&serde_json::json!({
+            "globals": {
+                "foo": "readable",
+                "bar": "writeable",
+                "baz": "off",
+                "qux": true,
+                "quux": false,
+                "corge": "readonly",
+                "grault": "writable"
+            }
+        }));
+        assert!(config.is_ok());
+
+        let Oxlintrc { globals, .. } = config.unwrap();
+        assert!(globals.is_enabled("foo"));
+        assert!(globals.is_enabled("bar"));
+        // Ensure they map to the correct variants
+        assert_eq!(globals.get("foo"), Some(&super::GlobalValue::Readonly));
+        assert_eq!(globals.get("bar"), Some(&super::GlobalValue::Writable));
+        assert_eq!(globals.get("baz"), Some(&super::GlobalValue::Off));
+        assert_eq!(globals.get("qux"), Some(&super::GlobalValue::Writable));
+        assert_eq!(globals.get("quux"), Some(&super::GlobalValue::Readonly));
+        assert_eq!(globals.get("corge"), Some(&super::GlobalValue::Readonly));
+        assert_eq!(globals.get("grault"), Some(&super::GlobalValue::Writable));
     }
 
     #[test]


### PR DESCRIPTION
Just ensuring they work correctly by checking that they get mapped to the correct enum variants.

- `readonly`/`readable`/`false` should map to Readonly
- `writable`/`writeable`/`true` should map to Writable
- `off` should map to Off