### PR TITLE
refactor(linter): Always pass the Rule itself to the DefaultRuleConfig.

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -83,9 +83,9 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// ```ignore
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Self {
-///         let config = serde_json::from_value::<DefaultRuleConfig<MyRuleConfig>>(value)
-///             .unwrap_or_default();
-///         Self(config.into_inner())
+///         serde_json::from_value::<DefaultRuleConfig<MyRule>>(value)
+///             .unwrap_or_default()
+///             .into_inner()
 ///     }
 /// }
 /// ```

--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -56,7 +56,7 @@ impl Default for AccessorPairsConfig {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct AccessorPairs(Box<AccessorPairsConfig>);
 
 impl std::ops::Deref for AccessorPairs {
@@ -122,10 +122,9 @@ declare_oxc_lint!(
 
 impl Rule for AccessorPairs {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = serde_json::from_value::<DefaultRuleConfig<AccessorPairsConfig>>(value)
+        serde_json::from_value::<DefaultRuleConfig<AccessorPairs>>(value)
             .unwrap_or_default()
-            .into_inner();
-        Self(Box::new(config))
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -54,16 +54,12 @@ fn report_coercion(ctx: &LintContext, span: Span, kind: CoercionKind, operand: &
 #[serde(rename_all = "camelCase", default)]
 pub struct NoImplicitCoercionConfig {
     /// When `true`, warns on implicit boolean coercion (e.g., `!!foo`).
-    /// Default: `true`
     boolean: bool,
     /// When `true`, warns on implicit number coercion (e.g., `+foo`).
-    /// Default: `true`
     number: bool,
     /// When `true`, warns on implicit string coercion (e.g., `"" + foo`).
-    /// Default: `true`
     string: bool,
     /// When `true`, disallows using template literals for string coercion (e.g., `` `${foo}` ``).
-    /// Default: `false`
     disallow_template_shorthand: bool,
     /// List of operators to allow. Valid values: `"!!"`, `"~"`, `"+"`, `"-"`, `"- -"`, `"*"`
     #[schemars(with = "Vec<String>")]
@@ -138,7 +134,7 @@ impl Default for NoImplicitCoercionConfig {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoImplicitCoercion(Box<NoImplicitCoercionConfig>);
 
 impl std::ops::Deref for NoImplicitCoercion {
@@ -184,10 +180,9 @@ declare_oxc_lint!(
 
 impl Rule for NoImplicitCoercion {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = serde_json::from_value::<DefaultRuleConfig<NoImplicitCoercionConfig>>(value)
+        serde_json::from_value::<DefaultRuleConfig<NoImplicitCoercion>>(value)
             .unwrap_or_default()
-            .into_inner();
-        Self(Box::new(config))
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -16,7 +16,7 @@ fn unexpected_hook_diagonsitc(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use setup or teardown hooks").with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoHooks(Box<NoHooksConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
@@ -102,10 +102,7 @@ declare_oxc_lint!(
 
 impl Rule for NoHooks {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = serde_json::from_value::<DefaultRuleConfig<NoHooksConfig>>(value)
-            .unwrap_or_default()
-            .into_inner();
-        Self(Box::new(config))
+        serde_json::from_value::<DefaultRuleConfig<NoHooks>>(value).unwrap_or_default().into_inner()
     }
 
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -52,7 +52,7 @@ fn duplicate_key_prop(key_value: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[schemars(transparent)]
 pub struct JsxKey(Box<JsxKeyConfig>);
 
@@ -109,10 +109,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxKey {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let config = serde_json::from_value::<DefaultRuleConfig<JsxKeyConfig>>(value)
-            .unwrap_or_default()
-            .into_inner();
-        Self(Box::new(config))
+        serde_json::from_value::<DefaultRuleConfig<JsxKey>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -32,7 +32,7 @@ enum PreferES6ClassOptionType {
     Never,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct PreferEs6Class(PreferES6ClassOptionType);
 
 declare_oxc_lint!(
@@ -63,11 +63,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferEs6Class {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(
-            serde_json::from_value::<DefaultRuleConfig<PreferES6ClassOptionType>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        )
+        serde_json::from_value::<DefaultRuleConfig<PreferEs6Class>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -32,7 +32,7 @@ fn consistent_indexed_object_style_diagnostic(
     OxcDiagnostic::warn(warning_message).with_help(help_message).with_label(span)
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ConsistentIndexedObjectStyle(ConsistentIndexedObjectStyleConfig);
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -109,11 +109,9 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentIndexedObjectStyle {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(
-            serde_json::from_value::<DefaultRuleConfig<ConsistentIndexedObjectStyleConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        )
+        serde_json::from_value::<DefaultRuleConfig<ConsistentIndexedObjectStyle>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
@@ -32,7 +32,7 @@ fn no_restricted_types_diagnostic(
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct NoRestrictedTypes(Box<NoRestrictedTypesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -150,11 +150,9 @@ declare_oxc_lint!(
 
 impl Rule for NoRestrictedTypes {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<NoRestrictedTypesConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<NoRestrictedTypes>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -30,7 +30,7 @@ fn switch_case_braces_diagnostic_unnecessary_braces(span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SwitchCaseBraces(Box<SwitchCaseBracesConfig>);
 
 impl Default for SwitchCaseBraces {
@@ -96,11 +96,9 @@ declare_oxc_lint!(
 
 impl Rule for SwitchCaseBraces {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<SwitchCaseBracesConfig>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        ))
+        serde_json::from_value::<DefaultRuleConfig<SwitchCaseBraces>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
@@ -47,7 +47,7 @@ enum DeclarationStyle {
     Runtime,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct DefineEmitsDeclaration(DeclarationStyle);
 
 declare_oxc_lint!(
@@ -129,11 +129,9 @@ declare_oxc_lint!(
 
 impl Rule for DefineEmitsDeclaration {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(
-            serde_json::from_value::<DefaultRuleConfig<DeclarationStyle>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        )
+        serde_json::from_value::<DefaultRuleConfig<DefineEmitsDeclaration>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
@@ -32,7 +32,7 @@ enum DeclarationStyle {
     Runtime,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct DefinePropsDeclaration(DeclarationStyle);
 
 declare_oxc_lint!(
@@ -84,11 +84,9 @@ declare_oxc_lint!(
 
 impl Rule for DefinePropsDeclaration {
     fn from_configuration(value: serde_json::Value) -> Self {
-        Self(
-            serde_json::from_value::<DefaultRuleConfig<DeclarationStyle>>(value)
-                .unwrap_or_default()
-                .into_inner(),
-        )
+        serde_json::from_value::<DefaultRuleConfig<DefinePropsDeclaration>>(value)
+            .unwrap_or_default()
+            .into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
Rather than passing the inner config.

With this change, we're consistent across all rules that use DefaultRuleConfig now. We can also replace the rule name with Self in the future.