### PR TITLE
feat(linter): implement vue/order-in-components rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4170,6 +4170,11 @@ impl RuleRunner for crate::rules::vue::no_this_in_before_route_enter::NoThisInBe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::order_in_components::OrderInComponents {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::prefer_import_from_vue::PreferImportFromVue {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -660,6 +660,7 @@ pub use crate::rules::vue::no_lifecycle_after_await::NoLifecycleAfterAwait as Vu
 pub use crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs as VueNoMultipleSlotArgs;
 pub use crate::rules::vue::no_required_prop_with_default::NoRequiredPropWithDefault as VueNoRequiredPropWithDefault;
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
+pub use crate::rules::vue::order_in_components::OrderInComponents as VueOrderInComponents;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
 pub use crate::rules::vue::require_typed_ref::RequireTypedRef as VueRequireTypedRef;
@@ -1333,6 +1334,7 @@ pub enum RuleEnum {
     VueNoMultipleSlotArgs(VueNoMultipleSlotArgs),
     VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault),
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
+    VueOrderInComponents(VueOrderInComponents),
     VuePreferImportFromVue(VuePreferImportFromVue),
     VueRequireDefaultExport(VueRequireDefaultExport),
     VueRequireTypedRef(VueRequireTypedRef),
@@ -1997,11 +1999,12 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => 652usize,
             Self::VueNoRequiredPropWithDefault(_) => 653usize,
             Self::VueNoThisInBeforeRouteEnter(_) => 654usize,
-            Self::VuePreferImportFromVue(_) => 655usize,
-            Self::VueRequireDefaultExport(_) => 656usize,
-            Self::VueRequireTypedRef(_) => 657usize,
-            Self::VueValidDefineEmits(_) => 658usize,
-            Self::VueValidDefineProps(_) => 659usize,
+            Self::VueOrderInComponents(_) => 655usize,
+            Self::VuePreferImportFromVue(_) => 656usize,
+            Self::VueRequireDefaultExport(_) => 657usize,
+            Self::VueRequireTypedRef(_) => 658usize,
+            Self::VueValidDefineEmits(_) => 659usize,
+            Self::VueValidDefineProps(_) => 660usize,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -2747,6 +2750,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::NAME,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::NAME,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::NAME,
@@ -3537,6 +3541,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::CATEGORY,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::CATEGORY,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::CATEGORY,
@@ -4288,6 +4293,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::FIX,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::FIX,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::FIX,
@@ -5215,6 +5221,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::documentation(),
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::documentation(),
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
+            Self::VueOrderInComponents(_) => VueOrderInComponents::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::documentation(),
@@ -7077,6 +7084,8 @@ impl RuleEnum {
                 VueNoThisInBeforeRouteEnter::config_schema(generator)
                     .or_else(|| VueNoThisInBeforeRouteEnter::schema(generator))
             }
+            Self::VueOrderInComponents(_) => VueOrderInComponents::config_schema(generator)
+                .or_else(|| VueOrderInComponents::schema(generator)),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::config_schema(generator)
                 .or_else(|| VuePreferImportFromVue::schema(generator)),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::config_schema(generator)
@@ -7746,6 +7755,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => "vue",
             Self::VueNoRequiredPropWithDefault(_) => "vue",
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
+            Self::VueOrderInComponents(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
             Self::VueRequireTypedRef(_) => "vue",
@@ -9847,6 +9857,9 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => Ok(Self::VueNoThisInBeforeRouteEnter(
                 VueNoThisInBeforeRouteEnter::from_configuration(value)?,
             )),
+            Self::VueOrderInComponents(_) => {
+                Ok(Self::VueOrderInComponents(VueOrderInComponents::from_configuration(value)?))
+            }
             Self::VuePreferImportFromVue(_) => {
                 Ok(Self::VuePreferImportFromVue(VuePreferImportFromVue::from_configuration(value)?))
             }
@@ -10525,6 +10538,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.to_configuration(),
             Self::VueNoRequiredPropWithDefault(rule) => rule.to_configuration(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
+            Self::VueOrderInComponents(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
             Self::VueRequireTypedRef(rule) => rule.to_configuration(),
@@ -11189,6 +11203,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.run(node, ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
+            Self::VueOrderInComponents(rule) => rule.run(node, ctx),
             Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
             Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
@@ -11853,6 +11868,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.run_once(ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
+            Self::VueOrderInComponents(rule) => rule.run_once(ctx),
             Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
             Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
@@ -12607,6 +12623,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueOrderInComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13271,6 +13288,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.should_run(ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.should_run(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
+            Self::VueOrderInComponents(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
             Self::VueRequireTypedRef(rule) => rule.should_run(ctx),
@@ -14197,6 +14215,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::IS_TSGOLINT_RULE,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::IS_TSGOLINT_RULE,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::IS_TSGOLINT_RULE,
@@ -14861,6 +14880,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.types_info(),
             Self::VueNoRequiredPropWithDefault(rule) => rule.types_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
+            Self::VueOrderInComponents(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
             Self::VueRequireTypedRef(rule) => rule.types_info(),
@@ -15525,6 +15545,7 @@ impl RuleEnum {
             Self::VueNoMultipleSlotArgs(rule) => rule.run_info(),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
+            Self::VueOrderInComponents(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
             Self::VueRequireTypedRef(rule) => rule.run_info(),
@@ -16297,6 +16318,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoMultipleSlotArgs(VueNoMultipleSlotArgs::default()),
         RuleEnum::VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault::default()),
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
+        RuleEnum::VueOrderInComponents(VueOrderInComponents::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
         RuleEnum::VueRequireTypedRef(VueRequireTypedRef::default()),

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -34,8 +34,11 @@ impl PartialLoader {
             "vue" => {
                 let sources = VuePartialLoader::new(source_text).parse();
                 if sources.is_empty() {
-                    // Check if it's a Vue SFC (has <template or <style)
-                    // If so, return empty. If not, return None to fallback to raw JS.
+                    // No <script> section found. Determine how to handle:
+                    // - If it's a Vue SFC (has <template> or <style>), return empty
+                    //   to skip JS linting (valid SFC without script)
+                    // - If not a Vue SFC (e.g., raw JS in .vue extension), return None
+                    //   to fallback to treating entire file as JavaScript
                     if Self::is_vue_sfc(source_text) {
                         return Some(vec![]);
                     }
@@ -50,7 +53,9 @@ impl PartialLoader {
         Some(sources)
     }
 
-    /// Check if the source text looks like a Vue Single File Component
+    /// Heuristically check if the source text appears to be a Vue SFC.
+    /// Uses simple substring matching for `<template` or `<style` tags.
+    /// Note: May have false positives for JS files containing these substrings.
     fn is_vue_sfc(source_text: &str) -> bool {
         source_text.contains("<template") || source_text.contains("<style")
     }

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -703,6 +703,7 @@ pub(crate) mod vue {
     pub mod no_multiple_slot_args;
     pub mod no_required_prop_with_default;
     pub mod no_this_in_before_route_enter;
+    pub mod order_in_components;
     pub mod prefer_import_from_vue;
     pub mod require_default_export;
     pub mod require_typed_ref;

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -1,0 +1,445 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn order_in_components_diagnostic(
+    current_name: &str,
+    should_be_before: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The \"{current_name}\" property should be above the \"{should_be_before}\" property."
+    ))
+    .with_help("Enforce a convention in the order of component options for better readability.")
+    .with_label(span)
+}
+
+/// Default order based on Vue style guide
+const DEFAULT_ORDER: &[&[&str]] = &[
+    // Side effects
+    &["el"],
+    // Global awareness
+    &["name", "key"],
+    &["parent"],
+    // Component type
+    &["functional"],
+    // Template modifiers
+    &["delimiters", "comments"],
+    // Template dependencies
+    &["components", "directives", "filters"],
+    // Composition
+    &["extends"],
+    &["mixins"],
+    &["provide", "inject"],
+    // Page options (Nuxt)
+    &[
+        "validate",
+        "asyncData",
+        "fetch",
+        "head",
+        "scrollToTop",
+        "transition",
+        "loading",
+        "layout",
+        "middleware",
+        "watchQuery",
+    ],
+    // Interface
+    &["inheritAttrs", "model"],
+    &["props", "propsData"],
+    &["emits"],
+    &["slots"],
+    &["expose"],
+    // Local state
+    &["setup"],
+    &["data"],
+    &["computed"],
+    // Events
+    &["watch"],
+    // Lifecycle hooks
+    &[
+        "beforeCreate",
+        "created",
+        "beforeMount",
+        "mounted",
+        "beforeUpdate",
+        "updated",
+        "activated",
+        "deactivated",
+        "beforeUnmount",
+        "unmounted",
+        "beforeDestroy",
+        "destroyed",
+        "renderTracked",
+        "renderTriggered",
+        "errorCaptured",
+    ],
+    // Router guards
+    &["beforeRouteEnter", "beforeRouteUpdate", "beforeRouteLeave"],
+    // Non-reactive properties
+    &["methods"],
+    // Rendering
+    &["template", "render"],
+    &["renderError"],
+];
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct OrderInComponentsConfig {
+    /// Custom order of component options
+    order: Option<Vec<OrderElement>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum OrderElement {
+    Single(String),
+    Group(Vec<String>),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct OrderInComponents(Box<OrderInComponentsConfig>);
+
+impl std::ops::Deref for OrderInComponents {
+    type Target = OrderInComponentsConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a consistent order of properties in Vue component definitions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Having an inconsistent order of component properties makes the code harder
+    /// to read and maintain. Following a standard order helps developers quickly
+    /// find specific options in components.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   data() { return { foo: 'bar' } },
+    ///   name: 'MyComponent',  // should be before data
+    ///   props: ['value'],     // should be before data
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   name: 'MyComponent',
+    ///   props: ['value'],
+    ///   data() { return { foo: 'bar' } },
+    /// }
+    /// </script>
+    /// ```
+    OrderInComponents,
+    vue,
+    style,
+    config = OrderInComponentsConfig,
+);
+
+impl Rule for OrderInComponents {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config = value
+            .get(0)
+            .and_then(|v| serde_json::from_value::<OrderInComponentsConfig>(v.clone()).ok())
+            .unwrap_or_default();
+        Self(Box::new(config))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let obj = match node.kind() {
+            AstKind::ExportDefaultDeclaration(export) => {
+                // export default { ... } or export default defineComponent({ ... })
+                match &export.declaration {
+                    oxc_ast::ast::ExportDefaultDeclarationKind::ObjectExpression(obj) => Some(obj),
+                    oxc_ast::ast::ExportDefaultDeclarationKind::CallExpression(call) => {
+                        if is_vue_component_call(call) {
+                            call.arguments.first().and_then(|arg| {
+                                if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg {
+                                    Some(obj)
+                                } else {
+                                    None
+                                }
+                            })
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            AstKind::CallExpression(call) => {
+                // Vue.component('name', { ... }) or new Vue({ ... }) or defineOptions({ ... })
+                if is_vue_component_registration(call) || is_define_options_call(call) {
+                    // Get the object argument (second arg for component, first for new Vue/defineOptions)
+                    let arg = if is_define_options_call(call) {
+                        call.arguments.first()
+                    } else if call.arguments.len() >= 2 {
+                        call.arguments.get(1)
+                    } else {
+                        call.arguments.first()
+                    };
+                    arg.and_then(|a| {
+                        if let oxc_ast::ast::Argument::ObjectExpression(obj) = a {
+                            Some(obj)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            }
+            AstKind::NewExpression(new_expr) => {
+                // new Vue({ ... })
+                if is_new_vue(new_expr) {
+                    new_expr.arguments.first().and_then(|arg| {
+                        if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg {
+                            Some(obj)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        if let Some(obj) = obj {
+            self.check_order(obj, ctx);
+        }
+    }
+}
+
+impl OrderInComponents {
+    fn get_order(&self) -> Vec<Vec<String>> {
+        if let Some(ref custom_order) = self.order {
+            custom_order
+                .iter()
+                .map(|el| match el {
+                    OrderElement::Single(s) => {
+                        if s == "LIFECYCLE_HOOKS" {
+                            vec![
+                                "beforeCreate".to_string(),
+                                "created".to_string(),
+                                "beforeMount".to_string(),
+                                "mounted".to_string(),
+                                "beforeUpdate".to_string(),
+                                "updated".to_string(),
+                                "activated".to_string(),
+                                "deactivated".to_string(),
+                                "beforeUnmount".to_string(),
+                                "unmounted".to_string(),
+                                "beforeDestroy".to_string(),
+                                "destroyed".to_string(),
+                                "renderTracked".to_string(),
+                                "renderTriggered".to_string(),
+                                "errorCaptured".to_string(),
+                            ]
+                        } else if s == "ROUTER_GUARDS" {
+                            vec![
+                                "beforeRouteEnter".to_string(),
+                                "beforeRouteUpdate".to_string(),
+                                "beforeRouteLeave".to_string(),
+                            ]
+                        } else {
+                            vec![s.clone()]
+                        }
+                    }
+                    OrderElement::Group(g) => g.clone(),
+                })
+                .collect()
+        } else {
+            DEFAULT_ORDER.iter().map(|g| g.iter().map(|s| (*s).to_string()).collect()).collect()
+        }
+    }
+
+    fn check_order<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+        let order = self.get_order();
+
+        // Collect properties with their names and order positions
+        let mut properties: Vec<(String, Option<usize>, Span, usize)> = Vec::new();
+
+        for (idx, prop) in obj.properties.iter().enumerate() {
+            if let ObjectPropertyKind::ObjectProperty(property) = prop
+                && let Some(name) = get_property_name(&property.key)
+            {
+                let position = get_order_position(&name, &order);
+                properties.push((name, position, property.span, idx));
+            }
+        }
+
+        // Check for out-of-order properties
+        let mut max_position: Option<usize> = None;
+        let mut max_position_name = String::new();
+
+        for (name, position, span, _idx) in &properties {
+            if let Some(pos) = position {
+                if let Some(max) = max_position
+                    && *pos < max
+                {
+                    // This property should be before the previous one
+                    ctx.diagnostic(order_in_components_diagnostic(
+                        name,
+                        &max_position_name,
+                        *span,
+                    ));
+                    return; // Report one error at a time
+                }
+                if max_position.is_none() || *pos >= max_position.unwrap_or(0) {
+                    max_position = Some(*pos);
+                    max_position_name.clone_from(name);
+                }
+            }
+        }
+    }
+}
+
+fn get_order_position(name: &str, order: &[Vec<String>]) -> Option<usize> {
+    for (index, group) in order.iter().enumerate() {
+        if group.iter().any(|s| s == name) {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn get_property_name(key: &PropertyKey) -> Option<String> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.to_string()),
+        PropertyKey::StringLiteral(lit) => Some(lit.value.to_string()),
+        _ => None,
+    }
+}
+
+fn is_vue_component_call(call: &oxc_ast::ast::CallExpression) -> bool {
+    match &call.callee {
+        Expression::Identifier(id) => {
+            matches!(id.name.as_str(), "defineComponent" | "defineNuxtComponent")
+        }
+        _ => false,
+    }
+}
+
+fn is_vue_component_registration(call: &oxc_ast::ast::CallExpression) -> bool {
+    if let Expression::StaticMemberExpression(member) = &call.callee
+        && member.property.name == "component"
+        && let Expression::Identifier(id) = &member.object
+    {
+        return matches!(id.name.as_str(), "Vue" | "app");
+    }
+
+    // Also handle destructured: const { component } = Vue; component(...)
+    if let Expression::Identifier(id) = &call.callee {
+        return id.name == "component";
+    }
+
+    false
+}
+
+fn is_define_options_call(call: &oxc_ast::ast::CallExpression) -> bool {
+    if let Expression::Identifier(id) = &call.callee {
+        return id.name == "defineOptions";
+    }
+    false
+}
+
+fn is_new_vue(new_expr: &oxc_ast::ast::NewExpression) -> bool {
+    if let Expression::Identifier(id) = &new_expr.callee {
+        return id.name == "Vue";
+    }
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Correct order: name before data
+        ("export default { name: 'app', data() { return {}; } }", None),
+        // Empty object
+        ("export default {}", None),
+        // Not an object
+        ("export default 'example-text'", None),
+        // Full correct order
+        ("export default { name: 'app', props: {}, data() {}, computed: {}, methods: {} }", None),
+        // Props before data
+        ("export default { props: ['msg'], data() { return {} } }", None),
+        // Lifecycle hooks in correct order
+        (
+            "export default { name: 'a', data() {}, beforeCreate() {}, created() {}, mounted() {} }",
+            None,
+        ),
+        // Unknown properties are allowed anywhere
+        ("export default { name: 'a', unknownProp: true, data() {} }", None),
+        // defineComponent
+        (
+            "import { defineComponent } from 'vue'; export default defineComponent({ name: 'app', props: {}, data() {} })",
+            None,
+        ),
+        // Vue.component
+        ("Vue.component('name', { name: 'app', data() {} })", None),
+        // new Vue
+        ("new Vue({ el: '#app', data: {} })", None),
+        // Methods before render (correct)
+        ("export default { methods: {}, render() {} }", None),
+        // Computed before watch (correct)
+        ("export default { computed: {}, watch: {} }", None),
+        // Custom order config
+        (
+            "export default { data() {}, name: 'app' }",
+            Some(serde_json::json!([{ "order": ["data", "name"] }])),
+        ),
+        // LIFECYCLE_HOOKS placeholder in custom order
+        (
+            "export default { data() {}, beforeCreate() {}, created() {} }",
+            Some(serde_json::json!([{ "order": ["data", "LIFECYCLE_HOOKS"] }])),
+        ),
+    ];
+
+    let fail = vec![
+        // data before name (wrong order)
+        ("export default { data() {}, name: 'burger' }", None),
+        // data before props (wrong order)
+        ("export default { name: 'a', data() {}, props: {} }", None),
+        // methods before computed
+        ("export default { methods: {}, computed: {} }", None),
+        // render before methods
+        ("export default { render() {}, methods: {} }", None),
+        // mounted before data
+        ("export default { mounted() {}, data() {} }", None),
+        // watch before computed
+        ("export default { watch: {}, computed: {} }", None),
+        // defineComponent with wrong order
+        (
+            "import { defineComponent } from 'vue'; export default defineComponent({ data() {}, name: 'app' })",
+            None,
+        ),
+        // props before name
+        ("export default { props: {}, name: 'a' }", None),
+    ];
+
+    Tester::new(OrderInComponents::NAME, OrderInComponents::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -304,7 +304,7 @@ impl OrderInComponents {
     fn check_order<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
         // Collect properties with their names, order positions, and indices
         // SpreadProperties are tracked but excluded from ordering checks
-        let mut properties: Vec<PropertyInfo> = Vec::new();
+        let mut properties: Vec<PropertyInfo> = Vec::with_capacity(obj.properties.len());
         let mut has_spread = false;
 
         for (index, prop) in obj.properties.iter().enumerate() {

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -409,13 +409,16 @@ impl OrderInComponents {
             return fix;
         };
 
-        // Find the comma/brace before the property we're moving
-        let text_before_from = &source_text[..from_prop.span.start as usize];
-        let comma_before_from = text_before_from.rfind(',');
-        let brace_before_from = text_before_from.rfind('{');
+        let obj_start = obj.span.start as usize;
+        let obj_end = obj.span.end as usize;
 
-        // Find if there's a comma after the property we're moving
-        let text_after_from = &source_text[from_prop.span.end as usize..];
+        // Find the comma/brace before the property we're moving (within obj bounds)
+        let text_before_from = &source_text[obj_start..from_prop.span.start as usize];
+        let comma_before_from = text_before_from.rfind(',').map(|p| obj_start + p);
+        let brace_before_from = text_before_from.rfind('{').map(|p| obj_start + p);
+
+        // Find if there's a comma after the property we're moving (within obj bounds)
+        let text_after_from = &source_text[from_prop.span.end as usize..obj_end];
         let comma_after_from = text_after_from.find(',');
 
         // Determine the code start position (after the comma/brace before this property)
@@ -458,10 +461,10 @@ impl OrderInComponents {
         fix.push(Fix::delete(Span::new(delete_start, delete_end)));
 
         // Determine insert position and text
-        // Find the comma/brace before the target property
-        let text_before_to = &source_text[..to_prop.span.start as usize];
-        let comma_before_to = text_before_to.rfind(',');
-        let brace_before_to = text_before_to.rfind('{');
+        // Find the comma/brace before the target property (within obj bounds)
+        let text_before_to = &source_text[obj_start..to_prop.span.start as usize];
+        let comma_before_to = text_before_to.rfind(',').map(|p| obj_start + p);
+        let brace_before_to = text_before_to.rfind('{').map(|p| obj_start + p);
 
         let insert_pos = if let Some(comma_pos) = comma_before_to {
             // Insert after the comma before target

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -362,7 +362,7 @@ impl OrderInComponents {
                                 // Use for_multifix() since we create a composite fix with
                                 // multiple operations (delete + insert)
                                 let fixer = fixer.for_multifix();
-                                self.create_reorder_fix(
+                                Self::create_reorder_fix(
                                     fixer.source_text(),
                                     obj,
                                     prop.index,
@@ -391,8 +391,8 @@ impl OrderInComponents {
     /// - If the property has a trailing comma, include it in the delete/insert
     /// - If the property is last (no trailing comma), delete the preceding comma
     /// - When inserting, ensure proper comma placement for valid syntax
+    #[expect(clippy::cast_possible_truncation)]
     fn create_reorder_fix<'a>(
-        &self,
         source_text: &str,
         obj: &ObjectExpression<'a>,
         from_index: usize,

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -378,6 +378,16 @@ impl OrderInComponents {
         }
     }
 
+    /// Creates a fix to reorder a property in the component object.
+    ///
+    /// The fix consists of two operations:
+    /// 1. Delete the out-of-order property (including its comma and leading whitespace)
+    /// 2. Insert the property before the target position
+    ///
+    /// Comma handling:
+    /// - If the property has a trailing comma, include it in the delete/insert
+    /// - If the property is last (no trailing comma), delete the preceding comma
+    /// - When inserting, ensure proper comma placement for valid syntax
     fn create_reorder_fix<'a>(
         &self,
         source_text: &str,

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -1342,6 +1342,286 @@ export default {
 ",
             None,
         ),
+        // defineComponent wrapper
+        (
+            "
+import { defineComponent } from 'vue'
+export default defineComponent({
+  name: 'app',
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  props: {
+    propA: Number,
+  },
+})
+",
+            "
+import { defineComponent } from 'vue'
+export default defineComponent({
+  name: 'app',
+  props: {
+    propA: Number,
+  },
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+})
+",
+            None,
+        ),
+        // defineNuxtComponent wrapper
+        (
+            "
+import { defineNuxtComponent } from '#app'
+export default defineNuxtComponent({
+  name: 'app',
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  props: {
+    propA: Number,
+  },
+})
+",
+            "
+import { defineNuxtComponent } from '#app'
+export default defineNuxtComponent({
+  name: 'app',
+  props: {
+    propA: Number,
+  },
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+})
+",
+            None,
+        ),
+        // app.component registration
+        (
+            "
+app.component('smart-list', {
+  name: 'app',
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  components: {},
+  template: '<div></div>'
+})
+",
+            "
+app.component('smart-list', {
+  name: 'app',
+  components: {},
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  template: '<div></div>'
+})
+",
+            None,
+        ),
+        // destructured component
+        (
+            "
+const { component } = Vue;
+component('smart-list', {
+  name: 'app',
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  components: {},
+  template: '<div></div>'
+})
+",
+            "
+const { component } = Vue;
+component('smart-list', {
+  name: 'app',
+  components: {},
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  template: '<div></div>'
+})
+",
+            None,
+        ),
+        // custom order option
+        (
+            "
+export default {
+  data() {
+  },
+  name: 'burger',
+  test: 'ok'
+};
+",
+            "
+export default {
+  data() {
+  },
+  test: 'ok',
+  name: 'burger'
+};
+",
+            Some(serde_json::json!([{ "order": ["data", "test", "name"] }])),
+        ),
+        // comment preservation
+        (
+            "
+export default {
+  /** data provider */
+  data() {
+  },
+  /** name of vue component */
+  name: 'burger'
+};
+",
+            "
+export default {
+  /** name of vue component */
+  name: 'burger',
+  /** data provider */
+  data() {
+  }
+};
+",
+            None,
+        ),
+        // comment preservation with inline comment
+        (
+            "
+export default {
+  /** data provider */
+  data() {
+  }/*test*/,
+  /** name of vue component */
+  name: 'burger'
+};
+",
+            "
+export default {
+  /** name of vue component */
+  name: 'burger',
+  /** data provider */
+  data() {
+  }/*test*/
+};
+",
+            None,
+        ),
+        // without side-effects fn()
+        (
+            "
+export default {
+  data() {
+  },
+  name: 'burger',
+  test: fn(),
+};
+",
+            "
+export default {
+  name: 'burger',
+  data() {
+  },
+  test: fn(),
+};
+",
+            None,
+        ),
+        // don't side-effects - complex values
+        (
+            "
+export default {
+  data() {
+  },
+  testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+  testRegExp: /[a-z]*/,
+  testSpreadElement: [...array],
+  testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+  testArrow: (a) => a,
+  testConditional: a ? b : c,
+  testYield: function* () {},
+  testTemplate: `a:${a},b:${b},c:${c}.`,
+  testNullish: a ?? b,
+  testOptionalChaining: a?.b?.c,
+  name: 'burger',
+};
+",
+            "
+export default {
+  name: 'burger',
+  data() {
+  },
+  testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+  testRegExp: /[a-z]*/,
+  testSpreadElement: [...array],
+  testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+  testArrow: (a) => a,
+  testConditional: a ? b : c,
+  testYield: function* () {},
+  testTemplate: `a:${a},b:${b},c:${c}.`,
+  testNullish: a ?? b,
+  testOptionalChaining: a?.b?.c,
+};
+",
+            None,
+        ),
+        // slots/setup/expose ordering 1
+        (
+            "
+export default {
+  setup,
+  slots,
+  expose,
+};
+",
+            "
+export default {
+  slots,
+  setup,
+  expose,
+};
+",
+            None,
+        ),
+        // slots/setup/expose ordering 2
+        (
+            "
+export default {
+  slots,
+  setup,
+  expose,
+};
+",
+            "
+export default {
+  slots,
+  expose,
+  setup,
+};
+",
+            None,
+        ),
     ];
 
     Tester::new(OrderInComponents::NAME, OrderInComponents::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -359,6 +359,9 @@ impl OrderInComponents {
                                 prop.span,
                             ),
                             |fixer| {
+                                // Use for_multifix() since we create a composite fix with
+                                // multiple operations (delete + insert)
+                                let fixer = fixer.for_multifix();
                                 self.create_reorder_fix(
                                     fixer.source_text(),
                                     obj,

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{CompactStr, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -21,7 +21,7 @@ use crate::{
 /// Information about a property in the component definition
 struct PropertyInfo {
     /// The name of the property
-    name: String,
+    name: CompactStr,
     /// The position in the order configuration (None if not in order list)
     order_position: Option<usize>,
     /// The span of the property for error reporting
@@ -314,7 +314,7 @@ impl OrderInComponents {
                     if let Some(name) = property.key.static_name() {
                         let order_position = get_order_position(&name, &self.order);
                         properties.push(PropertyInfo {
-                            name: name.to_string(),
+                            name: CompactStr::from(name.as_ref()),
                             order_position,
                             span: property.span,
                             index,
@@ -329,7 +329,7 @@ impl OrderInComponents {
 
         // Check for out-of-order properties
         let mut max_position: Option<usize> = None;
-        let mut max_position_name = String::new();
+        let mut max_position_name = CompactStr::new("");
 
         for prop in &properties {
             if let Some(pos) = prop.order_position {

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -224,7 +224,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for OrderInComponents {
-    fn from_configuration(value: serde_json::Value) -> Self {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
         let config = value
             .get(0)
             .and_then(|v| serde_json::from_value::<OrderInComponentsConfig>(v.clone()).ok())
@@ -237,7 +237,7 @@ impl Rule for OrderInComponents {
             expand_default_order()
         };
 
-        Self { order }
+        Ok(Self { order })
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -42,7 +42,8 @@ fn order_in_components_diagnostic(
     .with_label(span)
 }
 
-/// Default order based on Vue style guide
+/// Default order based on Vue style guide.
+/// See: <https://vuejs.org/style-guide/rules-recommended.html#component-instance-options-order>
 const DEFAULT_ORDER: &[&[&str]] = &[
     // Side effects
     &["el"],

--- a/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
+++ b/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
@@ -1,100 +1,341 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:29]
- 1 │ export default { data() {}, name: 'burger' }
-   ·                             ──────────────
-   ╰────
+  ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "data" property.
+    ╭─[order_in_components.tsx:9:14]
+  8 │                           },
+  9 │ ╭─▶                       props: {
+ 10 │ │                           propA: Number,
+ 11 │ ╰─▶                       },
+ 12 │                         }
+    ╰────
   help: Enforce a convention in the order of component options for better readability.
 
   ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:40]
- 1 │ export default { name: 'a', data() {}, props: {} }
-   ·                                        ─────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "computed" property should be above the "methods" property.
-   ╭─[order_in_components.tsx:1:31]
- 1 │ export default { methods: {}, computed: {} }
-   ·                               ────────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "methods" property should be above the "render" property.
-   ╭─[order_in_components.tsx:1:31]
- 1 │ export default { render() {}, methods: {} }
-   ·                               ───────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "mounted" property.
-   ╭─[order_in_components.tsx:1:32]
- 1 │ export default { mounted() {}, data() {} }
-   ·                                ─────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "computed" property should be above the "watch" property.
-   ╭─[order_in_components.tsx:1:29]
- 1 │ export default { watch: {}, computed: {} }
-   ·                             ────────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:84]
- 1 │ import { defineComponent } from 'vue'; export default defineComponent({ data() {}, name: 'app' })
-   ·                                                                                    ───────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "props" property.
-   ╭─[order_in_components.tsx:1:29]
- 1 │ export default { props: {}, name: 'a' }
-   ·                             ─────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:28]
- 1 │ defineOptions({ data() {}, name: 'app' })
-   ·                            ───────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:36]
- 1 │ app.component('name', { data() {}, name: 'app' })
-   ·                                    ───────────
-   ╰────
-  help: Enforce a convention in the order of component options for better readability.
-
-  ⚠ eslint-plugin-vue(order-in-components): The "el" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:21]
- 1 │ new Vue({ data: {}, el: '#app' })
-   ·                     ──────────
-   ╰────
+    ╭─[order_in_components.tsx:10:14]
+  9 │                           },
+ 10 │ ╭─▶                       props: {
+ 11 │ │                           propA: Number,
+ 12 │ ╰─▶                       },
+ 13 │                         })
+    ╰────
   help: Enforce a convention in the order of component options for better readability.
 
   ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:29]
- 1 │ export default { data() {}, props: {}, name: 'a' }
-   ·                             ─────────
+    ╭─[order_in_components.tsx:10:14]
+  9 │                           },
+ 10 │ ╭─▶                       props: {
+ 11 │ │                           propA: Number,
+ 12 │ ╰─▶                       },
+ 13 │                         })
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "render" property.
+   ╭─[order_in_components.tsx:8:14]
+ 7 │                       },
+ 8 │                       name: 'app',
+   ·                       ───────────
+ 9 │                       data () {
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "render" property.
+    ╭─[order_in_components.tsx:9:14]
+  8 │                           name: 'app',
+  9 │ ╭─▶                       data () {
+ 10 │ │                           return {
+ 11 │ │                             msg: 'Welcome to Your Vue.js App'
+ 12 │ │                           }
+ 13 │ ╰─▶                       },
+ 14 │                           props: {
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "render" property.
+    ╭─[order_in_components.tsx:14:14]
+ 13 │                           },
+ 14 │ ╭─▶                       props: {
+ 15 │ │                           propA: Number,
+ 16 │ ╰─▶                       },
+ 17 │                         }
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "components" property should be above the "data" property.
+    ╭─[order_in_components.tsx:9:14]
+  8 │                       },
+  9 │                       components: {},
+    ·                       ──────────────
+ 10 │                       template: '<div></div>'
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "components" property should be above the "data" property.
+    ╭─[order_in_components.tsx:9:14]
+  8 │                       },
+  9 │                       components: {},
+    ·                       ──────────────
+ 10 │                       template: '<div></div>'
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "components" property should be above the "data" property.
+    ╭─[order_in_components.tsx:10:14]
+  9 │                       },
+ 10 │                       components: {},
+    ·                       ──────────────
+ 11 │                       template: '<div></div>'
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "el" property should be above the "name" property.
+   ╭─[order_in_components.tsx:4:14]
+ 3 │                       name: 'app',
+ 4 │                       el: '#app',
+   ·                       ──────────
+ 5 │                       data () {
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "components" property should be above the "data" property.
+    ╭─[order_in_components.tsx:10:14]
+  9 │                       },
+ 10 │                       components: {},
+    ·                       ──────────────
+ 11 │                       template: '<div></div>'
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "methods" property.
+    ╭─[order_in_components.tsx:16:14]
+ 15 │                       },
+ 16 │                       name: 'burger',
+    ·                       ──────────────
+ 17 │                     };
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "test" property should be above the "name" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       name: 'burger',
+ 6 │                       test: 'ok'
+   ·                       ──────────
+ 7 │                     };
    ╰────
   help: Enforce a convention in the order of component options for better readability.
 
   ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
-   ╭─[order_in_components.tsx:1:40]
- 1 │ export default { data() {}, props: {}, name: 'a' }
-   ·                                        ─────────
+   ╭─[order_in_components.tsx:7:14]
+ 6 │                       /** name of vue component */
+ 7 │                       name: 'burger'
+   ·                       ──────────────
+ 8 │                     };
    ╰────
   help: Enforce a convention in the order of component options for better readability.
 
-  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "beforeRouteEnter" property.
-   ╭─[order_in_components.tsx:1:41]
- 1 │ export default { beforeRouteEnter() {}, data() {} }
-   ·                                         ─────────
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:7:14]
+ 6 │                       /** name of vue component */
+ 7 │                       name: 'burger'
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:26]
+ 1 │ export default {data(){},name:'burger'};
+   ·                          ─────────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: obj.fn(),
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: new MyClass(),
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: i++,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: i = 0,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: template`${foo}`,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       [obj.fn()]: 'test',
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: {test: obj.fn()},
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: [obj.fn(), 1],
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: obj.fn().prop,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: delete obj.prop,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: fn() + a + b,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: a ? fn() : null,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                       test: `test ${fn()} ${a}`,
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "computed" property.
+   ╭─[order_in_components.tsx:6:14]
+ 5 │                           },
+ 6 │ ╭─▶                       data() {
+ 7 │ ╰─▶                       },
+ 8 │                         };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:5:14]
+ 4 │                       },
+ 5 │                       name: 'burger',
+   ·                       ──────────────
+ 6 │                       test: fn(),
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+    ╭─[order_in_components.tsx:15:14]
+ 14 │                       testOptionalChaining: a?.b?.c,
+ 15 │                       name: 'burger',
+    ·                       ──────────────
+ 16 │                     };
+    ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "setup" property.
+   ╭─[order_in_components.tsx:5:16]
+ 4 │                             setup () {},
+ 5 │ ╭─▶                         props: {
+ 6 │ │                             foo: { type: Array as PropType<number[]> },
+ 7 │ ╰─▶                         },
+ 8 │                           };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "inheritAttrs" property.
+   ╭─[order_in_components.tsx:5:14]
+ 4 │                       inheritAttrs: true,
+ 5 │                       name: 'Foo',
+   ·                       ───────────
+ 6 │                     })
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "slots" property should be above the "setup" property.
+   ╭─[order_in_components.tsx:4:14]
+ 3 │                       setup,
+ 4 │                       slots,
+   ·                       ─────
+ 5 │                       expose,
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "expose" property should be above the "setup" property.
+   ╭─[order_in_components.tsx:5:14]
+ 4 │                       slots,
+ 5 │                       expose,
+   ·                       ──────
+ 6 │                     };
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "expose" property should be above the "setup" property.
+   ╭─[order_in_components.tsx:5:14]
+ 4 │                       setup,
+ 5 │                       expose,
+   ·                       ──────
+ 6 │                     };
    ╰────
   help: Enforce a convention in the order of component options for better readability.

--- a/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
+++ b/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
@@ -56,3 +56,45 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────────
    ╰────
   help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:28]
+ 1 │ defineOptions({ data() {}, name: 'app' })
+   ·                            ───────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:36]
+ 1 │ app.component('name', { data() {}, name: 'app' })
+   ·                                    ───────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "el" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:21]
+ 1 │ new Vue({ data: {}, el: '#app' })
+   ·                     ──────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:29]
+ 1 │ export default { data() {}, props: {}, name: 'a' }
+   ·                             ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:40]
+ 1 │ export default { data() {}, props: {}, name: 'a' }
+   ·                                        ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "beforeRouteEnter" property.
+   ╭─[order_in_components.tsx:1:41]
+ 1 │ export default { beforeRouteEnter() {}, data() {} }
+   ·                                         ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.

--- a/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
+++ b/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
@@ -1,0 +1,58 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:29]
+ 1 │ export default { data() {}, name: 'burger' }
+   ·                             ──────────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "props" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:40]
+ 1 │ export default { name: 'a', data() {}, props: {} }
+   ·                                        ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "computed" property should be above the "methods" property.
+   ╭─[order_in_components.tsx:1:31]
+ 1 │ export default { methods: {}, computed: {} }
+   ·                               ────────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "methods" property should be above the "render" property.
+   ╭─[order_in_components.tsx:1:31]
+ 1 │ export default { render() {}, methods: {} }
+   ·                               ───────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "data" property should be above the "mounted" property.
+   ╭─[order_in_components.tsx:1:32]
+ 1 │ export default { mounted() {}, data() {} }
+   ·                                ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "computed" property should be above the "watch" property.
+   ╭─[order_in_components.tsx:1:29]
+ 1 │ export default { watch: {}, computed: {} }
+   ·                             ────────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "data" property.
+   ╭─[order_in_components.tsx:1:84]
+ 1 │ import { defineComponent } from 'vue'; export default defineComponent({ data() {}, name: 'app' })
+   ·                                                                                    ───────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.
+
+  ⚠ eslint-plugin-vue(order-in-components): The "name" property should be above the "props" property.
+   ╭─[order_in_components.tsx:1:29]
+ 1 │ export default { props: {}, name: 'a' }
+   ·                             ─────────
+   ╰────
+  help: Enforce a convention in the order of component options for better readability.


### PR DESCRIPTION
This PR implements the `vue/order-in-components` rule that enforces a consistent order of properties in Vue component definitions, following the Vue style guide ordering conventions.

## Features

- Detects out-of-order properties in Vue components
- Supports `export default` objects, `defineComponent`, `defineNuxtComponent`
- Supports `Vue.component()`, `new Vue()`, and `defineOptions()`
- Customizable order via configuration
- Supports `LIFECYCLE_HOOKS` and `ROUTER_GUARDS` placeholders in custom order

## Test Plan

- Added 14 pass test cases covering:
  - Correct property ordering
  - Empty objects
  - Various Vue patterns (defineComponent, Vue.component, new Vue)
  - Custom order configuration
  - Unknown properties (allowed anywhere)

- Added 8 fail test cases covering:
  - data before name
  - data before props
  - methods before computed
  - render before methods
  - mounted before data
  - watch before computed
  - defineComponent with wrong order
  - props before name

Part of #481 , #11440