### PR TITLE
chore(linter): Cleanup some rule tests.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -310,7 +310,7 @@ fn test() {
         (
             "function foo(a, z) { a.b = 0; x.y = 0; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsFor": ["a", "x"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsFor": ["a", "x"] }, ]),
             ),
         ),
         (
@@ -320,31 +320,31 @@ fn test() {
         (
             "function foo(aFoo) { aFoo.b = 0; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] }, ]),
             ),
         ),
         (
             "function foo(aFoo) { ++aFoo.b; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] }, ]),
             ),
         ),
         (
             "function foo(aFoo) { delete aFoo.b; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] }, ]),
             ),
         ),
         (
             "function foo(a, z) { aFoo.b = 0; x.y = 0; }",
             Some(
-                serde_json::json!([				{					"props": true,					"ignorePropertyModificationsForRegex": ["^a.*$", "^x.*$"],				},			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$", "^x.*$"], }, ]),
             ),
         ),
         (
             "function foo(aFoo) { aFoo.b.c = 0;}",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] }, ]),
             ),
         ),
         (
@@ -368,7 +368,7 @@ fn test() {
         (
             "function foo(bar, baz) { bar.a = true; baz.b = false; }",
             Some(
-                serde_json::json!([				{					"props": true,					"ignorePropertyModificationsForRegex": ["^(foo|bar)$"],					"ignorePropertyModificationsFor": ["baz"],				},			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^(foo|bar)$"], "ignorePropertyModificationsFor": ["baz"], }, ]),
             ),
         ),
     ];
@@ -419,13 +419,13 @@ fn test() {
         (
             "function foo(bar) { [bar.a] = []; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^a.*$"] }, ]),
             ),
         ), // { "ecmaVersion": 6 },
         (
             "function foo(bar) { [bar.a] = []; }",
             Some(
-                serde_json::json!([				{ "props": true, "ignorePropertyModificationsForRegex": ["^B.*$"] },			]),
+                serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^B.*$"] }, ]),
             ),
         ), // { "ecmaVersion": 6 },
         (

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -283,7 +283,7 @@ fn test() {
         (
             "var foo = object.bar;",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": false },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": false }, ]),
             ),
         ),
         (
@@ -293,7 +293,7 @@ fn test() {
         (
             "var foo = object['bar'];",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": false },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": false }, ]),
             ),
         ),
         (
@@ -303,7 +303,7 @@ fn test() {
         (
             "var { bar: foo } = object;",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -313,7 +313,7 @@ fn test() {
         (
             "var { [bar]: foo } = object;",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -337,7 +337,7 @@ fn test() {
         (
             "var foo = array[0];",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "array": false } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": false } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -353,49 +353,47 @@ fn test() {
         (
             "foo = object.foo;",
             Some(
-                serde_json::json!([				{ "AssignmentExpression": { "object": false } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "AssignmentExpression": { "object": false } }, { "enforceForRenamedProperties": true } ]),
             ),
         ),
         (
             "foo = object.foo;",
             Some(
-                serde_json::json!([				{ "AssignmentExpression": { "object": false } },				{ "enforceForRenamedProperties": false },			]),
+                serde_json::json!([ { "AssignmentExpression": { "object": false } }, { "enforceForRenamedProperties": false } ]),
             ),
         ),
         (
             "foo = array[0];",
             Some(
-                serde_json::json!([				{ "AssignmentExpression": { "array": false } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "AssignmentExpression": { "array": false } }, { "enforceForRenamedProperties": true } ]),
             ),
         ),
         (
             "foo = array[0];",
-            Some(
-                serde_json::json!([				{ "AssignmentExpression": { "array": false } },				{ "enforceForRenamedProperties": false },			]),
-            ),
+            Some(serde_json::json!([ { "AssignmentExpression": { "array": false } } ])),
         ),
         (
             "foo = array[0];",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": true },					"AssignmentExpression": { "array": false },				},				{ "enforceForRenamedProperties": false },			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": true }, "AssignmentExpression": { "array": false } } ]),
             ),
         ),
         (
             "var foo = array[0];",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": false },					"AssignmentExpression": { "array": true },				},				{ "enforceForRenamedProperties": false },			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": false }, "AssignmentExpression": { "array": true } } ]),
             ),
         ),
         (
             "foo = object.foo;",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "object": true },					"AssignmentExpression": { "object": false },				},			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true }, "AssignmentExpression": { "object": false } } ]),
             ),
         ),
         (
             "var foo = object.foo;",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "object": false },					"AssignmentExpression": { "object": true },				},			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": false }, "AssignmentExpression": { "object": true } } ]),
             ),
         ),
         ("class Foo extends Bar { static foo() {var foo = super.foo} }", None),
@@ -411,43 +409,43 @@ fn test() {
         (
             "class C { #x; foo() { const x = this.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo() { const y = this.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo() { x = this.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo() { y = this.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo(a) { x = a.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo(a) { y = a.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "class C { #x; foo() { x = this.a.#x; } }",
             Some(
-                serde_json::json!([				{ "array": true, "object": true },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "array": true, "object": true }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
     ];
@@ -465,7 +463,7 @@ fn test() {
         (
             "var foobar = object.bar;",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -475,7 +473,7 @@ fn test() {
         (
             "var foo = object[bar];",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "object": true } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "object": true } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -492,7 +490,7 @@ fn test() {
         (
             "var foo = array[0];",
             Some(
-                serde_json::json!([				{ "VariableDeclarator": { "array": true } },				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": true } }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
@@ -502,25 +500,25 @@ fn test() {
         (
             "var foo = array[0];",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": true },					"AssignmentExpression": { "array": false },				},				{ "enforceForRenamedProperties": true },			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": true }, "AssignmentExpression": { "array": false }, }, { "enforceForRenamedProperties": true }, ]),
             ),
         ),
         (
             "var foo = array[0];",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": true },					"AssignmentExpression": { "array": false },				},			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": true }, "AssignmentExpression": { "array": false }, }, ]),
             ),
         ),
         (
             "foo = array[0];",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": false },					"AssignmentExpression": { "array": true },				},			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": false }, "AssignmentExpression": { "array": true }, }, ]),
             ),
         ),
         (
             "foo = object.foo;",
             Some(
-                serde_json::json!([				{					"VariableDeclarator": { "array": true, "object": false },					"AssignmentExpression": { "object": true },				},			]),
+                serde_json::json!([ { "VariableDeclarator": { "array": true, "object": false }, "AssignmentExpression": { "object": true }, }, ]),
             ),
         ),
         ("class Foo extends Bar { static foo() {var bar = super.foo.bar} }", None),

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -114,7 +114,7 @@ fn test() {
 			           *
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -126,7 +126,7 @@ fn test() {
 			           * @param {number} foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -160,12 +160,12 @@ fn test() {
 			           * @param {boolean} baz
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             None,
             Some(
-                serde_json::json!({ "settings": {        "jsdoc": {          "exemptDestructuredRootsFromChecks": true,        },      } }),
+                serde_json::json!({ "settings": { "jsdoc": { "exemptDestructuredRootsFromChecks": true } } }),
             ),
         ),
         (
@@ -176,12 +176,12 @@ fn test() {
 			           * @param root.bar
 			           */
 			          function quux (foo, {bar: {baz}}) {
-			
+
 			          }
 			      ",
             None,
             Some(
-                serde_json::json!({ "settings": {        "jsdoc": {          "exemptDestructuredRootsFromChecks": true,        },      } }),
+                serde_json::json!({ "settings": { "jsdoc": { "exemptDestructuredRootsFromChecks": true } } }),
             ),
         ),
     ];
@@ -193,7 +193,7 @@ fn test() {
 			           * @param foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -216,12 +216,12 @@ fn test() {
 			           * @arg foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
             Some(
-                serde_json::json!({ "settings": {        "jsdoc": {          "tagNamePreference": {            "param": "arg",          },        },      } }),
+                serde_json::json!({ "settings": { "jsdoc": { "tagNamePreference": { "param": "arg" } } } }),
             ),
         ),
         (
@@ -232,12 +232,10 @@ fn test() {
 			           * @param {boolean} baz
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
-            Some(
-                serde_json::json!([        {          "setDefaultDestructuredRootType": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "setDefaultDestructuredRootType": true } ])),
             None,
         ),
         (
@@ -248,12 +246,10 @@ fn test() {
 			           * @param {boolean} baz
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
-            Some(
-                serde_json::json!([        {          "setDefaultDestructuredRootType": false,        },      ]),
-            ),
+            Some(serde_json::json!([ { "setDefaultDestructuredRootType": false } ])),
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -215,7 +215,7 @@ fn test() {
         (r#"<a><img alt="documentation" /></a>;"#, None, None),
         (
             "<a>click here</a>",
-            Some(serde_json::json!([{        "words": ["disabling the defaults"],      }])),
+            Some(serde_json::json!([{ "words": ["disabling the defaults"] }])),
             None,
         ),
         (
@@ -248,9 +248,7 @@ fn test() {
         ),
         (
             "<Link>click here</Link>",
-            Some(
-                serde_json::json!([{        "words": ["disabling the defaults with components"],      }]),
-            ),
+            Some(serde_json::json!([{ "words": ["disabling the defaults with components"] }])),
             Some(
                 serde_json::json!({ "settings": { "jsx-a11y": { "components": { "Link": "a" } } } }),
             ),
@@ -303,7 +301,7 @@ fn test() {
         ),
         (
             "<a>a disallowed word</a>",
-            Some(serde_json::json!([{        "words": ["a disallowed word"],      }])),
+            Some(serde_json::json!([{ "words": ["a disallowed word"] }])),
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -1128,9 +1128,7 @@ fn test() {
 
                 const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
                 ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true } ])),
             None,
             None,
         ),
@@ -1144,9 +1142,7 @@ fn test() {
                     const func = (value: number) =>
                     ({ type: 'X', value }) as const satisfies R satisfies R;
                     ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true } ])),
             None,
             None,
         ),
@@ -1160,9 +1156,7 @@ fn test() {
                         const func = (value: number) =>
                         ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
                         ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true } ])),
             None,
             None,
         ),
@@ -1898,13 +1892,13 @@ fn test() {
 
         	new Accumulator().accumulate(() => 1);
         	",
-            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false }, ])),
             None,
             None,
         ),
         (
             "(() => true)();",
-            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false }, ])),
             None,
             None,
         ),
@@ -1927,7 +1921,7 @@ fn test() {
         	  },
         	});
         	",
-            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false } ])),
             None,
             None,
         ),
@@ -1937,7 +1931,7 @@ fn test() {
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
         	",
             Some(
-                serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": true,  }, ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": false, "allowHigherOrderFunctions": true } ]),
             ),
             None,
             None,
@@ -1948,7 +1942,7 @@ fn test() {
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
         	",
             Some(
-                serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": false,  }, ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": false, "allowHigherOrderFunctions": false } ]),
             ),
             None,
             None,
@@ -1958,20 +1952,20 @@ fn test() {
         	const func1 = (value: number) => ({ type: 'X', value }) as any;
         	const func2 = (value: number) => ({ type: 'X', value }) as Action;
         	",
-            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true } ])),
             None,
             None,
         ),
         (
             "const func = (value: number) => ({ type: 'X', value }) as const;",
-            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": false,  }, ])),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": false } ])),
             None,
             None,
         ),
         (
             "const log = (message: string) => void console.log(message);",
             Some(
-                serde_json::json!([ { "allowConciseArrowFunctionExpressionsStartingWithVoid": false },      ]),
+                serde_json::json!([ { "allowConciseArrowFunctionExpressionsStartingWithVoid": false } ]),
             ),
             None,
             None,
@@ -2039,7 +2033,7 @@ fn test() {
         	  },
         	};
         	",
-            Some(serde_json::json!([ { "allowedNames": ["test", "1"],  }, ])),
+            Some(serde_json::json!([ { "allowedNames": ["test", "1"] }, ])),
             None,
             None,
         ),
@@ -2074,7 +2068,7 @@ fn test() {
         	  return 'foo';
         	})();
         	",
-            Some(serde_json::json!([ { "allowIIFEs": false,  }, ])),
+            Some(serde_json::json!([ { "allowIIFEs": false }, ])),
             None,
             None,
         ),
@@ -2086,7 +2080,7 @@ fn test() {
         	  };
         	})();
         	",
-            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
+            Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
@@ -2096,13 +2090,13 @@ fn test() {
         	  return 'foo';
         	};
         	",
-            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
+            Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "let foo = (() => () => {})()();",
-            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
+            Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -156,9 +156,9 @@ fn test() {
         ("sorted = [...array]?.sort(compareFn)", None),
         ("sorted = array.sort(compareFn)", None),
         ("sorted = array?.sort(compareFn)", None),
-        ("array.sort()", Some(serde_json::json!([{"allowExpressionStatement": false}]))),
-        ("array?.sort()", Some(serde_json::json!([{"allowExpressionStatement": false}]))),
-        ("[...array].sort()", Some(serde_json::json!([{"allowExpressionStatement": false}]))),
+        ("array.sort()", Some(serde_json::json!([{ "allowExpressionStatement": false }]))),
+        ("array?.sort()", Some(serde_json::json!([{ "allowExpressionStatement": false }]))),
+        ("[...array].sort()", Some(serde_json::json!([{ "allowExpressionStatement": false }]))),
         ("sorted = [...(0, array)].sort()", None),
     ];
 
@@ -168,7 +168,7 @@ fn test() {
         (
             "a.sort()",
             "a.toSorted()",
-            Some(serde_json::json!([{"allowExpressionStatement": false}])),
+            Some(serde_json::json!([{ "allowExpressionStatement": false }])),
         ),
         ("sorted = array?.sort()", "sorted = array?.toSorted()", None),
     ];

--- a/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
@@ -139,7 +139,7 @@ fn test() {
             None,
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
         (
             r#"
 			      <script setup lang="ts">
@@ -151,7 +151,7 @@ fn test() {
             Some(serde_json::json!(["type-based"])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
         (
             r#"
 			      <script setup lang="ts">
@@ -187,7 +187,7 @@ fn test() {
             None,
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
         (
             r#"
 			        <script lang="ts">
@@ -204,7 +204,7 @@ fn test() {
             None,
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      }
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
     ];
 
     let fail = vec![
@@ -243,7 +243,7 @@ fn test() {
             Some(serde_json::json!(["runtime"])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      }
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
     ];
 
     Tester::new(DefinePropsDeclaration::NAME, DefinePropsDeclaration::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -347,7 +347,7 @@ fn test() {
             Some(serde_json::json!([{ "maxProps": 5 }])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parser": require("vue-eslint-parser"),        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
+        ), // { "parser": require("vue-eslint-parser"), "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
         (
             r#"
 			      <script setup lang="ts">
@@ -357,7 +357,7 @@ fn test() {
             Some(serde_json::json!([{ "maxProps": 2 }])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      }
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
     ];
 
     let fail = vec![
@@ -405,7 +405,7 @@ fn test() {
             Some(serde_json::json!([{ "maxProps": 2 }])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
         (
             r#"
 			      <script setup lang="ts">
@@ -423,7 +423,7 @@ fn test() {
             Some(serde_json::json!([{ "maxProps": 2 }])),
             None,
             Some(PathBuf::from("test.vue")),
-        ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      }
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
     ];
 
     Tester::new(MaxProps::NAME, MaxProps::PLUGIN, pass, fail).test_and_snapshot();


### PR DESCRIPTION
Basically just making them easier to read/more consistent by removing extra spaces/commas in the rule configs for tests.