### PR TITLE
feat(linter/plugins): validate options against schema

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -44,7 +44,7 @@ export type JsLoadPluginCb =
 
 /** JS callback to setup configs. */
 export type JsSetupConfigsCb =
-  ((arg: string) => void)
+  ((arg: string) => string | null)
 
 /**
  * NAPI entry point.

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -36,10 +36,11 @@ function loadPluginWrapper(path: string, packageName: string | null): Promise<st
  * Delegates to `setupConfigs`, which was lazy-loaded by `loadPluginWrapper`.
  *
  * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
+ * @returns `null` if success, or error message string
  */
-function setupConfigsWrapper(optionsJSON: string): void {
+function setupConfigsWrapper(optionsJSON: string): string | null {
   debugAssertIsNonNull(setupConfigs);
-  setupConfigs(optionsJSON);
+  return setupConfigs(optionsJSON);
 }
 
 /**

--- a/apps/oxlint/src-js/plugins/config.ts
+++ b/apps/oxlint/src-js/plugins/config.ts
@@ -1,4 +1,5 @@
 import { setOptions } from "./options.ts";
+import { getErrorMessage } from "../utils/utils.ts";
 
 /**
  * Populates Rust-resolved configuration options on the JS side.
@@ -9,8 +10,15 @@ import { setOptions } from "./options.ts";
  * The configuration relevant to each file would then be resolved on the JS side.
  *
  * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
+ * @returns `null` if success, or error message string
  */
-export function setupConfigs(optionsJSON: string): void {
-  // TODO: setup settings and globals using this function
-  setOptions(optionsJSON);
+export function setupConfigs(optionsJSON: string): string | null {
+  // TODO: Setup settings and globals using this function
+  try {
+    setOptions(optionsJSON);
+    return null;
+  } catch (err) {
+    // Return error message to Rust
+    return getErrorMessage(err);
+  }
 }

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -97,7 +97,9 @@ fn wrap_setup_configs(cb: JsSetupConfigsCb) -> ExternalLinterSetupConfigsCb {
         if status == Status::Ok {
             match rx.recv() {
                 // Setup succeeded
-                Ok(Ok(())) => Ok(()),
+                Ok(Ok(None)) => Ok(()),
+                // Setup failed
+                Ok(Ok(Some(err))) => Err(err),
                 // `setupConfigs` threw an error - should be impossible because it should be infallible
                 Ok(Err(err)) => Err(format!("`setupConfigs` threw an error: {err}")),
                 // Sender "hung up" - should be impossible because closure passed to `call_with_return_value`

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -335,7 +335,7 @@ impl CliRunner {
             if let Err(err) = res {
                 print_and_flush_stdout(
                     stdout,
-                    &format!("Failed to setup external plugin options: {err}\n"),
+                    &format!("Failed to setup JS plugin options:\n{err}\n"),
                 );
                 return CliRunResult::InvalidOptionConfig;
             }

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -60,7 +60,7 @@ pub type JsSetupConfigsCb = ThreadsafeFunction<
     // Arguments
     String, // Options array, as JSON string
     // Return value
-    (), // `void`
+    Option<String>, // `None` for success, or `Some` containing error message
     // Arguments (repeated)
     String,
     // Error status

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -28,6 +28,9 @@ const plugin: Plugin = {
     },
 
     options: {
+      meta: {
+        schema: false,
+      },
       create(context) {
         context.report({
           message:
@@ -48,6 +51,7 @@ const plugin: Plugin = {
           { toBe: false, notToBe: true },
           { deep: [{ deeper: { evenDeeper: [{ soDeep: { soSoDeep: true } }] } }] },
         ],
+        schema: false,
       },
       create(context) {
         context.report({
@@ -68,6 +72,7 @@ const plugin: Plugin = {
           { fromDefault: 6 },
           7,
         ],
+        schema: false,
       },
       create(context) {
         context.report({
@@ -83,6 +88,7 @@ const plugin: Plugin = {
     "empty-default-options": {
       meta: {
         defaultOptions: [],
+        schema: false,
       },
       create(context) {
         context.report({
@@ -106,7 +112,7 @@ const plugin: Plugin = {
               fromSchema: { type: "number", default: 10 },
               overrideSchema: { type: "number", default: 20 },
             },
-            additionalProperties: false,
+            additionalProperties: true,
           },
           {
             type: "string",

--- a/apps/oxlint/test/fixtures/options_invalid/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/options_invalid/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "options-invalid-plugin/options": ["error", "something_else"]
+  }
+}

--- a/apps/oxlint/test/fixtures/options_invalid/files/index.js
+++ b/apps/oxlint/test/fixtures/options_invalid/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/options_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/options_invalid/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to setup JS plugin options:
+Error: Options validation failed for rule 'options-invalid-plugin/options':
+Options:
+[
+  "something_else"
+]
+Errors:
+	Value "something_else" should be equal to one of the allowed values.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/options_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/options_invalid/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from "#oxlint";
+
+const plugin: Plugin = {
+  meta: {
+    name: "options-invalid-plugin",
+  },
+  rules: {
+    options: {
+      meta: {
+        schema: [
+          {
+            enum: ["always", "never"],
+          },
+        ],
+      },
+      create(_context) {
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
Fixes #15631.

#16930 implemented options validation against `rule.meta.schema`, for the purpose of supporting default options added by schema. But it didn't actually do anything if validation failed.

Implement validation of options against schema, and pass any errors back to Rust to print.