### PR TITLE
refactor(formatter): move the parsing group for sorting imports to the place where it is used

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -10,8 +10,7 @@ use oxc_allocator::{Allocator, Vec as ArenaVec};
 use crate::{
     formatter::format_element::{FormatElement, LineMode, document::Document},
     ir_transform::sort_imports::{
-        group_config::{GroupName, parse_groups_from_strings},
-        partitioned_chunk::PartitionedChunk,
+        group_config::parse_groups_from_strings, partitioned_chunk::PartitionedChunk,
         source_line::SourceLine,
     },
 };
@@ -21,14 +20,11 @@ use crate::{
 /// <https://perfectionist.dev/rules/sort-imports>
 pub struct SortImportsTransform {
     options: options::SortImportsOptions,
-    groups: Vec<Vec<GroupName>>,
 }
 
 impl SortImportsTransform {
     pub fn new(options: options::SortImportsOptions) -> Self {
-        // Parse string based groups into our internal representation for performance
-        let groups = parse_groups_from_strings(&options.groups);
-        Self { options, groups }
+        Self { options }
     }
 
     /// Transform the given `Document` by sorting import statements according to the specified options.
@@ -43,6 +39,8 @@ impl SortImportsTransform {
             return document.clone();
         }
 
+        // Parse string based groups into our internal representation for performance
+        let groups = parse_groups_from_strings(&self.options.groups);
         let prev_elements: &[FormatElement<'a>] = document;
 
         // Roughly speaking, sort-imports is a process of swapping lines.
@@ -184,7 +182,7 @@ impl SortImportsTransform {
                     // // chunk trailing
                     // ```
                     let (sorted_imports, orphan_contents, trailing_lines) =
-                        chunk.into_sorted_import_units(&self.groups, &self.options);
+                        chunk.into_sorted_import_units(&groups, &self.options);
 
                     // Output leading orphan content (after_slot: None)
                     for orphan in &orphan_contents {


### PR DESCRIPTION
Only parse the groups when needed, as I noticed it would return early when the document only has a hard line (which means the file is empty). Then parsing the group is a waste.

Additionally, I realized we may improve this further by moving this part into the CLI, since the `experimental_sort_imports` option is always the same in each file, but currently, we have to parse again and again in each file