### PR TITLE
fix(minifier/docs): correct hyperlink path in OPTIMIZATIONS.md 

### DIFF
--- a/crates/oxc_minifier/docs/OPTIMIZATIONS.md
+++ b/crates/oxc_minifier/docs/OPTIMIZATIONS.md
@@ -2,7 +2,7 @@
 
 Complete list of optimizations for maximum size reduction.
 
-Many optimizations rely on [`oxc_ecmascript`](../oxc_ecmascript) for ECMAScript operations like constant evaluation, type conversion, and side effect analysis.
+Many optimizations rely on [`oxc_ecmascript`](../../oxc_ecmascript) for ECMAScript operations like constant evaluation, type conversion, and side effect analysis.
 
 ## Current Optimizations (18)
 


### PR DESCRIPTION
correct hyperlink path in OPTIMIZATIONS.md for oxc_ecmascript reference