### PR TITLE
fix(ast_tools): support `u128` in `assert_layouts` generator

### DIFF
--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -13756,7 +13756,7 @@ function constructBoxTSExternalModuleReference(pos, ast) {
 function constructU64(pos, ast) {
   const { uint32 } = ast.buffer,
     pos32 = pos >> 2;
-  return uint32[pos32] + uint32[pos32 + 1] * 4294967296;
+  return uint32[pos32] + uint32[pos32 + 1] * /* 2^32 */ 4294967296;
 }
 
 function constructOptionNameSpan(pos, ast) {

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -463,17 +463,13 @@ fn calculate_layout_for_primitive(primitive_def: &PrimitiveDef) -> Layout {
         "u16" => Layout::from_type::<u16>(),
         "u32" => Layout::from_type::<u32>(),
         "u64" => Layout::from_type::<u64>(),
-        "u128" => {
-            panic!("Cannot calculate alignment for `u128`. It differs depending on Rust version.")
-        }
+        "u128" => Layout::from_type::<u128>(),
         "usize" => usize_layout,
         "i8" => Layout::from_type::<i8>(),
         "i16" => Layout::from_type::<i16>(),
         "i32" => Layout::from_type::<i32>(),
         "i64" => Layout::from_type::<i64>(),
-        "i128" => {
-            panic!("Cannot calculate alignment for `i128`. It differs depending on Rust version.")
-        }
+        "i128" => Layout::from_type::<i128>(),
         "isize" => usize_layout,
         "f32" => Layout::from_type::<f32>(),
         "f64" => Layout::from_type::<f64>(),
@@ -483,21 +479,13 @@ fn calculate_layout_for_primitive(primitive_def: &PrimitiveDef) -> Layout {
         "NonZeroU16" => Layout::from_type_with_niche_for_zero::<num::NonZeroU16>(),
         "NonZeroU32" => Layout::from_type_with_niche_for_zero::<num::NonZeroU32>(),
         "NonZeroU64" => Layout::from_type_with_niche_for_zero::<num::NonZeroU64>(),
-        "NonZeroU128" => {
-            panic!(
-                "Cannot calculate alignment for `NonZeroU128`. It differs depending on Rust version."
-            )
-        }
+        "NonZeroU128" => Layout::from_type_with_niche_for_zero::<num::NonZeroU128>(),
         "NonZeroUsize" => non_zero_usize_layout,
         "NonZeroI8" => Layout::from_type_with_niche_for_zero::<num::NonZeroI8>(),
         "NonZeroI16" => Layout::from_type_with_niche_for_zero::<num::NonZeroI16>(),
         "NonZeroI32" => Layout::from_type_with_niche_for_zero::<num::NonZeroI32>(),
         "NonZeroI64" => Layout::from_type_with_niche_for_zero::<num::NonZeroI64>(),
-        "NonZeroI128" => {
-            panic!(
-                "Cannot calculate alignment for `NonZeroI128`. It differs depending on Rust version."
-            )
-        }
+        "NonZeroI128" => Layout::from_type_with_niche_for_zero::<num::NonZeroI128>(),
         "NonZeroIsize" => non_zero_usize_layout,
         // Unlike `bool`, `AtomicBool` does not have any niches
         "AtomicBool" => Layout::from_type::<atomic::AtomicBool>(),

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -808,10 +808,21 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
         "u8" => "return uint8[pos];",
         // "u16" => "return uint16[pos >> 1];",
         "u32" => "return uint32[pos >> 2];",
+        // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
         #[rustfmt::skip]
         "u64" => "
             const pos32 = pos >> 2;
-            return uint32[pos32] + uint32[pos32 + 1] * 4294967296;
+            return uint32[pos32]
+                + uint32[pos32 + 1] * /* 2^32 */ 4294967296;
+        ",
+        // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
+        #[rustfmt::skip]
+        "u128" => "
+            const pos32 = pos >> 2;
+            return uint32[pos32]
+                + uint32[pos32 + 1] * /* 2^32 */ 4294967296
+                + uint32[pos32 + 2] * /* 2^64 */ 18446744073709551616
+                + uint32[pos32 + 3] * /* 2^96 */ 79228162514264337593543950336;
         ",
         "f64" => "return float64[pos >> 3];",
         "&str" => STR_DESERIALIZER_BODY,

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -905,11 +905,23 @@ fn generate_primitive(primitive_def: &PrimitiveDef, state: &mut State, schema: &
         "u8" => "return ast.buffer[pos];",
         // "u16" => "return uint16[pos >> 1];",
         "u32" => "return ast.buffer.uint32[pos >> 2];",
+        // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
         #[rustfmt::skip]
         "u64" => "
             const { uint32 } = ast.buffer,
                 pos32 = pos >> 2;
-            return uint32[pos32] + uint32[pos32 + 1] * 4294967296;
+            return uint32[pos32]
+                + uint32[pos32 + 1] * /* 2^32 */ 4294967296;
+        ",
+        // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
+        #[rustfmt::skip]
+        "u128" => "
+            const { uint32 } = ast.buffer,
+                pos32 = pos >> 2;
+            return uint32[pos32]
+                + uint32[pos32 + 1] * /* 2^32 */ 4294967296
+                + uint32[pos32 + 2] * /* 2^64 */ 18446744073709551616
+                + uint32[pos32 + 3] * /* 2^96 */ 79228162514264337593543950336;
         ",
         "f64" => "return ast.buffer.float64[pos >> 3];",
         "&str" => STR_DESERIALIZER_BODY,


### PR DESCRIPTION
Previously `u128` was not supported in `assert_layouts` generator, because Rust changed the alignment of `u128` from 8 to 16 - and therefore the alignment depended on Rust version.

That change happened some time ago now, and all Rust versions above our MSRV have `u128` with alignment of 16. So we can now support `u128` (and also `i128`, `NonZeroU128`, `NonZeroI128`).

Also support `u128` in `raw_transfer` and `raw_transfer_lazy` generators.

This will help with making lexer tokens serializable (#17025), since `Token` contains a `u128`.