### PR TITLE
chore(js): enable `oxlint --type-check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,11 +272,8 @@ jobs:
       - run: cargo lint -- -D warnings
       - run: cargo lint --profile dev-no-debug-assertions -- -D warnings
       - run: RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items
-      # Need to build Oxlint's JS bundle before linting `apps/oxlint`, because the tests reference
-      # the `index.d.ts` file produced by TSDown. Type-aware rules rely on this `.d.ts` file being present.
-      - name: Build Oxlint
-        working-directory: apps/oxlint
-        run: pnpm run build-js
+      - run: pnpm --filter oxlint-app build-js
+      - run: pnpm --filter oxfmt-app build-js
       - run: node --run lint
 
   conformance:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-test",
     "test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" test",
     "fmt": "oxfmt -c oxfmtrc.jsonc",
-    "lint": "oxlint -c oxlintrc.json --deny-warnings --type-aware --report-unused-disable-directives"
+    "lint": "oxlint -c oxlintrc.json --deny-warnings --type-aware --type-check --report-unused-disable-directives"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "0.18.2",

--- a/tasks/e2e/test/utils.ts
+++ b/tasks/e2e/test/utils.ts
@@ -64,7 +64,6 @@ async function fsRequire(code: string, format: "cjs" | "esm" | "iife") {
     const mockedWindow = {} as (typeof globalThis)["window"];
     globalThis.window = mockedWindow;
     fsRequire("/index.js");
-    // @ts-expect-error - ignore
     delete globalThis.window;
     return mockedWindow;
   }

--- a/tasks/e2e/tsconfig.json
+++ b/tasks/e2e/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "module": "esnext"
   }
 }

--- a/tasks/lint_rules/jsconfig.json
+++ b/tasks/lint_rules/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "checkJs": true,
+    "checkJs": false,
     "moduleResolution": "node",
     "lib": ["esnext"],
     "target": "esnext",


### PR DESCRIPTION
Finished in 1.7s on 259 files with 161 rules using 14 threads.

closes #16485