### PR TITLE
refactor(oxfmt): Restore accidentally removed TS types

### DIFF
--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -1,5 +1,6 @@
 import Tinypool from "tinypool";
 import { resolvePlugins } from "../libs/prettier";
+import type { FormatEmbeddedCodeParam, FormatFileParam } from "../libs/prettier";
 import type { Options } from "prettier";
 
 // Worker pool for parallel Prettier formatting
@@ -20,7 +21,9 @@ export async function formatEmbeddedCode(
   tagName: string,
   code: string,
 ): Promise<string> {
-  return pool!.run({ options, code, tagName }, { name: "formatEmbeddedCode" });
+  return pool!.run({ options, code, tagName } satisfies FormatEmbeddedCodeParam, {
+    name: "formatEmbeddedCode",
+  });
 }
 
 export async function formatFile(
@@ -29,5 +32,7 @@ export async function formatFile(
   fileName: string,
   code: string,
 ): Promise<string> {
-  return pool!.run({ options, code, fileName, parserName }, { name: "formatFile" });
+  return pool!.run({ options, code, fileName, parserName } satisfies FormatFileParam, {
+    name: "formatFile",
+  });
 }

--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -19,6 +19,8 @@ export async function resolvePlugins(): Promise<string[]> {
   return [];
 }
 
+// ---
+
 const TAG_TO_PARSER: Record<string, string> = {
   // CSS
   css: "css",
@@ -33,6 +35,12 @@ const TAG_TO_PARSER: Record<string, string> = {
   markdown: "markdown",
 };
 
+export type FormatEmbeddedCodeParam = {
+  code: string;
+  tagName: string;
+  options: Options;
+};
+
 /**
  * Format xxx-in-js code snippets
  *
@@ -44,11 +52,7 @@ export async function formatEmbeddedCode({
   code,
   tagName,
   options,
-}: {
-  code: string;
-  tagName: string;
-  options: Options;
-}): Promise<string> {
+}: FormatEmbeddedCodeParam): Promise<string> {
   // TODO: This should be resolved in Rust side
   const parserName = TAG_TO_PARSER[tagName];
 
@@ -67,6 +71,15 @@ export async function formatEmbeddedCode({
     .catch(() => code);
 }
 
+// ---
+
+export type FormatFileParam = {
+  code: string;
+  parserName: string;
+  fileName: string;
+  options: Options;
+};
+
 /**
  * Format non-js file
  *
@@ -77,12 +90,7 @@ export async function formatFile({
   parserName,
   fileName,
   options,
-}: {
-  code: string;
-  parserName: string;
-  fileName: string;
-  options: Options;
-}): Promise<string> {
+}: FormatFileParam): Promise<string> {
   if (!prettierCache) {
     prettierCache = await import("prettier");
   }


### PR DESCRIPTION
If we pass the wrong argument, the test will just fail, but well, type safety is a good.