### PR TITLE
fix(linter/plugins): freeze whole of merged options

### DIFF
--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -176,14 +176,13 @@ function mergeValues(configValue: JsonValue, defaultValue: JsonValue): JsonValue
 
   // Symbol properties are not possible in JSON, so no need to handle them here.
   //
-  // `defaultValue` is not from JSON, so we can't use a simple `for..in` loop over `defaultValue`.
-  // That would also pick up enumerable properties from prototype of `defaultValue`.
-  //
   // A malicious plugin could potentially get up to mischief here (prototype pollution?) if `defaultValue` is a `Proxy`.
   // But plugins are executable code, so they have far easier ways to do that. No point in defending against it here.
-  for (const key of Object.keys(defaultValue)) {
+  //
+  // `configValue` is from JSON, so we can use a simple `for..in` loop over `configValue`.
+  for (const key in configValue) {
     // `hasOwn` not `in`, in case `key` is `"__proto__"`
-    if (hasOwn(configValue, key)) {
+    if (hasOwn(defaultValue, key)) {
       // `key` is an own property of both `configValue` and `defaultValue`, so must be an own property of `merged` too.
       // Therefore, we don't need special handling for if `key` is `"__proto__"`.
       // All the property reads and writes here will affect only the owned properties of these objects,

--- a/apps/oxlint/test/fixtures/options/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/options/.oxlintrc.json
@@ -21,7 +21,8 @@
         "overrideDefault": 12,
         "nested": {
           "fromConfig": 13,
-          "overrideDefault": 14
+          "overrideDefault": 14,
+          "fromConfigObject": { "objectKey": 17 }
         }
       },
       15,

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -53,7 +53,10 @@
   |     "nested": {
   |       "fromDefault": 3,
   |       "overrideDefault": 14,
-  |       "fromConfig": 13
+  |       "fromConfig": 13,
+  |       "fromConfigObject": {
+  |         "objectKey": 17
+  |       }
   |     },
   |     "fromConfig": 11
   |   },


### PR DESCRIPTION
Fix options merging. Nested objects in options from config weren't getting frozen.