### PR TITLE
feat(linter/eslint-plugin-vitest): Add prefer-called-with as vitest compatible jest rule

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -52,6 +52,17 @@ declare_oxc_lint!(
     /// expect(anyArgsFunction).toBeCalledTimes(1);
     /// expect(uncalledFunction).not.toBeCalled();
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/prefer-comparison-matcher": "error"
+    ///   }
+    /// }
+    /// ```
     PreferCalledWith,
     jest,
     style,
@@ -108,7 +119,7 @@ impl PreferCalledWith {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
+    let mut pass = vec![
         ("expect(fn).toBeCalledWith();", None),
         ("expect(fn).toHaveBeenCalledWith();", None),
         ("expect(fn).toBeCalledWith(expect.anything());", None),
@@ -124,20 +135,53 @@ fn test() {
         ("expect(fn);", None),
     ];
 
-    let fail = vec![
+    let mut fail = vec![
         ("expect(fn).toBeCalled();", None),
         ("expect(fn).resolves.toBeCalled();", None),
         ("expect(fn).toHaveBeenCalled();", None),
     ];
 
-    let fix = vec![
+    let mut fix = vec![
         ("expect(fn).toBeCalled();", "expect(fn).toBeCalledWith();", None),
         ("expect(fn).resolves.toBeCalled();", "expect(fn).resolves.toBeCalledWith();", None),
         ("expect(fn).toHaveBeenCalled();", "expect(fn).toHaveBeenCalledWith();", None),
     ];
 
+    let vitest_pass = vec![
+        ("expect(fn).toBeCalledWith();", None),
+        ("expect(fn).toHaveBeenCalledWith();", None),
+        ("expect(fn).toBeCalledWith(expect.anything());", None),
+        ("expect(fn).toHaveBeenCalledWith(expect.anything());", None),
+        ("expect(fn).not.toBeCalled();", None),
+        ("expect(fn).rejects.not.toBeCalled();", None),
+        ("expect(fn).not.toHaveBeenCalled();", None),
+        ("expect(fn).not.toBeCalledWith();", None),
+        ("expect(fn).not.toHaveBeenCalledWith();", None),
+        ("expect(fn).resolves.not.toHaveBeenCalledWith();", None),
+        ("expect(fn).toBeCalledTimes(0);", None),
+        ("expect(fn).toHaveBeenCalledTimes(0);", None),
+        ("expect(fn);", None),
+    ];
+
+    let vitest_fail = vec![
+        ("expect(fn).toBeCalled();", None),
+        ("expect(fn).resolves.toBeCalled();", None),
+        ("expect(fn).toHaveBeenCalled();", None),
+    ];
+
+    let vitest_fix = vec![
+        ("expect(fn).toBeCalled();", "expect(fn).toBeCalledWith();", None),
+        ("expect(fn).resolves.toBeCalled();", "expect(fn).resolves.toBeCalledWith();", None),
+        ("expect(fn).toHaveBeenCalled();", "expect(fn).toHaveBeenCalledWith();", None),
+    ];
+
+    pass.extend(vitest_pass);
+    fail.extend(vitest_fail);
+    fix.extend(vitest_fix);
+
     Tester::new(PreferCalledWith::NAME, PreferCalledWith::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
     /// ```json
     /// {
     ///   "rules": {
-    ///      "vitest/prefer-comparison-matcher": "error"
+    ///      "vitest/prefer-called-with": "error"
     ///   }
     /// }
     /// ```

--- a/crates/oxc_linter/src/snapshots/jest_prefer_called_with.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_called_with.snap
@@ -21,3 +21,24 @@ source: crates/oxc_linter/src/tester.rs
    ·            ────────────────
    ╰────
   help: Prefer toHaveBeenCalledWith(/* expected args */)
+
+  ⚠ eslint-plugin-jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toBeCalled();
+   ·            ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ eslint-plugin-jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:21]
+ 1 │ expect(fn).resolves.toBeCalled();
+   ·                     ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ eslint-plugin-jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toHaveBeenCalled();
+   ·            ────────────────
+   ╰────
+  help: Prefer toHaveBeenCalledWith(/* expected args */)

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 40] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 41] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -55,6 +55,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 40] = [
     "no-standalone-expect",
     "no-test-prefixes",
     "no-test-return-statement",
+    "prefer-called-with",
     "prefer-comparison-matcher",
     "prefer-each",
     "prefer-equality-matcher",


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

# Summary 
Add `prefer-called-with` as a vitest compatible rule. 

Oxlint migrate PR: https://github.com/oxc-project/oxlint-migrate/pull/295

# Comment
This is the last PR of compatible vitest rule with the current codebase. So the following rules are going to be implement from zero, so the cadency of PR will be lower. The good news most of the remaining rules also apply to jest, so at the end bot plugin will have the same parity. 