### PR TITLE
fix(linter/plugins): error if plugin name alias is not normalized

### DIFF
--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "jsPlugins": [{ "name": "eslint-plugin-invalid", "specifier": "./plugin.ts" }],
+  "rules": {
+    "hahaha/no-debugger": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/files/index.js
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
@@ -1,0 +1,16 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse configuration file.
+
+  x Failed to load JS plugin: ./plugin.ts
+  |   Plugin alias 'eslint-plugin-invalid' is not valid. Must not start with 'eslint-plugin-', or be of form '@scope/eslint-plugin' or '@scope/eslint-plugin-name'.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from "#oxlint";
+
+const plugin: Plugin = {
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -46,6 +46,20 @@ pub fn normalize_plugin_name(plugin_name: &str) -> Cow<'_, str> {
     Cow::Borrowed(plugin_name)
 }
 
+/// Checks if the given plugin name is valid.
+///
+/// Returns `true` if the given plugin name is already in its normalized form.
+///
+/// Returns `false` if it starts with `eslint-plugin-`, or is of the form `@scope/eslint-plugin`
+/// or `@scope/eslint-plugin-something`.
+pub fn is_normal_plugin_name(plugin_name: &str) -> bool {
+    let normalized = normalize_plugin_name(plugin_name);
+    match normalized {
+        Cow::Owned(_) => false,
+        Cow::Borrowed(normalized) => normalized.len() == plugin_name.len(),
+    }
+}
+
 bitflags! {
     // NOTE: may be increased to a u32 if needed
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
#15569 introduced ability to define JS plugins with aliased names.

Check that that alias name is valid - i.e does not start with `eslint-plugin-*` etc.

We could allow this, but it seems like a recipe for bugs. It's a weird thing to do anyway, so just outlaw it.