### PR TITLE
chore(oxlint): bump min tsgolint pkg version to 0.9.2

### DIFF
--- a/npm/oxlint/scripts/generate-packages.js
+++ b/npm/oxlint/scripts/generate-packages.js
@@ -102,7 +102,7 @@ function writeManifest() {
   // Do not automatically install 'oxlint-tsgolint'.
   // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta
   manifestData.peerDependencies = {
-    "oxlint-tsgolint": ">=0.9.0",
+    "oxlint-tsgolint": ">=0.9.2",
   };
   manifestData.peerDependenciesMeta = {
     "oxlint-tsgolint": {


### PR DESCRIPTION
0\.9.2 includes an important fix, so we should force users to use the latest version