### PR TITLE
feat(linter): implement vitest/prefer-called-times

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3932,6 +3932,11 @@ impl RuleRunner for crate::rules::vitest::no_import_node_test::NoImportNodeTest 
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_called_times::PreferCalledTimes {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -658,6 +658,7 @@ pub(crate) mod promise {
 pub(crate) mod vitest {
     pub mod no_conditional_tests;
     pub mod no_import_node_test;
+    pub mod prefer_called_times;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;
@@ -1304,6 +1305,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::throw_new_error,
     vitest::no_conditional_tests,
     vitest::no_import_node_test,
+    vitest::prefer_called_times,
     vitest::prefer_to_be_falsy,
     vitest::prefer_to_be_object,
     vitest::prefer_to_be_truthy,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
@@ -72,8 +72,6 @@ impl Rule for PreferToHaveBeenCalledTimes {
             return;
         };
 
-        println!("jest_node: {:?}", ctx.source_range(call_expr.span()));
-
         let Some(parsed_expect_call) = parse_expect_jest_fn_call(call_expr, jest_node, ctx) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
@@ -66,20 +66,25 @@ impl Rule for PreferToHaveBeenCalledTimes {
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        let node = jest_node.node;
+        Self::run(jest_node, ctx);
+    }
+}
+impl PreferToHaveBeenCalledTimes {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
 
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
 
-        let Some(parsed_expect_call) = parse_expect_jest_fn_call(call_expr, jest_node, ctx) else {
+        let Some(parsed_expect_call) =
+            parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
             return;
         };
 
         Self::check_and_fix(&parsed_expect_call, call_expr, ctx);
     }
-}
-impl PreferToHaveBeenCalledTimes {
     fn check_and_fix<'a>(
         parsed_expect_call: &ParsedExpectFnCall<'a>,
         call_expr: &CallExpression<'a>,

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
@@ -97,13 +97,7 @@ impl PreferCalledTimes {
             return;
         }
 
-        let expect_argument = parsed_expect_call.head.parent.and_then(|parent| {
-            if let Expression::CallExpression(parent) = parent {
-                let expect_argument = parent.arguments.first();
-                return expect_argument;
-            }
-            None
-        });
+        let expect_argument = parsed_expect_call.expect_arguments.and_then(|args| args.first());
 
         ctx.diagnostic_with_fix(prefer_called_times_diagnostic(call_expr.span), |fixer| {
             let param_text = Self::build_expect_argument(expect_argument, fixer);

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use oxc_ast::{
     AstKind,
-    ast::{Argument, CallExpression, Expression},
+    ast::{Argument, CallExpression},
 };
 
 fn prefer_called_times_diagnostic(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
@@ -14,7 +14,6 @@ use oxc_ast::{
 };
 
 fn prefer_called_times_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`")
         .with_help("Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency")
         .with_label(span)
@@ -23,7 +22,6 @@ fn prefer_called_times_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct PreferCalledTimes;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 // See <https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md> for rule details.
 declare_oxc_lint!(
     /// ### What it does

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
@@ -1,0 +1,190 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    context::LintContext,
+    fixer::RuleFixer,
+    rule::Rule,
+    utils::{ParsedExpectFnCall, PossibleJestNode, parse_expect_jest_fn_call},
+};
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, Expression},
+};
+
+fn prefer_called_times_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`")
+        .with_help("Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferCalledTimes;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+// See <https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md> for rule details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule aims to enforce the use of `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` over `toBeCalledOnce()` or `toHaveBeenCalledOnce()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// This rule aims to enforce the use of `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` over `toBeCalledOnce()` or `toHaveBeenCalledOnce()`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// test('foo', () => {
+    ///   const mock = vi.fn()
+    ///   mock('foo')
+    ///   expect(mock).toBeCalledOnce()
+    ///   expect(mock).toHaveBeenCalledOnce()
+    /// })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// test('foo', () => {
+    ///   const mock = vi.fn()
+    ///   mock('foo')
+    ///   expect(mock).toBeCalledTimes(1)
+    ///   expect(mock).toHaveBeenCalledTimes(1)
+    /// })
+    /// ```
+    PreferCalledTimes,
+    vitest,
+    style,
+    fix,
+);
+
+impl Rule for PreferCalledTimes {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Some(parsed_expect_call) = parse_expect_jest_fn_call(call_expr, jest_node, ctx) else {
+            return;
+        };
+
+        Self::check_and_fix(&parsed_expect_call, call_expr, ctx);
+    }
+}
+
+impl PreferCalledTimes {
+    fn check_and_fix<'a>(
+        parsed_expect_call: &ParsedExpectFnCall<'a>,
+        call_expr: &CallExpression<'a>,
+        ctx: &LintContext<'a>,
+    ) {
+        let Some(matcher) = parsed_expect_call.matcher() else {
+            return;
+        };
+
+        let is_wanted_matcher = matcher.is_name_equal("toBeCalledOnce")
+            || matcher.is_name_equal("toHaveBeenCalledOnce");
+        if !is_wanted_matcher {
+            return;
+        }
+
+        let expect_argument = parsed_expect_call.head.parent.and_then(|parent| {
+            if let Expression::CallExpression(parent) = parent {
+                let expect_argument = parent.arguments.first();
+                return expect_argument;
+            }
+            None
+        });
+
+        ctx.diagnostic_with_fix(prefer_called_times_diagnostic(call_expr.span), |fixer| {
+            let param_text = Self::build_expect_argument(expect_argument, fixer);
+
+            let modifier_text =
+                parsed_expect_call.modifiers().iter().fold(String::new(), |mut acc, modifier| {
+                    use std::fmt::Write;
+                    write!(&mut acc, ".{}", fixer.source_range(modifier.span)).unwrap();
+                    acc
+                });
+
+            let method_text = if matcher.is_name_equal("toBeCalledOnce") {
+                "toBeCalledTimes"
+            } else {
+                "toHaveBeenCalledTimes"
+            };
+
+            let code = format!("expect({param_text}){modifier_text}.{method_text}(1)");
+
+            fixer.replace(call_expr.span, code)
+        });
+    }
+
+    fn build_expect_argument<'a>(
+        expect_argument: Option<&Argument<'_>>,
+        fixer: RuleFixer<'_, 'a>,
+    ) -> &'a str {
+        if let Some(arg) = expect_argument {
+            return fixer.source_range(arg.span());
+        }
+        ""
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "expect(fn).toBeCalledTimes(1);",
+        "expect(fn).toHaveBeenCalledTimes(1);",
+        "expect(fn).toBeCalledTimes(2);",
+        "expect(fn).toHaveBeenCalledTimes(2);",
+        "expect(fn).toBeCalledTimes(expect.anything());",
+        "expect(fn).toHaveBeenCalledTimes(expect.anything());",
+        "expect(fn).not.toBeCalledTimes(2);",
+        "expect(fn).rejects.not.toBeCalledTimes(1);",
+        "expect(fn).not.toHaveBeenCalledTimes(1);",
+        "expect(fn).resolves.not.toHaveBeenCalledTimes(1);",
+        "expect(fn).toBeCalledTimes(0);",
+        "expect(fn).toHaveBeenCalledTimes(0);",
+        "expect(fn);",
+    ];
+
+    let fail = vec![
+        "expect(fn).toBeCalledOnce();",
+        "expect(fn).toHaveBeenCalledOnce();",
+        "expect(fn).not.toBeCalledOnce();",
+        "expect(fn).not.toHaveBeenCalledOnce();",
+        "expect(fn).resolves.toBeCalledOnce();",
+        "expect(fn).resolves.toHaveBeenCalledOnce();",
+    ];
+
+    let fix = vec![
+        ("expect(fn).toBeCalledOnce();", "expect(fn).toBeCalledTimes(1);", None),
+        ("expect(fn).toHaveBeenCalledOnce();", "expect(fn).toHaveBeenCalledTimes(1);", None),
+        ("expect(fn).not.toBeCalledOnce();", "expect(fn).not.toBeCalledTimes(1);", None),
+        (
+            "expect(fn).not.toHaveBeenCalledOnce();",
+            "expect(fn).not.toHaveBeenCalledTimes(1);",
+            None,
+        ),
+        ("expect(fn).resolves.toBeCalledOnce();", "expect(fn).resolves.toBeCalledTimes(1);", None),
+        (
+            "expect(fn).resolves.toHaveBeenCalledOnce();",
+            "expect(fn).resolves.toHaveBeenCalledTimes(1);",
+            None,
+        ),
+    ];
+    Tester::new(PreferCalledTimes::NAME, PreferCalledTimes::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_called_times.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_called_times.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 427
+---
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).toBeCalledOnce();
+   · ───────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency
+
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).toHaveBeenCalledOnce();
+   · ─────────────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency
+
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).not.toBeCalledOnce();
+   · ───────────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency
+
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).not.toHaveBeenCalledOnce();
+   · ─────────────────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency
+
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).resolves.toBeCalledOnce();
+   · ────────────────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency
+
+  ⚠ eslint-plugin-vitest(prefer-called-times): Use `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` instead of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`
+   ╭─[prefer_called_times.tsx:1:1]
+ 1 │ expect(fn).resolves.toHaveBeenCalledOnce();
+   · ──────────────────────────────────────────
+   ╰────
+  help: Replace with `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` for clarity and consistency

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -153,6 +153,15 @@ fn parse_jest_expect_fn_call<'a>(
     }
 
     let kind = if is_type_of { JestFnKind::ExpectTypeOf } else { JestFnKind::Expect };
+    let expect_arguments = head.parent.and_then(|parent| {
+        if let Expression::CallExpression(parent) = parent {
+            return Some(&parent.arguments);
+        }
+        None
+    });
+
+    let matcher_arguments =
+        matcher.and_then(|matcher| members.get(matcher)).and_then(|_| Some(&call_expr.arguments));
 
     let parsed_expect_fn = ParsedExpectFnCall {
         kind,
@@ -164,6 +173,8 @@ fn parse_jest_expect_fn_call<'a>(
         matcher_index: matcher,
         modifier_indices: modifiers,
         expect_error,
+        expect_arguments,
+        matcher_arguments,
     };
 
     Some(if is_type_of {
@@ -367,6 +378,9 @@ pub struct ParsedExpectFnCall<'a> {
     pub name: Cow<'a, str>,
     pub local: Cow<'a, str>,
     pub head: KnownMemberExpressionProperty<'a>,
+    /// this args changed bases on condition
+    /// In `expect(fn).toBeCalledTimes(2)`, it will be `[2]`
+    /// In `expect(fn)`, it will be `fn`
     pub args: &'a oxc_allocator::Vec<'a, Argument<'a>>,
     // In `expect(1).not.resolved.toBe()`, "not", "resolved" will be modifier
     // it save a group of modifier index from members
@@ -375,6 +389,14 @@ pub struct ParsedExpectFnCall<'a> {
     // it save the matcher index from members
     pub matcher_index: Option<usize>,
     pub expect_error: Option<ExpectError>,
+
+    /// the arguments passed to the expect function
+    /// In `expect(1).toBe(2)`, it will be `[1]`
+    pub expect_arguments: Option<&'a oxc_allocator::Vec<'a, Argument<'a>>>,
+    /// the arguments passed to the matcher function
+    /// In `expect(1).toBe(2)`, it will be `[2]
+    /// In `expect(1)`, it will be `None`
+    pub matcher_arguments: Option<&'a oxc_allocator::Vec<'a, Argument<'a>>>,
 }
 
 impl<'a> ParsedExpectFnCall<'a> {

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -161,7 +161,7 @@ fn parse_jest_expect_fn_call<'a>(
     });
 
     let matcher_arguments =
-        matcher.and_then(|matcher| members.get(matcher)).and_then(|_| Some(&call_expr.arguments));
+        matcher.and_then(|matcher| members.get(matcher)).map(|_| &call_expr.arguments);
 
     let parsed_expect_fn = ParsedExpectFnCall {
         kind,


### PR DESCRIPTION
Ref: #4656 

This PR implements [vitest/prefer-called-times](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md) rule.

Test Plan



- [x] All fail cases pass
- [x] All pass cases pass
- [x] All expect fix get fix suggestions
- [x] No clippy warnings
- [x] Code formatted with just fmt

