### PR TITLE
feat(parser): add help for `new_dynamic_import` error

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -428,7 +428,9 @@ pub fn for_await(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn new_dynamic_import(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Cannot use new with dynamic import").with_label(span)
+    OxcDiagnostic::error("Cannot use new with dynamic import")
+        .with_label(span)
+        .with_help("Wrap this with parenthesis")
 }
 
 #[cold]

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -6120,6 +6120,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ new import("foo");
    ·     ─────────────
    ╰────
+  help: Wrap this with parenthesis
 
   × Dynamic imports can only accept a module specifier and an optional set of attributes as arguments
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import/multiple-args/input.js:1:1]
@@ -6158,6 +6159,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ new import("foo");
    ·     ─────────────
    ╰────
+  help: Wrap this with parenthesis
 
   × Dynamic imports can only accept a module specifier and an optional set of attributes as arguments
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import-createImportExpression-false/multiple-args/input.js:1:1]

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -15252,6 +15252,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ let f = () => new import.defer('./empty_FIXTURE.js');
     ·                   ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js:39:28]
@@ -15274,6 +15275,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ let f = () => new import.source('<module source>');
     ·                   ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-source-no-rest-param.js:43:29]
@@ -15288,6 +15290,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  37 │ let f = () => new import('');
     ·                   ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-no-rest-param.js:42:22]
@@ -15352,6 +15355,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js:40:16]
@@ -15376,6 +15380,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-source-no-rest-param.js:44:17]
@@ -15392,6 +15397,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-no-rest-param.js:43:10]
@@ -15466,6 +15472,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────────────────────────────
  40 │ });
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js:40:22]
@@ -15490,6 +15497,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ────────────────────────────────
  40 │ });
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-source-no-rest-param.js:44:23]
@@ -15506,6 +15514,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────
  39 │ });
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-no-rest-param.js:43:16]
@@ -15579,6 +15588,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ (async () => await new import.defer('./empty_FIXTURE.js'))
     ·                        ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js:39:33]
@@ -15601,6 +15611,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ (async () => await new import.source('<module source>'))
     ·                        ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-source-no-rest-param.js:43:34]
@@ -15615,6 +15626,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  37 │ (async () => await new import(''))
     ·                        ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-no-rest-param.js:42:27]
@@ -15695,6 +15707,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js:40:22]
@@ -15719,6 +15732,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-source-no-rest-param.js:44:23]
@@ -15735,6 +15749,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-no-rest-param.js:43:16]
@@ -15801,6 +15816,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js:40:16]
@@ -15825,6 +15841,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-source-no-rest-param.js:44:17]
@@ -15841,6 +15858,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-no-rest-param.js:43:10]
@@ -15889,6 +15907,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·                    ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js:40:29]
@@ -15913,6 +15932,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·                    ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-source-no-rest-param.js:44:30]
@@ -15929,6 +15949,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·                    ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-no-rest-param.js:43:23]
@@ -16029,6 +16050,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js:40:22]
@@ -16053,6 +16075,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-source-no-rest-param.js:44:23]
@@ -16069,6 +16092,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·             ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-no-rest-param.js:43:16]
@@ -16143,6 +16167,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js:40:16]
@@ -16167,6 +16192,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-source-no-rest-param.js:44:17]
@@ -16207,6 +16233,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js:40:16]
@@ -16231,6 +16258,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-source-no-rest-param.js:44:17]
@@ -16247,6 +16275,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-no-rest-param.js:43:10]
@@ -16297,6 +16326,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-no-rest-param.js:43:10]
@@ -16371,6 +16401,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ } while (false);
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js:40:16]
@@ -16395,6 +16426,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ } while (false);
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-source-no-rest-param.js:44:17]
@@ -16411,6 +16443,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ } while (false);
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-no-rest-param.js:43:10]
@@ -16492,6 +16525,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  40 │ } else new import.defer('./empty_FIXTURE.js');
     ·            ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js:41:21]
@@ -16514,6 +16548,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  40 │ } else new import.source('<module source>');
     ·            ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-source-no-rest-param.js:45:22]
@@ -16528,6 +16563,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  39 │ } else new import('');
     ·            ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-no-rest-param.js:44:15]
@@ -16592,6 +16628,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  42 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js:42:16]
@@ -16616,6 +16653,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  42 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-source-no-rest-param.js:46:17]
@@ -16632,6 +16670,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  41 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-no-rest-param.js:45:10]
@@ -16706,6 +16745,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js:40:16]
@@ -16730,6 +16770,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-source-no-rest-param.js:44:17]
@@ -16746,6 +16787,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-no-rest-param.js:43:10]
@@ -16794,6 +16836,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·              ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js:40:23]
@@ -16818,6 +16861,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·              ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-source-no-rest-param.js:44:24]
@@ -16834,6 +16878,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·              ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-no-rest-param.js:43:17]
@@ -16941,6 +16986,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ if (true) new import.defer('./empty_FIXTURE.js');
     ·               ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js:39:24]
@@ -16963,6 +17009,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  38 │ if (true) new import.source('<module source>');
     ·               ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-source-no-rest-param.js:43:25]
@@ -16977,6 +17024,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  37 │ if (true) new import('');
     ·               ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-no-rest-param.js:42:18]
@@ -17041,6 +17089,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js:40:16]
@@ -17065,6 +17114,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  40 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-source-no-rest-param.js:44:17]
@@ -17081,6 +17131,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-no-rest-param.js:43:10]
@@ -17155,6 +17206,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  42 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js:42:16]
@@ -17179,6 +17231,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  42 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-source-no-rest-param.js:46:17]
@@ -17195,6 +17248,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  41 │ };
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-while-no-rest-param.js:45:10]
@@ -17276,6 +17330,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  37 │ with (new import.defer('./empty_FIXTURE.js')) {}
     ·           ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js:38:20]
@@ -17298,6 +17353,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  37 │ with (new import.source('<module source>')) {}
     ·           ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-source-no-rest-param.js:42:21]
@@ -17312,6 +17368,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  36 │ with (new import('')) {}
     ·           ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-no-rest-param.js:41:14]
@@ -17376,6 +17433,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────────────────────────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js:39:16]
@@ -17400,6 +17458,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ────────────────────────────────
  39 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-source-no-rest-param.js:43:17]
@@ -17416,6 +17475,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·       ──────────
  38 │ }
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-no-rest-param.js:42:10]
@@ -17489,6 +17549,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  28 │ new import.defer('./empty_FIXTURE.js');
     ·     ──────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js:29:14]
@@ -17511,6 +17572,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  28 │ new import.source('<module source>');
     ·     ────────────────────────────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-source-no-rest-param.js:33:15]
@@ -17525,6 +17587,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  27 │ new import('');
     ·     ──────────
     ╰────
+  help: Wrap this with parenthesis
 
   × Unexpected token
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/top-level-no-rest-param.js:32:8]


### PR DESCRIPTION
Added help for `new_dynamic_import` error.

**Before**
```
  × Cannot use new with dynamic import
   ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-new/input.js:1:5]
 1 │ new import("foo");
   ·     ─────────────
   ╰────
```
**After**
```
  × Cannot use new with dynamic import
   ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-new/input.js:1:5]
 1 │ new import("foo");
   ·     ─────────────
   ╰────
  help: Wrap this with parenthesis
```