### PR TITLE
refactor(linter/plugins): store rule name in `RuleDetails`

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -407,11 +407,10 @@ export interface Context extends FileContext {
 
 /**
  * Create `Context` object for a rule.
- * @param fullRuleName - Full rule name, including plugin name e.g. `my-plugin/my-rule`
  * @param ruleDetails - `RuleDetails` object
  * @returns `Context` object
  */
-export function createContext(fullRuleName: string, ruleDetails: RuleDetails): Readonly<Context> {
+export function createContext(ruleDetails: RuleDetails): Readonly<Context> {
   // Create `Context` object for rule.
   //
   // All properties are enumerable, to support a pattern which some ESLint plugins use:
@@ -442,7 +441,7 @@ export function createContext(fullRuleName: string, ruleDetails: RuleDetails): R
       // It's not possible to allow access to `id` in `createOnce` in ESLint compatibility mode, so we don't
       // allow it here either. It's probably not very useful anyway - a rule should know what its own name is!
       if (filePath === null) throw new Error("Cannot access `context.id` in `createOnce`");
-      return fullRuleName;
+      return ruleDetails.fullName;
     },
     // Getter for rule options for this rule on this file
     get options(): Readonly<Options> {

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -52,6 +52,7 @@ export type RuleDetails = CreateRuleDetails | CreateOnceRuleDetails;
 
 interface RuleDetailsBase {
   // Static properties of the rule
+  readonly fullName: string;
   readonly context: Readonly<Context>;
   readonly isFixable: boolean;
   readonly messages: Readonly<Record<string, string>> | null;
@@ -144,6 +145,8 @@ export function registerPlugin(plugin: Plugin, packageName: string | null): Plug
     const ruleName = ruleNames[i],
       rule = rules[ruleName];
 
+    const fullRuleName = `${pluginName}/${ruleName}`;
+
     // Validate `rule.meta` and convert to vars with standardized shape
     let isFixable = false,
       messages: Record<string, string> | null = null,
@@ -209,6 +212,7 @@ export function registerPlugin(plugin: Plugin, packageName: string | null): Plug
 
     // Create `RuleDetails` object for rule.
     const ruleDetails: RuleDetails = {
+      fullName: fullRuleName,
       rule: rule as CreateRule, // Could also be `CreateOnceRule`, but just to satisfy type checker
       context: null!, // Filled in below
       isFixable,
@@ -223,7 +227,7 @@ export function registerPlugin(plugin: Plugin, packageName: string | null): Plug
     };
 
     // Create `Context` object for rule. This will be re-used for every file.
-    const context = createContext(`${pluginName}/${ruleName}`, ruleDetails);
+    const context = createContext(ruleDetails);
     (ruleDetails as Writable<RuleDetails>).context = context;
 
     if ("createOnce" in rule) {


### PR DESCRIPTION
Pure refactor. Store rule name in `RuleDetails` object. Therefore rule name doesn't need to be passed separately to `createContext`.