### PR TITLE
fix(linter/array-type): handle TSSatisfiesExpression

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2532,6 +2532,7 @@ impl RuleRunner for crate::rules::typescript::array_type::ArrayType {
         AstType::TSConditionalType,
         AstType::TSIndexedAccessType,
         AstType::TSMappedType,
+        AstType::TSSatisfiesExpression,
         AstType::TSTypeAliasDeclaration,
         AstType::TSTypeAnnotation,
         AstType::TSTypeParameterInstantiation,

--- a/crates/oxc_linter/src/snapshots/typescript_array_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_array_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 394
 ---
   ⚠ typescript-eslint(array-type): Array type using 'factories.User[]' is forbidden. Use 'Array<factories.User>' instead.
    ╭─[array_type.ts:1:8]
@@ -901,3 +902,24 @@ source: crates/oxc_linter/src/tester.rs
    ·                                        ──────
    ╰────
   help: Replace `T[K][]` with `Array<T[K]>`.
+
+  ⚠ typescript-eslint(array-type): Array type using 'readonly string[]' is forbidden. Use 'ReadonlyArray<string>' instead.
+   ╭─[array_type.ts:1:33]
+ 1 │ const x = [] as const satisfies readonly string[];
+   ·                                 ─────────────────
+   ╰────
+  help: Replace `readonly string[]` with `ReadonlyArray<string>`.
+
+  ⚠ typescript-eslint(array-type): Array type using 'Array<string>' is forbidden. Use 'string[]' instead.
+   ╭─[array_type.ts:1:33]
+ 1 │ const x = [] as const satisfies Array<string>;
+   ·                                 ─────────────
+   ╰────
+  help: Replace `Array<string>` with `string[]`.
+
+  ⚠ typescript-eslint(array-type): Array type using 'Array<string[]>' is forbidden. Use 'string[][]' instead.
+   ╭─[array_type.ts:1:24]
+ 1 │ const x = [] satisfies Array<string[]>;
+   ·                        ───────────────
+   ╰────
+  help: Replace `Array<string[]>` with `string[][]`.


### PR DESCRIPTION
Fixes #16897

The `array-type` rule was not checking array types in `satisfies` expressions. This adds handling for `TSSatisfiesExpression` AST node type to enforce array type style consistency.

## Changes

- Added `AstKind::TSSatisfiesExpression` case in the `run` method
- Regenerated `rule_runner_impls.rs` to include the new node type in `NODE_TYPES`
- Added pass/fail/fix test cases including nested scenarios