### PR TITLE
feat(linter): implement `eslint/no-sequences` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -700,6 +700,12 @@ impl RuleRunner for crate::rules::eslint::no_self_compare::NoSelfCompare {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::no_sequences::NoSequences {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SequenceExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_setter_return::NoSetterReturn {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ReturnStatement]));

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -145,6 +145,7 @@ pub(crate) mod eslint {
     pub mod no_script_url;
     pub mod no_self_assign;
     pub mod no_self_compare;
+    pub mod no_sequences;
     pub mod no_setter_return;
     pub mod no_shadow_restricted_names;
     pub mod no_sparse_arrays;
@@ -792,6 +793,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_script_url,
     eslint::no_self_assign,
     eslint::no_self_compare,
+    eslint::no_sequences,
     eslint::no_setter_return,
     eslint::no_shadow_restricted_names,
     eslint::no_sparse_arrays,

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -1,0 +1,221 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_sequences_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected use of comma operator")
+        .with_help("Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoSequences {
+    /// If this option is set to `false`, this rule disallows the comma operator
+    /// even when the expression sequence is explicitly wrapped in parentheses.
+    /// Default is `true`.
+    #[serde(default = "default_allow_in_parentheses")]
+    allow_in_parentheses: bool,
+}
+
+fn default_allow_in_parentheses() -> bool {
+    true
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of the comma operator.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The comma operator evaluates each of its operands (from left to right)
+    /// and returns the value of the last operand. However, this frequently
+    /// obscures side effects, and its use is often an accident.
+    ///
+    /// ### Options
+    ///
+    /// - `allowInParentheses` (default: `true`): If set to `false`, disallows
+    ///   the comma operator even when wrapped in parentheses.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// foo = doSomething(), val;
+    ///
+    /// 0, eval("doSomething();");
+    ///
+    /// do {} while ((doSomething(), !!test));
+    ///
+    /// // with allowInParentheses: false
+    /// foo = (doSomething(), val);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// foo = (doSomething(), val);
+    ///
+    /// (0, eval)("doSomething();");
+    ///
+    /// do {} while (((doSomething(), !!test)));
+    ///
+    /// for (i = 0, j = 10; i < j; i++, j--) {}
+    /// ```
+    NoSequences,
+    eslint,
+    restriction,
+);
+
+impl Rule for NoSequences {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let obj = value.get(0);
+
+        Self {
+            allow_in_parentheses: obj
+                .and_then(|v| v.get("allowInParentheses"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::SequenceExpression(seq_expr) = node.kind() else {
+            return;
+        };
+
+        // Always allow in for loop init and update
+        if Self::is_in_for_loop_init_or_update(node, ctx) {
+            return;
+        }
+
+        // Check for parentheses if allowed
+        if self.allow_in_parentheses && Self::is_allowed_by_parentheses(node, ctx) {
+            return;
+        }
+
+        // Report at the span of the first comma (between first and second expression)
+        let span = if seq_expr.expressions.len() >= 2 {
+            // Get span between first and second expression (where the comma is)
+            let first_end = seq_expr.expressions[0].span().end;
+            let second_start = seq_expr.expressions[1].span().start;
+            Span::new(first_end, second_start)
+        } else {
+            seq_expr.span
+        };
+
+        ctx.diagnostic(no_sequences_diagnostic(span));
+    }
+}
+
+impl NoSequences {
+    /// Check if the sequence expression is in a for loop's init or update position
+    fn is_in_for_loop_init_or_update(node: &AstNode, ctx: &LintContext) -> bool {
+        let nodes = ctx.nodes();
+        let parent = nodes.parent_node(node.id());
+
+        // Check if the parent is a ForStatement and this is in init or update
+        if let AstKind::ForStatement(for_stmt) = parent.kind() {
+            let node_span = node.span();
+
+            // Check if in init position
+            if let Some(init) = &for_stmt.init
+                && init.span() == node_span
+            {
+                return true;
+            }
+
+            // Check if in update position
+            if let Some(update) = &for_stmt.update
+                && update.span() == node_span
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Check if the sequence expression is allowed due to parentheses
+    fn is_allowed_by_parentheses(node: &AstNode, ctx: &LintContext) -> bool {
+        let nodes = ctx.nodes();
+        let parent = nodes.parent_node(node.id());
+
+        // Check if wrapped in parentheses
+        let is_wrapped_once = matches!(parent.kind(), AstKind::ParenthesizedExpression(_));
+
+        if !is_wrapped_once {
+            return false;
+        }
+
+        // For most cases, single parentheses are enough
+        // But for grammar positions that require parentheses (if, while, do-while, switch, with),
+        // we need double parentheses
+        let grandparent = nodes.parent_node(parent.id());
+
+        let requires_extra_parens = matches!(
+            grandparent.kind(),
+            AstKind::IfStatement(_)
+                | AstKind::WhileStatement(_)
+                | AstKind::DoWhileStatement(_)
+                | AstKind::SwitchStatement(_)
+                | AstKind::WithStatement(_)
+        );
+
+        if !requires_extra_parens {
+            return true;
+        }
+
+        // Need double parentheses for these cases
+        // Check if grandparent is also a ParenthesizedExpression
+        matches!(grandparent.kind(), AstKind::ParenthesizedExpression(_))
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // For loop init and update are allowed
+        ("for (i = 0, j = 10; i < j; i++, j--) {}", None),
+        ("for (a = 0, b = 10; a < b; a++, b--) foo();", None),
+        // Wrapped in parentheses (default allowInParentheses: true)
+        ("foo = (doSomething(), val);", None),
+        ("(0, eval)(\"doSomething();\");", None),
+        ("a = ((b, c), d);", None),
+        // Double parentheses for conditions
+        ("do {} while (((doSomething(), !!test)));", None),
+        ("while (((a, b))) {}", None),
+        ("if (((a, b))) {}", None),
+        ("switch (((a, b))) {}", None),
+        // Arrow function with parentheses (single is enough since body doesn't require parens)
+        ("const fn = (x) => (log(), x);", None),
+        // With allowInParentheses: true (explicit)
+        ("foo = (doSomething(), val);", Some(serde_json::json!([{ "allowInParentheses": true }]))),
+    ];
+
+    let fail = vec![
+        // Basic sequence without parentheses
+        ("foo = doSomething(), val;", None),
+        ("0, eval(\"doSomething();\");", None),
+        ("a = b, c;", None),
+        // Single parentheses in condition (needs double)
+        ("do {} while ((doSomething(), !!test));", None),
+        ("while ((a, b)) {}", None),
+        ("if ((a, b)) {}", None),
+        ("switch ((a, b)) {}", None),
+        // With allowInParentheses: false, even parenthesized sequences are errors
+        ("foo = (doSomething(), val);", Some(serde_json::json!([{ "allowInParentheses": false }]))),
+        (
+            "(0, eval)(\"doSomething();\");",
+            Some(serde_json::json!([{ "allowInParentheses": false }])),
+        ),
+    ];
+
+    Tester::new(NoSequences::NAME, NoSequences::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -5,7 +5,7 @@ use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule, rule::DefaultRuleConfig};
+use crate::{AstNode, context::LintContext, rule::DefaultRuleConfig, rule::Rule};
 
 fn no_sequences_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of comma operator")
@@ -76,9 +76,7 @@ declare_oxc_lint!(
 
 impl Rule for NoSequences {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     ///
     /// 0, eval("doSomething();");
     ///
-    /// do {} while ((doSomething(), !!test));
+    /// // Arrow function body needs double parentheses
+    /// const fn = () => (doSomething(), val);
     ///
     /// // with allowInParentheses: false
     /// foo = (doSomething(), val);
@@ -64,9 +65,13 @@ declare_oxc_lint!(
     ///
     /// (0, eval)("doSomething();");
     ///
-    /// do {} while (((doSomething(), !!test)));
+    /// // Single extra parentheses is enough for conditions
+    /// do {} while ((doSomething(), !!test));
     ///
     /// for (i = 0, j = 10; i < j; i++, j--) {}
+    ///
+    /// // Arrow function body needs double parentheses
+    /// const fn = () => ((doSomething(), val));
     /// ```
     NoSequences,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -206,10 +206,7 @@ fn test() {
         // For loop with parentheses around init/update - still allowed
         ("for ((a, b);;);", None),
         ("for (;; (a, b));", None),
-        (
-            "for ((a, b);;);",
-            Some(serde_json::json!([{ "allowInParentheses": false }])),
-        ),
+        ("for ((a, b);;);", Some(serde_json::json!([{ "allowInParentheses": false }]))),
         // Wrapped in parentheses (default allowInParentheses: true)
         ("foo = (doSomething(), val);", None),
         ("(0, eval)(\"doSomething();\");", None),
@@ -224,10 +221,7 @@ fn test() {
         // Arrow function body requires double parentheses
         ("const fn = (x) => ((log(), x));", None),
         // With allowInParentheses: true (explicit)
-        (
-            "foo = (doSomething(), val);",
-            Some(serde_json::json!([{ "allowInParentheses": true }])),
-        ),
+        ("foo = (doSomething(), val);", Some(serde_json::json!([{ "allowInParentheses": true }]))),
     ];
 
     let fail = vec![
@@ -245,10 +239,7 @@ fn test() {
         // Arrow function body with single parentheses (needs double per ESLint)
         ("const fn = (x) => (log(), x);", None),
         // With allowInParentheses: false, even parenthesized sequences are errors
-        (
-            "foo = (doSomething(), val);",
-            Some(serde_json::json!([{ "allowInParentheses": false }])),
-        ),
+        ("foo = (doSomething(), val);", Some(serde_json::json!([{ "allowInParentheses": false }]))),
         (
             "(0, eval)(\"doSomething();\");",
             Some(serde_json::json!([{ "allowInParentheses": false }])),

--- a/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
@@ -2,43 +2,155 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:20]
- 1 │ foo = doSomething(), val;
-   ·                    ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:2]
- 1 │ 0, eval("doSomething();");
+ 1 │ 1, 2;
    ·  ──
    ╰────
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:6]
- 1 │ a = b, c;
+ 1 │ a = 1, 2
    ·      ──
    ╰────
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:25]
- 1 │ const fn = (x) => (log(), x);
-   ·                         ──
+   ╭─[no_sequences.tsx:1:27]
+ 1 │ do {} while (doSomething(), !!test);
+   ·                           ──
    ╰────
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:21]
- 1 │ foo = (doSomething(), val);
+ 1 │ for (; doSomething(), !!test; );
    ·                     ──
    ╰────
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:18]
+ 1 │ if (doSomething(), !!test);
+   ·                  ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:22]
+ 1 │ switch (doSomething(), val) {}
+   ·                      ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:21]
+ 1 │ while (doSomething(), !!test);
+   ·                     ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:20]
+ 1 │ with (doSomething(), val) {}
+   ·                    ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:20]
+ 1 │ a => (doSomething(), a)
+   ·                    ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:4]
+ 1 │ (1), 2
+   ·    ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:6]
+ 1 │ ((1)) , (2)
+   ·      ───
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:10]
+ 1 │ while((1) , 2);
+   ·          ───
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:13]
+ 1 │ var foo = (1, 2);
+   ·             ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:3]
- 1 │ (0, eval)("doSomething();");
-   ·   ──
+ 1 │ (0,eval)("foo()");
+   ·   ─
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:10]
+ 1 │ foo(a, (b, c), d);
+   ·          ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:28]
+ 1 │ do {} while ((doSomething(), !!test));
+   ·                            ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:22]
+ 1 │ for (; (doSomething(), !!test); );
+   ·                      ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:19]
+ 1 │ if ((doSomething(), !!test));
+   ·                   ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:23]
+ 1 │ switch ((doSomething(), val)) {}
+   ·                       ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:22]
+ 1 │ while ((doSomething(), !!test));
+   ·                      ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:21]
+ 1 │ with ((doSomething(), val)) {}
+   ·                     ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:21]
+ 1 │ a => ((doSomething(), a))
+   ·                     ──
    ╰────
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.

--- a/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
@@ -51,6 +51,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:9]
+ 1 │ with ((a, b)) {}
+   ·         ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:25]
+ 1 │ const fn = (x) => (log(), x);
+   ·                         ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:21]
  1 │ foo = (doSomething(), val);
    ·                     ──

--- a/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
@@ -23,41 +23,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
 
   ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:28]
- 1 │ do {} while ((doSomething(), !!test));
-   ·                            ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:10]
- 1 │ while ((a, b)) {}
-   ·          ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:7]
- 1 │ if ((a, b)) {}
-   ·       ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:11]
- 1 │ switch ((a, b)) {}
-   ·           ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
-   ╭─[no_sequences.tsx:1:9]
- 1 │ with ((a, b)) {}
-   ·         ──
-   ╰────
-  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
-
-  ⚠ eslint(no-sequences): Unexpected use of comma operator
    ╭─[no_sequences.tsx:1:25]
  1 │ const fn = (x) => (log(), x);
    ·                         ──

--- a/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_sequences.snap
@@ -1,0 +1,65 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:20]
+ 1 │ foo = doSomething(), val;
+   ·                    ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:2]
+ 1 │ 0, eval("doSomething();");
+   ·  ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:6]
+ 1 │ a = b, c;
+   ·      ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:28]
+ 1 │ do {} while ((doSomething(), !!test));
+   ·                            ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:10]
+ 1 │ while ((a, b)) {}
+   ·          ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:7]
+ 1 │ if ((a, b)) {}
+   ·       ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:11]
+ 1 │ switch ((a, b)) {}
+   ·           ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:21]
+ 1 │ foo = (doSomething(), val);
+   ·                     ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.
+
+  ⚠ eslint(no-sequences): Unexpected use of comma operator
+   ╭─[no_sequences.tsx:1:3]
+ 1 │ (0, eval)("doSomething();");
+   ·   ──
+   ╰────
+  help: Do not use the comma operator. If you intended to write a sequence, wrap it in parentheses.


### PR DESCRIPTION
## Summary

Implements the `eslint/no-sequences` rule that disallows the use of the comma operator.

The comma operator evaluates each of its operands (from left to right) and returns the value of the last operand. However, this frequently obscures side effects, and its use is often an accident.

### Features

- Allows comma operator in for loop init and update expressions (standard JS pattern)
- `allowInParentheses` option (default: `true`) allows sequences wrapped in parentheses
- For grammar positions requiring parentheses (if, while, do-while, switch, with), double parentheses are needed to indicate intentionality

### Examples

**Incorrect:**
```javascript
foo = doSomething(), val;
0, eval("doSomething();");
do {} while ((doSomething(), !!test)); // needs double parens
```

**Correct:**
```javascript
foo = (doSomething(), val);
(0, eval)("doSomething();");
do {} while (((doSomething(), !!test))); // double parens
for (i = 0, j = 10; i < j; i++, j--) {} // for loop allowed
```

Closes https://github.com/oxc-project/oxc/issues/481 (partially - adds no-sequences)