### PR TITLE
build(napi): add `pnpm install @napi-rs/cli` to `reusable_release_napi` workflow

### DIFF
--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -207,6 +207,8 @@ jobs:
 
       - run: mkdir -p ${npm_dir}
 
+      - run: pnpm install @napi-rs/cli
+
       - run: pnpm napi create-npm-dirs --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
 
       - run: pnpm napi artifacts --package-json-path ${package_path}/package.json --build-output-dir ${package_path}/src-js --npm-dir ${npm_dir}


### PR DESCRIPTION
Another attempt to get NAPI packages release working, after #17101 failed.