### PR TITLE
chore(js): remove tsc from package scripts as we use `oxlint --type-c…

### DIFF
--- a/.github/workflows/ci_vscode.yml
+++ b/.github/workflows/ci_vscode.yml
@@ -39,10 +39,6 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: vscode
 
-      - name: Type-Check VSCode
-        working-directory: editors/vscode
-        run: pnpm run type-check
-
       - name: Build Language Server
         working-directory: editors/vscode
         run: pnpm run server:build:debug

--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -14,7 +14,7 @@
     "build-napi-test": "pnpm run build-napi",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.js",
-    "test": "tsc && vitest --dir test run"
+    "test": "vitest --dir test run"
   },
   "dependencies": {
     "prettier": "3.7.4",
@@ -26,7 +26,6 @@
     "@types/node": "catalog:",
     "execa": "^9.6.0",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "napi": {

--- a/apps/oxfmt/test/__snapshots__/external_formatter.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/external_formatter.test.ts.snap
@@ -25,7 +25,7 @@ package.json
 
     "build-js": "node scripts/build.js",
 
-    "test": "tsc && vitest --dir test run"
+    "test": "vitest --dir test run"
   },
   "engines": { "node": "^20.19.0 || >=22.12.0" },
   "dependencies": { "prettier": "3.7.4" },
@@ -44,7 +44,7 @@ package.json
     "build": "pnpm run build-napi-release && pnpm run build-js",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.js",
-    "test": "tsc && vitest --dir test run"
+    "test": "vitest --dir test run"
   },
   "dependencies": {
     "prettier": "3.7.4"

--- a/apps/oxfmt/test/fixtures/external_formatter/package.json
+++ b/apps/oxfmt/test/fixtures/external_formatter/package.json
@@ -9,7 +9,7 @@
 
     "build-js": "node scripts/build.js",
 
-    "test": "tsc && vitest --dir test run"
+    "test": "vitest --dir test run"
   },
   "engines": { "node": "^20.19.0 || >=22.12.0" },
   "dependencies": { "prettier": "3.7.4" },

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -18,7 +18,7 @@
     "build-napi-test": "pnpm run build-napi --features force_test_reporter",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.ts",
-    "test": "tsc && vitest --dir ./test run",
+    "test": "vitest --dir ./test run",
     "init-conformance": "cd conformance; ./init.sh",
     "conformance": "node ./conformance/src/index.ts"
   },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -42,8 +42,7 @@
     "test:single-folder": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=single-folder vscode-test",
     "test:multi-root": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=multi-root vscode-test",
     "test:oxlint": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxlint-lsp vscode-test",
-    "test:oxfmt": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxfmt-lsp vscode-test",
-    "type-check": "tsc --noEmit"
+    "test:oxfmt": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxfmt-lsp vscode-test"
   },
   "contributes": {
     "commands": [
@@ -281,9 +280,8 @@
     "@vscode/vsce": "^3.0.0",
     "cross-env": "catalog:",
     "ovsx": "^0.10.0",
-    "rolldown": "1.0.0-beta.54",
-    "tinyglobby": "^0.2.15",
-    "typescript": "catalog:"
+    "rolldown": "catalog:",
+    "tinyglobby": "^0.2.15"
   },
   "engines": {
     "vscode": "^1.93.0"

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -35,13 +35,12 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads",
-    "test": "tsc && vitest run --dir ./test"
+    "test": "vitest run --dir ./test"
   },
   "devDependencies": {
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
     "publint": "catalog:",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "napi": {

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -61,7 +61,7 @@
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads",
     "build-npm-dir": "rm -rf npm-dir && napi create-npm-dirs --npm-dir npm-dir && pnpm napi artifacts --npm-dir npm-dir --output-dir src-js",
     "build-browser-bundle": "node scripts/build-browser-bundle.js",
-    "test": "tsc && pnpm run test-node run",
+    "test": "pnpm run test-node run",
     "test-node": "vitest --dir ./test",
     "test-browser": "vitest -c vitest.config.browser.ts",
     "bench": "vitest bench --run ./bench.bench.js"
@@ -81,7 +81,6 @@
     "playwright": "^1.51.0",
     "publint": "catalog:",
     "tinypool": "^2.0.0",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "napi": {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -35,13 +35,12 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads",
-    "test": "tsc && vitest run --dir ./test"
+    "test": "vitest run --dir ./test"
   },
   "devDependencies": {
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
     "publint": "catalog:",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "napi": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.18.0(@arethetypeswrong/core@0.18.2)(publint@0.3.15)(typescript@5.9.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.15(@types/node@24.1.0)(@vitest/browser-playwright@4.0.15)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)
@@ -184,14 +181,11 @@ importers:
         specifier: ^0.10.0
         version: 0.10.7
       rolldown:
-        specifier: 1.0.0-beta.54
+        specifier: 'catalog:'
         version: 1.0.0-beta.54
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
 
   napi/minify:
     devDependencies:
@@ -204,9 +198,6 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.15
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.15(@types/node@24.1.0)(@vitest/browser-playwright@4.0.15)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)
@@ -250,9 +241,6 @@ importers:
       tinypool:
         specifier: ^2.0.0
         version: 2.0.0
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.15(@types/node@24.1.0)(@vitest/browser-playwright@4.0.15)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)
@@ -281,9 +269,6 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.15
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.15(@types/node@24.1.0)(@vitest/browser-playwright@4.0.15)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)


### PR DESCRIPTION
…heck`