### PR TITLE
build(napi): add `@napi-rs/cli` dev dependency to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "oxlint -c oxlintrc.json --deny-warnings --type-aware --type-check --report-unused-disable-directives"
   },
   "devDependencies": {
+    "@napi-rs/cli": "catalog:",
     "oxfmt": "^0.18.0",
     "oxlint": "^1.33.0",
     "oxlint-tsgolint": "0.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
 
   .:
     devDependencies:
+      '@napi-rs/cli':
+        specifier: 'catalog:'
+        version: 3.5.0(@emnapi/runtime@1.7.1)(@types/node@25.0.2)
       oxfmt:
         specifier: ^0.18.0
         version: 0.18.0


### PR DESCRIPTION
Publish of NAPI packages failed:

https://github.com/oxc-project/oxc/actions/runs/20357572068/job/58499858990
https://github.com/oxc-project/oxc/actions/runs/20357572052/job/58496266256
https://github.com/oxc-project/oxc/actions/runs/20357572042/job/58496286496

All failed on the final step of releasing the packages with:

```
> pnpm napi create-npm-dirs --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
Command "napi" not found
```

Probably this is not the *right* way to solve this problem, but I'm hoping that adding `@napi-rs/cli` as a dev dependency in root of the repo will at least allow getting the release to complete.