### PR TITLE
feat(parser): improve import attribute value error message

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1145,3 +1145,10 @@ pub fn jsx_attribute_value_empty_expression(span: Span) -> OxcDiagnostic {
     ts_error("17000", "JSX attributes must only be assigned a non-empty 'expression'.")
         .with_label(span)
 }
+
+#[cold]
+pub fn import_attribute_value_must_be_string_literal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Only string literals are allowed as module attribute values.")
+        .with_label(span)
+        .with_help("Wrap this with quotes")
+}

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -336,6 +336,11 @@ impl<'a> ParserImpl<'a> {
             _ => ImportAttributeKey::Identifier(self.parse_identifier_name()),
         };
         self.expect(Kind::Colon);
+        if !self.at(Kind::Str) {
+            return self.fatal_error(diagnostics::import_attribute_value_must_be_string_literal(
+                self.cur_token().span(),
+            ));
+        }
         let value = self.parse_literal_string();
         self.ast.import_attribute(self.end_span(span), key, value)
     }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -8831,17 +8831,19 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                         ╰── `:` expected
    ╰────
 
-  × Unexpected token
+  × Only string literals are allowed as module attribute values.
    ╭─[babel/packages/babel-parser/test/fixtures/es2025/import-attributes/valid-syntax-export-with-invalid-value/input.js:1:63]
  1 │ export { default } from "foo.json" with { type: "json", lazy: true, startAtLine: 1 };
    ·                                                               ────
    ╰────
+  help: Wrap this with quotes
 
-  × Unexpected token
+  × Only string literals are allowed as module attribute values.
    ╭─[babel/packages/babel-parser/test/fixtures/es2025/import-attributes/valid-syntax-with-invalid-value/input.js:1:55]
  1 │ import foo from "foo.json" with { type: "json", lazy: true, startAtLine: 1 };
    ·                                                       ────
    ╰────
+  help: Wrap this with quotes
 
   × Identifier `f` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-duplicate-using-bindings/input.js:3:17]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6731,12 +6731,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·        ╰── It can not be redeclared here
    ╰────
 
-  × Unexpected token
+  × Only string literals are allowed as module attribute values.
    ╭─[typescript/tests/cases/compiler/importAssertionNonstring.ts:1:52]
  1 │ import * as thing1 from "./mod.mjs" assert {field: 0};
    ·                                                    ─
  2 │ 
    ╰────
+  help: Wrap this with quotes
 
   × TS(1029): 'export' modifier must precede 'declare' modifier.
    ╭─[typescript/tests/cases/compiler/importDeclWithDeclareModifier.ts:5:9]
@@ -19890,12 +19891,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  1 │ import * as f from "./first" with {
    ╰────
 
-  × Unexpected token
+  × Only string literals are allowed as module attribute values.
    ╭─[typescript/tests/cases/conformance/importAttributes/importAttributes6.ts:1:51]
  1 │ import * as thing1 from "./mod.mjs" with { field: 0 };
    ·                                                   ─
  2 │ import * as thing2 from "./mod.mjs" with { field: `a` };
    ╰────
+  help: Wrap this with quotes
 
   × Expected `(` but found `;`
    ╭─[typescript/tests/cases/conformance/importDefer/dynamicImportDeferInvalidStandalone.ts:1:13]


### PR DESCRIPTION
Improved import attribute value parse error message.

**Before**
```
  × Unexpected token
   ╭─[babel/packages/babel-parser/test/fixtures/es2025/import-attributes/valid-syntax-export-with-invalid-value/input.js:1:63]
 1 │ export { default } from "foo.json" with { type: "json", lazy: true, startAtLine: 1 };
   ·                                                               ────
   ╰────
```
**After**
```
  × Only string literals are allowed as module attribute values.
   ╭─[babel/packages/babel-parser/test/fixtures/es2025/import-attributes/valid-syntax-export-with-invalid-value/input.js:1:63]
 1 │ export { default } from "foo.json" with { type: "json", lazy: true, startAtLine: 1 };
   ·                                                               ────
   ╰────
  help: Wrap this with quotes
```