### PR TITLE
test(parser): combine test cases for `let` as identifier

### DIFF
--- a/tasks/coverage/misc/fail/let-member-expression.js
+++ b/tasks/coverage/misc/fail/let-member-expression.js
@@ -1,0 +1,12 @@
+// Test that `let` cannot be used as identifier in member expression or call expression in module
+'use strict';
+
+let.x;
+
+let.x = 1;
+let()[x] = 1;
+
+let?.x;
+let?.y.z;
+let?.[0];
+let?.method();

--- a/tasks/coverage/misc/fail/let-optional-chaining.js
+++ b/tasks/coverage/misc/fail/let-optional-chaining.js
@@ -1,5 +1,0 @@
-// Test that `let` cannot be used as identifier with optional chaining in module
-let?.x;
-let?.y.z;
-let?.[0];
-let?.method();

--- a/tasks/coverage/misc/fail/oxc.js
+++ b/tasks/coverage/misc/fail/oxc.js
@@ -1,4 +1,0 @@
-'use strict';
-
-let.a = 1;
-let()[a] = 1;

--- a/tasks/coverage/misc/pass/let-member-expression.cjs
+++ b/tasks/coverage/misc/pass/let-member-expression.cjs
@@ -1,0 +1,10 @@
+// Test that `let` can be used as identifier in member expression or call expression in script
+let.x;
+
+let.x = 1;
+let()[x] = 1;
+
+let?.x;
+let?.y.z;
+let?.[0];
+let?.method();

--- a/tasks/coverage/misc/pass/let-optional-chaining.cjs
+++ b/tasks/coverage/misc/pass/let-optional-chaining.cjs
@@ -1,5 +1,0 @@
-// Test that `let` can be used as identifier with optional chaining in script
-let?.x;
-let?.y.z;
-let?.[0];
-let?.method();

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 53/53 (100.00%)
 Positive Passed: 53/53 (100.00%)
-Negative Passed: 122/122 (100.00%)
+Negative Passed: 121/121 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -291,35 +291,59 @@ Negative Passed: 122/122 (100.00%)
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/let-optional-chaining.js:2:1]
- 1 │ // Test that `let` cannot be used as identifier with optional chaining in module
- 2 │ let?.x;
+   ╭─[misc/fail/let-member-expression.js:4:1]
+ 3 │ 
+ 4 │ let.x;
    · ───
- 3 │ let?.y.z;
+ 5 │ 
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/let-optional-chaining.js:3:1]
- 2 │ let?.x;
- 3 │ let?.y.z;
+   ╭─[misc/fail/let-member-expression.js:6:1]
+ 5 │ 
+ 6 │ let.x = 1;
    · ───
- 4 │ let?.[0];
+ 7 │ let()[x] = 1;
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/let-optional-chaining.js:4:1]
- 3 │ let?.y.z;
- 4 │ let?.[0];
+   ╭─[misc/fail/let-member-expression.js:7:1]
+ 6 │ let.x = 1;
+ 7 │ let()[x] = 1;
    · ───
- 5 │ let?.method();
+ 8 │ 
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/let-optional-chaining.js:5:1]
- 4 │ let?.[0];
- 5 │ let?.method();
-   · ───
-   ╰────
+    ╭─[misc/fail/let-member-expression.js:9:1]
+  8 │ 
+  9 │ let?.x;
+    · ───
+ 10 │ let?.y.z;
+    ╰────
+
+  × The keyword 'let' is reserved
+    ╭─[misc/fail/let-member-expression.js:10:1]
+  9 │ let?.x;
+ 10 │ let?.y.z;
+    · ───
+ 11 │ let?.[0];
+    ╰────
+
+  × The keyword 'let' is reserved
+    ╭─[misc/fail/let-member-expression.js:11:1]
+ 10 │ let?.y.z;
+ 11 │ let?.[0];
+    · ───
+ 12 │ let?.method();
+    ╰────
+
+  × The keyword 'let' is reserved
+    ╭─[misc/fail/let-member-expression.js:12:1]
+ 11 │ let?.[0];
+ 12 │ let?.method();
+    · ───
+    ╰────
 
   × Expected `:` but found `EOF`
    ╭─[misc/fail/missing-conditional-alternative-type.ts:2:1]
@@ -3611,21 +3635,6 @@ Negative Passed: 122/122 (100.00%)
  3 │ }
    ╰────
   help: Add an identifier after '?.'
-
-  × The keyword 'let' is reserved
-   ╭─[misc/fail/oxc.js:3:1]
- 2 │ 
- 3 │ let.a = 1;
-   · ───
- 4 │ let()[a] = 1;
-   ╰────
-
-  × The keyword 'let' is reserved
-   ╭─[misc/fail/oxc.js:4:1]
- 3 │ let.a = 1;
- 4 │ let()[a] = 1;
-   · ───
-   ╰────
 
   × Expected switch clause
    ╭─[misc/fail/switch-invalid-clause.js:2:3]


### PR DESCRIPTION
Follow-on after #16840 and #16857. We had a few test cases relating to the same thing, and one of them called the undescriptive `oxc.js`. Combine them, and rename the test case files with a more accurate name.