### PR TITLE
fix(oxfmt): Resolve `.editorconfig` root dir from `cwd`

### DIFF
--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -72,6 +72,7 @@ impl FormatRunner {
         let oxfmtrc_path = resolve_oxfmtrc_path(&cwd, config_options.config.as_deref());
         let editorconfig_path = resolve_editorconfig_path(&cwd);
         let mut config_resolver = match ConfigResolver::from_config_paths(
+            &cwd,
             oxfmtrc_path.as_deref(),
             editorconfig_path.as_deref(),
         ) {

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -93,6 +93,7 @@ impl ConfigResolver {
     /// - Config file is specified but not found or invalid
     /// - Config file parsing fails
     pub fn from_config_paths(
+        cwd: &Path,
         oxfmtrc_path: Option<&Path>,
         editorconfig_path: Option<&Path>,
     ) -> Result<Self, String> {
@@ -120,7 +121,7 @@ impl ConfigResolver {
                 let str = utils::read_to_string(path)
                     .map_err(|_| format!("Failed to read {}: File not found", path.display()))?;
 
-                Some(EditorConfig::parse(&str))
+                Some(EditorConfig::parse(&str).with_cwd(cwd))
             }
             None => None,
         };

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -66,6 +66,7 @@ impl StdinRunner {
         let oxfmtrc_path = resolve_oxfmtrc_path(&cwd, config_options.config.as_deref());
         let editorconfig_path = resolve_editorconfig_path(&cwd);
         let mut config_resolver = match ConfigResolver::from_config_paths(
+            &cwd,
             oxfmtrc_path.as_deref(),
             editorconfig_path.as_deref(),
         ) {

--- a/apps/oxfmt/test/__snapshots__/editorconfig.test.ts.snap
+++ b/apps/oxfmt/test/__snapshots__/editorconfig.test.ts.snap
@@ -81,3 +81,60 @@ if (true) {
 
 --------------------"
 `;
+
+exports[`editorconfig > per-file overrides 1`] = `
+"--- FILE -----------
+test.js
+--- BEFORE ---------
+if (true) { console.log("js"); }
+
+--- AFTER ----------
+if (true) {
+  console.log("js");
+}
+
+--------------------
+
+--- FILE -----------
+test.ts
+--- BEFORE ---------
+if (true) { console.log("ts"); }
+
+--- AFTER ----------
+if (true) {
+    console.log("ts");
+}
+
+--------------------
+
+--- FILE -----------
+nested/deep/test.js
+--- BEFORE ---------
+if (true) { console.log("nested js"); }
+
+--- AFTER ----------
+if (true) {
+        console.log("nested js");
+}
+
+--------------------
+
+--- FILE -----------
+nested/deep/test.json
+--- BEFORE ---------
+{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8}
+
+--- AFTER ----------
+{
+	"a": 1,
+	"b": 2,
+	"c": 3,
+	"d": 4,
+	"e": 5,
+	"f": 6,
+	"g": 7,
+	"h": 8
+}
+
+--------------------"
+`;

--- a/apps/oxfmt/test/editorconfig.test.ts
+++ b/apps/oxfmt/test/editorconfig.test.ts
@@ -34,16 +34,14 @@ describe("editorconfig", () => {
   //   [*] indent_style=space, indent_size=2
   //   [*.ts] indent_size=4
   //   [nested/**/*.js] indent_size=8
-  //   [nested/**/*.json] indent_size=8, max_line_length=40
+  //   [nested/deep/*.json] indent_style=tab, max_line_length=40
   //
   // Expected:
   // - test.js: tabWidth=2 (from [*], not matched by [nested/**/*.js])
   // - test.ts: tabWidth=4 (from [*.ts])
   // - nested/deep/test.js: tabWidth=8 (from [nested/**/*.js], deep path glob)
-  // - nested/deep/test.json: tabWidth=8, printWidth=40 (from [nested/**/*.json], deep path glob for external formatter)
-  // TODO: Should fix `editor_config_parser` to accept `cwd` for `resolve()`
-  // oxlint-disable-next-line vitest/no-disabled-tests
-  it.skip("per-file overrides", async () => {
+  // - nested/deep/test.json: useTab=true, printWidth=40 (from [nested/deep/*.json], deep path glob for external formatter)
+  it("per-file overrides", async () => {
     const cwd = join(fixturesDir, "per_file_override");
     const snapshot = await runWriteModeAndSnapshot(cwd, [
       "test.js",

--- a/apps/oxfmt/test/fixtures/editorconfig/per_file_override/.editorconfig
+++ b/apps/oxfmt/test/fixtures/editorconfig/per_file_override/.editorconfig
@@ -9,5 +9,5 @@ indent_size = 4
 indent_size = 8
 
 [nested/deep/*.json]
-indent_size = 8
+indent_style = tab
 max_line_length = 40


### PR DESCRIPTION
Follow up #17044 

- Set `cwd` to `EditorConfig` to handle absolute path
- Restore skipped tests