### PR TITLE
feat(parser): add token collection option

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -162,6 +162,7 @@ unsafe fn parse_raw_impl(
             .with_options(ParseOptions {
                 parse_regular_expression: true,
                 allow_return_outside_function: true,
+                collect_tokens: true,
                 ..ParseOptions::default()
             })
             .parse();

--- a/crates/oxc_formatter/src/service/mod.rs
+++ b/crates/oxc_formatter/src/service/mod.rs
@@ -11,6 +11,7 @@ pub fn get_parse_options() -> ParseOptions {
         allow_v8_intrinsics: true,
         // `oxc_formatter` expects this to be `false`, otherwise panics
         preserve_parens: false,
+        collect_tokens: false,
     }
 }
 

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -442,7 +442,8 @@ mod test {
         fn run_test(source_text: String, expected_escaped: String, is_only_part: bool) {
             let allocator = Allocator::default();
             let unique = UniquePromise::new_for_tests_and_benchmarks();
-            let mut lexer = Lexer::new(&allocator, &source_text, SourceType::default(), unique);
+            let mut lexer =
+                Lexer::new(&allocator, &source_text, SourceType::default(), false, unique);
             let token = lexer.next_token();
             assert_eq!(
                 token.kind(),

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -480,16 +480,16 @@ impl<'a> ParserImpl<'a> {
             errors.push(error);
         }
         let (module_record, module_record_errors) = self.module_record_builder.build();
+        let tokens = if self.options.collect_tokens { Some(self.lexer.tokens()) } else { None };
         if errors.len() != 1 {
             errors.reserve(self.lexer.errors.len() + self.errors.len());
-            errors.append(&mut self.lexer.errors);
-            errors.append(&mut self.errors);
+            errors.extend(self.lexer.errors);
+            errors.extend(self.errors);
             // Skip checking for exports in TypeScript {
             if !self.source_type.is_typescript() {
                 errors.extend(module_record_errors);
             }
         }
-        let tokens = if self.options.collect_tokens { Some(self.lexer.tokens()) } else { None };
         let irregular_whitespaces =
             self.lexer.trivia_builder.irregular_whitespaces.into_boxed_slice();
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -218,6 +218,7 @@ impl Oxc {
     ) -> (Program<'a>, oxc::syntax::module_record::ModuleRecord<'a>) {
         let parser_options = ParseOptions {
             parse_regular_expression: true,
+            collect_tokens: false,
             allow_return_outside_function: parser_options.allow_return_outside_function,
             preserve_parens: parser_options.preserve_parens,
             allow_v8_intrinsics: parser_options.allow_v8_intrinsics,

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -19,7 +19,6 @@ fn bench_parser(criterion: &mut Criterion) {
                 Parser::new(&allocator, source_text, source_type)
                     .with_options(ParseOptions {
                         parse_regular_expression: true,
-                        collect_tokens: true,
                         ..ParseOptions::default()
                     })
                     .parse();
@@ -45,6 +44,7 @@ fn bench_parser_with_tokens(criterion: &mut Criterion) {
                 Parser::new(&allocator, source_text, source_type)
                     .with_options(ParseOptions {
                         parse_regular_expression: true,
+                        collect_tokens: true,
                         ..ParseOptions::default()
                     })
                     .parse();

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -19,6 +19,7 @@ fn bench_parser(criterion: &mut Criterion) {
                 Parser::new(&allocator, source_text, source_type)
                     .with_options(ParseOptions {
                         parse_regular_expression: true,
+                        collect_tokens: true,
                         ..ParseOptions::default()
                     })
                     .parse();


### PR DESCRIPTION
Part of #16207. This is just to measure the performance impact of unconditionally always storing tokens in an `oxc_allocator::Vec`.