### PR TITLE
chore(oxfmt): Add `AGENTS.md` for `apps/oxfmt`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Rust workspace with key directories:
 
 - `crates/` - Core functionality (start here when exploring)
 - `apps/` - Application binaries (oxlint, oxfmt)
+  - When working on `oxfmt`, refer to `./apps/oxfmt/AGENTS.md`
 - `napi/` - Node.js bindings
 - `npm/` - npm packages
 - `tasks/` - Development tools/automation

--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -1,0 +1,32 @@
+# Coding agent guides for `apps/oxfmt`
+
+## Overview
+
+`oxfmt` has multiple entry points:
+
+- Pure Rust CLI
+  - Entry point: `main()` in `src/main.rs`
+- JS/Rust hybrid CLI using napi-rs
+  - Entry point: `src-js/cli.ts` which uses `run_cli()` from `src/main_napi.rs`
+- Node.js API using napi-rs
+  - Entry point: `src-js/index.ts` which uses `format()` from `src/main_napi.rs`
+
+When making changes, consider the impact on all paths.
+
+## Verification
+
+```sh
+cargo c
+cargo c --no-default-features
+cargo c --features detect_code_removal
+```
+
+Also run clippy for the same configurations and resolve all warnings.
+
+Run tests with:
+
+```sh
+pnpm build-test
+pnpm t
+cargo t
+```


### PR DESCRIPTION
While it was possible to load it with `@` in the root's `AGENTS.md`, but it's fine to do only when necessary.

Will merge after CI.