### PR TITLE
feat(parser): improve error message for `yield` as identifier usage

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -481,9 +481,17 @@ pub fn identifier_async(x0: &str, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn identifier_generator(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Cannot use `{x0}` as an identifier in a generator context"))
-        .with_label(span1)
+pub fn identifier_generator(x0: &str, span1: Span, looks_like_expression: bool) -> OxcDiagnostic {
+    let diagnostic =
+        OxcDiagnostic::error(format!("Cannot use `{x0}` as an identifier in a generator context"))
+            .with_label(span1);
+    if looks_like_expression {
+        diagnostic.with_help(format!(
+            "Wrap this in parentheses if you want to use a `{x0}` expression here"
+        ))
+    } else {
+        diagnostic
+    }
 }
 
 #[cold]

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -131,7 +131,14 @@ impl<'a> ParserImpl<'a> {
         }
         // It is a Syntax Error if this production has a [Yield] parameter.
         if ctx.has_yield() && kind == Kind::Yield {
-            self.error(diagnostics::identifier_generator("yield", span));
+            let next_token = self.lexer.peek_token();
+            let looks_like_yield_expression =
+                !next_token.is_on_new_line() && next_token.kind().is_after_await_or_yield();
+            self.error(diagnostics::identifier_generator(
+                "yield",
+                span,
+                looks_like_yield_expression,
+            ));
         }
     }
 

--- a/tasks/coverage/misc/fail/minus-yield-100.js
+++ b/tasks/coverage/misc/fail/minus-yield-100.js
@@ -1,0 +1,1 @@
+export function* foo() { -yield 100 }

--- a/tasks/coverage/misc/pass/minus-yield-100.js
+++ b/tasks/coverage/misc/pass/minus-yield-100.js
@@ -1,0 +1,1 @@
+export function* foo() { -(yield 100) }

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 53/53 (100.00%)
-Positive Passed: 53/53 (100.00%)
+AST Parsed     : 54/54 (100.00%)
+Positive Passed: 54/54 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 53/53 (100.00%)
-Positive Passed: 53/53 (100.00%)
+AST Parsed     : 54/54 (100.00%)
+Positive Passed: 54/54 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 53/53 (100.00%)
-Positive Passed: 53/53 (100.00%)
-Negative Passed: 121/121 (100.00%)
+AST Parsed     : 54/54 (100.00%)
+Positive Passed: 54/54 (100.00%)
+Negative Passed: 122/122 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -344,6 +344,20 @@ Negative Passed: 121/121 (100.00%)
  12 │ let?.method();
     · ───
     ╰────
+
+  × Cannot use `yield` as an identifier in a generator context
+   ╭─[misc/fail/minus-yield-100.js:1:27]
+ 1 │ export function* foo() { -yield 100 }
+   ·                           ─────
+   ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[misc/fail/minus-yield-100.js:1:32]
+ 1 │ export function* foo() { -yield 100 }
+   ·                                ▲
+   ╰────
+  help: Try inserting a semicolon here
 
   × Expected `:` but found `EOF`
    ╭─[misc/fail/missing-conditional-alternative-type.ts:2:1]

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -18439,6 +18439,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  17 │ var g = function*() { yield 3 + yield 4; };
     ·                                 ─────
     ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/expressions/generators/yield-weak-binding.js:17:38]
@@ -20146,6 +20147,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·                    ─────
  19 │ };
     ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/expressions/object/method-definition/yield-weak-binding.js:18:25]
@@ -28309,6 +28311,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·                    ─────
  19 │ }
     ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/statements/class/definition/methods-gen-yield-weak-binding.js:18:25]
@@ -37727,6 +37730,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
  17 │ function* g() { yield 3 + yield 4; }
     ·                           ─────
     ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/statements/generators/yield-weak-binding.js:17:32]
@@ -38481,6 +38485,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·     ─────
  26 │ }
     ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/statements/let/syntax/let-newline-yield-in-generator-function.js:25:10]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3565,6 +3565,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·              ─────
  5 │ }
    ╰────
+  help: Wrap this in parentheses if you want to use a `yield` expression here
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/compiler/castOfYield.ts:4:19]

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 53/53 (100.00%)
-Positive Passed: 34/53 (64.15%)
+AST Parsed     : 54/54 (100.00%)
+Positive Passed: 35/54 (64.81%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 53/53 (100.00%)
-Positive Passed: 53/53 (100.00%)
+AST Parsed     : 54/54 (100.00%)
+Positive Passed: 54/54 (100.00%)


### PR DESCRIPTION
Improved error message for `yield` as identifier usage.

**Before**
```
  × Cannot use `yield` as an identifier in a generator context
    ╭─[test262/test/language/expressions/generators/yield-weak-binding.js:17:33]
 16 │ 
 17 │ var g = function*() { yield 3 + yield 4; };
    ·                                 ─────
    ╰────
```
**After**
```
  × Cannot use `yield` as an identifier in a generator context
    ╭─[test262/test/language/expressions/generators/yield-weak-binding.js:17:33]
 16 │ 
 17 │ var g = function*() { yield 3 + yield 4; };
    ·                                 ─────
    ╰────
  help: Wrap this in parentheses if you want to use a `yield` expression here
```