### PR TITLE
chore(linter/plugins): Add more values to globals fixture test.

### DIFF
--- a/apps/oxlint/test/fixtures/globals/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/globals/.oxlintrc.json
@@ -12,7 +12,11 @@
     "React": "readonly",
     "process": "writable",
     "console": "readonly",
-    "window": "off"
+    "window": "off",
+    "foo": "writeable",
+    "bar": "readable",
+    "baz": true,
+    "qux": false
   },
   "overrides": [
     {

--- a/apps/oxlint/test/fixtures/globals/output.snap.md
+++ b/apps/oxlint/test/fixtures/globals/output.snap.md
@@ -6,7 +6,11 @@
   x globals-plugin(globals): {
   |   "React": "readonly",
   |   "console": "readonly",
+  |   "baz": "writable",
+  |   "foo": "writable",
   |   "process": "writable",
+  |   "bar": "readonly",
+  |   "qux": "readonly",
   |   "window": "off"
   | }
    ,-[files/index.js:1:1]
@@ -17,8 +21,12 @@
   x globals-plugin(globals): {
   |   "React": "writable",
   |   "console": "readonly",
-  |   "customGlobal": "readonly",
+  |   "baz": "writable",
+  |   "foo": "writable",
   |   "process": "off",
+  |   "bar": "readonly",
+  |   "qux": "readonly",
+  |   "customGlobal": "readonly",
   |   "window": "off"
   | }
    ,-[files/nested/index.js:1:1]


### PR DESCRIPTION
Add a few other values in the oxlintrc.json file to ensure that the various possible input values are tested. These should work and be parsed correctly by the config deserializer, generally.

The "weird" values are booleans and readable/writeable. They are supported for backwards-compatibility with older ESLint configs.

cc: @overlookmotel not sure if this is desired, or if this should be a separate test file? Just making sure we have support for the various globals variants that need to be accepted.