### PR TITLE
feat(parser): improve diagnostic message for phase imports

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1162,3 +1162,21 @@ pub fn import_attribute_value_must_be_string_literal(span: Span) -> OxcDiagnosti
         .with_label(span)
         .with_help("Wrap this with quotes")
 }
+
+// TS18058
+#[cold]
+pub fn default_import_not_allowed_in_defer(span: Span) -> OxcDiagnostic {
+    ts_error("18058", "Default imports are not allowed in a deferred import.").with_label(span)
+}
+
+// TS18059
+#[cold]
+pub fn named_import_not_allowed_in_defer(span: Span) -> OxcDiagnostic {
+    ts_error("18059", "Named imports are not allowed in a deferred import.").with_label(span)
+}
+
+#[cold]
+pub fn only_default_import_allowed_in_source_phase(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Only a single default import is allowed in a source phase import.")
+        .with_label(span)
+}

--- a/tasks/coverage/misc/fail/oxc-11532.js
+++ b/tasks/coverage/misc/fail/oxc-11532.js
@@ -1,3 +1,3 @@
 import source { x } from 'x';
-import defer { x } from "x";
-import defer x from "x";
+import defer { x2 } from "x";
+import defer x3 from "x";

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -459,12 +459,26 @@ Negative Passed: 122/122 (100.00%)
    ·             ──
    ╰────
 
-  × Expected `from` but found `{`
-   ╭─[misc/fail/oxc-11532.js:1:15]
+  × Only a single default import is allowed in a source phase import.
+   ╭─[misc/fail/oxc-11532.js:1:8]
  1 │ import source { x } from 'x';
-   ·               ┬
-   ·               ╰── `from` expected
- 2 │ import defer { x } from "x";
+   ·        ──────
+ 2 │ import defer { x2 } from "x";
+   ╰────
+
+  × TS(18059): Named imports are not allowed in a deferred import.
+   ╭─[misc/fail/oxc-11532.js:2:8]
+ 1 │ import source { x } from 'x';
+ 2 │ import defer { x2 } from "x";
+   ·        ─────
+ 3 │ import defer x3 from "x";
+   ╰────
+
+  × TS(18058): Default imports are not allowed in a deferred import.
+   ╭─[misc/fail/oxc-11532.js:3:8]
+ 2 │ import defer { x2 } from "x";
+ 3 │ import defer x3 from "x";
+   ·        ─────
    ╰────
 
   × Expected `}` but found `function`

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -22117,12 +22117,18 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·           ─────────
     ╰────
 
-  × Expected `from` but found `Identifier`
-    ╭─[test262/test/language/import/import-defer/syntax/invalid-default-and-defer-namespace.js:34:14]
+  × TS(18058): Default imports are not allowed in a deferred import.
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-default-and-defer-namespace.js:34:8]
  33 │ 
  34 │ import defer x, * as ns from "./dep_FIXTURE.js";
-    ·              ┬
-    ·              ╰── `from` expected
+    ·        ─────
+    ╰────
+
+  × Cannot use import statement outside a module
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-default-and-defer-namespace.js:34:1]
+ 33 │ 
+ 34 │ import defer x, * as ns from "./dep_FIXTURE.js";
+    · ──────
     ╰────
 
   × Expected `from` but found `as`
@@ -22140,20 +22146,32 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/using/syntax/us
     ·           ─────
     ╰────
 
-  × Expected `from` but found `Identifier`
-    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-default.js:34:14]
+  × TS(18058): Default imports are not allowed in a deferred import.
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-default.js:34:8]
  33 │ 
  34 │ import defer x from "./dep_FIXTURE.js";
-    ·              ┬
-    ·              ╰── `from` expected
+    ·        ─────
     ╰────
 
-  × Expected `from` but found `{`
-    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-named.js:34:14]
+  × Cannot use import statement outside a module
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-default.js:34:1]
+ 33 │ 
+ 34 │ import defer x from "./dep_FIXTURE.js";
+    · ──────
+    ╰────
+
+  × TS(18059): Named imports are not allowed in a deferred import.
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-named.js:34:8]
  33 │ 
  34 │ import defer { default as x } from "./dep_FIXTURE.js";
-    ·              ┬
-    ·              ╰── `from` expected
+    ·        ─────
+    ╰────
+
+  × Cannot use import statement outside a module
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-named.js:34:1]
+ 33 │ 
+ 34 │ import defer { default as x } from "./dep_FIXTURE.js";
+    · ──────
     ╰────
 
   × Unexpected token

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -19959,19 +19959,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                   ────
    ╰────
 
-  × Expected `from` but found `Identifier`
-   ╭─[typescript/tests/cases/conformance/importDefer/importDeferInvalidDefault.ts:1:14]
+  × TS(18058): Default imports are not allowed in a deferred import.
+   ╭─[typescript/tests/cases/conformance/importDefer/importDeferInvalidDefault.ts:1:8]
  1 │ import defer foo from "./a";
-   ·              ─┬─
-   ·               ╰── `from` expected
+   ·        ─────
  2 │ 
    ╰────
 
-  × Expected `from` but found `{`
-   ╭─[typescript/tests/cases/conformance/importDefer/importDeferInvalidNamed.ts:1:14]
+  × TS(18059): Named imports are not allowed in a deferred import.
+   ╭─[typescript/tests/cases/conformance/importDefer/importDeferInvalidNamed.ts:1:8]
  1 │ import defer { foo } from "./a";
-   ·              ┬
-   ·              ╰── `from` expected
+   ·        ─────
  2 │ 
    ╰────
 
@@ -19982,11 +19980,16 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                   ╰── `from` expected
    ╰────
 
-  × Expected `from` but found `type`
-   ╭─[typescript/tests/cases/conformance/importDefer/importDeferTypeConflict2.ts:1:14]
+  × TS(18058): Default imports are not allowed in a deferred import.
+   ╭─[typescript/tests/cases/conformance/importDefer/importDeferTypeConflict2.ts:1:8]
  1 │ import defer type * as ns1 from "./a";
-   ·              ──┬─
-   ·                ╰── `from` expected
+   ·        ─────
+   ╰────
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/importDefer/importDeferTypeConflict2.ts:1:19]
+ 1 │ import defer type * as ns1 from "./a";
+   ·                   ─
    ╰────
 
   × The only valid meta property for import is import.meta


### PR DESCRIPTION
We now produce the same error codes as typescript