### PR TITLE
fear(allocator): introduce CapacityLimit for FixedSizedAllocator

### DIFF
--- a/crates/oxc_allocator/src/pool/mod.rs
+++ b/crates/oxc_allocator/src/pool/mod.rs
@@ -46,16 +46,24 @@ impl AllocatorPool {
 
     /// Create a new [`AllocatorPool`] for use across the specified number of threads,
     /// which uses fixed-size allocators (suitable for raw transfer).
+    ///
+    /// If `max_count` is `Some`, the pool will block when trying to get an allocator
+    /// if the maximum number of allocators has been reached, waiting until one is returned.
+    /// If `max_count` is `None`, there is no limit on the number of allocators.
     #[cfg(feature = "fixed_size")]
-    pub fn new_fixed_size(thread_count: usize) -> AllocatorPool {
+    pub fn new_fixed_size(thread_count: usize, max_count: Option<u32>) -> AllocatorPool {
         #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
         {
-            Self(AllocatorPoolInner::FixedSize(FixedSizeAllocatorPool::new(thread_count)))
+            Self(AllocatorPoolInner::FixedSize(FixedSizeAllocatorPool::new(
+                thread_count,
+                max_count,
+            )))
         }
 
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         {
             let _thread_count = thread_count; // Avoid unused vars lint warning
+            let _max_count = max_count; // Avoid unused vars lint warning
             panic!("Fixed size allocators are only supported on 64-bit little-endian platforms");
         }
     }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -212,7 +212,7 @@ impl Runtime {
         // If an external linter is used (JS plugins), we must use fixed-size allocators,
         // for compatibility with raw transfer
         let allocator_pool = if linter.has_external_linter() {
-            AllocatorPool::new_fixed_size(thread_count)
+            AllocatorPool::new_fixed_size(thread_count, None)
         } else {
             AllocatorPool::new(thread_count)
         };


### PR DESCRIPTION
For some windows machines, we need to limit the total number of fixed sized allocators to less than thread count, however it is OK to use all threads. 

this PE introduces a limiter for this, and introduces atomic waits that wait until a new fixed sized allocator is available.