### PR TITLE
fix(linter): OOM problems with custom plugins

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -394,17 +394,15 @@ impl CliRunner {
         // we use OsFileSystem instead of RawTransferFileSystem because we use standard allocators for parsing.
         let file_system = if has_external_linter {
             #[cfg(all(feature = "napi", target_pointer_width = "64", target_endian = "little"))]
-            {
-                if use_cross_module {
-                    // Use standard file system - source text will be copied to fixed-size allocator later
-                    None
-                } else {
-                    // Use raw transfer file system - source text goes directly to fixed-size allocator
-                    Some(
-                        &crate::js_plugins::RawTransferFileSystem
-                            as &(dyn oxc_linter::RuntimeFileSystem + Sync + Send),
-                    )
-                }
+            if use_cross_module {
+                // Use standard file system - source text will be copied to fixed-size allocator later
+                None
+            } else {
+                // Use raw transfer file system - source text goes directly to fixed-size allocator
+                Some(
+                    &crate::js_plugins::RawTransferFileSystem
+                        as &(dyn oxc_linter::RuntimeFileSystem + Sync + Send),
+                )
             }
 
             #[cfg(not(all(

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -352,21 +352,6 @@ impl CliRunner {
             .with_report_unused_directives(report_unused_directives);
 
         let number_of_files = files_to_lint.len();
-
-        // Due to the architecture of the import plugin and JS plugins,
-        // linting a large number of files with both enabled can cause resource exhaustion.
-        // See: https://github.com/oxc-project/oxc/issues/15863
-        if number_of_files > 10_000 && use_cross_module && has_external_linter {
-            print_and_flush_stdout(
-                stdout,
-                &format!(
-                    "Failed to run oxlint.\n{}\n",
-                    render_report(&handler, &OxcDiagnostic::error(format!("Linting {number_of_files} files with both import plugin and JS plugins enabled can cause resource exhaustion.")).with_help("See https://github.com/oxc-project/oxc/issues/15863 for more details."))
-                ),
-            );
-            return CliRunResult::TooManyFilesWithImportAndJsPlugins;
-        }
-
         let tsconfig = basic_options.tsconfig;
         if let Some(path) = tsconfig.as_ref() {
             if path.is_file() {
@@ -404,14 +389,22 @@ impl CliRunner {
             }
         };
 
-        // Configure the file system for external linter if needed
+        // Configure the file system for external linter if needed.
+        // When using the copy-to-fixed-allocator approach (cross-module + JS plugins),
+        // we use OsFileSystem instead of RawTransferFileSystem because we use standard allocators for parsing.
         let file_system = if has_external_linter {
             #[cfg(all(feature = "napi", target_pointer_width = "64", target_endian = "little"))]
             {
-                Some(
-                    &crate::js_plugins::RawTransferFileSystem
-                        as &(dyn oxc_linter::RuntimeFileSystem + Sync + Send),
-                )
+                if use_cross_module {
+                    // Use standard file system - source text will be copied to fixed-size allocator later
+                    None
+                } else {
+                    // Use raw transfer file system - source text goes directly to fixed-size allocator
+                    Some(
+                        &crate::js_plugins::RawTransferFileSystem
+                            as &(dyn oxc_linter::RuntimeFileSystem + Sync + Send),
+                    )
+                }
             }
 
             #[cfg(not(all(

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -391,7 +391,7 @@ impl CliRunner {
 
         // Configure the file system for external linter if needed.
         // When using the copy-to-fixed-allocator approach (cross-module + JS plugins),
-        // we use OsFileSystem instead of RawTransferFileSystem because we use standard allocators for parsing.
+        // we use `OsFileSystem` instead of `RawTransferFileSystem`, because we use standard allocators for parsing.
         let file_system = if has_external_linter {
             #[cfg(all(feature = "napi", target_pointer_width = "64", target_endian = "little"))]
             if use_cross_module {

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -17,7 +17,6 @@ pub enum CliRunResult {
     ConfigFileInitFailed,
     ConfigFileInitSucceeded,
     TsGoLintError,
-    TooManyFilesWithImportAndJsPlugins,
 }
 
 impl Termination for CliRunResult {
@@ -38,8 +37,7 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionSeverityWithoutFilter
             | Self::InvalidOptionSeverityWithoutPluginName
             | Self::InvalidOptionSeverityWithoutRuleName
-            | Self::TsGoLintError
-            | Self::TooManyFilesWithImportAndJsPlugins => ExitCode::FAILURE,
+            | Self::TsGoLintError => ExitCode::FAILURE,
         }
     }
 }

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -134,10 +134,6 @@ impl FixedSizeAllocatorPool {
                 return None;
             }
 
-            // Protect against IDs wrapping around.
-            // TODO: Does this work? Do we need it anyway?
-            assert!(id < u32::MAX, "Created too many allocators");
-
             // Try to claim this ID. If another thread got there first, retry with new ID.
             if self
                 .next_id

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -407,7 +407,7 @@ impl Linter {
             return;
         }
 
-        // If js_allocator_pool is provided, use clone-into-fixed-allocator approach
+        // If `js_allocator_pool` is provided, use clone-into-fixed-allocator approach
         if let Some(js_pool) = js_allocator_pool {
             self.clone_into_fixed_size_allocator_and_run_external_rules(
                 external_rules,
@@ -489,8 +489,8 @@ impl Linter {
 
         // Copy source text to the START of the fixed-size allocator.
         // This is critical - the JS deserializer expects source text at offset 0.
-        // SAFETY: The js_allocator is from a fixed-size allocator pool, which wraps the allocator
-        // in a custom Drop that doesn't actually drop it (it returns it to the pool), so the
+        // SAFETY: `js_allocator` is from a fixed-size allocator pool, which wraps the allocator
+        // in a custom `Drop` that doesn't actually drop it (it returns it to the pool), so the
         // memory remains valid. This matches the safety requirements of `alloc_bytes_start`.
         let new_source_text: &str = unsafe {
             let bytes = original_source_text.as_bytes();
@@ -499,8 +499,8 @@ impl Linter {
             std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr.as_ptr(), bytes.len()))
         };
 
-        // Clone Program into fixed-size allocator.
-        // We need to allocate the Program struct ITSELF in the allocator, not just its contents.
+        // Clone `Program` into fixed-size allocator.
+        // We need to allocate the `Program` struct ITSELF in the allocator, not just its contents.
         // `clone_in` returns a value on the stack, but we need it in the allocator for raw transfer.
         let program: &mut Program<'_> = {
             let mut program = original_program.clone_in(&js_allocator);

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -518,6 +518,9 @@ impl Linter {
             &js_allocator,
             program,
         );
+
+        // The `AllocatorGuard` (`js_allocator`) is dropped here, returning the allocator to the pool.
+        // This ensures that we never have too many allocators in play at once, avoiding OOM.
     }
 
     /// Convert spans to UTF-16, write metadata, call external linter, and process diagnostics.

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -45,6 +45,7 @@ pub struct Runtime {
     pub(super) linter: Linter,
     resolver: Option<Resolver>,
 
+    /// Pool of allocators for parsing and linting.
     allocator_pool: AllocatorPool,
 
     /// Separate pool of fixed-size allocators for copying AST before JS transfer.

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -48,8 +48,8 @@ pub struct Runtime {
     allocator_pool: AllocatorPool,
 
     /// Separate pool of fixed-size allocators for copying AST before JS transfer.
-    /// Only created when using the copy-to-fixed-allocator approach (large file count
-    /// with both import plugin and JS plugins enabled).
+    /// Only created when using the copy-to-fixed-allocator approach
+    /// (both import plugin and JS plugins enabled).
     #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
     js_allocator_pool: Option<AllocatorPool>,
 
@@ -216,7 +216,7 @@ impl Runtime {
         let thread_count = rayon::current_num_threads();
 
         // Determine whether to use the copy-to-fixed-allocator approach.
-        // This is used when we have both JS plugins and import plugin enabled with a large file count.
+        // This is used when we have both JS plugins and import plugin enabled.
         // In this case, we use standard allocators for parsing/linting (lower memory usage),
         // and copy the AST to a fixed-size allocator only when passing to JS plugins.
         #[cfg(all(target_pointer_width = "64", target_endian = "little"))]

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -216,18 +216,27 @@ impl Runtime {
 
         let thread_count = rayon::current_num_threads();
 
-        // Determine whether to use the copy-to-fixed-allocator approach.
-        // This is used when we have both JS plugins and import plugin enabled.
-        // In this case, we use standard allocators for parsing/linting (lower memory usage),
-        // and copy the AST to a fixed-size allocator only when passing to JS plugins.
+        // Create allocator pools.
+        //
+        // * If both JS plugins and import plugin enabled, use copy-to-fixed-allocator approach.
+        //   This approach is to use standard allocators for parsing/linting (lower memory usage),
+        //   and copy ASTs to a fixed-size allocator only when passing to JS plugins.
+        //
+        // * If JS plugins, but no import plugin, use fixed-size allocators for everything.
+        //   Without import plugin, there's no danger of memory exhaustion, as no more than <thread coount>
+        //   ASTs are live at any given time.
+        //
+        // * If no JS plugins, use standard allocators for parsing/linting.
         #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
-        let use_copy_approach = options.cross_module && linter.has_external_linter();
-
-        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
-        let (allocator_pool, js_allocator_pool) = if use_copy_approach {
-            (AllocatorPool::new(thread_count), Some(AllocatorPool::new_fixed_size(thread_count)))
-        } else if linter.has_external_linter() {
-            (AllocatorPool::new_fixed_size(thread_count), None)
+        let (allocator_pool, js_allocator_pool) = if linter.has_external_linter() {
+            if options.cross_module {
+                (
+                    AllocatorPool::new(thread_count),
+                    Some(AllocatorPool::new_fixed_size(thread_count)),
+                )
+            } else {
+                (AllocatorPool::new_fixed_size(thread_count), None)
+            }
         } else {
             (AllocatorPool::new(thread_count), None)
         };

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -47,6 +47,12 @@ pub struct Runtime {
 
     allocator_pool: AllocatorPool,
 
+    /// Separate pool of fixed-size allocators for copying AST before JS transfer.
+    /// Only created when using the copy-to-fixed-allocator approach (large file count
+    /// with both import plugin and JS plugins enabled).
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    js_allocator_pool: Option<AllocatorPool>,
+
     /// The module graph keyed by module paths. It is looked up when populating `loaded_modules`.
     /// The values are module records of sections (check the docs of `ProcessedModule.section_module_records`)
     /// Its entries are kept across groups because modules discovered in former groups could be referenced by modules in latter groups.
@@ -209,13 +215,24 @@ impl Runtime {
 
         let thread_count = rayon::current_num_threads();
 
-        // If an external linter is used (JS plugins), we must use fixed-size allocators,
-        // for compatibility with raw transfer
-        let allocator_pool = if linter.has_external_linter() {
-            AllocatorPool::new_fixed_size(thread_count)
+        // Determine whether to use the copy-to-fixed-allocator approach.
+        // This is used when we have both JS plugins and import plugin enabled with a large file count.
+        // In this case, we use standard allocators for parsing/linting (lower memory usage),
+        // and copy the AST to a fixed-size allocator only when passing to JS plugins.
+        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+        let use_copy_approach = options.cross_module && linter.has_external_linter();
+
+        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+        let (allocator_pool, js_allocator_pool) = if use_copy_approach {
+            (AllocatorPool::new(thread_count), Some(AllocatorPool::new_fixed_size(thread_count)))
+        } else if linter.has_external_linter() {
+            (AllocatorPool::new_fixed_size(thread_count), None)
         } else {
-            AllocatorPool::new(thread_count)
+            (AllocatorPool::new(thread_count), None)
         };
+
+        #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+        let allocator_pool = AllocatorPool::new(thread_count);
 
         let resolver = options.cross_module.then(|| {
             Self::get_resolver(options.tsconfig.or_else(|| Some(options.cwd.join("tsconfig.json"))))
@@ -223,6 +240,8 @@ impl Runtime {
 
         Self {
             allocator_pool,
+            #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+            js_allocator_pool,
             cwd: options.cwd,
             linter,
             resolver,
@@ -598,9 +617,18 @@ impl Runtime {
                             return;
                         }
 
-                        let (mut messages, disable_directives) = me
-                            .linter
-                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard);
+                        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+                        let js_pool = me.js_allocator_pool.as_ref();
+                        #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+                        let js_pool = None::<&AllocatorPool>;
+
+                        let (mut messages, disable_directives) =
+                            me.linter.run_with_disable_directives(
+                                path,
+                                context_sub_hosts,
+                                allocator_guard,
+                                js_pool,
+                            );
 
                         // Store the disable directives for this file
                         if let Some(disable_directives) = disable_directives {
@@ -712,9 +740,15 @@ impl Runtime {
                         }
 
                         let path = Path::new(&module_to_lint.path);
+
+                        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+                        let js_pool = me.js_allocator_pool.as_ref();
+                        #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+                        let js_pool = None::<&AllocatorPool>;
+
                         let (section_messages, disable_directives) = me
                             .linter
-                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard);
+                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard, js_pool);
 
                         if let Some(disable_directives) = disable_directives {
                             me.disable_directives_map


### PR DESCRIPTION
This PR fixes OOM (Out of Memory) problems when using JS plugins together with the import plugin for cross-module analysis.

Previously, a stopgap solution simply refused to run when >10,000 files were linted with both features enabled.

This PR implements a real fix using a deferred cloning strategy: standard allocators are used for parsing/linting (efficient, dynamic sizing), and the AST is only copied into a fixed-size allocator briefly when calling JS plugins.

This dramatically reduces memory usage from n_files × 6 GiB to n_files × dynamic + thread_count × 6 GiB.