### PR TITLE
feat(linter): implement eslint/no-inline-comments

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -461,6 +461,11 @@ impl RuleRunner for crate::rules::eslint::no_import_assign::NoImportAssign {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::no_inline_comments::NoInlineComments {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::eslint::no_inner_declarations::NoInnerDeclarations {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::Function, AstType::VariableDeclaration]));

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -109,6 +109,7 @@ pub(crate) mod eslint {
     pub mod no_global_assign;
     pub mod no_implicit_coercion;
     pub mod no_import_assign;
+    pub mod no_inline_comments;
     pub mod no_inner_declarations;
     pub mod no_invalid_regexp;
     pub mod no_irregular_whitespace;
@@ -710,6 +711,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::max_params,
     eslint::new_cap,
     eslint::no_implicit_coercion,
+    eslint::no_inline_comments,
     eslint::no_loop_func,
     eslint::no_useless_computed_key,
     eslint::no_unassigned_vars,

--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -1,0 +1,572 @@
+use lazy_regex::Regex;
+use oxc_ast::{AstKind, Comment};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn no_inline_comments_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected comment inline with code")
+        .with_help("Move the comment to a separate line")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NoInlineComments(Option<Box<Regex>>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows comments on the same line as code.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Comments placed at the end of a line of code can make code harder to read.
+    /// They can easily be missed when scanning vertically, and they make lines longer.
+    /// Moving comments to their own lines makes them more prominent and reduces line length.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// var a = 1; // inline comment
+    /// var b = 2; /* another inline comment */
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // comment on its own line
+    /// var a = 1;
+    ///
+    /// /* block comment on its own line */
+    /// var b = 2;
+    /// ```
+    NoInlineComments,
+    eslint,
+    pedantic
+);
+
+impl Rule for NoInlineComments {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config = value.get(0);
+
+        let ignore_pattern = config
+            .and_then(|v| v.get("ignorePattern"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| Regex::new(s).ok())
+            .map(Box::new);
+
+        Self(ignore_pattern)
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        let source_text = ctx.source_text();
+
+        // Pre-collect JSXEmptyExpression spans for efficient lookup
+        // Using Vec since JSXEmptyExpression nodes are typically few, and we need range containment checks
+        let jsx_empty_expr_spans: Vec<Span> = ctx
+            .nodes()
+            .iter()
+            .filter_map(|node| {
+                if let AstKind::JSXEmptyExpression(expr) = node.kind() {
+                    Some(expr.span)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for comment in ctx.semantic().comments() {
+            let comment_span = comment.span;
+            let comment_text = ctx.source_range(comment.content_span());
+
+            // Check if this matches the ignorePattern
+            if let Some(ref pattern) = self.0
+                && pattern.is_match(comment_text)
+            {
+                continue;
+            }
+
+            // Check if this is an eslint directive comment (eslint-disable, eslint-disable-line, etc.)
+            if is_directive_comment(comment, comment_text) {
+                continue;
+            }
+
+            // Get the content before and after the comment on its line(s)
+            let (preamble, postamble) = get_comment_context(source_text, comment_span);
+
+            // A comment is inline if there's code on the same line before or after it
+            let is_inline = !preamble.is_empty() || !postamble.is_empty();
+
+            if !is_inline {
+                continue;
+            }
+
+            // Check for JSX empty expression exception
+            // Comments inside {/* comment */} are allowed if they're the only content
+            if is_jsx_expression_comment(
+                &jsx_empty_expr_spans,
+                comment_span,
+                preamble,
+                postamble,
+            ) {
+                continue;
+            }
+
+            ctx.diagnostic(no_inline_comments_diagnostic(comment_span));
+        }
+    }
+}
+
+/// Checks if a comment text is an ESLint/OxLint directive or special comment
+fn is_directive_comment(comment: &Comment, text: &str) -> bool {
+    let trimmed = text.trim();
+
+    // eslint-disable, eslint-disable-line, eslint-disable-next-line
+    // oxlint-disable, oxlint-disable-line, oxlint-disable-next-line
+    // eslint-enable, oxlint-enable
+    if trimmed.starts_with("eslint-") || trimmed.starts_with("oxlint-") {
+        return true;
+    }
+
+    // Block comments only: /* eslint ... */ (ESLint config directive with space)
+    // This matches ESLint's ESLINT_DIRECTIVE_PATTERN which accepts "eslint " or "eslint-"
+    if comment.is_block()
+        && (trimmed.starts_with("eslint ")
+            || trimmed.starts_with("eslint\t")
+            || trimmed.starts_with("oxlint ")
+            || trimmed.starts_with("oxlint\t"))
+    {
+        return true;
+    }
+
+    // Block comments only: global, globals, exported (ESLint only recognizes these in block comments)
+    if comment.is_block()
+        && (trimmed.starts_with("global ")
+            || trimmed.starts_with("global\t")
+            || trimmed.starts_with("globals ")
+            || trimmed.starts_with("globals\t")
+            || trimmed.starts_with("exported ")
+            || trimmed.starts_with("exported\t"))
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Returns (preamble, postamble) - the non-whitespace content before and after the comment on its lines
+fn get_comment_context(source_text: &str, comment_span: Span) -> (&str, &str) {
+    let start = comment_span.start as usize;
+    let end = comment_span.end as usize;
+
+    // Find the start of the line containing the comment start
+    let line_start = source_text[..start].rfind('\n').map_or(0, |i| i + 1);
+
+    // Find the end of the line containing the comment end
+    let line_end = source_text[end..].find('\n').map_or(source_text.len(), |i| end + i);
+
+    // Get content before the comment on its starting line
+    let preamble = source_text[line_start..start].trim();
+
+    // Get content after the comment on its ending line
+    let postamble = source_text[end..line_end].trim();
+
+    (preamble, postamble)
+}
+
+/// Checks if a comment is inside a JSX expression container and is the only content
+/// This allows patterns like: {/* comment */} or { /* comment */ }
+/// But NOT: {/* comment */}</div> (where </div> is on the same line)
+fn is_jsx_expression_comment(
+    jsx_empty_expr_spans: &[Span],
+    comment_span: Span,
+    preamble: &str,
+    postamble: &str,
+) -> bool {
+    // For JSX expression comments to be allowed:
+    // - preamble should be empty or just "{" (not ending with other content before {)
+    // - postamble should be empty or just "}" (not having content after })
+    // This means `{/* comment */}` alone on a line is OK, but `{/* comment */}</div>` is NOT
+
+    // Check preamble: should be empty or end with just "{"
+    let preamble_valid = preamble.is_empty() || preamble == "{";
+
+    // Check postamble: should be empty or be just "}"
+    let postamble_valid = postamble.is_empty() || postamble == "}";
+
+    if !preamble_valid || !postamble_valid {
+        return false;
+    }
+
+    // Check if the comment is inside a JSXEmptyExpression using pre-collected spans
+    jsx_empty_expr_spans.iter().any(|expr_span| expr_span.contains_inclusive(comment_span))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "// A valid comment before code
+			var a = 1;",
+            None,
+        ),
+        (
+            "var a = 2;
+			// A valid comment after code",
+            None,
+        ),
+        ("// A solitary comment", None),
+        ("var a = 1; // eslint-disable-line no-debugger", None),
+        ("var a = 1; /* eslint-disable-line no-debugger */", None),
+        // ESLint config directive with space (/* eslint ... */)
+        (r#"var a = 1; /* eslint no-console: "off" */"#, None),
+        (r#"var a = 1; /* eslint-env node */"#, None),
+        // global/globals/exported only in block comments
+        ("foo(); /* global foo */", None),
+        ("foo(); /* globals foo */", None),
+        ("var foo; /* exported foo */", None),
+        (
+            "var a = (
+			            <div>
+			            {/*comment*/}
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            { /* comment */ }
+			            <h1>Some heading</h1>
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            {// comment
+			            }
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            { // comment
+			            }
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            {/* comment 1 */
+			            /* comment 2 */}
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            {/*
+			              * comment 1
+			              */
+			             /*
+			              * comment 2
+			              */}
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            "var a = (
+			            <div>
+			            {/*
+			               multi
+			               line
+			               comment
+			            */}
+			            </div>
+			        )",
+            None,
+        ),
+        (
+            r#"import(/* webpackChunkName: "my-chunk-name" */ './locale/en');"#,
+            Some(serde_json::json!([{ "ignorePattern": "webpackChunkName" }])),
+        ),
+        (
+            "var foo = 2; // Note: This comment is legal.",
+            Some(serde_json::json!([{ "ignorePattern": "Note:" }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("var a = 1; /*A block comment inline after code*/", None),
+        ("/*A block comment inline before code*/ var a = 2;", None),
+        // Line comments with global/globals/exported are NOT directive (only block comments are)
+        ("foo(); // global foo", None),
+        ("foo(); // globals foo", None),
+        ("var foo; // exported foo", None),
+        (
+            "/* something */ var a = 2;",
+            Some(serde_json::json!([{ "ignorePattern": "otherthing" }])),
+        ),
+        ("var a = 3; //A comment inline with code", None),
+        ("var a = 3; // someday use eslint-disable-line here", None),
+        (
+            "var a = 3; // other line comment",
+            Some(serde_json::json!([{ "ignorePattern": "something" }])),
+        ),
+        (
+            "var a = 4;
+			/**A
+			 * block
+			 * comment
+			 * inline
+			 * between
+			 * code*/ var foo = a;",
+            None,
+        ),
+        ("var a = \n			{/**/}", None),
+        (
+            "var a = (
+			                <div>{/* comment */}</div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>{// comment
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>{/* comment */
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>{/*
+			                       * comment
+			                       */
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>{/*
+			                       * comment
+			                       */}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>{/*
+			                       * comment
+			                       */}</div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {/*
+			                  * comment
+			                  */}</div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                 /*
+			                  * comment
+			                  */}</div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                /* comment */}</div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {b/* comment */}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {/* comment */b}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {// comment
+			                    b
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {/* comment */
+			                    b
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {/*
+			                  * comment
+			                  */
+			                    b
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    b// comment
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    /* comment */b
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    b/* comment */
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    b
+			                /*
+			                 * comment
+			                 */}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    b
+			                /* comment */}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    { /* this is an empty object literal, not braces for js code! */ }
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    {// comment
+			                    }
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    {
+			                    /* comment */}
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+			                </div>
+			            )",
+            None,
+        ),
+        (
+            "var a = (
+			                <div>
+			                {
+			                    /* overlapping
+			                    */ /*
+			                       lines */
+			                }
+			                </div>
+			            )",
+            None,
+        ),
+    ];
+
+    Tester::new(NoInlineComments::NAME, NoInlineComments::PLUGIN, pass, fail)
+        .with_snapshot_suffix("jsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -197,8 +197,8 @@ fn get_comment_context(source_text: &str, comment_span: Span) -> (&str, &str) {
 }
 
 /// Checks if a comment is inside a JSX expression container and is the only content
-/// This allows patterns like: {/* comment */} or { /* comment */ }
-/// But NOT: {/* comment */}</div> (where </div> is on the same line)
+/// This allows patterns like: `{/* comment */}` or `{ /* comment */ }`
+/// But NOT: `{/* comment */}</div>` (where `</div>` is on the same line)
 fn is_jsx_expression_comment(
     jsx_empty_expr_spans: &[Span],
     comment_span: Span,
@@ -208,7 +208,7 @@ fn is_jsx_expression_comment(
     // For JSX expression comments to be allowed:
     // - preamble should be empty or just "{" (not ending with other content before {)
     // - postamble should be empty or just "}" (not having content after })
-    // This means `{/* comment */}` alone on a line is OK, but `{/* comment */}</div>` is NOT
+    // This means `{/* comment */}` alone on a line is OK, but `{/* comment */}</div>` is not
 
     // Check preamble: should be empty or end with just "{"
     let preamble_valid = preamble.is_empty() || preamble == "{";

--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -105,12 +105,7 @@ impl Rule for NoInlineComments {
 
             // Check for JSX empty expression exception
             // Comments inside {/* comment */} are allowed if they're the only content
-            if is_jsx_expression_comment(
-                &jsx_empty_expr_spans,
-                comment_span,
-                preamble,
-                postamble,
-            ) {
+            if is_jsx_expression_comment(&jsx_empty_expr_spans, comment_span, preamble, postamble) {
                 continue;
             }
 

--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -320,7 +320,7 @@ fn test() {
         ),
         (
             r#"import(/* webpackChunkName: "my-chunk-name" */ './locale/en');"#,
-            Some(serde_json::json!([{ "ignorePattern": "webpackChunkName" }])),
+            Some(serde_json::json!([{ "ignorePattern": "(?:webpackChunkName):\\s.+" }])),
         ),
         (
             "var foo = 2; // Note: This comment is legal.",
@@ -335,141 +335,93 @@ fn test() {
         ("foo(); // global foo", None),
         ("foo(); // globals foo", None),
         ("var foo; // exported foo", None),
-        (
-            "/* something */ var a = 2;",
-            Some(serde_json::json!([{ "ignorePattern": "otherthing" }])),
-        ),
+        ("/* something */ var a = 2;", Some(serde_json::json!([{ "ignorePattern": "otherthing" }]))),
         ("var a = 3; //A comment inline with code", None),
         ("var a = 3; // someday use eslint-disable-line here", None),
-        (
-            "var a = 3; // other line comment",
-            Some(serde_json::json!([{ "ignorePattern": "something" }])),
-        ),
-        (
-            "var a = 4;
+        ("var a = 3; // other line comment", Some(serde_json::json!([{ "ignorePattern": "something" }]))),
+        ("var a = 4;
 			/**A
 			 * block
 			 * comment
 			 * inline
 			 * between
-			 * code*/ var foo = a;",
-            None,
-        ),
-        ("var a = \n			{/**/}", None),
-        (
-            "var a = (
+			 * code*/ var foo = a;", None),
+("var a =
+			{/**/}", None),
+("var a = (
 			                <div>{/* comment */}</div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>{// comment
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>{/* comment */
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>{/*
 			                       * comment
 			                       */
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>{/*
 			                       * comment
 			                       */}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>{/*
 			                       * comment
 			                       */}</div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {/*
 			                  * comment
 			                  */}</div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                 /*
 			                  * comment
 			                  */}</div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                /* comment */}</div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {b/* comment */}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {/* comment */b}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {// comment
 			                    b
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {/* comment */
 			                    b
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {/*
 			                  * comment
@@ -477,41 +429,29 @@ fn test() {
 			                    b
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    b// comment
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    /* comment */b
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    b/* comment */
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    b
@@ -519,61 +459,43 @@ fn test() {
 			                 * comment
 			                 */}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    b
 			                /* comment */}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    { /* this is an empty object literal, not braces for js code! */ }
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    {// comment
 			                    }
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    {
 			                    /* comment */}
 			                }
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
 			                </div>
-			            )",
-            None,
-        ),
-        (
-            "var a = (
+			            )", None),
+("var a = (
 			                <div>
 			                {
 			                    /* overlapping
@@ -581,12 +503,8 @@ fn test() {
 			                       lines */
 			                }
 			                </div>
-			            )",
-            None,
-        ),
+			            )", None)
     ];
 
-    Tester::new(NoInlineComments::NAME, NoInlineComments::PLUGIN, pass, fail)
-        .with_snapshot_suffix("jsx")
-        .test_and_snapshot();
+    Tester::new(NoInlineComments::NAME, NoInlineComments::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_inline_comments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inline_comments.snap
@@ -1,0 +1,326 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 1; /*A block comment inline after code*/
+   ·            ─────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:1]
+ 1 │ /*A block comment inline before code*/ var a = 2;
+   · ──────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:8]
+ 1 │ foo(); // global foo
+   ·        ─────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:8]
+ 1 │ foo(); // globals foo
+   ·        ──────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:10]
+ 1 │ var foo; // exported foo
+   ·          ───────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:1]
+ 1 │ /* something */ var a = 2;
+   · ───────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; //A comment inline with code
+   ·            ────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; // someday use eslint-disable-line here
+   ·            ───────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; // other line comment
+   ·            ─────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:4]
+ 1 │     var a = 4;
+ 2 │ ╭─▶             /**A
+ 3 │ │                * block
+ 4 │ │                * comment
+ 5 │ │                * inline
+ 6 │ │                * between
+ 7 │ ╰─▶              * code*/ var foo = a;
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:5]
+ 1 │ var a =
+ 2 │             {/**/}
+   ·              ────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{/* comment */}</div>
+   ·                                   ─────────────
+ 3 │                         )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{// comment
+   ·                                   ──────────
+ 3 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{/* comment */
+   ·                                   ─────────────
+ 3 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */
+ 5 │                                 }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */}
+ 5 │                                 </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */}</div>
+ 5 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                                 <div>
+ 3 │ ╭─▶                             {/*
+ 4 │ │                                 * comment
+ 5 │ ╰─▶                               */}</div>
+ 6 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:21]
+ 3 │                                 {
+ 4 │ ╭─▶                              /*
+ 5 │ │                                 * comment
+ 6 │ ╰─▶                               */}</div>
+ 7 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:20]
+ 3 │                             {
+ 4 │                             /* comment */}</div>
+   ·                             ─────────────
+ 5 │                         )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:22]
+ 2 │                             <div>
+ 3 │                             {b/* comment */}
+   ·                               ─────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {/* comment */b}
+   ·                              ─────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {// comment
+   ·                              ──────────
+ 4 │                                 b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {/* comment */
+   ·                              ─────────────
+ 4 │                                 b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                                 <div>
+ 3 │ ╭─▶                             {/*
+ 4 │ │                                 * comment
+ 5 │ ╰─▶                               */
+ 6 │                                     b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 b// comment
+   ·                                  ──────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:24]
+ 3 │                             {
+ 4 │                                 /* comment */b
+   ·                                 ─────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 b/* comment */
+   ·                                  ─────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:20]
+ 4 │                                     b
+ 5 │ ╭─▶                             /*
+ 6 │ │                                * comment
+ 7 │ ╰─▶                              */}
+ 8 │                                 </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:20]
+ 4 │                                 b
+ 5 │                             /* comment */}
+   ·                             ─────────────
+ 6 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:26]
+ 3 │                             {
+ 4 │                                 { /* this is an empty object literal, not braces for js code! */ }
+   ·                                   ──────────────────────────────────────────────────────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 {// comment
+   ·                                  ──────────
+ 5 │                                 }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:24]
+ 4 │                                 {
+ 5 │                                 /* comment */}
+   ·                                 ─────────────
+ 6 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:22]
+ 2 │                             <div>
+ 3 │                             { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+   ·                               ──────────────────────────────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:61]
+ 2 │                             <div>
+ 3 │                             { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+   ·                                                                      ─────────────────────────────────────────────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:24]
+ 3 │                                 {
+ 4 │ ╭─▶                                 /* overlapping
+ 5 │ ╰─▶                                 */ /*
+ 6 │                                        lines */
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:27]
+ 4 │                                     /* overlapping
+ 5 │ ╭─▶                                 */ /*
+ 6 │ ╰─▶                                    lines */
+ 7 │                                 }
+   ╰────
+  help: Move the comment to a separate line

--- a/crates/oxc_linter/src/snapshots/eslint_no_inline_comments@jsx.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inline_comments@jsx.snap
@@ -1,0 +1,326 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 1; /*A block comment inline after code*/
+   ·            ─────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:1]
+ 1 │ /*A block comment inline before code*/ var a = 2;
+   · ──────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:8]
+ 1 │ foo(); // global foo
+   ·        ─────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:8]
+ 1 │ foo(); // globals foo
+   ·        ──────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:10]
+ 1 │ var foo; // exported foo
+   ·          ───────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:1]
+ 1 │ /* something */ var a = 2;
+   · ───────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; //A comment inline with code
+   ·            ────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; // someday use eslint-disable-line here
+   ·            ───────────────────────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:1:12]
+ 1 │ var a = 3; // other line comment
+   ·            ─────────────────────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:4]
+ 1 │     var a = 4;
+ 2 │ ╭─▶             /**A
+ 3 │ │                * block
+ 4 │ │                * comment
+ 5 │ │                * inline
+ 6 │ │                * between
+ 7 │ ╰─▶              * code*/ var foo = a;
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:5]
+ 1 │ var a = 
+ 2 │             {/**/}
+   ·              ────
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{/* comment */}</div>
+   ·                                   ─────────────
+ 3 │                         )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{// comment
+   ·                                   ──────────
+ 3 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │ var a = (
+ 2 │                             <div>{/* comment */
+   ·                                   ─────────────
+ 3 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */
+ 5 │                                 }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */}
+ 5 │                                 </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:2:26]
+ 1 │     var a = (
+ 2 │ ╭─▶                             <div>{/*
+ 3 │ │                                      * comment
+ 4 │ ╰─▶                                    */}</div>
+ 5 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                                 <div>
+ 3 │ ╭─▶                             {/*
+ 4 │ │                                 * comment
+ 5 │ ╰─▶                               */}</div>
+ 6 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:21]
+ 3 │                                 {
+ 4 │ ╭─▶                              /*
+ 5 │ │                                 * comment
+ 6 │ ╰─▶                               */}</div>
+ 7 │                             )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:20]
+ 3 │                             {
+ 4 │                             /* comment */}</div>
+   ·                             ─────────────
+ 5 │                         )
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:22]
+ 2 │                             <div>
+ 3 │                             {b/* comment */}
+   ·                               ─────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {/* comment */b}
+   ·                              ─────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {// comment
+   ·                              ──────────
+ 4 │                                 b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                             <div>
+ 3 │                             {/* comment */
+   ·                              ─────────────
+ 4 │                                 b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:21]
+ 2 │                                 <div>
+ 3 │ ╭─▶                             {/*
+ 4 │ │                                 * comment
+ 5 │ ╰─▶                               */
+ 6 │                                     b
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 b// comment
+   ·                                  ──────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:24]
+ 3 │                             {
+ 4 │                                 /* comment */b
+   ·                                 ─────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 b/* comment */
+   ·                                  ─────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:20]
+ 4 │                                     b
+ 5 │ ╭─▶                             /*
+ 6 │ │                                * comment
+ 7 │ ╰─▶                              */}
+ 8 │                                 </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:20]
+ 4 │                                 b
+ 5 │                             /* comment */}
+   ·                             ─────────────
+ 6 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:26]
+ 3 │                             {
+ 4 │                                 { /* this is an empty object literal, not braces for js code! */ }
+   ·                                   ──────────────────────────────────────────────────────────────
+ 5 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:25]
+ 3 │                             {
+ 4 │                                 {// comment
+   ·                                  ──────────
+ 5 │                                 }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:24]
+ 4 │                                 {
+ 5 │                                 /* comment */}
+   ·                                 ─────────────
+ 6 │                             }
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:22]
+ 2 │                             <div>
+ 3 │                             { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+   ·                               ──────────────────────────────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:3:61]
+ 2 │                             <div>
+ 3 │                             { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+   ·                                                                      ─────────────────────────────────────────────────────
+ 4 │                             </div>
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:4:24]
+ 3 │                                 {
+ 4 │ ╭─▶                                 /* overlapping
+ 5 │ ╰─▶                                 */ /*
+ 6 │                                        lines */
+   ╰────
+  help: Move the comment to a separate line
+
+  ⚠ eslint(no-inline-comments): Unexpected comment inline with code
+   ╭─[no_inline_comments.tsx:5:27]
+ 4 │                                     /* overlapping
+ 5 │ ╭─▶                                 */ /*
+ 6 │ ╰─▶                                    lines */
+ 7 │                                 }
+   ╰────
+  help: Move the comment to a separate line


### PR DESCRIPTION
## Summary

Implement the ESLint `no-inline-comments` rule which disallows comments on the same line as code.

### Features
- Detects inline comments (both line and block comments)
- Supports `ignorePattern` option for regex-based exceptions
- Exempts ESLint/OxLint directive comments (`eslint-disable`, `eslint `, etc.)
- Exempts `global`, `globals`, and `exported` directive comments (block comments only, matching ESLint behavior)
- Handles JSX empty expression comments (`{/* comment */}`)

### Performance optimizations
- Pre-collects `JSXEmptyExpression` spans to avoid repeated AST traversal
- Returns `&str` slices instead of `String` allocations in comment context detection

Closes #2987