### PR TITLE
feat(linter): Add `ignoreCase` option to `react/jsx-no-duplicate-props` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use oxc_ast::{
     AstKind,
     ast::{JSXAttributeItem, JSXAttributeName},
@@ -92,8 +93,7 @@ impl Rule for JsxNoDuplicateProps {
             };
 
             let ident_name: Cow<'a, str> = if self.ignore_case {
-                // Use ASCII lowercase to avoid allocating unless needed
-                Cow::Owned(ident.name.as_str().to_ascii_lowercase())
+                ident.name.as_str().cow_to_ascii_lowercase()
             } else {
                 Cow::Borrowed(ident.name.as_str())
             };

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -28,15 +28,15 @@ fn jsx_no_duplicate_props_diagnostic(prop_name: &str, span1: Span, span2: Span) 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct JsxNoDuplicateProps {
-    // If set to `true`, the rule will consider props duplicates even if
-    // they use different casing.
-    //
-    // For example, with `ignoreCase` set to `true`, the following code would be considered
-    // to have duplicate props:
-    //
-    // ```jsx
-    // <InputField inputProps="foo" InputProps="bar" />;
-    // ```
+    /// If set to `true`, the rule will consider props duplicates even if
+    /// they use different casing.
+    ///
+    /// For example, with `ignoreCase` set to `true`, the following code would be considered
+    /// to have duplicate props:
+    ///
+    /// ```jsx
+    /// <InputField inputProps="foo" InputProps="bar" />;
+    /// ```
     ignore_case: bool,
 }
 

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_duplicate_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_duplicate_props.snap
@@ -8,6 +8,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove one of the props, or rename them so each prop is distinct.
 
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "a" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:6]
+ 1 │ <App a a />;
+   ·      ─ ─
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
   ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "A" is duplicated.
    ╭─[jsx_no_duplicate_props.tsx:1:6]
  1 │ <App A b c A />;
@@ -66,5 +73,40 @@ source: crates/oxc_linter/src/tester.rs
  5 │                 a={{foo: 'bar'}}
    ·                 ─
  6 │                 b="b"
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "a" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:6]
+ 1 │ <App a a />;
+   ·      ─ ─
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "a" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:6]
+ 1 │ <App A a />;
+   ·      ─ ─
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "A" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:6]
+ 1 │ <App a b c A />;
+   ·      ─     ─
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "B" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:12]
+ 1 │ <App A="a" b="b" B="B" />;
+   ·            ─     ─
+   ╰────
+  help: Remove one of the props, or rename them so each prop is distinct.
+
+  ⚠ eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop "InputProps" is duplicated.
+   ╭─[jsx_no_duplicate_props.tsx:1:6]
+ 1 │ <App inputProps="foo" InputProps="bar" />;
+   ·      ──────────       ──────────
    ╰────
   help: Remove one of the props, or rename them so each prop is distinct.


### PR DESCRIPTION
This adds the ignoreCase option to the rule. I am unsure if the move from Atom to Cow is necessary, but I couldn't figure out how to get it converted to lowercase as an Atom without converting it to something else anyway.

Adds tests from the upstream rule as well.

Fixes https://github.com/oxc-project/oxc/issues/16968.

Config docs:

```md

## Configuration

This rule accepts a configuration object with the following properties:

### ignoreCase

type: `boolean`

default: `false`

If set to `true`, the rule will consider props duplicates even if
they use different casing.

For example, with `ignoreCase` set to `true`, the following code would be considered
to have duplicate props:

\```jsx
<InputField inputProps="foo" InputProps="bar" />;
\```
```