### PR TITLE
test(linter/plugins): improve test for plugin aliases

### DIFF
--- a/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/plugin.ts
+++ b/apps/oxlint/test/fixtures/custom_plugin_name_alias_reserved_name/plugin.ts
@@ -2,7 +2,7 @@ import type { Plugin } from "#oxlint";
 
 const plugin: Plugin = {
   meta: {
-    name: "jsdoc",
+    name: "legal-plugin-name",
   },
   rules: {
     "no-debugger": {


### PR DESCRIPTION
Follow-on after #15569. This fixture is to test that illegal *aliases* produce an error. So make the plugin name defined in the plugin a legal name, to make sure the test tests what it's meant to.