### PR TITLE
chore(linter): Ensure that no unknown fields are allowed in OxlintOverride struct.

### DIFF
--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -76,6 +76,7 @@ impl JsonSchema for OxlintOverrides {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct OxlintOverride {
     /// A list of glob patterns to override.
     ///

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -509,7 +509,8 @@ expression: json
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OxlintOverrides": {
       "type": "array",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -505,7 +505,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OxlintOverrides": {
       "type": "array",


### PR DESCRIPTION
Ensure that extra fields are not allowed inside overrides, to make it clear to users when they have added an invalid field.

Pulled out of #16822 since I think it's worth including regardless of that PR.