### PR TITLE
feat(linter/eslint-plugin-vitest): Add require-hook as vitest compatible jest rule

### DIFF
--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -9,13 +9,14 @@ use oxc_semantic::AstNode;
 use oxc_span::{CompactStr, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::borrow::Cow;
 
 use crate::{
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
     utils::{
         JestFnKind, JestGeneralFnKind, PossibleJestNode, get_node_name, is_type_of_jest_fn_call,
-        parse_jest_fn_call,
+        valid_vitest_fn::is_valid_vitest_call,
     },
 };
 
@@ -159,6 +160,17 @@ declare_oxc_lint!(
     ///     clearCityDatabase();
     /// });
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-hook.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/require-hook": "error"
+    ///   }
+    /// }
+    /// ```
     RequireHook,
     jest,
     style,
@@ -175,7 +187,7 @@ impl Rule for RequireHook {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Program(program) => {
-                self.check_block_body(node, &program.body, ctx);
+                self.check_block_body(&program.body, ctx);
             }
             AstKind::CallExpression(call_expr) => {
                 if !is_type_of_jest_fn_call(
@@ -187,15 +199,16 @@ impl Rule for RequireHook {
                 {
                     return;
                 }
+
                 match &call_expr.arguments[1] {
                     Argument::FunctionExpression(func_expr) => {
                         if let Some(func_body) = &func_expr.body {
-                            self.check_block_body(node, &func_body.statements, ctx);
+                            self.check_block_body(&func_body.statements, ctx);
                         }
                     }
                     Argument::ArrowFunctionExpression(arrow_func_expr) => {
                         if !arrow_func_expr.expression {
-                            self.check_block_body(node, &arrow_func_expr.body.statements, ctx);
+                            self.check_block_body(&arrow_func_expr.body.statements, ctx);
                         }
                     }
                     _ => (),
@@ -209,18 +222,17 @@ impl Rule for RequireHook {
 impl RequireHook {
     fn check_block_body<'a>(
         &self,
-        node: &AstNode<'a>,
         statements: &'a OxcVec<'a, Statement<'_>>,
         ctx: &LintContext<'a>,
     ) {
         for stmt in statements {
-            self.check(node, stmt, ctx);
+            self.check(stmt, ctx);
         }
     }
 
-    fn check<'a>(&self, node: &AstNode<'a>, stmt: &'a Statement<'_>, ctx: &LintContext<'a>) {
+    fn check<'a>(&self, stmt: &'a Statement<'_>, ctx: &LintContext<'a>) {
         if let Statement::ExpressionStatement(expr_stmt) = stmt {
-            self.check_should_report_in_hook(node, &expr_stmt.expression, ctx);
+            self.check_should_report_in_hook(&expr_stmt.expression, ctx);
         } else if let Statement::VariableDeclaration(var_decl) = stmt
             && var_decl.kind != VariableDeclarationKind::Const
             && var_decl.declarations.iter().any(|decl| {
@@ -234,18 +246,19 @@ impl RequireHook {
         }
     }
 
-    fn check_should_report_in_hook<'a>(
-        &self,
-        node: &AstNode<'a>,
-        expr: &'a Expression<'a>,
-        ctx: &LintContext<'a>,
-    ) {
+    fn check_should_report_in_hook<'a>(&self, expr: &'a Expression<'a>, ctx: &LintContext<'a>) {
         if let Expression::CallExpression(call_expr) = expr {
             let name = get_node_name(&call_expr.callee);
 
-            if !(parse_jest_fn_call(call_expr, &PossibleJestNode { node, original: None }, ctx)
-                .is_some()
+            let node_name_split: Vec<&str> = name.split('.').collect();
+
+            let Some(fn_type) = node_name_split.first() else {
+                return;
+            };
+
+            if !(is_valid_vitest_call(&[Cow::Borrowed(fn_type)])
                 || name.starts_with("jest.")
+                || name.starts_with("vi.")
                 || self.allowed_function_calls.contains(&name))
             {
                 ctx.diagnostic(use_hook(call_expr.span));
@@ -258,7 +271,7 @@ impl RequireHook {
 fn tests() {
     use crate::tester::Tester;
 
-    let pass = vec![
+    let mut pass = vec![
         ("describe()", None),
         ("describe(\"just a title\")", None),
         (
@@ -482,7 +495,7 @@ fn tests() {
         ),
     ];
 
-    let fail = vec![
+    let mut fail = vec![
         ("setup();", None),
         (
             "
@@ -633,7 +646,310 @@ fn tests() {
         ),
     ];
 
+    let vitest_pass = vec![
+        ("describe()", None),
+        ("describe.for([])('%s', (value) => {})", None),
+        (
+            "describe('a test', () =>
+			test('something', () => {
+			        expect(true).toBe(true);
+			}));",
+            None,
+        ),
+        (
+            "describe('scoped', () => {
+			      test.scoped({ example: 'value' });
+			    });",
+            None,
+        ),
+        (
+            "
+			import { myFn } from '../functions';
+			test('myFn', () => {
+			expect(myFn()).toBe(1);
+			});
+			",
+            None,
+        ), // { "parserOptions": { "sourceType": "module" } },
+        (
+            "
+			class MockLogger {
+			  log() {}
+			     }
+
+			     test('myFn', () => {
+			       expect(myFn()).toBe(1);
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     const { myFn } = require('../functions');
+
+			     describe('myFn', () => {
+			       it('returns one', () => {
+			      expect(myFn()).toBe(1);
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     describe('some tests', () => {
+			       it('is true', () => {
+			      expect(true).toBe(true);
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     describe('some tests', () => {
+			       it('is true', () => {
+			      expect(true).toBe(true);
+			       });
+
+			       describe('more tests', () => {
+			      it('is false', () => {
+			        expect(true).toBe(false);
+			      });
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     describe('some tests', () => {
+			       let consoleLogSpy;
+
+			       beforeEach(() => {
+			      consoleLogSpy = vi.spyOn(console, 'log');
+			       });
+
+			       it('prints a message', () => {
+			      printMessage('hello world');
+
+			      expect(consoleLogSpy).toHaveBeenCalledWith('hello world');
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     let consoleErrorSpy = null;
+
+			     beforeEach(() => {
+			       consoleErrorSpy = vi.spyOn(console, 'error');
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     let consoleErrorSpy = undefined;
+
+			     beforeEach(() => {
+			       consoleErrorSpy = vi.spyOn(console, 'error');
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     describe('some tests', () => {
+			       beforeEach(() => {
+			      setup();
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     beforeEach(() => {
+			       initializeCityDatabase();
+			     });
+
+			     afterEach(() => {
+			       clearCityDatabase();
+			     });
+
+			     test('city database has Vienna', () => {
+			       expect(isCity('Vienna')).toBeTruthy();
+			     });
+
+			     test('city database has San Juan', () => {
+			       expect(isCity('San Juan')).toBeTruthy();
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			     describe('cities', () => {
+			       beforeEach(() => {
+			      initializeCityDatabase();
+			       });
+
+			       test('city database has Vienna', () => {
+			      expect(isCity('Vienna')).toBeTruthy();
+			       });
+
+			       test('city database has San Juan', () => {
+			      expect(isCity('San Juan')).toBeTruthy();
+			       });
+
+			       afterEach(() => {
+			      clearCityDatabase();
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			       enableAutoDestroy(afterEach);
+
+			       describe('some tests', () => {
+			      it('is false', () => {
+			        expect(true).toBe(true);
+			      });
+			       });
+			     ",
+            Some(serde_json::json!([{ "allowedFunctionCalls": ["enableAutoDestroy"] }])),
+        ),
+    ];
+
+    let vitest_fail = vec![
+        ("setup();", None),
+        (
+            "
+			       describe('some tests', () => {
+			      setup();
+			       });
+			     ",
+            None,
+        ),
+        (
+            "
+			       let { setup } = require('./test-utils');
+
+			       describe('some tests', () => {
+			      setup();
+			       });
+			     ",
+            None,
+        ),
+        (
+            "
+			     describe('some tests', () => {
+			       setup();
+
+			       it('is true', () => {
+			      expect(true).toBe(true);
+			       });
+
+			       describe('more tests', () => {
+			      setup();
+
+			      it('is false', () => {
+			        expect(true).toBe(false);
+			      });
+			       });
+			     });
+			      ",
+            None,
+        ),
+        (
+            "
+			       let consoleErrorSpy = vi.spyOn(console, 'error');
+
+			       describe('when loading cities from the api', () => {
+			      let consoleWarnSpy = vi.spyOn(console, 'warn');
+			       });
+			     ",
+            None,
+        ),
+        (
+            "
+			       let consoleErrorSpy = null;
+
+			       describe('when loading cities from the api', () => {
+			      let consoleWarnSpy = vi.spyOn(console, 'warn');
+			       });
+			     ",
+            None,
+        ),
+        ("let value = 1", None),
+        ("let consoleErrorSpy, consoleWarnSpy = vi.spyOn(console, 'error');", None),
+        ("let consoleErrorSpy = vi.spyOn(console, 'error'), consoleWarnSpy;", None),
+        (
+            "
+			       import { database, isCity } from '../database';
+			       import { loadCities } from '../api';
+
+			       vi.mock('../api');
+
+			       const initializeCityDatabase = () => {
+			      database.addCity('Vienna');
+			      database.addCity('San Juan');
+			      database.addCity('Wellington');
+			       };
+
+			       const clearCityDatabase = () => {
+			      database.clear();
+			       };
+
+			       initializeCityDatabase();
+
+			       test('that persists cities', () => {
+			      expect(database.cities.length).toHaveLength(3);
+			       });
+
+			       test('city database has Vienna', () => {
+			      expect(isCity('Vienna')).toBeTruthy();
+			       });
+
+			       test('city database has San Juan', () => {
+			      expect(isCity('San Juan')).toBeTruthy();
+			       });
+
+			       describe('when loading cities from the api', () => {
+			      let consoleWarnSpy = vi.spyOn(console, 'warn');
+
+			      loadCities.mockResolvedValue(['Wellington', 'London']);
+
+			      it('does not duplicate cities', async () => {
+			        await database.loadCities();
+
+			        expect(database.cities).toHaveLength(4);
+			      });
+
+			      it('logs any duplicates', async () => {
+			        await database.loadCities();
+
+			        expect(consoleWarnSpy).toHaveBeenCalledWith(
+			       'Ignored duplicate cities: Wellington',
+			        );
+			      });
+			       });
+
+			       clearCityDatabase();
+			     ",
+            None,
+        ), // { "parserOptions": { "sourceType": "module" } }
+    ];
+
+    pass.extend(vitest_pass);
+    fail.extend(vitest_fail);
+
     Tester::new(RequireHook::NAME, RequireHook::PLUGIN, pass, fail)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jest_require_hook.snap
+++ b/crates/oxc_linter/src/snapshots/jest_require_hook.snap
@@ -154,3 +154,139 @@ source: crates/oxc_linter/src/tester.rs
  15 │                 });
     ╰────
   help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:1:1]
+ 1 │ setup();
+   · ───────
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:3:10]
+ 2 │                    describe('some tests', () => {
+ 3 │                   setup();
+   ·                   ───────
+ 4 │                    });
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:2:11]
+ 1 │ 
+ 2 │                    let { setup } = require('./test-utils');
+   ·                    ────────────────────────────────────────
+ 3 │ 
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:5:10]
+ 4 │                    describe('some tests', () => {
+ 5 │                   setup();
+   ·                   ───────
+ 6 │                    });
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:3:11]
+ 2 │                  describe('some tests', () => {
+ 3 │                    setup();
+   ·                    ───────
+ 4 │ 
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+    ╭─[require_hook.tsx:10:10]
+  9 │                    describe('more tests', () => {
+ 10 │                   setup();
+    ·                   ───────
+ 11 │ 
+    ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:2:11]
+ 1 │ 
+ 2 │                    let consoleErrorSpy = vi.spyOn(console, 'error');
+   ·                    ─────────────────────────────────────────────────
+ 3 │ 
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:5:10]
+ 4 │                    describe('when loading cities from the api', () => {
+ 5 │                   let consoleWarnSpy = vi.spyOn(console, 'warn');
+   ·                   ───────────────────────────────────────────────
+ 6 │                    });
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:5:10]
+ 4 │                    describe('when loading cities from the api', () => {
+ 5 │                   let consoleWarnSpy = vi.spyOn(console, 'warn');
+   ·                   ───────────────────────────────────────────────
+ 6 │                    });
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:1:1]
+ 1 │ let value = 1
+   · ─────────────
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:1:1]
+ 1 │ let consoleErrorSpy, consoleWarnSpy = vi.spyOn(console, 'error');
+   · ─────────────────────────────────────────────────────────────────
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+   ╭─[require_hook.tsx:1:1]
+ 1 │ let consoleErrorSpy = vi.spyOn(console, 'error'), consoleWarnSpy;
+   · ─────────────────────────────────────────────────────────────────
+   ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+    ╭─[require_hook.tsx:17:11]
+ 16 │ 
+ 17 │                    initializeCityDatabase();
+    ·                    ────────────────────────
+ 18 │ 
+    ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+    ╭─[require_hook.tsx:51:11]
+ 50 │ 
+ 51 │                    clearCityDatabase();
+    ·                    ───────────────────
+ 52 │                  
+    ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+    ╭─[require_hook.tsx:32:10]
+ 31 │                    describe('when loading cities from the api', () => {
+ 32 │                   let consoleWarnSpy = vi.spyOn(console, 'warn');
+    ·                   ───────────────────────────────────────────────
+ 33 │ 
+    ╰────
+  help: This should be done within a hook
+
+  ⚠ eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.
+    ╭─[require_hook.tsx:34:10]
+ 33 │ 
+ 34 │                   loadCities.mockResolvedValue(['Wellington', 'London']);
+    ·                   ──────────────────────────────────────────────────────
+ 35 │ 
+    ╰────
+  help: This should be done within a hook

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 38] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 39] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -59,6 +59,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 38] = [
     "prefer-each",
     "prefer-equality-matcher",
     "prefer-expect-resolves",
+    "require-hook",
     "prefer-hooks-in-order",
     "prefer-hooks-on-top",
     "prefer-lowercase-title",

--- a/crates/oxc_linter/src/utils/vitest/valid_vitest_fn.rs
+++ b/crates/oxc_linter/src/utils/vitest/valid_vitest_fn.rs
@@ -75,6 +75,7 @@ static VALID_VITEST_FN_CALL_CHAINS: phf::Set<&'static str> = phf::phf_set![
     "describe.concurrent.todo.shuffle",
     "describe.concurrent.todo.skip",
     "describe.each",
+    "describe.for",
     "describe.only",
     "describe.only.concurrent",
     "describe.only.concurrent.each",


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

# Sumarry
Add `require hook` as a vitest compatible rule.

Oxlint-migrate PR: https://github.com/oxc-project/oxlint-migrate/pull/288

# Changes made
I had to sligthy modify the implementation to be compatible with both frameworks. The modifications were for 2 specific tests:

```javascripts
("describe.for([])('%s', (value) => {})", None),
(
  "describe('scoped', () => {
      test.scoped({ example: 'value' });
   });",
  None,
 ),
```

Both test cases must pass. The first test case failed because `describe.for` [only exists in vitest](https://vitest.dev/api/#describe-for) and this exact part of `parse_jest_fn.rs` failed in the jest branch.

https://github.com/oxc-project/oxc/blob/eba07e6fd945069e7694e3880b36e4f0f8f78d6d/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs#L109C1-L115C10

Second test failed because `test.scoped` doesn't exist neither frameworks, `scoped` is a custom property made by a user. Reviewing the Jest and Vitest eslint code they are only interested in the beginning, not in the full chain. 
