### PR TITLE
refactor(oxfmt): Avoid clone options

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -68,7 +68,7 @@ impl FormatService {
 
             tracing::debug!("Format {}", path.strip_prefix(&self.cwd).unwrap().display());
             let (code, is_changed) =
-                match self.formatter.format(&entry, &source_text, &resolved_options) {
+                match self.formatter.format(&entry, &source_text, resolved_options) {
                     FormatResult::Success { code, is_changed } => (code, is_changed),
                     FormatResult::Error(diagnostics) => {
                         let errors = DiagnosticService::wrap_diagnostics(

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -46,7 +46,7 @@ impl SourceFormatter {
         &self,
         entry: &FormatFileStrategy,
         source_text: &str,
-        resolved_options: &ResolvedOptions,
+        resolved_options: ResolvedOptions,
     ) -> FormatResult {
         let result = match (entry, resolved_options) {
             (
@@ -82,7 +82,7 @@ impl SourceFormatter {
                 path,
                 parser_name,
                 external_options,
-                *sort_package_json,
+                sort_package_json,
             ),
             _ => unreachable!("FormatFileStrategy and ResolvedOptions variant mismatch"),
         };
@@ -99,8 +99,8 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         source_type: SourceType,
-        format_options: &FormatOptions,
-        external_options: &Value,
+        format_options: FormatOptions,
+        external_options: Value,
     ) -> Result<String, OxcDiagnostic> {
         let source_type = enable_jsx_source_type(source_type);
         let allocator = self.allocator_pool.get();
@@ -113,18 +113,21 @@ impl SourceFormatter {
             return Err(ret.errors.into_iter().next().unwrap());
         }
 
-        let base_formatter = Formatter::new(&allocator, format_options.clone());
+        #[cfg(feature = "napi")]
+        let is_embed_off = format_options.embedded_language_formatting.is_off();
+
+        let base_formatter = Formatter::new(&allocator, format_options);
 
         #[cfg(feature = "napi")]
         let formatted = {
-            if format_options.embedded_language_formatting.is_off() {
+            if is_embed_off {
                 base_formatter.format(&ret.program)
             } else {
                 let embedded_formatter = self
                     .external_formatter
                     .as_ref()
                     .expect("`external_formatter` must exist when `napi` feature is enabled")
-                    .to_embedded_formatter(external_options.clone());
+                    .to_embedded_formatter(external_options);
                 base_formatter.format_with_embedded(&ret.program, embedded_formatter)
             }
         };
@@ -154,18 +157,19 @@ impl SourceFormatter {
     }
 
     /// Format TOML file using `taplo`.
-    fn format_by_taplo(source_text: &str, options: &taplo::formatter::Options) -> String {
-        taplo::formatter::format(source_text, options.clone())
+    fn format_by_taplo(source_text: &str, options: taplo::formatter::Options) -> String {
+        taplo::formatter::format(source_text, options)
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).
     #[cfg(feature = "napi")]
+    #[expect(clippy::needless_pass_by_value)]
     fn format_by_external_formatter(
         &self,
         source_text: &str,
         path: &Path,
         parser_name: &str,
-        external_options: &Value,
+        external_options: Value,
     ) -> Result<String, OxcDiagnostic> {
         let external_formatter = self
             .external_formatter
@@ -181,7 +185,7 @@ impl SourceFormatter {
         let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
 
         external_formatter
-            .format_file(external_options, parser_name, file_name, source_text)
+            .format_file(&external_options, parser_name, file_name, source_text)
             .map_err(|err| {
                 OxcDiagnostic::error(format!(
                     "Failed to format file with external formatter: {}\n{err}",
@@ -197,7 +201,7 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         parser_name: &str,
-        external_options: &Value,
+        external_options: Value,
         sort_package_json: bool,
     ) -> Result<String, OxcDiagnostic> {
         let source_text: Cow<'_, str> = if sort_package_json {

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -175,7 +175,7 @@ pub async fn format(
 
     // Use `block_in_place()` to avoid nested async runtime access
     match tokio::task::block_in_place(|| {
-        formatter.format(&strategy, &source_text, &resolved_options)
+        formatter.format(&strategy, &source_text, resolved_options)
     }) {
         CoreFormatResult::Success { code, .. } => FormatResult { code, errors: vec![] },
         CoreFormatResult::Error(diagnostics) => {

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -115,7 +115,7 @@ impl StdinRunner {
 
         // Use `block_in_place()` to avoid nested async runtime access
         match tokio::task::block_in_place(|| {
-            source_formatter.format(&strategy, &source_text, &resolved_options)
+            source_formatter.format(&strategy, &source_text, resolved_options)
         }) {
             FormatResult::Success { code, .. } => {
                 utils::print_and_flush(stdout, &code);


### PR DESCRIPTION
For perf, avoid cloning `xxx_options` everywhere.