### PR TITLE
refactor(linter/plugins): replace `@ts-expect-error` comment with `as` casting

### DIFF
--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -259,8 +259,7 @@ export function wrapVisitFnWithSelectorMatch(
       esqueryMatches(
         node as unknown as EsqueryNode,
         esquerySelector,
-        // @ts-expect-error - Our TS types don't align perfectly with estree
-        ancestors,
+        ancestors as unknown as EsqueryNode[],
         ESQUERY_OPTIONS,
       )
     ) {


### PR DESCRIPTION
Alternative to #16931. Prefer `as` casting to `// @ts-expect-error` comment.