### PR TITLE
fix(linter/plugins): fix indentation in error message

### DIFF
--- a/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/output.snap.md
@@ -17,7 +17,7 @@ Failed to parse configuration file.
   | Then reference rules using your alias:
   | 
   | "rules": {
-  | "jsdoc-js/rule-name": "error"
+  |   "jsdoc-js/rule-name": "error"
   | }
   | 
   | See: https://oxc.rs/docs/guide/usage/linter/js-plugins.html

--- a/apps/oxlint/test/fixtures/reserved_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/reserved_name/output.snap.md
@@ -17,7 +17,7 @@ Failed to parse configuration file.
   | Then reference rules using your alias:
   | 
   | "rules": {
-  | "import-js/rule-name": "error"
+  |   "import-js/rule-name": "error"
   | }
   | 
   | See: https://oxc.rs/docs/guide/usage/linter/js-plugins.html

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -670,9 +670,7 @@ impl Display for ConfigBuilderError {
                      \n\
                      Then reference rules using your alias:\n\
                      \n\
-                     \"rules\": {{\n\
-                       \"{plugin_name}-js/rule-name\": \"error\"\n\
-                     }}\n\
+                     \"rules\": {{\n  \"{plugin_name}-js/rule-name\": \"error\"\n}}\n\
                      \n\
                      See: https://oxc.rs/docs/guide/usage/linter/js-plugins.html",
                 )?;


### PR DESCRIPTION
Follow-on after #15569. Just improve indentation in error message when user tries to use a reserved plugin name.