### PR TITLE
fix(playground): pass transform target to minifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,6 +2229,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc",
+ "oxc_compat",
  "oxc_formatter",
  "oxc_linter",
  "oxc_napi",

--- a/napi/playground/Cargo.toml
+++ b/napi/playground/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["ast_visit", "codegen", "minifier", "mangler", "semantic", "serialize", "transformer", "isolated_declarations", "regular_expression", "cfg"] }
+oxc_compat = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_napi = { workspace = true }


### PR DESCRIPTION
The playground minifier was not respecting the transform target option, causing ES features like optional chaining to be used even when targeting older browsers that do not support them.

Closes #16889