### PR TITLE
refactor(linter/plugins): simplify binding `it.only` in `RuleTester`

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -74,7 +74,7 @@ let it: ItFn = typeof globalObj.it === "function" ? globalObj.it : defaultIt;
 
 // `it.only` function. Can be overwritten via `RuleTester.it` or `RuleTester.itOnly` setters.
 let itOnly: ItFn | null =
-  it !== defaultIt && typeof it.only === "function" ? Function.bind.call(it.only, it) : null;
+  it !== defaultIt && typeof it.only === "function" ? it.only.bind(it) : null;
 
 /**
  * Get `it` function.
@@ -349,7 +349,7 @@ export class RuleTester {
   static set it(value: ItFn) {
     it = value;
     if (typeof it.only === "function") {
-      itOnly = Function.bind.call(it.only, it);
+      itOnly = it.only.bind(it);
     } else {
       itOnly = null;
     }


### PR DESCRIPTION
Tiny refactor. `Function` does not actually have a property called `bind` - it's on `Function.prototype`.