### PR TITLE
fix(regular_expression): correct named capture group reference error

### DIFF
--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -531,7 +531,7 @@ impl<'a> PatternParser<'a> {
                 // [SS:EE] AtomEscape :: k GroupName
                 // It is a Syntax Error if GroupSpecifiersThatMatch(GroupName) is empty.
                 if !self.state.capturing_group_names.contains(name.as_str()) {
-                    return Err(diagnostics::empty_group_specifier(
+                    return Err(diagnostics::invalid_named_reference(
                         self.span_factory.create(span_start, self.reader.offset()),
                     ));
                 }
@@ -545,7 +545,7 @@ impl<'a> PatternParser<'a> {
                 ))));
             }
 
-            return Err(diagnostics::invalid_named_reference(
+            return Err(diagnostics::empty_group_specifier(
                 self.span_factory.create(span_start, self.reader.offset()),
             ));
         }

--- a/crates/oxc_regular_expression/tests/snapshots/diagnostics__test.snap
+++ b/crates/oxc_regular_expression/tests/snapshots/diagnostics__test.snap
@@ -108,7 +108,7 @@ expression: snapshot
 
 # invalid_named_reference
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
    ╭─[/\k<a>/u:1:2]
  1 │ /\k<a>/u
    ·  ─────

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -23839,70 +23839,70 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·         ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-2-u.js:21:9]
  20 │ 
  21 │ /(?<a>a)\k<ab>/u;
     ·         ──────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-2.js:21:9]
  20 │ 
  21 │ /(?<a>a)\k<ab>/;
     ·         ──────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-3-u.js:21:10]
  20 │ 
  21 │ /(?<ab>a)\k<a>/u;
     ·          ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-3.js:21:10]
  20 │ 
  21 │ /(?<ab>a)\k<a>/;
     ·          ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-4-u.js:21:2]
  20 │ 
  21 │ /\k<a>(?<ab>a)/u;
     ·  ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-4.js:21:2]
  20 │ 
  21 │ /\k<a>(?<ab>a)/;
     ·  ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-5.js:21:2]
  20 │ 
  21 │ /\k<a>(?<b>x)/;
     ·  ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-u.js:21:9]
  20 │ 
  21 │ /(?<a>.)\k<b>/u;
     ·         ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-without-group-u.js:21:2]
  20 │ 
  21 │ /\k<a>/u;
     ·  ─────
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname.js:21:9]
  20 │ 
  21 │ /(?<a>.)\k<b>/;
@@ -24000,14 +24000,14 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·    ──
     ╰────
 
-  × Invalid regular expression: Invalid named reference
+  × Invalid regular expression: Group specifier is empty
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-incomplete-groupname-6.js:16:2]
  15 │ 
  16 │ /\k(?<a>.)/;
     ·  ──
     ╰────
 
-  × Invalid regular expression: Invalid named reference
+  × Invalid regular expression: Group specifier is empty
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-incomplete-groupname-u.js:16:9]
  15 │ 
  16 │ /(?<a>.)\k/u;
@@ -24021,7 +24021,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·    ─
     ╰────
 
-  × Invalid regular expression: Invalid named reference
+  × Invalid regular expression: Group specifier is empty
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-incomplete-groupname-without-group-3-u.js:16:2]
  15 │ 
  16 │ /\k/u;
@@ -24035,7 +24035,7 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·    ──
     ╰────
 
-  × Invalid regular expression: Invalid named reference
+  × Invalid regular expression: Group specifier is empty
     ╭─[test262/test/language/literals/regexp/named-groups/invalid-incomplete-groupname.js:16:9]
  15 │ 
  16 │ /(?<a>.)\k/;

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -10095,7 +10095,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  18 │ ];
     ╰────
 
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
    ╭─[typescript/tests/cases/compiler/regularExpressionGroupNameSuggestions.ts:1:24]
  1 │ const regex = /(?<foo>)\k<Foo>/;
    ·                        ───────


### PR DESCRIPTION
The error message was swapped.
```diff
-  × Invalid regular expression: Group specifier is empty
+  × Invalid regular expression: Invalid named reference
    ╭─[test262/test/language/literals/regexp/named-groups/invalid-dangling-groupname-2-u.js:21:9]
 20 │ 
 21 │ /(?<a>a)\k<ab>/u;
    ·         ──────
    ╰────
```