### PR TITLE
refactor(oxfmt): Resolve options on each path, preparing for `.editorconfig` support

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -31,7 +31,7 @@ export declare const enum Severity {
  *
  * Since it internally uses `await prettier.format()` in JS side, `formatSync()` cannot be provided.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, tagName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -46,7 +46,7 @@ export interface FormatResult {
  *
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
- * 2. `setup_config_cb`: Callback to setup Prettier config
+ * 2. `init_external_formatter_cb`: Callback to initialize external formatter
  * 3. `format_embedded_cb`: Callback to format embedded code in templates
  * 4. `format_file_cb`: Callback to format files
  *
@@ -54,4 +54,4 @@ export interface FormatResult {
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, setupConfigCb: (configJSON: string, numThreads: number) => Promise<string[]>, formatEmbeddedCb: (tagName: string, code: string) => Promise<string>, formatFileCb: (parserName: string, fileName: string, code: string) => Promise<string>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, tagName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,5 +1,5 @@
 import { runCli } from "./bindings.js";
-import { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
+import { initExternalFormatter, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 import { runInit, runMigratePrettier } from "./migration/index.js";
 
 void (async () => {
@@ -7,7 +7,12 @@ void (async () => {
 
   // Call the Rust CLI to parse args and determine mode
   // NOTE: If the mode is formatter CLI, it will also perform formatting and return an exit code
-  const [mode, exitCode] = await runCli(args, setupConfig, formatEmbeddedCode, formatFile);
+  const [mode, exitCode] = await runCli(
+    args,
+    initExternalFormatter,
+    formatEmbeddedCode,
+    formatFile,
+  );
 
   switch (mode) {
     // Handle `--init` and `--migrate` command in JS

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,5 +1,5 @@
 import { format as napiFormat } from "./bindings.js";
-import { setupConfig, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
+import { initExternalFormatter, formatEmbeddedCode, formatFile } from "./prettier-proxy.js";
 
 export async function format(fileName: string, sourceText: string, options?: FormatOptions) {
   if (typeof fileName !== "string") throw new TypeError("`fileName` must be a string");
@@ -9,7 +9,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     fileName,
     sourceText,
     options ?? {},
-    setupConfig,
+    initExternalFormatter,
     formatEmbeddedCode,
     formatFile,
   );

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -9,7 +9,7 @@ use super::{
     service::{FormatService, SuccessResult},
     walk::Walk,
 };
-use crate::core::{SourceFormatter, load_config, resolve_config_path, utils};
+use crate::core::{ConfigResolver, SourceFormatter, resolve_config_path, utils};
 
 #[derive(Debug)]
 pub struct FormatRunner {
@@ -63,54 +63,57 @@ impl FormatRunner {
         };
         let num_of_threads = rayon::current_num_threads();
 
-        // Find config file
+        // Find and load config file
         // NOTE: Currently, we only load single config file.
         // - from `--config` if specified
         // - else, search nearest for the nearest `.oxfmtrc.json` from cwd upwards
         let config_path = resolve_config_path(&cwd, config_options.config.as_deref());
-        // Load and parse config file
-        // - `format_options`: Parsed formatting options used by `oxc_formatter`
-        // - `external_config`: JSON value used by `external_formatter`, populated with `format_options`
-        let (format_options, oxfmt_options, external_config) =
-            match load_config(config_path.as_deref()) {
-                Ok(c) => c,
-                Err(err) => {
-                    utils::print_and_flush(
-                        stderr,
-                        &format!("Failed to load configuration file.\n{err}\n"),
-                    );
-                    return CliRunResult::InvalidOptionConfig;
-                }
-            };
+        let mut config_resolver = match ConfigResolver::from_config_path(config_path.as_deref()) {
+            Ok(r) => r,
+            Err(err) => {
+                utils::print_and_flush(
+                    stderr,
+                    &format!("Failed to load configuration file.\n{err}\n"),
+                );
+                return CliRunResult::InvalidOptionConfig;
+            }
+        };
+        let ignore_patterns = match config_resolver.build_and_validate() {
+            Ok(patterns) => patterns,
+            Err(err) => {
+                utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
+                return CliRunResult::InvalidOptionConfig;
+            }
+        };
 
-        // TODO: Plugins support
-        // - Parse returned `languages`
-        // - Allow its `extensions` and `filenames` in `walk.rs`
-        // - Pass `parser` to `SourceFormatter`
         // Use `block_in_place()` to avoid nested async runtime access
         #[cfg(feature = "napi")]
-        if let Err(err) = tokio::task::block_in_place(|| {
+        match tokio::task::block_in_place(|| {
             self.external_formatter
                 .as_ref()
                 .expect("External formatter must be set when `napi` feature is enabled")
-                .setup_config(&external_config.to_string(), num_of_threads)
+                .init(num_of_threads)
         }) {
-            utils::print_and_flush(
-                stderr,
-                &format!("Failed to setup external formatter config.\n{err}\n"),
-            );
-            return CliRunResult::InvalidOptionConfig;
+            // TODO: Plugins support
+            // - Parse returned `languages`
+            // - Allow its `extensions` and `filenames` in `walk.rs`
+            // - Pass `parser` to `SourceFormatter`
+            Ok(_) => {}
+            Err(err) => {
+                utils::print_and_flush(
+                    stderr,
+                    &format!("Failed to setup external formatter.\n{err}\n"),
+                );
+                return CliRunResult::InvalidOptionConfig;
+            }
         }
-
-        #[cfg(not(feature = "napi"))]
-        let _ = (external_config, oxfmt_options.sort_package_json);
 
         let walker = match Walk::build(
             &cwd,
             &paths,
             &ignore_options.ignore_path,
             ignore_options.with_node_modules,
-            &oxfmt_options.ignore_patterns,
+            &ignore_patterns,
         ) {
             Ok(Some(walker)) => walker,
             // All target paths are ignored
@@ -145,16 +148,16 @@ impl FormatRunner {
         }
 
         // Create `SourceFormatter` instance
-        let source_formatter = SourceFormatter::new(num_of_threads, format_options);
+        let source_formatter = SourceFormatter::new(num_of_threads);
         #[cfg(feature = "napi")]
-        let source_formatter = source_formatter
-            .with_external_formatter(self.external_formatter, oxfmt_options.sort_package_json);
+        let source_formatter = source_formatter.with_external_formatter(self.external_formatter);
 
         let format_mode_clone = format_mode.clone();
 
         // Spawn a thread to run formatting service with streaming entries
         rayon::spawn(move || {
-            let format_service = FormatService::new(cwd, format_mode_clone, source_formatter);
+            let format_service =
+                FormatService::new(cwd, format_mode_clone, source_formatter, config_resolver);
             format_service.run_streaming(rx_entry, &tx_error, &tx_success);
         });
 

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -7,7 +7,7 @@ use oxc_formatter::{
     oxfmtrc::{OxfmtOptions, Oxfmtrc},
 };
 
-use super::utils;
+use super::{FormatFileStrategy, utils};
 
 /// Resolve config file path from cwd and optional explicit path.
 pub fn resolve_config_path(cwd: &Path, config_path: Option<&Path>) -> Option<PathBuf> {
@@ -33,42 +33,179 @@ pub fn resolve_config_path(cwd: &Path, config_path: Option<&Path>) -> Option<Pat
     })
 }
 
-/// # Errors
-/// Returns error if:
-/// - Config file is specified but not found or invalid
-/// - Config file parsing fails
-pub fn load_config(
-    config_path: Option<&Path>,
-) -> Result<(FormatOptions, OxfmtOptions, Value), String> {
-    // Read and parse config file, or use empty JSON if not found
-    let json_string = match config_path {
-        Some(path) => {
-            let mut json_string = utils::read_to_string(path)
-                // Do not include OS error, it differs between platforms
-                .map_err(|_| format!("Failed to read config {}: File not found", path.display()))?;
-            // Strip comments (JSONC support)
-            json_strip_comments::strip(&mut json_string).map_err(|err| {
-                format!("Failed to strip comments from {}: {err}", path.display())
-            })?;
-            json_string
+/// Resolved options for each file type.
+/// Each variant contains only the options needed for that formatter.
+pub enum ResolvedOptions {
+    /// For JS/TS files formatted by oxc_formatter.
+    OxcFormatter {
+        format_options: FormatOptions,
+        /// For embedded language formatting (e.g., CSS in template literals)
+        external_options: Value,
+    },
+    /// For non-JS files formatted by external formatter (Prettier).
+    #[cfg(feature = "napi")]
+    ExternalFormatter { external_options: Value },
+    /// For `package.json` files: optionally sorted then formatted.
+    #[cfg(feature = "napi")]
+    ExternalFormatterPackageJson { external_options: Value, sort_package_json: bool },
+}
+
+/// Configuration resolver that derives all config values from a single `serde_json::Value`.
+///
+/// Priority order: `Oxfmtrc::default()` → (TODO: editorconfig) → user's oxfmtrc
+pub struct ConfigResolver {
+    /// User's raw config as JSON value.
+    /// It contains every possible field, even those not recognized by `Oxfmtrc`.
+    /// e.g. `printWidth`: recognized by both `Oxfmtrc` and Prettier
+    /// e.g. `vueIndentScriptAndStyle`: not recognized by `Oxfmtrc`, but used by Prettier
+    /// e.g. `svelteSortAttributes`: not recognized by Prettier by default
+    raw_config: Value,
+    /// Cached parsed options after validation.
+    /// Used to avoid re-parsing during per-file resolution, if `.editorconfig` is not used.
+    /// NOTE: Currently, only `.editorconfig` provides per-file overrides, `.oxfmtrc` does not.
+    cached_options: Option<(FormatOptions, OxfmtOptions, Value)>,
+    // TODO: Add editorconfig support
+}
+
+impl ConfigResolver {
+    /// Create a new resolver from a raw JSON config value.
+    #[cfg(feature = "napi")]
+    pub fn from_value(raw_config: Value) -> Self {
+        Self { raw_config, cached_options: None }
+    }
+
+    /// Create a resolver by loading config from a file path.
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Config file is specified but not found or invalid
+    /// - Config file parsing fails
+    pub fn from_config_path(config_path: Option<&Path>) -> Result<Self, String> {
+        // Read and parse config file, or use empty JSON if not found
+        let json_string = match config_path {
+            Some(path) => {
+                let mut json_string = utils::read_to_string(path)
+                    // Do not include OS error, it differs between platforms
+                    .map_err(|_| {
+                        format!("Failed to read config {}: File not found", path.display())
+                    })?;
+                // Strip comments (JSONC support)
+                json_strip_comments::strip(&mut json_string).map_err(|err| {
+                    format!("Failed to strip comments from {}: {err}", path.display())
+                })?;
+                json_string
+            }
+            None => "{}".to_string(),
+        };
+
+        // Parse as raw JSON value
+        let raw_config: Value = serde_json::from_str(&json_string)
+            .map_err(|err| format!("Failed to parse config: {err}"))?;
+
+        Ok(Self { raw_config, cached_options: None })
+    }
+
+    /// Validate config and return ignore patterns for file walking.
+    ///
+    /// # Errors
+    /// Returns error if config deserialization fails.
+    pub fn build_and_validate(&mut self) -> Result<Vec<String>, String> {
+        let oxfmtrc: Oxfmtrc = serde_json::from_value(self.raw_config.clone())
+            .map_err(|err| format!("Failed to deserialize Oxfmtrc: {err}"))?;
+
+        // TODO: Apply editorconfig settings
+        // if let Some(editorconfig) = &self.editorconfig {
+        //   // Priority: oxfmtrc default < editorconfig < user's oxfmtrc
+        //   if oxfmtrc.print_width.is_none() && let Some(max_line_length) = editorconfig.get_max_line_length() {
+        //     oxfmtrc.print_width = Some(max_line_length);
+        //   }
+        //   // ... others
+        // }
+
+        let (format_options, oxfmt_options) = oxfmtrc
+            .into_options()
+            .map_err(|err| format!("Failed to parse configuration.\n{err}"))?;
+
+        // Apply our defaults for Prettier options too
+        // e.g. set `printWidth: 100` if not specified (= Prettier default: 80)
+        let mut external_options = self.raw_config.clone();
+        Oxfmtrc::populate_prettier_config(&format_options, &mut external_options);
+
+        let ignore_patterns = oxfmt_options.ignore_patterns.clone();
+
+        // NOTE: Save cache for fast path: no per-file overrides
+        self.cached_options = Some((format_options, oxfmt_options, external_options));
+
+        Ok(ignore_patterns)
+    }
+
+    /// Resolve format options for a specific file.
+    pub fn resolve(&self, strategy: &FormatFileStrategy) -> ResolvedOptions {
+        // TODO: Check if editorconfig has any overrides for this file
+        let has_editorconfig_and_overrides = false;
+
+        #[cfg_attr(not(feature = "napi"), allow(unused_variables))]
+        let (format_options, oxfmt_options, external_options) = if has_editorconfig_and_overrides {
+            self.resolve_with_overrides(strategy)
+        } else {
+            // Resolve format options for a specific file.
+            // Either:
+            // - `.editorconfig` is NOT used
+            // - or used but per-file overrides do NOT exist for this file
+            self.cached_options
+                .clone()
+                .expect("`build_and_validate()` must be called before `resolve()`")
+        };
+
+        match strategy {
+            FormatFileStrategy::OxcFormatter { .. } => {
+                ResolvedOptions::OxcFormatter { format_options, external_options }
+            }
+            #[cfg(feature = "napi")]
+            FormatFileStrategy::ExternalFormatter { .. } => {
+                ResolvedOptions::ExternalFormatter { external_options }
+            }
+            #[cfg(feature = "napi")]
+            FormatFileStrategy::ExternalFormatterPackageJson { .. } => {
+                ResolvedOptions::ExternalFormatterPackageJson {
+                    external_options,
+                    sort_package_json: oxfmt_options.sort_package_json,
+                }
+            }
+            #[cfg(not(feature = "napi"))]
+            _ => {
+                unreachable!("If `napi` feature is disabled, this should not be passed here")
+            }
         }
-        None => "{}".to_string(),
-    };
+    }
 
-    // Parse as raw JSON value (to pass to external formatter)
-    let mut raw_config: Value = serde_json::from_str(&json_string)
-        .map_err(|err| format!("Failed to parse config: {err}"))?;
+    /// Resolve format options for a specific file.
+    /// Since `.editorconfig` may contain per-file patterns, options are resolved per-file.
+    fn resolve_with_overrides(
+        &self,
+        _strategy: &FormatFileStrategy,
+    ) -> (FormatOptions, OxfmtOptions, Value) {
+        let oxfmtrc: Oxfmtrc = serde_json::from_value(self.raw_config.clone())
+            .expect("`build_and_validate()` should catch this before `resolve()`");
 
-    // NOTE: Field validation for `enum` are done here
-    let oxfmtrc: Oxfmtrc = serde_json::from_str(&json_string)
-        .map_err(|err| format!("Failed to deserialize config: {err}"))?;
+        // TODO: Apply base + per-file editorconfig settings
+        // if let Some(editorconfig) = &self.editorconfig.resolve(strategy.path()) {
+        //   // Priority: oxfmtrc default < editorconfig < user's oxfmtrc
+        //   if oxfmtrc.print_width.is_none() && let Some(max_line_length) = editorconfig.get_max_line_length() {
+        //     oxfmtrc.print_width = Some(max_line_length);
+        //   }
+        //   // ... others
+        // }
 
-    // NOTE: Other validation based on it's field values are done here
-    let (format_options, oxfmt_options) =
-        oxfmtrc.into_options().map_err(|err| format!("Failed to parse configuration.\n{err}"))?;
+        let (format_options, oxfmt_options) = oxfmtrc
+            .into_options()
+            .expect("If this fails, there is an issue with editorconfig insertion above");
 
-    // Populate `raw_config` with resolved options to apply our defaults
-    Oxfmtrc::populate_prettier_config(&format_options, &mut raw_config);
+        // Apply our defaults for Prettier options too
+        // e.g. set `printWidth: 100` if not specified (= Prettier default: 80)
+        let mut external_options = self.raw_config.clone();
+        Oxfmtrc::populate_prettier_config(&format_options, &mut external_options);
 
-    Ok((format_options, oxfmt_options, raw_config))
+        (format_options, oxfmt_options, external_options)
+    }
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -5,18 +5,17 @@ use napi::{
     bindgen_prelude::{FnArgs, Promise, block_on},
     threadsafe_function::ThreadsafeFunction,
 };
+use serde_json::Value;
 
-use oxc_formatter::EmbeddedFormatterCallback;
-
-/// Type alias for the setup config callback function signature.
-/// Takes (config_json, num_threads) as arguments and returns plugin languages.
-pub type JsSetupConfigCb = ThreadsafeFunction<
+/// Type alias for the init external formatter callback function signature.
+/// Takes num_threads as argument and returns plugin languages.
+pub type JsInitExternalFormatterCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(String, u32)>, // (config_json, num_threads)
+    FnArgs<(u32,)>, // (num_threads,)
     // Return type (what JS function returns)
     Promise<Vec<String>>,
     // Arguments (repeated)
-    FnArgs<(String, u32)>,
+    FnArgs<(u32,)>,
     // Error status
     Status,
     // CalleeHandled
@@ -24,14 +23,14 @@ pub type JsSetupConfigCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (tag_name, code) as separate arguments and returns formatted code.
+/// Takes (options, tag_name, code) as separate arguments and returns formatted code.
 pub type JsFormatEmbeddedCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(String, String)>, // (tag_name, code) as separate arguments
+    FnArgs<(Value, String, String)>, // (options, tag_name, code)
     // Return type (what JS function returns)
     Promise<String>,
     // Arguments (repeated)
-    FnArgs<(String, String)>,
+    FnArgs<(Value, String, String)>,
     // Error status
     Status,
     // CalleeHandled
@@ -39,40 +38,47 @@ pub type JsFormatEmbeddedCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (parser_name, file_name, code) as separate arguments and returns formatted code.
+/// Takes (options, parser_name, file_name, code) as separate arguments and returns formatted code.
 pub type JsFormatFileCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(String, String, String)>, // (parser_name, file_name, code) as separate arguments
+    FnArgs<(Value, String, String, String)>, // (options, parser_name, file_name, code)
     // Return type (what JS function returns)
     Promise<String>,
     // Arguments (repeated)
-    FnArgs<(String, String, String)>,
+    FnArgs<(Value, String, String, String)>,
     // Error status
     Status,
     // CalleeHandled
     false,
 >;
 
-/// Callback function type for formatting files.
-/// Takes (parser_name, file_name, code) and returns formatted code or an error.
-type FormatFileCallback = Arc<dyn Fn(&str, &str, &str) -> Result<String, String> + Send + Sync>;
+/// Callback function type for formatting embedded code with config.
+/// Takes (options, tag_name, code) and returns formatted code or an error.
+type FormatEmbeddedWithConfigCallback =
+    Arc<dyn Fn(&Value, &str, &str) -> Result<String, String> + Send + Sync>;
 
-/// Callback function type for setup config.
-/// Takes (config_json, num_threads) and returns plugin languages.
-type SetupConfigCallback = Arc<dyn Fn(&str, usize) -> Result<Vec<String>, String> + Send + Sync>;
+/// Callback function type for formatting files with config.
+/// Takes (options, parser_name, file_name, code) and returns formatted code or an error.
+type FormatFileWithConfigCallback =
+    Arc<dyn Fn(&Value, &str, &str, &str) -> Result<String, String> + Send + Sync>;
+
+/// Callback function type for init external formatter.
+/// Takes num_threads and returns plugin languages.
+type InitExternalFormatterCallback =
+    Arc<dyn Fn(usize) -> Result<Vec<String>, String> + Send + Sync>;
 
 /// External formatter that wraps a JS callback.
 #[derive(Clone)]
 pub struct ExternalFormatter {
-    pub setup_config: SetupConfigCallback,
-    pub format_embedded: EmbeddedFormatterCallback,
-    pub format_file: FormatFileCallback,
+    pub init: InitExternalFormatterCallback,
+    pub format_embedded: FormatEmbeddedWithConfigCallback,
+    pub format_file: FormatFileWithConfigCallback,
 }
 
 impl std::fmt::Debug for ExternalFormatter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ExternalFormatter")
-            .field("setup_config", &"<callback>")
+            .field("init", &"<callback>")
             .field("format_embedded", &"<callback>")
             .field("format_file", &"<callback>")
             .finish()
@@ -82,44 +88,43 @@ impl std::fmt::Debug for ExternalFormatter {
 impl ExternalFormatter {
     /// Create an [`ExternalFormatter`] from JS callbacks.
     pub fn new(
-        setup_config_cb: JsSetupConfigCb,
+        init_cb: JsInitExternalFormatterCb,
         format_embedded_cb: JsFormatEmbeddedCb,
         format_file_cb: JsFormatFileCb,
     ) -> Self {
-        let rust_setup_config = wrap_setup_config(setup_config_cb);
+        let rust_init = wrap_init_external_formatter(init_cb);
         let rust_format_embedded = wrap_format_embedded(format_embedded_cb);
         let rust_format_file = wrap_format_file(format_file_cb);
         Self {
-            setup_config: rust_setup_config,
+            init: rust_init,
             format_embedded: rust_format_embedded,
             format_file: rust_format_file,
         }
     }
 
-    /// Setup Prettier config using the JS callback.
-    pub fn setup_config(
-        &self,
-        config_json: &str,
-        num_threads: usize,
-    ) -> Result<Vec<String>, String> {
-        (self.setup_config)(config_json, num_threads)
+    /// Initialize external formatter using the JS callback.
+    pub fn init(&self, num_threads: usize) -> Result<Vec<String>, String> {
+        (self.init)(num_threads)
     }
 
-    /// Convert this external formatter to the oxc_formatter::EmbeddedFormatter type
-    pub fn to_embedded_formatter(&self) -> oxc_formatter::EmbeddedFormatter {
-        let callback = Arc::clone(&self.format_embedded);
-        // The callback already expects &str, so just use it directly
+    /// Convert this external formatter to the oxc_formatter::EmbeddedFormatter type.
+    /// The options is captured in the closure and passed to JS on each call.
+    pub fn to_embedded_formatter(&self, options: Value) -> oxc_formatter::EmbeddedFormatter {
+        let format_embedded = Arc::clone(&self.format_embedded);
+        let callback =
+            Arc::new(move |tag_name: &str, code: &str| (format_embedded)(&options, tag_name, code));
         oxc_formatter::EmbeddedFormatter::new(callback)
     }
 
     /// Format non-js file using the JS callback.
     pub fn format_file(
         &self,
+        options: &Value,
         parser_name: &str,
         file_name: &str,
         code: &str,
     ) -> Result<String, String> {
-        (self.format_file)(parser_name, file_name, code)
+        (self.format_file)(options, parser_name, file_name, code)
     }
 }
 
@@ -137,30 +142,30 @@ impl ExternalFormatter {
 // Therefore, `block_in_place()` is used at the call site
 // to temporarily convert the current async task into a blocking context.
 
-/// Wrap JS `setupConfig` callback as a normal Rust function.
-fn wrap_setup_config(cb: JsSetupConfigCb) -> SetupConfigCallback {
-    Arc::new(move |config_json: &str, num_threads: usize| {
+/// Wrap JS `initExternalFormatter` callback as a normal Rust function.
+fn wrap_init_external_formatter(cb: JsInitExternalFormatterCb) -> InitExternalFormatterCallback {
+    Arc::new(move |num_threads: usize| {
         block_on(async {
             #[expect(clippy::cast_possible_truncation)]
-            let status =
-                cb.call_async(FnArgs::from((config_json.to_string(), num_threads as u32))).await;
+            let status = cb.call_async(FnArgs::from((num_threads as u32,))).await;
             match status {
                 Ok(promise) => match promise.await {
                     Ok(languages) => Ok(languages),
-                    Err(err) => Err(format!("JS setupConfig promise rejected: {err}")),
+                    Err(err) => Err(format!("JS initExternalFormatter promise rejected: {err}")),
                 },
-                Err(err) => Err(format!("Failed to call JS setupConfig callback: {err}")),
+                Err(err) => Err(format!("Failed to call JS initExternalFormatter callback: {err}")),
             }
         })
     })
 }
 
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
-fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback {
-    Arc::new(move |tag_name: &str, code: &str| {
+fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> FormatEmbeddedWithConfigCallback {
+    Arc::new(move |options: &Value, tag_name: &str, code: &str| {
         block_on(async {
-            let status =
-                cb.call_async(FnArgs::from((tag_name.to_string(), code.to_string()))).await;
+            let status = cb
+                .call_async(FnArgs::from((options.clone(), tag_name.to_string(), code.to_string())))
+                .await;
             match status {
                 Ok(promise) => match promise.await {
                     Ok(formatted_code) => Ok(formatted_code),
@@ -177,11 +182,12 @@ fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> EmbeddedFormatterCallback {
 }
 
 /// Wrap JS `formatFile` callback as a normal Rust function.
-fn wrap_format_file(cb: JsFormatFileCb) -> FormatFileCallback {
-    Arc::new(move |parser_name: &str, file_name: &str, code: &str| {
+fn wrap_format_file(cb: JsFormatFileCb) -> FormatFileWithConfigCallback {
+    Arc::new(move |options: &Value, parser_name: &str, file_name: &str, code: &str| {
         block_on(async {
             let status = cb
                 .call_async(FnArgs::from((
+                    options.clone(),
                     parser_name.to_string(),
                     file_name.to_string(),
                     code.to_string(),

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -7,8 +7,9 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_options};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use serde_json::Value;
 
-use super::FormatFileStrategy;
+use super::{FormatFileStrategy, ResolvedOptions};
 
 pub enum FormatResult {
     Success { is_changed: bool, code: String },
@@ -17,20 +18,14 @@ pub enum FormatResult {
 
 pub struct SourceFormatter {
     allocator_pool: AllocatorPool,
-    format_options: FormatOptions,
-    #[cfg(feature = "napi")]
-    pub is_sort_package_json: bool,
     #[cfg(feature = "napi")]
     external_formatter: Option<super::ExternalFormatter>,
 }
 
 impl SourceFormatter {
-    pub fn new(num_of_threads: usize, format_options: FormatOptions) -> Self {
+    pub fn new(num_of_threads: usize) -> Self {
         Self {
             allocator_pool: AllocatorPool::new(num_of_threads),
-            format_options,
-            #[cfg(feature = "napi")]
-            is_sort_package_json: false,
             #[cfg(feature = "napi")]
             external_formatter: None,
         }
@@ -41,32 +36,51 @@ impl SourceFormatter {
     pub fn with_external_formatter(
         mut self,
         external_formatter: Option<super::ExternalFormatter>,
-        sort_package_json: bool,
     ) -> Self {
         self.external_formatter = external_formatter;
-        self.is_sort_package_json = sort_package_json;
         self
     }
 
-    /// Format a file based on its source type.
-    pub fn format(&self, entry: &FormatFileStrategy, source_text: &str) -> FormatResult {
-        let result = match entry {
-            FormatFileStrategy::OxcFormatter { path, source_type } => {
-                self.format_by_oxc_formatter(source_text, path, *source_type)
+    /// Format a file based on its entry type and resolved options.
+    pub fn format(
+        &self,
+        entry: &FormatFileStrategy,
+        source_text: &str,
+        resolved_options: &ResolvedOptions,
+    ) -> FormatResult {
+        let result = match (entry, resolved_options) {
+            (
+                FormatFileStrategy::OxcFormatter { path, source_type },
+                ResolvedOptions::OxcFormatter { format_options, external_options },
+            ) => self.format_by_oxc_formatter(
+                source_text,
+                path,
+                *source_type,
+                format_options,
+                external_options,
+            ),
+            #[cfg(feature = "napi")]
+            (
+                FormatFileStrategy::ExternalFormatter { path, parser_name },
+                ResolvedOptions::ExternalFormatter { external_options },
+            ) => {
+                self.format_by_external_formatter(source_text, path, parser_name, external_options)
             }
             #[cfg(feature = "napi")]
-            FormatFileStrategy::ExternalFormatter { path, parser_name } => {
-                self.format_by_external_formatter(source_text, path, parser_name)
-            }
-            #[cfg(feature = "napi")]
-            FormatFileStrategy::ExternalFormatterPackageJson { path, parser_name } => {
-                self.format_by_external_formatter_package_json(source_text, path, parser_name)
-            }
-            #[cfg(not(feature = "napi"))]
-            FormatFileStrategy::ExternalFormatter { .. }
-            | FormatFileStrategy::ExternalFormatterPackageJson { .. } => {
-                unreachable!("If `napi` feature is disabled, this should not be passed here")
-            }
+            (
+                FormatFileStrategy::ExternalFormatterPackageJson { path, parser_name },
+                ResolvedOptions::ExternalFormatterPackageJson {
+                    external_options,
+                    sort_package_json,
+                },
+            ) => self.format_by_external_formatter_package_json(
+                source_text,
+                path,
+                parser_name,
+                external_options,
+                *sort_package_json,
+            ),
+            _ => unreachable!("FormatFileStrategy and ResolvedOptions variant mismatch"),
         };
 
         match result {
@@ -81,6 +95,8 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         source_type: SourceType,
+        format_options: &FormatOptions,
+        external_options: &Value,
     ) -> Result<String, OxcDiagnostic> {
         let source_type = enable_jsx_source_type(source_type);
         let allocator = self.allocator_pool.get();
@@ -93,23 +109,26 @@ impl SourceFormatter {
             return Err(ret.errors.into_iter().next().unwrap());
         }
 
-        let base_formatter = Formatter::new(&allocator, self.format_options.clone());
+        let base_formatter = Formatter::new(&allocator, format_options.clone());
 
         #[cfg(feature = "napi")]
         let formatted = {
-            if self.format_options.embedded_language_formatting.is_off() {
+            if format_options.embedded_language_formatting.is_off() {
                 base_formatter.format(&ret.program)
             } else {
                 let embedded_formatter = self
                     .external_formatter
                     .as_ref()
                     .expect("`external_formatter` must exist when `napi` feature is enabled")
-                    .to_embedded_formatter();
+                    .to_embedded_formatter(external_options.clone());
                 base_formatter.format_with_embedded(&ret.program, embedded_formatter)
             }
         };
         #[cfg(not(feature = "napi"))]
-        let formatted = base_formatter.format(&ret.program);
+        let formatted = {
+            let _ = external_options;
+            base_formatter.format(&ret.program)
+        };
 
         let code = formatted.print().map_err(|err| {
             OxcDiagnostic::error(format!(
@@ -137,6 +156,7 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         parser_name: &str,
+        external_options: &Value,
     ) -> Result<String, OxcDiagnostic> {
         let external_formatter = self
             .external_formatter
@@ -151,12 +171,14 @@ impl SourceFormatter {
         // but since some plugins might depend on `filepath`, we pass the actual file name as well.
         let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
 
-        external_formatter.format_file(parser_name, file_name, source_text).map_err(|err| {
-            OxcDiagnostic::error(format!(
-                "Failed to format file with external formatter: {}\n{err}",
-                path.display()
-            ))
-        })
+        external_formatter
+            .format_file(external_options, parser_name, file_name, source_text)
+            .map_err(|err| {
+                OxcDiagnostic::error(format!(
+                    "Failed to format file with external formatter: {}\n{err}",
+                    path.display()
+                ))
+            })
     }
 
     /// Format `package.json`: optionally sort then format by external formatter.
@@ -166,8 +188,10 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         parser_name: &str,
+        external_options: &Value,
+        sort_package_json: bool,
     ) -> Result<String, OxcDiagnostic> {
-        let source_text: Cow<'_, str> = if self.is_sort_package_json {
+        let source_text: Cow<'_, str> = if sort_package_json {
             Cow::Owned(sort_package_json::sort_package_json(source_text).map_err(|err| {
                 OxcDiagnostic::error(format!(
                     "Failed to sort package.json: {}\n{err}",
@@ -178,6 +202,6 @@ impl SourceFormatter {
             Cow::Borrowed(source_text)
         };
 
-        self.format_by_external_formatter(&source_text, path, parser_name)
+        self.format_by_external_formatter(&source_text, path, parser_name, external_options)
     }
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -6,11 +6,11 @@ pub mod utils;
 #[cfg(feature = "napi")]
 mod external_formatter;
 
-pub use config::{load_config, resolve_config_path};
+pub use config::{ConfigResolver, ResolvedOptions, resolve_config_path};
 pub use format::{FormatResult, SourceFormatter};
 pub use support::FormatFileStrategy;
 
 #[cfg(feature = "napi")]
 pub use external_formatter::{
-    ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsSetupConfigCb,
+    ExternalFormatter, JsFormatEmbeddedCb, JsFormatFileCb, JsInitExternalFormatterCb,
 };

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::cli::{CliRunResult, FormatCommand, Mode};
 use crate::core::{
-    ExternalFormatter, FormatFileStrategy, FormatResult, SourceFormatter, load_config,
+    ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, SourceFormatter,
     resolve_config_path, utils,
 };
 
@@ -64,28 +64,35 @@ impl StdinRunner {
 
         // Load config
         let config_path = resolve_config_path(&cwd, config_options.config.as_deref());
-        let (format_options, oxfmt_options, external_config) =
-            match load_config(config_path.as_deref()) {
-                Ok(c) => c,
-                Err(err) => {
-                    utils::print_and_flush(
-                        stderr,
-                        &format!("Failed to load configuration file.\n{err}\n"),
-                    );
-                    return CliRunResult::InvalidOptionConfig;
-                }
-            };
+        let mut config_resolver = match ConfigResolver::from_config_path(config_path.as_deref()) {
+            Ok(r) => r,
+            Err(err) => {
+                utils::print_and_flush(
+                    stderr,
+                    &format!("Failed to load configuration file.\n{err}\n"),
+                );
+                return CliRunResult::InvalidOptionConfig;
+            }
+        };
+        match config_resolver.build_and_validate() {
+            Ok(_) => {}
+            Err(err) => {
+                utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
+                return CliRunResult::InvalidOptionConfig;
+            }
+        }
 
-        // TODO: Plugins support
         // Use `block_in_place()` to avoid nested async runtime access
-        if let Err(err) = tokio::task::block_in_place(|| {
-            external_formatter.setup_config(&external_config.to_string(), num_of_threads)
-        }) {
-            utils::print_and_flush(
-                stderr,
-                &format!("Failed to setup external formatter config.\n{err}\n"),
-            );
-            return CliRunResult::InvalidOptionConfig;
+        match tokio::task::block_in_place(|| external_formatter.init(num_of_threads)) {
+            // TODO: Plugins support
+            Ok(_) => {}
+            Err(err) => {
+                utils::print_and_flush(
+                    stderr,
+                    &format!("Failed to setup external formatter.\n{err}\n"),
+                );
+                return CliRunResult::InvalidOptionConfig;
+            }
         }
 
         // Determine format strategy from filepath
@@ -94,12 +101,17 @@ impl StdinRunner {
             return CliRunResult::InvalidOptionConfig;
         };
 
+        // Resolve options for the stdin file entry
+        let resolved_options = config_resolver.resolve(&strategy);
+
         // Create formatter and format
-        let source_formatter = SourceFormatter::new(num_of_threads, format_options)
-            .with_external_formatter(Some(external_formatter), oxfmt_options.sort_package_json);
+        let source_formatter =
+            SourceFormatter::new(num_of_threads).with_external_formatter(Some(external_formatter));
 
         // Use `block_in_place()` to avoid nested async runtime access
-        match tokio::task::block_in_place(|| source_formatter.format(&strategy, &source_text)) {
+        match tokio::task::block_in_place(|| {
+            source_formatter.format(&strategy, &source_text, &resolved_options)
+        }) {
             FormatResult::Success { code, .. } => {
                 utils::print_and_flush(stdout, &code);
                 CliRunResult::FormatSucceeded


### PR DESCRIPTION
Refactoring for #15850 

### Before this PR
- The config file and its option values were resolved only once at the beginning
- They were kept for `OxcFormatter` and also being cached via `setupConfig()` for `ExternalFormatter`
- When calling `SourceFormatter.format()`, it always referenced those values

### After this PR
- The config file and its option values are resolved only once at the beginning
- Those values are still kept as before
  - But, this is for a fast path when there are no per-path overrides in `.editorconfig`
- When calling `SourceFormatter.format()`
  - If `.editorconfig` exists and has per-path overrides, they are re-resolved per path
  - Otherwise, it continues to reference the initially cached values

We only support the root `.editorconfig`, but since glob-based per-path overrides can be written there, we have to resolve options on each path. Some performance impact is unavoidable.

However, in scenarios where `.editorconfig` doesn't exist, or exists but has no per-path overrides, the cost is limited to just cloning the cached values per path.