### PR TITLE
feat(linter): implement vue/no-deprecated-destroyed-lifecycle

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4009,6 +4009,13 @@ impl RuleRunner for crate::rules::vue::max_props::MaxProps {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4012,8 +4012,9 @@ impl RuleRunner for crate::rules::vue::max_props::MaxProps {
 impl RuleRunner
     for crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportDefaultDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup {

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -680,6 +680,7 @@ pub(crate) mod vue {
     pub mod define_props_declaration;
     pub mod define_props_destructuring;
     pub mod max_props;
+    pub mod no_deprecated_destroyed_lifecycle;
     pub mod no_export_in_script_setup;
     pub mod no_import_compiler_macros;
     pub mod no_multiple_slot_args;
@@ -1322,6 +1323,7 @@ oxc_macros::declare_all_lint_rules! {
     vue::define_props_declaration,
     vue::define_props_destructuring,
     vue::max_props,
+    vue::no_deprecated_destroyed_lifecycle,
     vue::no_export_in_script_setup,
     vue::no_import_compiler_macros,
     vue::no_multiple_slot_args,

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
@@ -1,0 +1,390 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        CallExpression, ExportDefaultDeclarationKind, Expression, ObjectExpression,
+        ObjectPropertyKind, PropertyKey,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn no_deprecated_destroyed_lifecycle_diagnostic(
+    span: Span,
+    deprecated: &str,
+    replacement: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The `{deprecated}` lifecycle hook is deprecated. Use `{replacement}` instead."
+    ))
+    .with_help(format!("Replace `{deprecated}` with `{replacement}`."))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDeprecatedDestroyedLifecycle;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks in Vue.js 3.0.0+.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In Vue.js 3.0.0+, the `destroyed` and `beforeDestroy` lifecycle hooks have been renamed
+    /// to `unmounted` and `beforeUnmount` respectively. Using the old names is deprecated and
+    /// may cause confusion or compatibility issues.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   beforeDestroy() {},
+    ///   destroyed() {},
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   beforeUnmount() {},
+    ///   unmounted() {},
+    /// }
+    /// </script>
+    /// ```
+    NoDeprecatedDestroyedLifecycle,
+    vue,
+    correctness,
+    fix
+);
+
+impl Rule for NoDeprecatedDestroyedLifecycle {
+    fn run_once(&self, ctx: &LintContext) {
+        for node in ctx.nodes() {
+            match node.kind() {
+                AstKind::ExportDefaultDeclaration(export_default_decl) => {
+                    // Handle `export default { ... }`
+                    match &export_default_decl.declaration {
+                        ExportDefaultDeclarationKind::ObjectExpression(obj_expr) => {
+                            check_object_properties(obj_expr, ctx);
+                        }
+                        ExportDefaultDeclarationKind::CallExpression(call_expr) => {
+                            // Handle `export default defineComponent({ ... })`
+                            check_define_component(call_expr, ctx);
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Check if this is a `defineComponent({ ... })` call and check its properties
+fn check_define_component<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+    let Some(ident) = call_expr.callee.get_identifier_reference() else {
+        return;
+    };
+
+    if ident.name != "defineComponent" {
+        return;
+    }
+
+    let Some(first_arg) = call_expr.arguments.first() else {
+        return;
+    };
+
+    let Some(Expression::ObjectExpression(obj_expr)) = first_arg.as_expression() else {
+        return;
+    };
+
+    check_object_properties(obj_expr, ctx);
+}
+
+/// Check object properties for deprecated lifecycle hooks
+fn check_object_properties<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+    for prop in &obj_expr.properties {
+        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else {
+            continue;
+        };
+
+        let Some((key_name, key_span, is_shorthand, key_type)) = get_property_key_info(obj_prop)
+        else {
+            continue;
+        };
+
+        let replacement = match key_name.as_str() {
+            "beforeDestroy" => "beforeUnmount",
+            "destroyed" => "unmounted",
+            _ => continue,
+        };
+
+        ctx.diagnostic_with_fix(
+            no_deprecated_destroyed_lifecycle_diagnostic(key_span, &key_name, replacement),
+            |fixer| {
+                // Format replacement based on key type
+                let formatted_replacement = match key_type {
+                    KeyType::Identifier => {
+                        if is_shorthand {
+                            // For shorthand properties like `beforeDestroy,` we need to convert to
+                            // `beforeUnmount: beforeDestroy,`
+                            format!("{replacement}:{key_name}")
+                        } else {
+                            replacement.to_string()
+                        }
+                    }
+                    KeyType::StringLiteral => {
+                        // Preserve single quotes for string literals
+                        format!("'{replacement}'")
+                    }
+                    KeyType::TemplateLiteral => {
+                        // Preserve backticks for template literals
+                        format!("`{replacement}`")
+                    }
+                };
+                fixer.replace(key_span, formatted_replacement)
+            },
+        );
+    }
+}
+
+/// Type of property key to determine correct fix format
+#[derive(Clone, Copy)]
+enum KeyType {
+    Identifier,
+    StringLiteral,
+    TemplateLiteral,
+}
+
+/// Get the property key name, span, whether it's a shorthand property, and key type
+fn get_property_key_info(
+    prop: &oxc_ast::ast::ObjectProperty,
+) -> Option<(String, Span, bool, KeyType)> {
+    match &prop.key {
+        PropertyKey::StaticIdentifier(ident) => {
+            Some((ident.name.to_string(), ident.span, prop.shorthand, KeyType::Identifier))
+        }
+        PropertyKey::StringLiteral(lit) => {
+            Some((lit.value.to_string(), lit.span, false, KeyType::StringLiteral))
+        }
+        PropertyKey::TemplateLiteral(tpl) if tpl.is_no_substitution_template() => {
+            tpl.single_quasi().map(|s| (s.to_string(), tpl.span, false, KeyType::TemplateLiteral))
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+			      <script>
+			      export default {
+			        unmounted () {},
+			        beforeUnmount () {},
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        unmounted,
+			        beforeUnmount,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        beforeCreate,
+			        created,
+			        beforeMount,
+			        mounted,
+			        beforeUpdate,
+			        updated,
+			        activated,
+			        deactivated,
+			        beforeUnmount,
+			        unmounted,
+			        errorCaptured,
+			        renderTracked,
+			        renderTriggered,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        beforeUnmount:beforeDestroy,
+			        unmounted:destroyed,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        ...beforeDestroy,
+			        ...destroyed,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        [beforeDestroy] () {},
+			        [destroyed] () {},
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+			      <script>
+			      export default {
+			        beforeDestroy () {},
+			        destroyed () {},
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        beforeDestroy,
+			        destroyed,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        beforeCreate,
+			        created,
+			        beforeMount,
+			        mounted,
+			        beforeUpdate,
+			        updated,
+			        activated,
+			        deactivated,
+			        beforeDestroy,
+			        destroyed,
+			        errorCaptured,
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        ['beforeDestroy']() {},
+			        ['destroyed']() {},
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+			      <script>
+			      export default {
+			        [`beforeDestroy`]() {},
+			        [`destroyed`]() {},
+			      }
+			      </script>
+			      ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    // Fix tests use pure JavaScript (no <script> tags) because the fix test
+    // framework doesn't support custom file paths
+    let fix = vec![
+        (
+            "export default { beforeDestroy() {}, destroyed() {} }",
+            "export default { beforeUnmount() {}, unmounted() {} }",
+            None,
+        ),
+        (
+            "export default { beforeDestroy, destroyed }",
+            "export default { beforeUnmount:beforeDestroy, unmounted:destroyed }",
+            None,
+        ),
+        (
+            "export default { ['beforeDestroy']() {}, ['destroyed']() {} }",
+            "export default { ['beforeUnmount']() {}, ['unmounted']() {} }",
+            None,
+        ),
+        (
+            "export default { [`beforeDestroy`]() {}, [`destroyed`]() {} }",
+            "export default { [`beforeUnmount`]() {}, [`unmounted`]() {} }",
+            None,
+        ),
+    ];
+    Tester::new(
+        NoDeprecatedDestroyedLifecycle::NAME,
+        NoDeprecatedDestroyedLifecycle::PLUGIN,
+        pass,
+        fail,
+    )
+    .expect_fix(fix)
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
@@ -66,23 +66,17 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDeprecatedDestroyedLifecycle {
-    fn run_once(&self, ctx: &LintContext) {
-        for node in ctx.nodes() {
-            let AstKind::ExportDefaultDeclaration(export_default_decl) = node.kind() else {
-                continue;
-            };
+    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ExportDefaultDeclaration(export_default_decl) = node.kind() else { return };
 
-            // Handle `export default { ... }`
-            match &export_default_decl.declaration {
-                ExportDefaultDeclarationKind::ObjectExpression(obj_expr) => {
-                    check_object_properties(obj_expr, ctx);
-                }
-                ExportDefaultDeclarationKind::CallExpression(call_expr) => {
-                    // Handle `export default defineComponent({ ... })`
-                    check_define_component(call_expr, ctx);
-                }
-                _ => {}
+        match &export_default_decl.declaration {
+            ExportDefaultDeclarationKind::ObjectExpression(obj_expr) => {
+                check_object_properties(obj_expr, ctx);
             }
+            ExportDefaultDeclarationKind::CallExpression(call_expr) => {
+                check_define_component(call_expr, ctx);
+            }
+            _ => {}
         }
     }
 }

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
@@ -372,34 +372,124 @@ fn test() {
         ),
     ];
 
-    // Fix tests use pure JavaScript (no <script> tags) because the fix test
-    // framework doesn't support custom file paths
     let fix = vec![
         (
-            "export default { beforeDestroy() {}, destroyed() {} }",
-            "export default { beforeUnmount() {}, unmounted() {} }",
+            "
+			      <script>
+			      export default {
+			        beforeDestroy () {},
+			        destroyed () {},
+			      }
+			      </script>
+			      ",
+            "
+			      <script>
+			      export default {
+			        beforeUnmount () {},
+			        unmounted () {},
+			      }
+			      </script>
+			      ",
             None,
+            Some(PathBuf::from("test.vue")),
         ),
         (
-            "export default { beforeDestroy, destroyed }",
-            "export default { beforeUnmount:beforeDestroy, unmounted:destroyed }",
+            "
+			      <script>
+			      export default {
+			        beforeDestroy,
+			        destroyed,
+			      }
+			      </script>
+			      ",
+            "
+			      <script>
+			      export default {
+			        beforeUnmount:beforeDestroy,
+			        unmounted:destroyed,
+			      }
+			      </script>
+			      ",
             None,
+            Some(PathBuf::from("test.vue")),
         ),
         (
-            "export default { ['beforeDestroy']() {}, ['destroyed']() {} }",
-            "export default { ['beforeUnmount']() {}, ['unmounted']() {} }",
+            "
+			      <script>
+			      export default {
+			        beforeCreate,
+			        created,
+			        beforeMount,
+			        mounted,
+			        beforeUpdate,
+			        updated,
+			        activated,
+			        deactivated,
+			        beforeDestroy,
+			        destroyed,
+			        errorCaptured,
+			      }
+			      </script>
+			      ",
+            "
+			      <script>
+			      export default {
+			        beforeCreate,
+			        created,
+			        beforeMount,
+			        mounted,
+			        beforeUpdate,
+			        updated,
+			        activated,
+			        deactivated,
+			        beforeUnmount:beforeDestroy,
+			        unmounted:destroyed,
+			        errorCaptured,
+			      }
+			      </script>
+			      ",
             None,
+            Some(PathBuf::from("test.vue")),
         ),
         (
-            "export default { [`beforeDestroy`]() {}, [`destroyed`]() {} }",
-            "export default { [`beforeUnmount`]() {}, [`unmounted`]() {} }",
+            "
+			      <script>
+			      export default {
+			        ['beforeDestroy']() {},
+			        ['destroyed']() {},
+			      }
+			      </script>
+			      ",
+            "
+			      <script>
+			      export default {
+			        ['beforeUnmount']() {},
+			        ['unmounted']() {},
+			      }
+			      </script>
+			      ",
             None,
+            Some(PathBuf::from("test.vue")),
         ),
-        // Do not autofix when the replacement hook already exists (avoids duplicate keys).
         (
-            "export default { unmounted() {}, destroyed() {} }",
-            "export default { unmounted() {}, destroyed() {} }",
+            "
+			      <script>
+			      export default {
+			        [`beforeDestroy`]() {},
+			        [`destroyed`]() {},
+			      }
+			      </script>
+			      ",
+            "
+			      <script>
+			      export default {
+			        [`beforeUnmount`]() {},
+			        [`unmounted`]() {},
+			      }
+			      </script>
+			      ",
             None,
+            Some(PathBuf::from("test.vue")),
         ),
     ];
     Tester::new(

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_destroyed_lifecycle.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_destroyed_lifecycle.snap
@@ -1,0 +1,92 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:4:12]
+ 3 │                   export default {
+ 4 │                     beforeDestroy () {},
+   ·                     ─────────────
+ 5 │                     destroyed () {},
+   ╰────
+  help: Replace `beforeDestroy` with `beforeUnmount`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:5:12]
+ 4 │                     beforeDestroy () {},
+ 5 │                     destroyed () {},
+   ·                     ─────────
+ 6 │                   }
+   ╰────
+  help: Replace `destroyed` with `unmounted`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:4:12]
+ 3 │                   export default {
+ 4 │                     beforeDestroy,
+   ·                     ─────────────
+ 5 │                     destroyed,
+   ╰────
+  help: Replace `beforeDestroy` with `beforeUnmount`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:5:12]
+ 4 │                     beforeDestroy,
+ 5 │                     destroyed,
+   ·                     ─────────
+ 6 │                   }
+   ╰────
+  help: Replace `destroyed` with `unmounted`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.
+    ╭─[no_deprecated_destroyed_lifecycle.tsx:12:12]
+ 11 │                     deactivated,
+ 12 │                     beforeDestroy,
+    ·                     ─────────────
+ 13 │                     destroyed,
+    ╰────
+  help: Replace `beforeDestroy` with `beforeUnmount`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.
+    ╭─[no_deprecated_destroyed_lifecycle.tsx:13:12]
+ 12 │                     beforeDestroy,
+ 13 │                     destroyed,
+    ·                     ─────────
+ 14 │                     errorCaptured,
+    ╰────
+  help: Replace `destroyed` with `unmounted`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:4:13]
+ 3 │                   export default {
+ 4 │                     ['beforeDestroy']() {},
+   ·                      ───────────────
+ 5 │                     ['destroyed']() {},
+   ╰────
+  help: Replace `beforeDestroy` with `beforeUnmount`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:5:13]
+ 4 │                     ['beforeDestroy']() {},
+ 5 │                     ['destroyed']() {},
+   ·                      ───────────
+ 6 │                   }
+   ╰────
+  help: Replace `destroyed` with `unmounted`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:4:13]
+ 3 │                   export default {
+ 4 │                     [`beforeDestroy`]() {},
+   ·                      ───────────────
+ 5 │                     [`destroyed`]() {},
+   ╰────
+  help: Replace `beforeDestroy` with `beforeUnmount`.
+
+  ⚠ eslint-plugin-vue(no-deprecated-destroyed-lifecycle): The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.
+   ╭─[no_deprecated_destroyed_lifecycle.tsx:5:13]
+ 4 │                     [`beforeDestroy`]() {},
+ 5 │                     [`destroyed`]() {},
+   ·                      ───────────
+ 6 │                   }
+   ╰────
+  help: Replace `destroyed` with `unmounted`.


### PR DESCRIPTION
## Summary

Implements `vue/no-deprecated-destroyed-lifecycle` rule that detects deprecated Vue 2 lifecycle hooks and suggests Vue 3 alternatives.

- Detects `beforeDestroy` → suggests `beforeUnmount`
- Detects `destroyed` → suggests `unmounted`
- Works with `export default { ... }` and `defineComponent({ ... })`
- Handles all key types: identifiers, string literals, template literals
- Handles shorthand properties by converting to `newName: oldName` syntax

Part of #11440

## Test plan

- [x] Unit tests for pass/fail cases
- [x] Fix tests for autofix functionality
- [x] Snapshot tests generated

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.