### PR TITLE
docs(traverse): update safety comments

### DIFF
--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -147,7 +147,7 @@ export default function generateAncestorsCode(types) {
     /// i.e. \`Ancestor\`s can only exist within the body of \`enter_*\` and \`exit_*\` methods
     /// and cannot "escape" from them.
     //
-    // INVARIANTS:
+    // SAFETY
     // * This type must be \`#[repr(u16)]\`.
     // * Variant discriminants must correspond to those in \`AncestorType\`.
     //

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -42,7 +42,7 @@ export default function generateWalkFunctionsCode(types) {
 
     /// Walk AST with \`Traverse\` impl.
     ///
-    /// # Safety
+    /// # SAFETY
     /// * \`program\` must be a pointer to a valid \`Program\` which has lifetime \`'a\`
     ///   (\`Program<'a>\`).
     /// * \`ctx\` must contain a \`TraverseAncestry<'a>\` with single \`Ancestor::None\` on its stack.

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -329,7 +329,7 @@ pub(crate) enum AncestorType {
 /// i.e. `Ancestor`s can only exist within the body of `enter_*` and `exit_*` methods
 /// and cannot "escape" from them.
 //
-// INVARIANTS:
+// SAFETY
 // * This type must be `#[repr(u16)]`.
 // * Variant discriminants must correspond to those in `AncestorType`.
 //

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -25,7 +25,7 @@ use crate::{
 
 /// Walk AST with `Traverse` impl.
 ///
-/// # Safety
+/// # SAFETY
 /// * `program` must be a pointer to a valid `Program` which has lifetime `'a`
 ///   (`Program<'a>`).
 /// * `ctx` must contain a `TraverseAncestry<'a>` with single `Ancestor::None` on its stack.


### PR DESCRIPTION
Follow-on after #16758. Update "SAFETY" docs comments which were altered in that PR to make clippy pass.