### PR TITLE
fix(linter): `import/consistent-type-specifier-style`: add support for declaration files

### DIFF
--- a/crates/oxc_linter/src/snapshots/import_consistent_type_specifier_style.snap
+++ b/crates/oxc_linter/src/snapshots/import_consistent_type_specifier_style.snap
@@ -84,3 +84,59 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────────────────────
    ╰────
   help: Replace top‐level import type with an inline type specifier.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.ts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.ts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.mts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.mts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.cts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './index.d.cts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './app.d.css.ts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.
+
+  ⚠ eslint-plugin-import(consistent-type-specifier-style): Type imports from declaration files must use top-level `import type` syntax.
+   ╭─[consistent_type_specifier_style.tsx:1:10]
+ 1 │ import { type Foo } from './app.d.css.ts';
+   ·          ────────
+   ╰────
+  help: Replace inline type specifiers with a top-level import type statement.


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/16649

declaration files must be imported with `import type`, so this adds a few test cases to check that and ensure it gets fixed properly. admittedly the declaration file checking doesn't feel right, surely we have a utility for this already?