### PR TITLE
test(linter): print all failing linter test cases

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     ffi::OsStr,
+    fmt::Write,
     path::{Path, PathBuf},
     sync::Arc,
     sync::mpsc,
@@ -369,10 +370,28 @@ impl Tester {
         self
     }
 
+    #[expect(clippy::print_stdout)]
     pub fn test(&mut self) {
-        self.test_pass();
-        self.test_fail();
-        self.test_fix();
+        let failed = self.test_pass();
+        let passed = self.test_fail();
+        let fix_failures = self.test_fix();
+
+        if !failed.is_empty() {
+            println!("{}", format_test_failures("expected to pass, but failed", &failed));
+        }
+        if !passed.is_empty() {
+            println!("{}", format_test_failures("expected to fail, but passed", &passed));
+        }
+        if !fix_failures.is_empty() {
+            println!("{}", format_fix_failures(&fix_failures));
+        }
+
+        assert!(
+            failed.is_empty() && passed.is_empty() && fix_failures.is_empty(),
+            "Some tests failed for rule {}/{} (see output above)",
+            self.plugin_name,
+            self.rule_name
+        );
     }
 
     pub fn test_and_snapshot(&mut self) {
@@ -398,53 +417,46 @@ impl Tester {
         });
     }
 
-    fn test_pass(&mut self) {
+    fn test_pass(&mut self) -> Vec<TestFailure> {
+        // output index is used to track position in `self.snapshot`, which accumulates all diagnostics
+        // but we only want to show the diagnostic for this test case
+        let mut output_index = 0;
+        let mut failed = vec![];
         for TestCase { source, rule_config, eslint_config, path } in self.expect_pass.clone() {
             let result =
                 self.run(&source, rule_config.clone(), eslint_config, path, ExpectFixKind::None, 0);
             let passed = result == TestResult::Passed;
-            let config = rule_config.map_or_else(
-                || "\n\n------------------------\n".to_string(),
-                |v| {
-                    format!(
-                        "\n-------- rule config --------\n{}",
-                        serde_json::to_string_pretty(&v).unwrap()
-                    )
-                },
-            );
-            assert!(
-                passed,
-                "expected test to pass, but it failed:\n\n-------- source --------\n\n{source}\n\n-------- error --------\n{}{config}\n",
-                self.snapshot
-            );
+            if !passed {
+                failed.push(TestFailure::ExpectedToPass {
+                    source,
+                    rule_config,
+                    diagnostic: self.snapshot[output_index..].to_string(),
+                });
+            }
+            output_index = self.snapshot.len();
         }
+        failed
     }
 
-    fn test_fail(&mut self) {
+    fn test_fail(&mut self) -> Vec<TestFailure> {
+        let mut passed = vec![];
         for TestCase { source, rule_config, eslint_config, path } in self.expect_fail.clone() {
             let result =
                 self.run(&source, rule_config.clone(), eslint_config, path, ExpectFixKind::None, 0);
             let failed = result == TestResult::Failed;
-            let config = rule_config.map_or_else(
-                || "\n\n------------------------".to_string(),
-                |v| {
-                    format!(
-                        "\n-------- rule config --------\n{}",
-                        serde_json::to_string_pretty(&v).unwrap()
-                    )
-                },
-            );
-            assert!(
-                failed,
-                "expected test to fail, but it passed:\n\n-------- source --------\n\n{source}{config}\n",
-            );
+            if !failed {
+                passed.push(TestFailure::ExpectedToFail { source, rule_config });
+            }
         }
+        passed
     }
 
     #[expect(clippy::cast_possible_truncation)] // there are no rules with over 255 different possible fixes
-    fn test_fix(&mut self) {
+    fn test_fix(&mut self) -> Vec<FixFailure> {
+        let mut failures = vec![];
+
         // If auto-fixes are reported, make sure some fix test cases are provided
-        let rule = self.find_rule();
+        let rule: &RuleEnum = self.find_rule();
         let Some(fix_test_cases) = self.expect_fix.clone() else {
             assert!(
                 !rule.fix().has_fix(),
@@ -452,7 +464,7 @@ impl Tester {
                 rule.plugin_name(),
                 rule.name()
             );
-            return;
+            return failures;
         };
 
         for fix in fix_test_cases {
@@ -461,16 +473,34 @@ impl Tester {
                 let result =
                     self.run(&source, config.clone(), None, None, expect.kind, index as u8);
                 match result {
-                    TestResult::Fixed(fixed_str) => assert_eq!(
-                        expect.expected, fixed_str,
-                        r#"Expected "{source}" to be fixed into "{}""#,
-                        expect.expected
-                    ),
-                    TestResult::Passed => panic!("Expected a fix, but test passed: {source}"),
-                    TestResult::Failed => panic!("Expected a fix, but test failed: {source}"),
+                    TestResult::Fixed(fixed_str) => {
+                        if expect.expected != fixed_str {
+                            failures.push(FixFailure {
+                                source: source.clone(),
+                                expected: expect.expected.clone(),
+                                actual: fixed_str,
+                            });
+                        }
+                    }
+                    TestResult::Passed => {
+                        failures.push(FixFailure {
+                            source: source.clone(),
+                            expected: expect.expected.clone(),
+                            actual: String::from("<test passed, no fix applied>"),
+                        });
+                    }
+                    TestResult::Failed => {
+                        failures.push(FixFailure {
+                            source: source.clone(),
+                            expected: expect.expected.clone(),
+                            actual: String::from("<test failed, no fix applied>"),
+                        });
+                    }
                 }
             }
         }
+
+        failures
     }
 
     fn run(
@@ -574,4 +604,142 @@ impl Tester {
                 panic!("Rule in plugin {} not found: {}", &self.plugin_name, &self.rule_name)
             })
     }
+}
+
+struct FixFailure {
+    /// Test source code
+    source: String,
+    /// Expected source code after fix
+    expected: String,
+    /// Actual source code after fix
+    actual: String,
+}
+
+enum TestFailure {
+    ExpectedToPass {
+        /// Test source code
+        source: String,
+        /// Rule configuration used in the test
+        rule_config: Option<Value>,
+        /// Error/diagnostic output produced by the test
+        diagnostic: String,
+    },
+    ExpectedToFail {
+        /// Test source code
+        source: String,
+        /// Rule configuration used in the test
+        rule_config: Option<Value>,
+    },
+}
+
+/// Format source code for display in test failure output.
+/// If the source has more than `max_lines` lines, it will be truncated.
+/// Otherwise, multi-line sources are displayed with proper indentation.
+fn format_test_source(source: &str, max_lines: usize) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let line_count = lines.len();
+
+    if line_count <= 1 {
+        // Single line: display inline
+        source.to_string()
+    } else if line_count <= max_lines {
+        // Multi-line but within limit: display with indentation
+        let mut result = String::new();
+        for (i, line) in lines.iter().enumerate() {
+            if i == 0 {
+                result.push_str("| ");
+            } else {
+                result.push_str("      │ ");
+            }
+            result.push_str(line);
+            result.push('\n');
+        }
+        result
+    } else {
+        // Too many lines: truncate with summary
+        let mut result = String::new();
+        for (i, line) in lines.iter().take(max_lines).enumerate() {
+            if i == 0 {
+                result.push_str("| ");
+            } else {
+                result.push_str("      │ ");
+            }
+            result.push_str(line);
+            result.push('\n');
+        }
+        writeln!(result, "      │ ... ({} more line(s))", line_count - max_lines).unwrap();
+        result
+    }
+}
+
+/// Format a code block for display, showing inline for single lines or with pipes for multi-line.
+fn format_code_block(output: &mut String, code: &str) {
+    let lines: Vec<&str> = code.lines().collect();
+    if lines.len() <= 1 {
+        // Single line: display inline
+        let _ = writeln!(output, "{code}");
+    } else {
+        // Multi-line: display with pipes
+        let _ = writeln!(output);
+        for line in lines {
+            let _ = writeln!(output, "      │ {line}");
+        }
+    }
+}
+
+fn format_test_failures(reason: &str, failures: &[TestFailure]) -> String {
+    let count = failures.len();
+    let mut output = String::new();
+    let _ =
+        writeln!(output, "\n{count} test case{} {reason}:\n", if count == 1 { "" } else { "s" });
+
+    for (index, failure) in failures.iter().enumerate() {
+        match failure {
+            TestFailure::ExpectedToPass { diagnostic, rule_config, source } => {
+                let formatted_source = format_test_source(source, 10);
+                let _ = writeln!(output, "  {:>2}. {formatted_source}", index + 1);
+                let _ = writeln!(
+                    output,
+                    "      Diagnostic:\n{}",
+                    diagnostic.cow_replace('\n', "\n      ")
+                );
+                if let Some(config) = &rule_config {
+                    // Format config compactly on one line if possible
+                    let config_str = serde_json::to_string(config).unwrap_or_default();
+                    let _ = writeln!(output, "      config: {config_str}");
+                }
+            }
+            TestFailure::ExpectedToFail { rule_config, source } => {
+                let formatted_source = format_test_source(source, 10);
+                let _ = writeln!(output, "  {:>2}. {formatted_source}", index + 1);
+                if let Some(config) = &rule_config {
+                    // Format config compactly on one line if possible
+                    let config_str = serde_json::to_string(config).unwrap_or_default();
+                    let _ = writeln!(output, "      config: {config_str}");
+                }
+            }
+        }
+    }
+    output
+}
+
+fn format_fix_failures(failures: &[FixFailure]) -> String {
+    let count = failures.len();
+    let mut output = String::new();
+    let _ = writeln!(
+        output,
+        "\n{count} fix{} did not produce expected output:\n",
+        if count == 1 { "" } else { "es" }
+    );
+
+    for (index, failure) in failures.iter().enumerate() {
+        let _ = write!(output, "  {:>2}.    Input: ", index + 1);
+        format_code_block(&mut output, &failure.source);
+        let _ = write!(output, "      Expected: ");
+        format_code_block(&mut output, &failure.expected);
+        let _ = write!(output, "        Actual: ");
+        format_code_block(&mut output, &failure.actual);
+        let _ = writeln!(output);
+    }
+    output
 }


### PR DESCRIPTION
- Closes https://github.com/oxc-project/oxc/issues/16845

Prints a list of all the test cases that failed, instead of just failing on the first one.

- Prints a numbered list and total of cases that failed, for each type of test that failed (expect to pass, expect to fail, expect to fix)
- Prints source code + config for each failure
- Truncates long source code if applicable, and shortens single-line code to be inline

## Example output


```
---- rules::eslint::use_isnan::test stdout ----

22 test cases expected to pass, but failed:

   1. switch(foo) {}
      config: [{"enforceForSwitchCase":true}]
   2. switch(foo) { case bar: NaN; }
      config: [{"enforceForSwitchCase":true}]
   3. switch(foo) { default: NaN; }
      config: [{"enforceForSwitchCase":true}]
   4. switch(Nan) {}
      config: [{"enforceForSwitchCase":true}]
   5. switch('NaN') { default: break; }
      config: [{"enforceForSwitchCase":true}]
   6. switch(foo(NaN)) {}
      config: [{"enforceForSwitchCase":true}]
   7. switch(foo.NaN) {}
      config: [{"enforceForSwitchCase":true}]
   8. switch(foo) { case Nan: break }
      config: [{"enforceForSwitchCase":true}]
   9. switch(foo) { case 'NaN': break }
      config: [{"enforceForSwitchCase":true}]
  10. switch(foo) { case foo(NaN): break }
      config: [{"enforceForSwitchCase":true}]
  11. switch(foo) { case foo.NaN: break }
      config: [{"enforceForSwitchCase":true}]
  12. switch(foo) { case bar: break; case 1: break; default: break; }
      config: [{"enforceForSwitchCase":true}]
  13. switch(foo) { case bar: Number.NaN; }
      config: [{"enforceForSwitchCase":true}]
  14. switch(foo) { default: Number.NaN; }
      config: [{"enforceForSwitchCase":true}]
  15. switch(Number.Nan) {}
      config: [{"enforceForSwitchCase":true}]
  16. switch('Number.NaN') { default: break; }
      config: [{"enforceForSwitchCase":true}]
  17. switch(foo(Number.NaN)) {}
      config: [{"enforceForSwitchCase":true}]
  18. switch(foo.Number.NaN) {}
      config: [{"enforceForSwitchCase":true}]
  19. switch(foo) { case Number.Nan: break }
      config: [{"enforceForSwitchCase":true}]
  20. switch(foo) { case 'Number.NaN': break }
      config: [{"enforceForSwitchCase":true}]
  21. switch(foo) { case foo(Number.NaN): break }
      config: [{"enforceForSwitchCase":true}]
  22. switch(foo) { case foo.Number.NaN: break }
      config: [{"enforceForSwitchCase":true}]



10 test cases expected to fail, but passed:

   1. 123 == NaN;
   2. 123 === NaN;
   3. 123 != NaN;
   4. 123 !== NaN;
   5. 123 == Number.NaN;
   6. 123 === Number.NaN;
   7. 123 != Number.NaN;
   8. 123 !== Number.NaN;
   9. x === Number?.NaN;
  10. x === Number['NaN'];



8 fixes did not produce expected output:

   1.    Input: 1 == NaN
      Expected: isNaN(1)
        Actual: <test passed, no fix applied>

   2.    Input: 1 === NaN
      Expected: isNaN(1)
        Actual: <test passed, no fix applied>

   3.    Input: 1 != NaN
      Expected: !isNaN(1)
        Actual: <test passed, no fix applied>

   4.    Input: 1 !== NaN
      Expected: !isNaN(1)
        Actual: <test passed, no fix applied>

   5.    Input: 1 == Number.NaN
      Expected: isNaN(1)
        Actual: <test passed, no fix applied>

   6.    Input: 1 === Number.NaN
      Expected: isNaN(1)
        Actual: <test passed, no fix applied>

   7.    Input: 1 != Number.NaN
      Expected: !isNaN(1)
        Actual: <test passed, no fix applied>

   8.    Input: 1 !== Number.NaN
      Expected: !isNaN(1)
        Actual: <test passed, no fix applied>
```

```
---- rules::typescript::prefer_literal_enum_member::test stdout ----

thread 'rules::typescript::prefer_literal_enum_member::test' (883345) panicked at crates/oxc_linter/src/tester.rs:414:13:

8 test cases expected to pass but failed:

   1. | 
      │                 enum ValidRegex {
      │                 A = /test/,
      │             }
      │                     

   2. | 
      │                 enum ValidString {
      │                   A = 'test',
      │                 }
      │                     

   3. | 
      │                 enum ValidNumber {
      │                   A = 42,
      │                 }
      │                     

   4. | 
      │                 enum ValidNumber {
      │                   A = -42,
      │                 }
      │                     

   5. | 
      │                 enum ValidNumber {
      │                   A = +42,
      │                 }
      │                     

   6. | 
      │                 enum ValidNull {
      │                   A = null,
      │                 }
      │                     

   7. | 
      │                 enum ValidQuotedKeyWithAssignment {
      │                   'a' = 1,
      │                 }
      │                     

   8. | 
      │                 enum Foo {
      │                   A = 1 << 0,
      │                   B = 1 >> 0,
      │                   C = 1 >>> 0,
      │                   D = 1 | 0,
      │                   E = 1 & 0,
      │                   F = 1 ^ 0,
      │                   G = ~1,
      │                 }
      │ ... (1 more line(s))

      config: [{"allowBitwiseExpressions":true}]
```

```
---- rules::eslint::yoda::test stdout ----

thread 'rules::eslint::yoda::test' (883045) panicked at crates/oxc_linter/src/tester.rs:430:13:

16 test cases expected to fail but passed:

   1. if (x <= 'foo' || 'bar' < x) {}
      config: ["always",{"exceptRange":true}]
   2. if ("red" == value) {}
      config: ["never"]
   3. if (true === value) {}
      config: ["never"]
   4. if (null !== value) {}
      config: ["never"]
   5. if ("red" <= value) {}
      config: ["never"]
   6. if (true >= value) {}
      config: ["never"]
   7. function foo() { return (null > value); }
      config: ["never"]
   8. if (value == "red") {}
      config: ["always"]
   9. if (value === true) {}
      config: ["always"]
  10. x < ('foo')in bar
      config: ["always"]
  11. false <= ((x))in foo
      config: ["never"]
  12. false <= ((x)) in foo
      config: ["never"]
  13. if('a' <= x && x < 'b') {}
      config: ["always"]
  14. if ('b' <= x && x < 'a') {}
      config: ["never",{"exceptRange":true}]
  15. if('a' <= x && x < 1) {}
      config: ["never",{"exceptRange":true}]
  16. {( t=='' )}
      config: ["always",{"onlyEquality":true}]
```

```
---- rules::eslint::no_unneeded_ternary::test stdout ----

thread 'rules::eslint::no_unneeded_ternary::test' (939816) panicked at crates/oxc_linter/src/tester.rs:537:13:

3 fixes did not produce expected output:

   1.    Input: var a = foo ? foo : 'No';
      Expected: var a = foo || 'No';
        Actual: var a = foo || ('No');

   2.    Input: f(x ? x : 1);
      Expected: f(x || 1);
        Actual: f(x || (1));

   3.    Input: x ? x : 1;
      Expected: x || 1;
        Actual: x || (1);
```