### PR TITLE
refactor(formatter): remove unnecessary clone for `experimental_sort_imports` option

### DIFF
--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -77,15 +77,13 @@ impl<'a> Formatted<'a> {
         &self.document
     }
 
+    pub fn document_mut(&mut self) -> &mut Document<'a> {
+        &mut self.document
+    }
+
     /// Consumes `self` and returns the formatted document.
     pub fn into_document(self) -> Document<'a> {
         self.document
-    }
-}
-
-impl<'a> Formatted<'a> {
-    pub fn apply_transform(&mut self, transform: impl FnOnce(&Document<'a>) -> Document<'a>) {
-        self.document = transform(&self.document);
     }
 }
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -8,6 +8,7 @@ mod source_line;
 use oxc_allocator::{Allocator, Vec as ArenaVec};
 
 use crate::{
+    SortImportsOptions,
     formatter::format_element::{FormatElement, LineMode, document::Document},
     ir_transform::sort_imports::{
         group_config::parse_groups_from_strings, partitioned_chunk::PartitionedChunk,
@@ -18,29 +19,27 @@ use crate::{
 /// An IR transform that sorts import statements according to specified options.
 /// Heavily inspired by ESLint's `@perfectionist/sort-imports` rule.
 /// <https://perfectionist.dev/rules/sort-imports>
-pub struct SortImportsTransform {
-    options: options::SortImportsOptions,
-}
+pub struct SortImportsTransform;
 
 impl SortImportsTransform {
-    pub fn new(options: options::SortImportsOptions) -> Self {
-        Self { options }
-    }
-
     /// Transform the given `Document` by sorting import statements according to the specified options.
     ///
     // NOTE: `Document` and its `FormatElement`s are already well-formatted.
     // It means that:
     // - There is no redundant spaces, no consecutive line breaks, etc...
     // - Last element is always `FormatElement::Line(Hard)`.
-    pub fn transform<'a>(&self, document: &Document<'a>, allocator: &'a Allocator) -> Document<'a> {
+    pub fn transform<'a>(
+        document: &Document<'a>,
+        options: &SortImportsOptions,
+        allocator: &'a Allocator,
+    ) -> Option<Document<'a>> {
         // Early return for empty files
         if document.len() == 1 && matches!(document[0], FormatElement::Line(LineMode::Hard)) {
-            return document.clone();
+            return None;
         }
 
         // Parse string based groups into our internal representation for performance
-        let groups = parse_groups_from_strings(&self.options.groups);
+        let groups = parse_groups_from_strings(&options.groups);
         let prev_elements: &[FormatElement<'a>] = document;
 
         // Roughly speaking, sort-imports is a process of swapping lines.
@@ -123,12 +122,12 @@ impl SortImportsTransform {
                 }
                 // `SourceLine::Empty` and `SourceLine::CommentOnly` can be boundaries depending on options.
                 // Otherwise, they will be the leading/trailing lines of `PartitionedChunk::Imports`.
-                SourceLine::Empty if !self.options.partition_by_newline => {
+                SourceLine::Empty if !options.partition_by_newline => {
                     current_chunk.add_imports_line(line);
                 }
                 // TODO: Support more flexible comment handling?
                 // e.g. Specific text by regex, only line comments, etc.
-                SourceLine::CommentOnly(..) if !self.options.partition_by_comment => {
+                SourceLine::CommentOnly(..) if !options.partition_by_comment => {
                     current_chunk.add_imports_line(line);
                 }
                 // This `SourceLine` is a boundary!
@@ -182,7 +181,7 @@ impl SortImportsTransform {
                     // // chunk trailing
                     // ```
                     let (sorted_imports, orphan_contents, trailing_lines) =
-                        chunk.into_sorted_import_units(&groups, &self.options);
+                        chunk.into_sorted_import_units(&groups, options);
 
                     // Output leading orphan content (after_slot: None)
                     for orphan in &orphan_contents {
@@ -200,7 +199,7 @@ impl SortImportsTransform {
                         // Insert newline when:
                         // 1. Group changes
                         // 2. Previous import was not ignored (don't insert after ignored)
-                        if self.options.newlines_between {
+                        if options.newlines_between {
                             let current_group_idx = sorted_import.group_idx;
                             if let Some(prev_idx) = prev_group_idx
                                 && prev_idx != current_group_idx
@@ -217,7 +216,7 @@ impl SortImportsTransform {
                             line.write(
                                 prev_elements,
                                 &mut next_elements,
-                                self.options.partition_by_newline,
+                                options.partition_by_newline,
                             );
                         }
                         sorted_import.import_line.write(prev_elements, &mut next_elements, false);
@@ -267,6 +266,6 @@ impl SortImportsTransform {
             }
         }
 
-        Document::from(next_elements)
+        Some(Document::from(next_elements))
     }
 }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -68,8 +68,6 @@ impl<'a> Formatter<'a> {
         let parent = self.allocator.alloc(AstNodes::Dummy());
         let program_node = AstNode::new(program, parent, self.allocator);
 
-        let experimental_sort_imports = self.options.experimental_sort_imports.clone();
-
         let context = FormatContext::new(
             program.source_text,
             program.source_type,
@@ -86,9 +84,14 @@ impl<'a> Formatter<'a> {
 
         // Basic formatting and `document.propagate_expand()` are already done here.
         // Now apply additional transforms if enabled.
-        if let Some(sort_imports_options) = experimental_sort_imports {
-            let sort_imports = SortImportsTransform::new(sort_imports_options);
-            formatted.apply_transform(|doc| sort_imports.transform(doc, self.allocator));
+        if let Some(sort_imports_options) = &formatted.context().options().experimental_sort_imports
+            && let Some(transformed_document) = SortImportsTransform::transform(
+                formatted.document(),
+                sort_imports_options,
+                self.allocator,
+            )
+        {
+            *formatted.document_mut() = transformed_document;
         }
 
         formatted


### PR DESCRIPTION
Remove the unnecessary clone, since `experimental_sort_imports` is a complex struct that is not cheap to clone. I also removed `apply_transform` to avoid a borrow checker problem, as it borrows `&mut self`, and there is already an immutable reference borrowed by `formatted.context().options().experimental_sort_imports`.