### PR TITLE
refactor(linter/plugins): consistently format `@ts-expect-error` comments

### DIFF
--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -259,7 +259,7 @@ export function wrapVisitFnWithSelectorMatch(
       esqueryMatches(
         node as unknown as EsqueryNode,
         esquerySelector,
-        // @ts-expect-error: our TS types don't align perfectly with estree
+        // @ts-expect-error - Our TS types don't align perfectly with estree
         ancestors,
         ESQUERY_OPTIONS,
       )

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -162,7 +162,7 @@ export async function testFixtureWithCommand(options: TestFixtureOptions): Promi
 // Matches `/path/to/oxc`, `/path/to/oxc/`, `/path/to/oxc/whatever`,
 // when preceded by whitespace, `(`, or a quote, and followed by whitespace, `)`, or a quote.
 const PATH_REGEXP = new RegExp(
-  // @ts-expect-error `RegExp.escape` is new in NodeJS v24
+  // @ts-expect-error - `RegExp.escape` is new in NodeJS v24
   `(?<=^|[\\s\\('"\`])${RegExp.escape(REPO_ROOT_PATH)}(${RegExp.escape(pathSep)}[^\\s\\)'"\`]*)?(?=$|[\\s\\)'"\`])`,
   "g",
 );


### PR DESCRIPTION
Style nit. Format all `@ts-expect-error` comments in `apps/oxlint`. I don't know what formatting is the best, but we might as well be consistent.