### PR TITLE
refactor(linter/plugins): simplify ser/deser of `ExternalPluginEntry`

### DIFF
--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -9,9 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};
 
-use super::external_plugins::{
-    ExternalPluginEntry, deserialize_external_plugins, external_plugins_schema,
-};
+use super::external_plugins::{ExternalPluginEntry, external_plugins_schema};
 
 // nominal wrapper required to add JsonSchema impl
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -102,12 +100,7 @@ pub struct OxlintOverride {
     ///
     /// Note: JS plugins are experimental and not subject to semver.
     /// They are not supported in language server at present.
-    #[serde(
-        rename = "jsPlugins",
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_external_plugins"
-    )]
+    #[serde(rename = "jsPlugins", default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "external_plugins_schema")]
     pub external_plugins: Option<FxHashSet<ExternalPluginEntry>>,
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -14,9 +14,7 @@ use crate::{LintPlugins, utils::read_to_string};
 use super::{
     categories::OxlintCategories,
     env::OxlintEnv,
-    external_plugins::{
-        ExternalPluginEntry, deserialize_external_plugins, external_plugins_schema,
-    },
+    external_plugins::{ExternalPluginEntry, external_plugins_schema},
     globals::OxlintGlobals,
     overrides::OxlintOverrides,
     rules::OxlintRules,
@@ -81,12 +79,7 @@ pub struct Oxlintrc {
     ///
     /// Note: JS plugins are experimental and not subject to semver.
     /// They are not supported in language server at present.
-    #[serde(
-        rename = "jsPlugins",
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_external_plugins"
-    )]
+    #[serde(rename = "jsPlugins", default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "external_plugins_schema")]
     pub external_plugins: Option<FxHashSet<ExternalPluginEntry>>,
     pub categories: OxlintCategories,


### PR DESCRIPTION
Follow-on after #15569. Simplify serialization/deserialization of `ExternalPluginEntry`. Since we now have a type for this, there's no need for `deserialize_external_plugins` any more.