### PR TITLE
test(estree): update `estree-conformance` submodule

### DIFF
--- a/.github/scripts/clone-parallel.sh
+++ b/.github/scripts/clone-parallel.sh
@@ -8,11 +8,11 @@ set -euo pipefail
 
 # Submodule commit SHAs - updated automatically by .github/workflows/update_submodules.yml
 # NOTE: Prettier version is now pinned to v3.7.3 (not updated by workflow above), Update manually as needed
-TEST262_SHA="947fee33f81e261afd4fc6020b2a1d3ac23efa60"
+TEST262_SHA="84082e2705b9119d91789f9745df78a6fcecf7ca"
 BABEL_SHA="84d21e4e129468b62ca5e05f8029c18d785f3345"
 TYPESCRIPT_SHA="b78f0899ab6ffe1890f1adff6f5acd82da31f5d8"
 PRETTIER_SHA="fdfa6701767f5140a85902ecc9fb6444f5b4e3f8"
-ESTREE_CONFORMANCE_SHA="e0aa1b46e2da9b30fb86d429166f6ea4b61999ec"
+ESTREE_CONFORMANCE_SHA="4f260c1591a93881d1bb76ef194450b4c60f76e0"
 NODE_COMPAT_TABLE_SHA="499beb6f1daa36f10c26b85a7f3ec3b3448ded23"
 
 # Default values for which submodules to clone

--- a/napi/parser/test/parse-raw-worker.ts
+++ b/napi/parser/test/parse-raw-worker.ts
@@ -146,7 +146,9 @@ async function runJsxCase(
 }
 
 // Run TypeScript test case
-const TS_CASE_HEADER = "__ESTREE_TEST__:PASS:\n```json\n";
+const TS_CASE_HEADER = "__ESTREE_TEST__:";
+const TS_CASE_HEADER_AST = "AST:\n```json\n";
+const TS_CASE_HEADER_AST_LEN = TS_CASE_HEADER_AST.length;
 const TS_CASE_FOOTER = "\n```\n";
 const TS_CASE_FOOTER_LEN = TS_CASE_FOOTER.length;
 
@@ -166,10 +168,14 @@ async function runTsCase(
   if (sourceText.charCodeAt(0) === 0xfeff) sourceText = sourceText.slice(1);
 
   const { tests } = makeUnitsFromTest(tsPath, sourceText);
-  const estreeJsons = casesJson
-    .split(TS_CASE_HEADER)
-    .slice(1)
-    .map((part) => part.slice(0, -TS_CASE_FOOTER_LEN));
+
+  const estreeJsons = [];
+  for (const part of casesJson.split(TS_CASE_HEADER).slice(1)) {
+    if (part.startsWith(TS_CASE_HEADER_AST)) {
+      estreeJsons.push(part.slice(TS_CASE_HEADER_AST_LEN, -TS_CASE_FOOTER_LEN));
+    }
+  }
+
   expect(estreeJsons.length).toEqual(tests.length);
 
   for (let i = 0; i < tests.length; i++) {

--- a/tasks/coverage/snapshots/codegen_test262.snap
+++ b/tasks/coverage/snapshots/codegen_test262.snap
@@ -1,5 +1,5 @@
-commit: 947fee33
+commit: 84082e27
 
 codegen_test262 Summary:
-AST Parsed     : 46453/46453 (100.00%)
-Positive Passed: 46453/46453 (100.00%)
+AST Parsed     : 46467/46467 (100.00%)
+Positive Passed: 46467/46467 (100.00%)

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: e0aa1b46
+commit: 4f260c15
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,8 +1,8 @@
-commit: 947fee33
+commit: 84082e27
 
 estree_test262 Summary:
-AST Parsed     : 46205/46205 (100.00%)
-Positive Passed: 46196/46205 (99.98%)
+AST Parsed     : 46219/46219 (100.00%)
+Positive Passed: 46210/46219 (99.98%)
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js

--- a/tasks/coverage/snapshots/formatter_test262.snap
+++ b/tasks/coverage/snapshots/formatter_test262.snap
@@ -1,8 +1,8 @@
-commit: 947fee33
+commit: 84082e27
 
 formatter_test262 Summary:
-AST Parsed     : 46453/46453 (100.00%)
-Positive Passed: 46450/46453 (99.99%)
+AST Parsed     : 46467/46467 (100.00%)
+Positive Passed: 46464/46467 (99.99%)
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR-LF.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -1,8 +1,8 @@
-commit: 947fee33
+commit: 84082e27
 
 minifier_test262 Summary:
-AST Parsed     : 44035/44035 (100.00%)
-Positive Passed: 44032/44035 (99.99%)
+AST Parsed     : 44049/44049 (100.00%)
+Positive Passed: 44046/44049 (99.99%)
 Compress: tasks/coverage/test262/test/intl402/Temporal/PlainDate/prototype/toLocaleString/lone-options-accepted.js
 
 Compress: tasks/coverage/test262/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/lone-options-accepted.js

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -1,8 +1,8 @@
-commit: 947fee33
+commit: 84082e27
 
 parser_test262 Summary:
-AST Parsed     : 46445/46453 (99.98%)
-Positive Passed: 46437/46453 (99.97%)
+AST Parsed     : 46459/46467 (99.98%)
+Positive Passed: 46451/46467 (99.97%)
 Negative Passed: 4579/4581 (99.96%)
 Expect Syntax Error: tasks/coverage/test262/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js
 

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -1,8 +1,8 @@
-commit: 947fee33
+commit: 84082e27
 
 semantic_test262 Summary:
-AST Parsed     : 46453/46453 (100.00%)
-Positive Passed: 44801/46453 (96.44%)
+AST Parsed     : 46467/46467 (100.00%)
+Positive Passed: 44815/46467 (96.44%)
 semantic Error: tasks/coverage/test262/test/annexB/language/expressions/assignmenttargettype/callexpression-as-for-in-lhs.js
 Cannot assign to this expression
 

--- a/tasks/coverage/snapshots/transformer_test262.snap
+++ b/tasks/coverage/snapshots/transformer_test262.snap
@@ -1,5 +1,5 @@
-commit: 947fee33
+commit: 84082e27
 
 transformer_test262 Summary:
-AST Parsed     : 46453/46453 (100.00%)
-Positive Passed: 46453/46453 (100.00%)
+AST Parsed     : 46467/46467 (100.00%)
+Positive Passed: 46467/46467 (100.00%)


### PR DESCRIPTION
Bump `estree-conformance` and `test262` submodules.

`estree-conformance` submodule now contains snapshots for tokens conformance testing: https://github.com/oxc-project/estree-conformance/pull/131 & https://github.com/oxc-project/estree-conformance/pull/134
