### PR TITLE
perf(linter/plugins): use `DEFAULT_OPTIONS` for rules with empty array as default options

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -168,11 +168,14 @@ export function registerPlugin(plugin: Plugin, packageName: string | null): Plug
         if (!isArray(inputDefaultOptions)) {
           throw new TypeError("`rule.meta.defaultOptions` must be an array if provided");
         }
-        // TODO: This isn't quite safe, as `defaultOptions` isn't from JSON, and `deepFreezeJsonArray`
-        // assumes it is. We should perform options merging on Rust side instead, and also validate
-        // `defaultOptions` against options schema.
-        deepFreezeJsonArray(inputDefaultOptions);
-        defaultOptions = inputDefaultOptions;
+
+        if (inputDefaultOptions.length !== 0) {
+          // TODO: This isn't quite safe, as `defaultOptions` isn't from JSON, and `deepFreezeJsonArray`
+          // assumes it is. We should perform options merging on Rust side instead, and also validate
+          // `defaultOptions` against options schema.
+          deepFreezeJsonArray(inputDefaultOptions);
+          defaultOptions = inputDefaultOptions;
+        }
       }
 
       // Extract messages for messageId support

--- a/apps/oxlint/test/fixtures/options/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/options/.oxlintrc.json
@@ -28,14 +28,16 @@
       true,
       [],
       16
-    ]
+    ],
+    "options-plugin/empty-default-options": ["error", "from-config", 42]
   },
   "overrides": [
     {
       "files": ["files/nested/**"],
       "rules": {
         "options-plugin/options": ["error", { "somethingElse": true }],
-        "options-plugin/merge-options": ["error", { "fromConfig": 21 }, { "fromConfig": 22 }]
+        "options-plugin/merge-options": ["error", { "fromConfig": 21 }, { "fromConfig": 22 }],
+        "options-plugin/empty-default-options": "error"
       }
     }
   ]

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -34,6 +34,17 @@
    : ^
    `----
 
+  x options-plugin(empty-default-options):
+  | options: [
+  |   "from-config",
+  |   42
+  | ]
+  | isDeepFrozen: true
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^
+   `----
+
   x options-plugin(merge-options):
   | options: [
   |   {
@@ -116,6 +127,14 @@
    : ^
    `----
 
+  x options-plugin(empty-default-options):
+  | options: []
+  | isDeepFrozen: true
+   ,-[files/nested/index.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x options-plugin(merge-options):
   | options: [
   |   {
@@ -162,7 +181,7 @@
    : ^
    `----
 
-Found 0 warnings and 8 errors.
+Found 0 warnings and 10 errors.
 Finished in Xms on 2 files using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -26,6 +26,7 @@ const plugin: Plugin = {
         return {};
       },
     },
+
     options: {
       create(context) {
         context.report({
@@ -37,6 +38,7 @@ const plugin: Plugin = {
         return {};
       },
     },
+
     "default-options": {
       meta: {
         defaultOptions: [
@@ -57,6 +59,7 @@ const plugin: Plugin = {
         return {};
       },
     },
+
     "merge-options": {
       meta: {
         defaultOptions: [
@@ -65,6 +68,21 @@ const plugin: Plugin = {
           { fromDefault: 6 },
           7,
         ],
+      },
+      create(context) {
+        context.report({
+          message:
+            `\noptions: ${JSON.stringify(context.options, null, 2)}\n` +
+            `isDeepFrozen: ${isDeepFrozen(context.options)}`,
+          node: SPAN,
+        });
+        return {};
+      },
+    },
+
+    "empty-default-options": {
+      meta: {
+        defaultOptions: [],
       },
       create(context) {
         context.report({


### PR DESCRIPTION
Small optimization to options merging. Treat rules which define `defaultOptions` as an empty array the same as those which provide no `defaultOptions` at all. This makes options merging take a faster path for these rules.