### PR TITLE
refactor(formatter): remove unused `source_text` field from Formatter

### DIFF
--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -32,13 +32,12 @@ use self::formatter::prelude::tag::Label;
 
 pub struct Formatter<'a> {
     allocator: &'a Allocator,
-    source_text: &'a str,
     options: FormatOptions,
 }
 
 impl<'a> Formatter<'a> {
     pub fn new(allocator: &'a Allocator, options: FormatOptions) -> Self {
-        Self { allocator, source_text: "", options }
+        Self { allocator, options }
     }
 
     /// Formats the given AST `Program` and returns the formatted string.
@@ -62,15 +61,12 @@ impl<'a> Formatter<'a> {
     }
 
     pub fn format_impl(
-        mut self,
+        self,
         program: &'a Program<'a>,
         embedded_formatter: Option<EmbeddedFormatter>,
     ) -> Formatted<'a> {
         let parent = self.allocator.alloc(AstNodes::Dummy());
         let program_node = AstNode::new(program, parent, self.allocator);
-
-        let source_text = program.source_text;
-        self.source_text = source_text;
 
         let experimental_sort_imports = self.options.experimental_sort_imports.clone();
 


### PR DESCRIPTION
No usage, so remove it