### PR TITLE
docs(linter): Fix the config option docs for no-inline-comments rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -20,6 +20,7 @@ fn no_inline_comments_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoInlineComments(Box<NoInlineCommentsConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoInlineCommentsConfig {
     /// A regex pattern to ignore certain inline comments.
     ///


### PR DESCRIPTION
Fix the casing on `ignorePattern`.