### PR TITLE
release(crates): oxc v0.104.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "oxc"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "itertools",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1913,14 +1913,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "insta",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "insta",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "insta",
  "itertools",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "base64",
  "compact_str",
@@ -2493,7 +2493,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "cow-utils",
  "insta",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,33 +103,33 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # publish = true
-oxc = { version = "0.103.0", path = "crates/oxc" } # Main entry point
-oxc_allocator = { version = "0.103.0", path = "crates/oxc_allocator" } # Memory management
-oxc_ast = { version = "0.103.0", path = "crates/oxc_ast" } # AST definitions
-oxc_ast_macros = { version = "0.103.0", path = "crates/oxc_ast_macros" } # AST proc macros
-oxc_ast_visit = { version = "0.103.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
-oxc_cfg = { version = "0.103.0", path = "crates/oxc_cfg" } # Control flow graph
-oxc_codegen = { version = "0.103.0", path = "crates/oxc_codegen" } # Code generation
-oxc_compat = { version = "0.103.0", path = "crates/oxc_compat" } # Browser compatibility
-oxc_data_structures = { version = "0.103.0", path = "crates/oxc_data_structures" } # Shared data structures
-oxc_diagnostics = { version = "0.103.0", path = "crates/oxc_diagnostics" } # Error reporting
-oxc_ecmascript = { version = "0.103.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
-oxc_estree = { version = "0.103.0", path = "crates/oxc_estree" } # ESTree format
-oxc_isolated_declarations = { version = "0.103.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
-oxc_mangler = { version = "0.103.0", path = "crates/oxc_mangler" } # Name mangling
-oxc_minifier = { version = "0.103.0", path = "crates/oxc_minifier" } # Code minification
-oxc_minify_napi = { version = "0.103.0", path = "napi/minify" } # Node.js minifier binding
-oxc_napi = { version = "0.103.0", path = "crates/oxc_napi" } # NAPI utilities
-oxc_parser = { version = "0.103.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
-oxc_parser_napi = { version = "0.103.0", path = "napi/parser" } # Node.js parser binding
-oxc_regular_expression = { version = "0.103.0", path = "crates/oxc_regular_expression" } # Regex parser
-oxc_semantic = { version = "0.103.0", path = "crates/oxc_semantic" } # Semantic analysis
-oxc_span = { version = "0.103.0", path = "crates/oxc_span" } # Source positions
-oxc_syntax = { version = "0.103.0", path = "crates/oxc_syntax" } # Syntax utilities
-oxc_transform_napi = { version = "0.103.0", path = "napi/transform" } # Node.js transformer binding
-oxc_transformer = { version = "0.103.0", path = "crates/oxc_transformer" } # Code transformation
-oxc_transformer_plugins = { version = "0.103.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
-oxc_traverse = { version = "0.103.0", path = "crates/oxc_traverse" } # AST traversal
+oxc = { version = "0.104.0", path = "crates/oxc" } # Main entry point
+oxc_allocator = { version = "0.104.0", path = "crates/oxc_allocator" } # Memory management
+oxc_ast = { version = "0.104.0", path = "crates/oxc_ast" } # AST definitions
+oxc_ast_macros = { version = "0.104.0", path = "crates/oxc_ast_macros" } # AST proc macros
+oxc_ast_visit = { version = "0.104.0", path = "crates/oxc_ast_visit" } # AST visitor pattern
+oxc_cfg = { version = "0.104.0", path = "crates/oxc_cfg" } # Control flow graph
+oxc_codegen = { version = "0.104.0", path = "crates/oxc_codegen" } # Code generation
+oxc_compat = { version = "0.104.0", path = "crates/oxc_compat" } # Browser compatibility
+oxc_data_structures = { version = "0.104.0", path = "crates/oxc_data_structures" } # Shared data structures
+oxc_diagnostics = { version = "0.104.0", path = "crates/oxc_diagnostics" } # Error reporting
+oxc_ecmascript = { version = "0.104.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
+oxc_estree = { version = "0.104.0", path = "crates/oxc_estree" } # ESTree format
+oxc_isolated_declarations = { version = "0.104.0", path = "crates/oxc_isolated_declarations" } # TS declaration generation
+oxc_mangler = { version = "0.104.0", path = "crates/oxc_mangler" } # Name mangling
+oxc_minifier = { version = "0.104.0", path = "crates/oxc_minifier" } # Code minification
+oxc_minify_napi = { version = "0.104.0", path = "napi/minify" } # Node.js minifier binding
+oxc_napi = { version = "0.104.0", path = "crates/oxc_napi" } # NAPI utilities
+oxc_parser = { version = "0.104.0", path = "crates/oxc_parser", features = ["regular_expression"] } # JS/TS parser
+oxc_parser_napi = { version = "0.104.0", path = "napi/parser" } # Node.js parser binding
+oxc_regular_expression = { version = "0.104.0", path = "crates/oxc_regular_expression" } # Regex parser
+oxc_semantic = { version = "0.104.0", path = "crates/oxc_semantic" } # Semantic analysis
+oxc_span = { version = "0.104.0", path = "crates/oxc_span" } # Source positions
+oxc_syntax = { version = "0.104.0", path = "crates/oxc_syntax" } # Syntax utilities
+oxc_transform_napi = { version = "0.104.0", path = "napi/transform" } # Node.js transformer binding
+oxc_transformer = { version = "0.104.0", path = "crates/oxc_transformer" } # Code transformation
+oxc_transformer_plugins = { version = "0.104.0", path = "crates/oxc_transformer_plugins" } # Transformer plugins
+oxc_traverse = { version = "0.104.0", path = "crates/oxc_traverse" } # AST traversal
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- d209c21 allocator: Add cap to FixedSizeAllocatorPool and block when exhausted (#17023) (Cameron)
+- fb2af91 allocator: Add bitset utils (#17042) (zhaoting zhou)
+
+### 🐛 Bug Fixes
+
+- fb9e193 linter: OOM problems with custom plugins (#17082) (overlookmotel)
+
+### ⚡ Performance
+
+- b657bb6 allocator: Reduce time `Mutex` lock is held in `FixedSizeAllocatorPool::get` (#17079) (overlookmotel)
+
 ## [0.99.0] - 2025-11-24
 
 ### 🚀 Features

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_allocator"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_macros/CHANGELOG.md
+++ b/crates/oxc_ast_macros/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### ⚡ Performance
+
+- 1f3b19b ast: `#[ast]` macro use `#[repr(transparent)]` for single-field structs (#17052) (overlookmotel)
+
 ## [0.99.0] - 2025-11-24
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_macros"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ast_visit"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_cfg"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- 67e9f9e codegen: Keep comments on the export specifiers (#16943) (夕舞八弦)
+
 ## [0.103.0] - 2025-12-15
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_codegen"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_compat/CHANGELOG.md
+++ b/crates/oxc_compat/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- c16082c tasks/compat_data: Integrate `node-compat-table` (#16831) (Boshen)
+
 ## [0.97.0] - 2025-11-11
 
 ### 🚀 Features

--- a/crates/oxc_compat/Cargo.toml
+++ b/crates/oxc_compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_compat"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_data_structures"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_diagnostics"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_ecmascript"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_estree"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_isolated_declarations"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_mangler"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- 3d2b492 minifier: Fold iife arrow functions in call expressions (#16477) (Armano)
+- 74eae13 minifier: Remove unused import specifiers (#16797) (camc314)
+
+### 🐛 Bug Fixes
+
+- 47b4c2f minifier/docs: Correct hyperlink path in OPTIMIZATIONS.md  (#16986) (GRK)
+
 ## [0.103.0] - 2025-12-15
 
 ### 🚀 Features

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minifier"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_napi"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- cb515fa parser: Improve error message for `yield` as identifier usage (#16950) (sapphi-red)
+- dcc856b parser: Add help for `new_dynamic_import` error (#16949) (sapphi-red)
+- c3c79f8 parser: Improve import attribute value error message (#16948) (sapphi-red)
+
+### ⚡ Performance
+
+- 225f229 parser: Use SmallVec for duplicate default export detection (#16801) (camc314)
+
 ## [0.103.0] - 2025-12-15
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🐛 Bug Fixes
+
+- 5a2af88 regular_expression: Correct named capture group reference error (#16952) (sapphi-red)
+
 ## [0.96.0] - 2025-10-30
 
 ### 🚜 Refactor

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_regular_expression"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_semantic"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- 5586823 span: Extract TS declaration file check to its own function (#17037) (camchenry)
+
 ## [0.100.0] - 2025-12-01
 
 ### ⚡ Performance

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_span"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_syntax"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🐛 Bug Fixes
+
+- 3002649 transformer/typescript: Remove unused import equals declaration (#16776) (Dunqing)
+
 ## [0.103.0] - 2025-12-15
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transformer_plugins"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 📚 Documentation
+
+- a9c419f traverse: Update safety comments (#16944) (overlookmotel)
+
 ## [0.100.0] - 2025-12-01
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_traverse"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_minify_napi"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/minify/index.js
+++ b/napi/minify/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-minify/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-minify/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-minify/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-minify/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-minify/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-minify/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-minify/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-minify/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-minify/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.103.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.103.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-minify",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Oxc Minifier Node API",
   "keywords": [
     "minify",

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
+## [0.104.0] - 2025-12-19
+
+### 🚀 Features
+
+- 291b57b ast_tools: Generate TS declaration files for deserializer and walk files (#16912) (camc314)
+
+### 🐛 Bug Fixes
+
+- e59132b parser/napi: Fix lazy deser (#17069) (overlookmotel)
+- a92faf0 ast_tools: Support `u128` in `assert_layouts` generator (#17050) (overlookmotel)
+
 ## [0.103.0] - 2025-12-15
 
 ### 🚀 Features

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_parser_napi"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-parser",
-  "version": "0.102.0",
+  "version": "0.104.0",
   "description": "Oxc Parser Node API",
   "keywords": [
     "oxc",

--- a/napi/parser/src-js/bindings.js
+++ b/napi/parser/src-js/bindings.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-parser/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-parser/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-parser/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-parser/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-parser/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-parser/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-parser/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-parser/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-parser/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_transform_napi"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-transform/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-transform/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-transform/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-transform/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-transform/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-transform/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-transform/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-transform/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-transform/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.102.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.102.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.104.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.104.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-transform",
-  "version": "0.102.0",
+  "version": "0.104.0",
   "description": "Oxc Transformer Node API",
   "keywords": [
     "oxc",

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/types",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Types for Oxc AST nodes",
   "keywords": [
     "AST",

--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-project/runtime",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Oxc's modular runtime helpers",
   "homepage": "https://oxc.rs",
   "repository": {


### PR DESCRIPTION
### 🚀 Features

- d209c21 allocator: Add cap to FixedSizeAllocatorPool and block when exhausted (#17023) (Cameron)
- fb2af91 allocator: Add bitset utils (#17042) (zhaoting zhou)
- c16082c tasks/compat_data: Integrate `node-compat-table` (#16831) (Boshen)
- 5586823 span: Extract TS declaration file check to its own function (#17037) (camchenry)
- 3d2b492 minifier: Fold iife arrow functions in call expressions (#16477) (Armano)
- 67e9f9e codegen: Keep comments on the export specifiers (#16943) (夕舞八弦)
- cb515fa parser: Improve error message for `yield` as identifier usage (#16950) (sapphi-red)
- dcc856b parser: Add help for `new_dynamic_import` error (#16949) (sapphi-red)
- c3c79f8 parser: Improve import attribute value error message (#16948) (sapphi-red)
- 291b57b ast_tools: Generate TS declaration files for deserializer and walk files (#16912) (camc314)
- 74eae13 minifier: Remove unused import specifiers (#16797) (camc314)

### 🐛 Bug Fixes

- fb9e193 linter: OOM problems with custom plugins (#17082) (overlookmotel)
- e59132b parser/napi: Fix lazy deser (#17069) (overlookmotel)
- a92faf0 ast_tools: Support `u128` in `assert_layouts` generator (#17050) (overlookmotel)
- 47b4c2f minifier/docs: Correct hyperlink path in OPTIMIZATIONS.md  (#16986) (GRK)
- 3002649 transformer/typescript: Remove unused import equals declaration (#16776) (Dunqing)
- 5a2af88 regular_expression: Correct named capture group reference error (#16952) (sapphi-red)

### ⚡ Performance

- b657bb6 allocator: Reduce time `Mutex` lock is held in `FixedSizeAllocatorPool::get` (#17079) (overlookmotel)
- 1f3b19b ast: `#[ast]` macro use `#[repr(transparent)]` for single-field structs (#17052) (overlookmotel)
- 225f229 parser: Use SmallVec for duplicate default export detection (#16801) (camc314)

### 📚 Documentation

- a9c419f traverse: Update safety comments (#16944) (overlookmotel)