### PR TITLE
fix(linter): Correct vitest plugin source to be `@vitest/eslint-plugin`

### DIFF
--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -66,7 +66,7 @@ bitflags! {
         const JSDOC = 1 << 5;
         /// `eslint-plugin-jest`
         const JEST = 1 << 6;
-        /// `eslint-plugin-vitest`
+        /// `@vitest/eslint-plugin`
         const VITEST = 1 << 7;
         /// `eslint-plugin-jsx-a11y`
         const JSX_A11Y = 1 << 8;
@@ -345,6 +345,9 @@ mod tests {
         assert_eq!(LintPlugins::try_from("react"), Ok(LintPlugins::REACT));
         assert_eq!(LintPlugins::try_from("unicorn"), Ok(LintPlugins::UNICORN));
         assert_eq!(LintPlugins::try_from("@typescript-eslint"), Ok(LintPlugins::TYPESCRIPT));
+
+        assert_eq!(LintPlugins::try_from("vitest"), Ok(LintPlugins::VITEST));
+        assert_eq!(LintPlugins::try_from("eslint-plugin-vitest"), Ok(LintPlugins::VITEST));
     }
 
     #[test]

--- a/tasks/lint_rules/package.json
+++ b/tasks/lint_rules/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@next/eslint-plugin-next": "latest",
     "@typescript-eslint/eslint-plugin": "latest",
+    "@vitest/eslint-plugin": "latest",
     "eslint": "^9.13.0",
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
@@ -17,7 +18,6 @@
     "eslint-plugin-react-hooks": "latest",
     "eslint-plugin-react-perf": "^3.3.3",
     "eslint-plugin-unicorn": "latest",
-    "eslint-plugin-vitest": "latest",
     "eslint-plugin-vue": "latest"
   }
 }

--- a/tasks/lint_rules/src/eslint-rules.mjs
+++ b/tasks/lint_rules/src/eslint-rules.mjs
@@ -39,7 +39,7 @@ import pluginNext from "@next/eslint-plugin-next";
 // https://github.com/eslint-community/eslint-plugin-promise/blob/v7.1.0/index.js
 import pluginPromise from "eslint-plugin-promise";
 // https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/src/index.ts
-import pluginVitest from "eslint-plugin-vitest";
+import pluginVitest from "@vitest/eslint-plugin";
 // https://github.com/vuejs/eslint-plugin-vue
 import pluginVue from "eslint-plugin-vue";
 
@@ -299,7 +299,7 @@ export const ALL_TARGET_PLUGINS = new Map([
   ["react-perf", { npm: ["eslint-plugin-react-perf"], issueNo: 2041 }],
   ["nextjs", { npm: ["@next/eslint-plugin-next"], issueNo: 1929 }],
   ["promise", { npm: ["eslint-plugin-promise"], issueNo: 4655 }],
-  ["vitest", { npm: ["eslint-plugin-vitest"], issueNo: 4656 }],
+  ["vitest", { npm: ["@vitest/eslint-plugin"], issueNo: 4656 }],
   ["vue", { npm: ["eslint-plugin-vue"], issueNo: 11440 }],
 ]);
 


### PR DESCRIPTION
https://github.com/vitest-dev/eslint-plugin-vitest/issues/537

Also, we should maybe add `@vitest/` as an alias in `unalias_plugin_name` (and oxlint-migrate?). But it doesn't seem like `@vitest/` is used anywhere for flat-file configs, so it should be fine.

This will ensure the linter rule list is also updated with various rules that were added upstream but haven't been reflected in our rule list yet.

```
## Recommended rules

<details open>
<summary>
  ✅: 13, 🚫: 0, ⏳: 1 / total: 16
</summary>

| Status | Name |
| :----: | :--- |
| ✅ | [vitest/expect-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/expect-expect.md) |
| ✅ | [vitest/no-commented-out-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md) |
| ✅ | [vitest/no-conditional-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md) |
| ✅ | [vitest/no-disabled-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md) |
| ✅ | [vitest/no-focused-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md) |
| ✅ | [vitest/no-identical-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md) |
| ✅ | [vitest/no-import-node-test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-import-node-test.md) |
| ✅ | [vitest/no-interpolation-in-snapshots](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md) |
| ✅ | [vitest/no-mocks-import](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md) |
| ✅ | [vitest/no-standalone-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md) |
|  | [vitest/prefer-called-exactly-once-with](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-exactly-once-with.md) |
| ✅⏳ | [vitest/require-local-test-context-for-concurrent-snapshots](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-local-test-context-for-concurrent-snapshots.md) |
| ✅ | [vitest/valid-describe-callback](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-describe-callback.md) |
| ✅ | [vitest/valid-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect.md) |
|  | [vitest/valid-expect-in-promise](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect-in-promise.md) |
|  | [vitest/valid-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md) |

✅ = Implemented, 🚫 = No need to implement, ⏳ = Fix pending

</details>


## Not recommended rules

<details open>
<summary>
  ✅: 33, 🚫: 0, ⏳: 0 / total: 61
</summary>

| Status | Name |
| :----: | :--- |
|  | [vitest/consistent-each-for](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-each-for.md) |
|  | [vitest/consistent-test-filename](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md) |
| ✅ | [vitest/consistent-test-it](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md) |
|  | [vitest/consistent-vitest-vi](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-vitest-vi.md) |
|  | [vitest/hoisted-apis-on-top](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/hoisted-apis-on-top.md) |
| ✅ | [vitest/max-expects](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md) |
| ✅ | [vitest/max-nested-describe](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md) |
| ✅ | [vitest/no-alias-methods](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-alias-methods.md) |
| ✅ | [vitest/no-conditional-in-test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md) |
| ✅ | [vitest/no-conditional-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-tests.md) |
| ✅ | [vitest/no-duplicate-hooks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md) |
| ✅ | [vitest/no-hooks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md) |
|  | [vitest/no-importing-vitest-globals](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-importing-vitest-globals.md) |
| ✅ | [vitest/no-large-snapshots](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-large-snapshots.md) |
| ✅ | [vitest/no-restricted-matchers](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md) |
| ✅ | [vitest/no-restricted-vi-methods](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md) |
| ✅ | [vitest/no-test-prefixes](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md) |
| ✅ | [vitest/no-test-return-statement](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-return-statement.md) |
|  | [vitest/padding-around-after-all-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-after-all-blocks.md) |
|  | [vitest/padding-around-after-each-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-after-each-blocks.md) |
|  | [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) |
|  | [vitest/padding-around-before-all-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-before-all-blocks.md) |
|  | [vitest/padding-around-before-each-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-before-each-blocks.md) |
|  | [vitest/padding-around-describe-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-describe-blocks.md) |
|  | [vitest/padding-around-expect-groups](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-expect-groups.md) |
|  | [vitest/padding-around-test-blocks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-test-blocks.md) |
|  | [vitest/prefer-called-once](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-once.md) |
|  | [vitest/prefer-called-times](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md) |
|  | [vitest/prefer-called-with](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md) |
| ✅ | [vitest/prefer-comparison-matcher](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-comparison-matcher.md) |
|  | [vitest/prefer-describe-function-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-describe-function-title.md) |
| ✅ | [vitest/prefer-each](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md) |
| ✅ | [vitest/prefer-equality-matcher](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md) |
|  | [vitest/prefer-expect-assertions](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md) |
| ✅ | [vitest/prefer-expect-resolves](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md) |
|  | [vitest/prefer-expect-type-of](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-type-of.md) |
| ✅ | [vitest/prefer-hooks-in-order](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md) |
| ✅ | [vitest/prefer-hooks-on-top](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md) |
|  | [vitest/prefer-import-in-mock](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-import-in-mock.md) |
|  | [vitest/prefer-importing-vitest-globals](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-importing-vitest-globals.md) |
| ✅ | [vitest/prefer-lowercase-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-lowercase-title.md) |
| ✅ | [vitest/prefer-mock-promise-shorthand](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md) |
|  | [vitest/prefer-snapshot-hint](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-snapshot-hint.md) |
| ✅ | [vitest/prefer-spy-on](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-spy-on.md) |
|  | [vitest/prefer-strict-boolean-matchers](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-boolean-matchers.md) |
| ✅ | [vitest/prefer-strict-equal](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-equal.md) |
| ✅ | [vitest/prefer-to-be](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be.md) |
| ✅ | [vitest/prefer-to-be-falsy](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-falsy.md) |
| ✅ | [vitest/prefer-to-be-object](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-object.md) |
| ✅ | [vitest/prefer-to-be-truthy](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-truthy.md) |
| ✅ | [vitest/prefer-to-contain](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-contain.md) |
| ✅ | [vitest/prefer-to-have-length](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md) |
| ✅ | [vitest/prefer-todo](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md) |
|  | [vitest/prefer-vi-mocked](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-vi-mocked.md) |
|  | [vitest/require-awaited-expect-poll](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-awaited-expect-poll.md) |
| ✅ | [vitest/require-hook](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-hook.md) |
|  | [vitest/require-import-vi-mock](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-import-vi-mock.md) |
|  | [vitest/require-mock-type-parameters](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-mock-type-parameters.md) |
| ✅ | [vitest/require-to-throw-message](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md) |
| ✅ | [vitest/require-top-level-describe](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md) |
|  | [vitest/warn-todo](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/warn-todo.md) |

✅ = Implemented, 🚫 = No need to implement, ⏳ = Fix pending

</details>


## Deprecated rules

<details >
<summary>
  ✅: 0, 🚫: 1, ⏳: 0 / total: 1
</summary>

| Status | Name |
| :----: | :--- |
| 🚫 | [vitest/no-done-callback](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md) |

✅ = Implemented, 🚫 = No need to implement, ⏳ = Fix pending

</details>
```