### PR TITLE
fix(oxfmt): Update api `FormatOptions` type with `& Record<string, unknown>`

### DIFF
--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -84,7 +84,7 @@ export type FormatOptions = {
   experimentalSortImports?: SortImportsOptions;
   /** Experimental: Sort `package.json` keys. (Default: `true`) */
   experimentalSortPackageJson?: boolean;
-};
+} & Record<string, unknown>; // Also allow additional options for we don't have typed yet.
 
 /**
  * Configuration options for sort imports.

--- a/apps/oxfmt/test/__snapshots__/external_formatter_with_config.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/external_formatter_with_config.test.ts.snap
@@ -26,19 +26,19 @@ export default {name:"Test",data(){return {foo:"bar",baz:123}}}
 </template>
 
 <script>
-export default {
-	name: 'Test',
-	data() {
-		return { foo: 'bar', baz: 123 };
-	},
-};
+	export default {
+		name: 'Test',
+		data() {
+			return { foo: 'bar', baz: 123 };
+		},
+	};
 </script>
 
 <style>
-.foo {
-	color: red;
-	background: blue;
-}
+	.foo {
+		color: red;
+		background: blue;
+	}
 </style>
 
 --------------------"

--- a/apps/oxfmt/test/api.test.ts
+++ b/apps/oxfmt/test/api.test.ts
@@ -39,4 +39,35 @@ describe("API Tests", () => {
     });
     expect(errors.length).toBe(1);
   });
+
+  test("should `format()` with options work", async () => {
+    const pkgJSON = JSON.stringify({
+      version: "1.0.0",
+      name: "my-package",
+    });
+    const result1 = await format("package.json", pkgJSON);
+    expect(result1.code).toBe(`{\n  "name": "my-package",\n  "version": "1.0.0"\n}\n`);
+    expect(result1.errors).toStrictEqual([]);
+
+    const result2 = await format("package.json", pkgJSON, { experimentalSortPackageJson: false });
+    expect(result2.code).toBe(`{\n  "version": "1.0.0",\n  "name": "my-package"\n}\n`);
+    expect(result2.errors).toStrictEqual([]);
+
+    const vueCode = `
+<template><div>Vue</div></template>
+<style>div{color:red;}</style>
+`.trim();
+    const result3 = await format("Component.vue", vueCode, {
+      vueIndentScriptAndStyle: true,
+    });
+    expect(result3.code).toBe(
+      `
+<template><div>Vue</div></template>
+<style>
+  div{color:red;}
+</style>
+`.trimStart(),
+    );
+    expect(result3.errors).toStrictEqual([]);
+  });
 });

--- a/apps/oxfmt/test/fixtures/external_formatter_with_config/.oxfmtrc.json
+++ b/apps/oxfmt/test/fixtures/external_formatter_with_config/.oxfmtrc.json
@@ -2,5 +2,6 @@
   "printWidth": 40,
   "useTabs": true,
   "singleQuote": true,
-  "embeddedLanguageFormatting": "auto"
+  "embeddedLanguageFormatting": "auto",
+  "vueIndentScriptAndStyle": true
 }


### PR DESCRIPTION
Add `& Record<string, unknown>` to `FormatOptions` for `oxfmt.format()`.

This is needed to accept options like `vueIndentScriptAndStyle`, (which are `Oxfmtrc` currently unaware of) and various plugin options.

Also added tests for it and others too.