### PR TITLE
chore(all): update editorconfig for rust files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[*.rs]
+indent_size = 4


### PR DESCRIPTION
Ensure the indentation for rust files is 4 spaces.

This shouldn't cause any problems for oxfmt and also won't make my editor try to use 2 spaces for rust code :)