### PR TITLE
chore(rulegen): Improve the rule template and config json handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,6 +2943,7 @@ version = "0.0.0"
 dependencies = [
  "convert_case",
  "handlebars",
+ "insta",
  "lazy-regex",
  "oxc_allocator",
  "oxc_ast",

--- a/justfile
+++ b/justfile
@@ -154,6 +154,7 @@ watch-oxlint-node *args='':
 # Create a new lint rule for any plugin
 new-rule name plugin='eslint':
   cargo run -p rulegen {{name}} {{plugin}}
+  just fmt
 
 # Legacy aliases for backward compatibility
 new-jest-rule name: (new-rule name "jest")

--- a/tasks/rulegen/Cargo.toml
+++ b/tasks/rulegen/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [[bin]]
 name = "rulegen"
-test = false
+test = true
 doctest = false
 
 [dependencies]
@@ -26,3 +26,6 @@ handlebars = { workspace = true }
 lazy-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
+++ b/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
@@ -1,35 +1,36 @@
+---
+source: tasks/rulegen/src/template.rs
+expression: rendered
+---
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-{{#if has_hash_map}}
-use rustc_hash::FxHashMap;
-{{/if}}
-{{#if has_hash_set}}
-use rustc_hash::FxHashSet;
-{{/if}}
-{{#if rule_config}}
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-{{/if}}
 
 use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
-    {{#if rule_config}}rule::{DefaultRuleConfig, Rule},{{else}}rule::Rule,{{/if}}
+    rule::{DefaultRuleConfig, Rule},
     AstNode,
 };
 
-fn {{snake_rule_name}}_diagnostic(span: Span) -> OxcDiagnostic {
+fn my_rule_diagnostic(span: Span) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("Should be an imperative statement about what is wrong.")
         .with_help("Should be a command-like statement that tells the user how to fix the issue.")
         .with_label(span)
 }
 
-{{rule_config}}
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename_all = "camelCase", default)]
+struct ConfigObject {
+    pub foo: String,
+    pub bar: Option<i32>,
+}
 
-#[derive(Debug, Default, Clone{{#if rule_config_tuple}}, Deserialize, Serialize, JsonSchema{{/if}})]
-pub struct {{pascal_rule_name}}{{#if rule_config_tuple}}{{rule_config_tuple}}{{/if}};
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct MyRule(ConfigObject);
 
 // See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
@@ -44,35 +45,31 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```{{language}}
+    /// ```ts
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```{{language}}
+    /// ```ts
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
-    {{pascal_rule_name}},
-    {{mod_name}},
+    MyRule,
+    eslint,
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
     pending, // TODO: describe fix capabilities. Remove if no fix can be done,
              // keep at 'pending' if you think one could be added but don't know how.
              // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
-{{#if rule_config}}
-    config = {{pascal_rule_name}},
-{{/if}}
+    config = MyRule,
 );
 
-impl Rule for {{pascal_rule_name}} {
-{{#if rule_config}}
+impl Rule for MyRule {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<Self>>(value)
             .unwrap_or_default()
             .into_inner()
     }
 
-{{/if}}
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
 
     }
@@ -81,24 +78,18 @@ impl Rule for {{pascal_rule_name}} {
 #[test]
 fn test() {
     use crate::tester::Tester;
-    {{#if has_filename}}
     use std::path::PathBuf;
-    {{/if}}
 
     let pass = vec![
-        {{pass_cases}}
+        ("a")
     ];
 
     let fail = vec![
-        {{fail_cases}}
+        ("b")
     ];
 
-    {{#if fix_cases}}
     let fix = vec![
-        {{fix_cases}}
+        ("fixed")
     ];
-    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
-    {{else}}
-    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).test_and_snapshot();
-    {{/if}}
+    Tester::new(MyRule::NAME, MyRule::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }


### PR DESCRIPTION
The rule configs often came out weird previously, and now the config objects in the tests look a bit less bad for generated rules :) 

Done with help from Copilot + Claude Opus. 

Also run `just fmt` after generating a rule, to avoid some problems with the sort order of defined rules by default, and update the template.txt to use some common patterns.