### PR TITLE
feat(linter): add ignoredTypeNames option to no-base-to-string rule

### DIFF
--- a/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
@@ -8,6 +8,12 @@
       {
         "considerDefaultExhaustiveForUnions": true
       }
+    ],
+    "typescript/no-base-to-string": [
+      "error",
+      {
+        "ignoredTypeNames": ["Error", "RegExp", "URL", "URLSearchParams", "CustomStringifiable"]
+      }
     ]
   }
 }

--- a/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
@@ -14,4 +14,12 @@ switch (day) {
     break;
 }
 
-export { result };
+// Test no-base-to-string with ignoredTypeNames option
+// CustomStringifiable is in the ignoredTypeNames list, so this should NOT error
+declare class CustomStringifiable {
+  value: string;
+}
+declare const custom: CustomStringifiable;
+const customStr = custom.toString();
+
+export { result, customStr };


### PR DESCRIPTION
Add configuration support for the typescript/no-base-to-string rule with an ignoredTypeNames option that allows specifying types that are safe to call toString() on, even if they don't provide a custom implementation.

Default ignored types: Error, RegExp, URL, URLSearchParams

🤖 generated with help from Claude Opus 4.5

closes https://github.com/oxc-project/tsgolint/issues/517