### PR TITLE
fix(parser/napi): fix lazy deser

### DIFF
--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -1,8 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer_lazy.rs`.
 
-import { constructorError, TOKEN } from "../raw-transfer/lazy-common.js";
-import { NodeArray } from "../raw-transfer/node-array.js";
+import { constructorError, TOKEN } from "../../raw-transfer/lazy-common.js";
+import { NodeArray } from "../../raw-transfer/node-array.js";
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -157,8 +157,8 @@ fn generate(
     let constructors = &state.constructors;
     #[rustfmt::skip]
     let constructors = format!("
-        import {{ constructorError, TOKEN }} from '../raw-transfer/lazy-common.js';
-        import {{ NodeArray }} from '../raw-transfer/node-array.js';
+        import {{ constructorError, TOKEN }} from '../../raw-transfer/lazy-common.js';
+        import {{ NodeArray }} from '../../raw-transfer/node-array.js';
 
         const textDecoder = new TextDecoder('utf-8', {{ ignoreBOM: true }}),
             decodeStr = textDecoder.decode.bind(textDecoder),


### PR DESCRIPTION
Lazy deserialization in `oxc-parser` was broken by #16957. Fix it.