### PR TITLE
fix(linter): Prevent extra fields from being present on oxlint config file

### DIFF
--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -132,8 +132,14 @@ expression: json
           "$ref": "#/definitions/OxlintSettings"
         }
       ]
+    },
+    "$schema": {
+      "type": "string",
+      "description": "Schema URI for editor tooling",
+      "markdownDescription": "Schema URI for editor tooling"
     }
   },
+  "additionalProperties": false,
   "allowComments": true,
   "allowTrailingCommas": true,
   "definitions": {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -128,8 +128,14 @@
           "$ref": "#/definitions/OxlintSettings"
         }
       ]
+    },
+    "$schema": {
+      "type": "string",
+      "description": "Schema URI for editor tooling",
+      "markdownDescription": "Schema URI for editor tooling"
     }
   },
+  "additionalProperties": false,
   "allowComments": true,
   "allowTrailingCommas": true,
   "definitions": {


### PR DESCRIPTION
This adds a `$schema` field to the JSON Schema, but otherwise disallows any fields not explicitly defined in the Oxlintrc struct.

This ensures that we can warn the user if they have invalid config fields:

<img width="695" height="417" alt="Screenshot 2025-12-14 at 11 22 02 PM" src="https://github.com/user-attachments/assets/8dc2252e-58ad-4bb5-a84e-cd468ad35941" />

The improved enforcement ensures the correct usage of the configuration file, and this change found a bug in another rule (see #16873).