### PR TITLE
test(linter/plugins): enable `import` plugin on one test fixture

### DIFF
--- a/apps/oxlint/test/fixtures/basic_many_files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_many_files/.oxlintrc.json
@@ -1,5 +1,6 @@
 {
   "jsPlugins": ["./plugin.ts"],
+  "plugins": ["import"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error"
   }


### PR DESCRIPTION
Enable `import` plugin on a test fixture which contains a bunch of files. Obviously this is not a very robust test of `import` plugin - JS plugins interaction, but it's at least a smoke test of a sort.