### PR TITLE
fix(linter): Fix `vitest/no-restricted-vi-methods` and add tests for it.

### DIFF
--- a/apps/oxlint/fixtures/disable_vitest_rules/.oxlintrc-vitest.json
+++ b/apps/oxlint/fixtures/disable_vitest_rules/.oxlintrc-vitest.json
@@ -1,0 +1,15 @@
+{
+  "plugins": ["vitest"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "vitest/no-restricted-vi-methods": [
+      "error",
+      {
+        "advanceTimersByTime": null,
+        "spyOn": "Don't use spies"
+      }
+    ]
+  }
+}

--- a/apps/oxlint/fixtures/disable_vitest_rules/test.js
+++ b/apps/oxlint/fixtures/disable_vitest_rules/test.js
@@ -1,0 +1,24 @@
+// File should have a total of 1 error from the vitest rule, and 1 warning about an unnecessary disable.
+import { vi } from 'vitest';
+
+vi.useFakeTimers();
+
+it('calls the callback after 1 second via advanceTimersByTime', () => {
+  vi.advanceTimersByTime(1000);
+})
+
+test('plays video', () => {
+  // oxlint-disable vitest/no-restricted-vi-methods
+  vi.spyOn(audio, 'play'); // this is disabled by the block above, should be no error.
+  // oxlint-enable vitest/no-restricted-vi-methods
+
+  // oxlint-disable-next-line vitest/no-restricted-vi-methods
+  const spy = vi.spyOn(video, 'play'); // this is disabled by the line above, should be no error.
+
+  // This one should trigger a warning about an unnecessary disable:
+  // oxlint-disable-next-line vitest/no-restricted-vi-methods
+  video.play();
+
+  // Next line should not have an error, as we disable the rule.
+  vi.spyOn(audio, 'play'); // oxlint-disable-line vitest/no-restricted-vi-methods
+})

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1153,6 +1153,16 @@ mod test {
     }
 
     #[test]
+    // Test to ensure that a vitest rule based on the jest rule is
+    // handled correctly when it has a different name.
+    // e.g. `vitest/no-restricted-vi-methods` vs `jest/no-restricted-jest-methods`
+    fn test_disable_vitest_rules() {
+        let args =
+            &["-c", ".oxlintrc-vitest.json", "--report-unused-disable-directives", "test.js"];
+        Tester::new().with_cwd("fixtures/disable_vitest_rules".into()).test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_two_rules_with_same_rule_name_from_different_plugins() {
         // Issue: <https://github.com/oxc-project/oxc/issues/8485>
         let args = &["-c", ".oxlintrc.json", "test.js"];

--- a/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
@@ -1,0 +1,29 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc-vitest.json --report-unused-disable-directives test.js
+working directory: fixtures/disable_vitest_rules
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-jest-methods.html\eslint-plugin-jest(no-restricted-jest-methods)]8;;\: Use of `advanceTimersByTime` is not allowed
+   ,-[test.js:7:6]
+ 6 | it('calls the callback after 1 second via advanceTimersByTime', () => {
+ 7 |   vi.advanceTimersByTime(1000);
+   :      ^^^^^^^^^^^^^^^^^^^
+ 8 | })
+   `----
+
+  ! Unused eslint-disable directive (no problems were reported).
+    ,-[test.js:19:5]
+ 18 |   // This one should trigger a warning about an unnecessary disable:
+ 19 |   // oxlint-disable-next-line vitest/no-restricted-vi-methods
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 20 |   video.play();
+    `----
+
+Found 1 warning and 1 error.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -147,6 +147,11 @@ fn transform_rule_and_plugin_name<'a>(
     rule_name: &'a str,
     plugin_name: &'a str,
 ) -> (&'a str, &'a str) {
+    // Special case: vitest/no-restricted-vi-methods is implemented by jest/no-restricted-jest-methods
+    if plugin_name == "vitest" && rule_name == "no-restricted-vi-methods" {
+        return ("no-restricted-jest-methods", "jest");
+    }
+
     let plugin_name = match plugin_name {
         "vitest" if is_jest_rule_adapted_to_vitest(rule_name) => "jest",
         "unicorn" if rule_name == "no-negated-condition" => "eslint",

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -26,7 +26,8 @@ pub struct NoRestrictedJestMethods(Box<NoRestrictedJestMethodsConfig>);
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoRestrictedJestMethodsConfig {
-    /// A mapping of restricted Jest method names to custom messages.
+    /// A mapping of restricted Jest method names to custom messages - or
+    /// `null`, for a generic message.
     restricted_jest_methods: FxHashMap<String, String>,
 }
 
@@ -45,9 +46,12 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Certain Jest methods may be deprecated, discouraged in specific
+    /// Certain Jest or Vitest methods may be deprecated, discouraged in specific
     /// contexts, or incompatible with your testing environment. Restricting
     /// them helps maintain consistent and reliable test practices.
+    ///
+    /// By default, no methods are restricted by this rule.
+    /// You must configure the rule for it to disable anything.
     ///
     /// ### Examples
     ///
@@ -75,7 +79,7 @@ declare_oxc_lint!(
     /// ```json
     /// {
     ///   "rules": {
-    ///      "vitest/no-restricted-vi-methods": "error"
+    ///      "vitest/no-restricted-vi-methods": ["error", { "badFunction": "Don't use `badFunction`, it is bad." }]
     ///   }
     /// }
     /// ```


### PR DESCRIPTION
This fixes a few things:

- Fixes the config builder so `vitest/no-restricted-vi-methods` can actually be enabled via the config file.
- Fixes disabling the `vitest/no-restricted-vi-methods` rule via a disable directive comment.

`vitest/no-restricted-vi-methods` wasn't being remapped correctly by the config builder, as the config builder only remapped `jest/any-name` to `vitest/any-name`, and there was no special handling for rules which need to map to an entirely different name. This has added that logic.

`vitest/no-restricted-jest-methods` _does_ work, but that's not what it should be called or how it should work.

Also a minor docs improvements.

I'm unsure if this is sufficiently performant, honestly, but it fixes the problem. There is very likely a better way to do this.

As an aside, the disable comment logic seems... very prone to failure if we're just doing a `name.contains(rule_name)` in most cases. That'd allow `// oxlint-disable-next-line a` to work on any rule with an `a` in the name, I think?