### PR TITLE
refactor(linter/plugins): move `RuleOptionsSchema` type into `options.ts`

### DIFF
--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -9,7 +9,7 @@ export type * as ESTree from "./generated/types.d.ts";
 export type { Context, LanguageOptions } from "./plugins/context.ts";
 export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
 export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
-export type { Options } from "./plugins/options.ts";
+export type { Options, RuleOptionsSchema } from "./plugins/options.ts";
 export type { Diagnostic, DiagnosticData, Suggestion } from "./plugins/report.ts";
 export type {
   Definition,
@@ -44,7 +44,6 @@ export type {
 export type {
   RuleMeta,
   RuleDocs,
-  RuleOptionsSchema,
   RuleDeprecatedInfo,
   RuleReplacedByInfo,
   RuleReplacedByExternalSpecifier,

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -22,6 +22,16 @@ const { freeze } = Object,
  */
 export type Options = JsonValue[];
 
+/**
+ * Schema describing valid options for a rule.
+ * `schema` property of `RuleMeta`.
+ *
+ * `false` opts out of schema validation. This is not recommended, as it increases the chance of bugs and mistakes.
+ */
+// TODO: Make this more precise.
+// TODO: Use this to validate options in configs.
+export type RuleOptionsSchema = Record<string, unknown> | unknown[] | false;
+
 // Default rule options
 export const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 

--- a/apps/oxlint/src-js/plugins/rule_meta.ts
+++ b/apps/oxlint/src-js/plugins/rule_meta.ts
@@ -1,4 +1,4 @@
-import type { Options } from "./options.ts";
+import type { Options, RuleOptionsSchema } from "./options.ts";
 
 /**
  * Rule metadata.
@@ -83,16 +83,6 @@ export interface RuleDocs {
    */
   [key: string]: unknown;
 }
-
-/**
- * Schema describing valid options for a rule.
- * `schema` property of `RuleMeta`.
- *
- * `false` opts out of schema validation. This is not recommended, as it increases the chance of bugs and mistakes.
- */
-// TODO: Make this more precise.
-// TODO: Use this to validate options in configs.
-export type RuleOptionsSchema = Record<string, unknown> | unknown[] | false;
 
 /**
  * Info about deprecation of a rule, and possible replacements.


### PR DESCRIPTION
Pure refactor. Move the type def for `RuleOptionsSchema` into `options.ts`, which is a more appropriate place for it.