### PR TITLE
test(linter/plugins): use subpath imports in test fixtures

### DIFF
--- a/apps/oxlint/test/fixtures/custom_plugin_name_alias/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_name_alias/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "../../../dist/index.js";
+import type { Plugin } from "#oxlint";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "../../../dist/index.js";
+import type { Plugin } from "#oxlint";
 
 const plugin: Plugin = {
   meta: {


### PR DESCRIPTION
For consistency with rest of the fixtures.