### PR TITLE
fix(minifier): preserve sideeffectful destructing delcaration for array and object destruction

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -253,7 +253,6 @@ mod test {
         test_same_options("var {} = null", &options);
         test_same_options("var {} = a", &options);
         test_same_options("var {} = null", &options);
-        test_same_options("var {} = null", &options);
         test_same_options("var {} = void 0", &options);
 
         test_same_options("var x; foo(x)", &options);

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -17,9 +17,9 @@ impl<'a> PeepholeOptimizations {
             | Expression::StringLiteral(_)
             | Expression::TemplateLiteral(_) => true,
             Expression::Identifier(ident) => {
-                ctx.scoping.current_scope_flags().is_function()
-                    && ident.name == "arguments"
+                ident.name == "arguments"
                     && ctx.is_global_reference(ident)
+                    && ctx.current_scope_flags().is_function()
             }
             _ => false,
         }


### PR DESCRIPTION
fixes #17038

expands logic used to determine if we can remove empty array and object patterns by checking if assigned value is valid:
