### PR TITLE
docs(linter/plugins): fix typo in doc comment

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -204,7 +204,7 @@ const GLOBALS = new Set([
 /**
  * Create a plugin to replace usage of properties of globals with global vars defined in `utils/globals.ts`.
  *
- * This more performant, due to reduced property lookups, and minifies better.
+ * This is more performant, due to reduced property lookups, and minifies better.
  *
  * ```ts
  * // Original code


### PR DESCRIPTION
Follow-on after #16961. Just fix a typo in a comment.