### PR TITLE
chore(vscode)!: don't ship internal language server

### DIFF
--- a/.github/workflows/ci_vscode.yml
+++ b/.github/workflows/ci_vscode.yml
@@ -47,10 +47,6 @@ jobs:
           pnpm fmt
           git diff --exit-code
 
-      - name: Build Language Server
-        working-directory: editors/vscode
-        run: pnpm run server:build:debug
-
       - name: Build oxlint (with napi)
         working-directory: editors/vscode
         run: pnpm run oxlint:build:debug

--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -71,35 +71,6 @@ jobs:
           pnpm run preinstall
           pnpm run compile
 
-      - name: Install cross
-        uses: taiki-e/install-action@61e5998d108b2b55a81b9b386c18bd46e4237e4f # v2.63.1
-        with:
-          tool: cross
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      # Please do not set a cache for release builds; they are evicted before they can be re-used, yet they consume significant cache storage before eviction.
-
-      - name: Add Rust Target
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Build with cross
-        run: cross build -p oxc_language_server --release --target=${{ matrix.target }}
-
-      - name: Copy binary
-        if: runner.os == 'Windows'
-        run: |
-          mkdir -p editors/vscode/target/release
-          # .vscodeignore uses `!target/release/oxc_language_server.exe` to package the binary
-          cp target/${{ matrix.target }}/release/oxc_language_server.exe editors/vscode/target/release/oxc_language_server.exe
-
-      - name: Copy binary
-        if: runner.os != 'Windows'
-        run: |
-          mkdir -p editors/vscode/target/release/
-          # .vscodeignore uses `!target/release/oxc_language_server` to package the binary
-          cp target/${{ matrix.target }}/release/oxc_language_server editors/vscode/target/release/oxc_language_server
-
       - name: Package Extension
         working-directory: editors/vscode
         run: |

--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -12,8 +12,6 @@ const multiRootWorkspaceConfig = {
 };
 writeFileSync(multiRootWorkspaceFile, JSON.stringify(multiRootWorkspaceConfig, null, 2));
 
-const ext = process.platform === "win32" ? ".exe" : "";
-
 const baseTest = {
   files: "out/**/*.spec.js",
   workspaceFolder: "./test_workspace",
@@ -28,38 +26,23 @@ const baseTest = {
 
 const allTestSuites = new Map([
   [
-    "single-folder",
-    {
-      ...baseTest,
-      env: {
-        SINGLE_FOLDER_WORKSPACE: "true",
-        SERVER_PATH_DEV: path.resolve(
-          import.meta.dirname,
-          `./target/debug/oxc_language_server${ext}`,
-        ),
-      },
-    },
-  ],
-  [
-    "multi-root",
-    {
-      ...baseTest,
-      workspaceFolder: multiRootWorkspaceFile,
-      env: {
-        MULTI_FOLDER_WORKSPACE: "true",
-        SERVER_PATH_DEV: path.resolve(
-          import.meta.dirname,
-          `./target/debug/oxc_language_server${ext}`,
-        ),
-      },
-    },
-  ],
-  [
     "oxlint-lsp",
     {
       ...baseTest,
       env: {
         SINGLE_FOLDER_WORKSPACE: "true",
+        SERVER_PATH_DEV: path.resolve(import.meta.dirname, `../../apps/oxlint/dist/cli.js`),
+        SKIP_FORMATTER_TEST: "true",
+      },
+    },
+  ],
+  [
+    "oxlint-lsp-multi-root",
+    {
+      ...baseTest,
+      workspaceFolder: multiRootWorkspaceFile,
+      env: {
+        MULTI_FOLDER_WORKSPACE: "true",
         SERVER_PATH_DEV: path.resolve(import.meta.dirname, `../../apps/oxlint/dist/cli.js`),
         SKIP_FORMATTER_TEST: "true",
       },

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -4,5 +4,3 @@
 !out/main.js
 !package.json
 !README.md
-!target/release/oxc_language_server
-!target/release/oxc_language_server.exe

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -7,18 +7,11 @@ import {
   OxfmtWorkspaceConfigInterface,
   OxlintWorkspaceConfigInterface,
   WorkspaceConfig,
-  WorkspaceConfigInterface,
 } from "./WorkspaceConfig";
 
 export class ConfigService implements IDisposable {
   public static readonly namespace = "oxc";
   private readonly _disposables: IDisposable[] = [];
-
-  /**
-   * Indicates whether the `oxc_language_server` is being used as the formatter.
-   * If true, the formatter functionality is handled by the language server itself.
-   */
-  public useOxcLanguageServerForFormatting: boolean = false;
 
   public vsCodeConfig: VSCodeConfig;
 
@@ -44,14 +37,12 @@ export class ConfigService implements IDisposable {
     this._disposables.push(disposeChangeListener);
   }
 
-  public get languageServerConfig(): {
+  public get oxlintServerConfig(): {
     workspaceUri: string;
-    options: WorkspaceConfigInterface | OxlintWorkspaceConfigInterface;
+    options: OxlintWorkspaceConfigInterface;
   }[] {
     return [...this.workspaceConfigs.entries()].map(([path, config]) => {
-      const options = this.useOxcLanguageServerForFormatting
-        ? config.toLanguageServerConfig()
-        : config.toOxlintConfig();
+      const options = config.toOxlintConfig();
 
       return {
         workspaceUri: Uri.file(path).toString(),

--- a/editors/vscode/client/WorkspaceConfig.ts
+++ b/editors/vscode/client/WorkspaceConfig.ts
@@ -19,7 +19,7 @@ export enum FixKind {
 /**
  * See `"contributes.configuration"` in `package.json`
  */
-export interface WorkspaceConfigInterface {
+interface WorkspaceConfigInterface {
   /**
    * oxlint config path
    *
@@ -266,13 +266,6 @@ export class WorkspaceConfig {
   updateFormattingConfigPath(value: string | null): PromiseLike<void> {
     this._formattingConfigPath = value;
     return this.configuration.update("fmt.configPath", value, ConfigurationTarget.WorkspaceFolder);
-  }
-
-  public toLanguageServerConfig(): WorkspaceConfigInterface {
-    return {
-      ...this.toOxlintConfig(),
-      ...this.toOxfmtConfig(),
-    };
   }
 
   public toOxlintConfig(): OxlintWorkspaceConfigInterface {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -1,6 +1,5 @@
 import { commands, ExtensionContext, window, workspace } from "vscode";
 
-import { join } from "node:path";
 import { OxcCommands } from "./commands";
 import { ConfigService } from "./ConfigService";
 import StatusBarItemHandler from "./StatusBarItemHandler";
@@ -76,57 +75,29 @@ export async function activate(context: ExtensionContext) {
     ),
   );
 
-  // when no oxlint binary path are provided, fallback to internal oxc_language_server
-  if (!binaryPaths[0]) {
-    const ext = process.platform === "win32" ? ".exe" : "";
-    // NOTE: The `./target/release` path is aligned with the path defined in .github/workflows/release_vscode.yml
-    binaryPaths[0] =
-      process.env.SERVER_PATH_DEV ??
-      join(context.extensionPath, `./target/release/oxc_language_server${ext}`);
-  }
-
-  // remove this block, when `oxfmt` binary is always required. This will be a breaking change.
-  if (
-    binaryPaths.some((path) => path?.includes("oxc_language_server")) &&
-    !configService.vsCodeConfig.binPathOxfmt
-  ) {
-    configService.useOxcLanguageServerForFormatting = true;
-  }
-
   await Promise.all(
     tools.map((tool): Promise<void> => {
       const binaryPath = binaryPaths[tools.indexOf(tool)];
 
-      // For the linter this should never happen, but just in case.
       if (!binaryPath && tool instanceof Linter) {
         statusBarItemHandler.setColorAndIcon("statusBarItem.errorBackground", "error");
         statusBarItemHandler.updateToolTooltip(
           "linter",
-          "**oxlint disabled**\n\nError: No valid oxc language server binary found.",
+          "**oxlint disabled**\n\nError: No valid oxlint binary found.",
         );
         return Promise.resolve();
       }
 
-      if (tool instanceof Formatter) {
-        if (configService.useOxcLanguageServerForFormatting) {
-          // The formatter is already handled by the linter tool in this case.
-          statusBarItemHandler.updateToolTooltip(
-            "formatter",
-            "**oxfmt disabled**\n\noxc_language_server is used for formatting.",
-          );
-          outputChannelFormat.appendLine("oxc_language_server is used for formatting.");
-          return Promise.resolve();
-        } else if (!binaryPath) {
-          // No valid binary found for the formatter.
-          statusBarItemHandler.updateToolTooltip(
-            "formatter",
-            "**oxfmt disabled**\n\nNo valid oxfmt binary found.",
-          );
-          outputChannelFormat.appendLine(
-            "No valid oxfmt binary found. Formatter will not be activated.",
-          );
-          return Promise.resolve();
-        }
+      if (!binaryPath && tool instanceof Formatter) {
+        // No valid binary found for the formatter.
+        statusBarItemHandler.updateToolTooltip(
+          "formatter",
+          "**oxfmt disabled**\n\nNo valid oxfmt binary found.",
+        );
+        outputChannelFormat.appendLine(
+          "No valid oxfmt binary found. Formatter will not be activated.",
+        );
+        return Promise.resolve();
       }
 
       // binaryPath is guaranteed to be defined here.

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -13,7 +13,6 @@ import {
 import {
   ConfigurationParams,
   ExecuteCommandRequest,
-  InitializeParams,
   ShowMessageNotification,
 } from "vscode-languageclient";
 
@@ -35,16 +34,6 @@ const languageClientName = "oxc";
 
 const enum LspCommands {
   FixAll = "oxc.fixAll",
-}
-
-class NoFormatterLanguageClient extends LanguageClient {
-  protected fillInitializeParams(params: InitializeParams): void {
-    // Disable formatting capabilities to prevent conflicts with the formatter tool.
-    delete params.capabilities.textDocument?.formatting;
-    delete params.capabilities.textDocument?.rangeFormatting;
-
-    super.fillInitializeParams(params);
-  }
 }
 
 export default class LinterTool implements ToolInterface {
@@ -156,7 +145,7 @@ export default class LinterTool implements ToolInterface {
           scheme: "file",
         },
       ],
-      initializationOptions: configService.languageServerConfig,
+      initializationOptions: configService.oxlintServerConfig,
       outputChannel,
       traceOutputChannel: outputChannel,
       middleware: {
@@ -184,9 +173,7 @@ export default class LinterTool implements ToolInterface {
               }
 
               return (
-                configService
-                  .getWorkspaceConfig(Uri.parse(item.scopeUri))
-                  ?.toLanguageServerConfig() ?? null
+                configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxlintConfig() ?? null
               );
             });
           },
@@ -194,12 +181,7 @@ export default class LinterTool implements ToolInterface {
       },
     };
 
-    // If the formatter is not handled by the language server, disable formatting capabilities to prevent conflicts.
-    if (configService.useOxcLanguageServerForFormatting) {
-      this.client = new LanguageClient(languageClientName, serverOptions, clientOptions);
-    } else {
-      this.client = new NoFormatterLanguageClient(languageClientName, serverOptions, clientOptions);
-    }
+    this.client = new LanguageClient(languageClientName, serverOptions, clientOptions);
 
     const onNotificationDispose = this.client.onNotification(
       ShowMessageNotification.type,
@@ -285,11 +267,11 @@ export default class LinterTool implements ToolInterface {
     }
 
     // update the initializationOptions for a possible restart
-    this.client.clientOptions.initializationOptions = configService.languageServerConfig;
+    this.client.clientOptions.initializationOptions = configService.oxlintServerConfig;
 
     if (configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
       await this.client.sendNotification("workspace/didChangeConfiguration", {
-        settings: configService.languageServerConfig,
+        settings: configService.oxlintServerConfig,
       });
     }
   }
@@ -310,19 +292,19 @@ export default class LinterTool implements ToolInterface {
       return {
         bgColor: "statusBarItem.offlineBackground",
         icon: "circle-slash",
-        tooltipText: "oxc is disabled (no .oxlintrc.json found)",
+        tooltipText: "oxlint is disabled (no .oxlintrc.json found)",
       };
     } else if (!enable) {
       return {
         bgColor: "statusBarItem.warningBackground",
         icon: "check",
-        tooltipText: "oxc is disabled",
+        tooltipText: "oxlint is disabled",
       };
     } else {
       return {
         bgColor: "statusBarItem.activeBackground",
         icon: "check-all",
-        tooltipText: "oxc is enabled",
+        tooltipText: "oxlint is enabled",
       };
     }
   }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -43,9 +43,8 @@
     "server:build:debug": "cross-env CARGO_TARGET_DIR=./target cargo build -p oxc_language_server",
     "server:build:release": "cross-env CARGO_TARGET_DIR=./target cargo build -p oxc_language_server --release",
     "test": "cross-env TEST=true pnpm run compile && vscode-test",
-    "test:single-folder": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=single-folder vscode-test",
-    "test:multi-root": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=multi-root vscode-test",
     "test:oxlint": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxlint-lsp vscode-test",
+    "test:oxlint-multi-root": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxlint-lsp-multi-root vscode-test",
     "test:oxfmt": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxfmt-lsp vscode-test"
   },
   "dependencies": {

--- a/editors/vscode/tests/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/WorkspaceConfig.spec.ts
@@ -87,32 +87,6 @@ suite('WorkspaceConfig', () => {
     strictEqual(wsConfig.get('fmt.configPath'), './oxfmt.json');
   });
 
-  test('toLanguageServerConfig method', async () => {
-    const config = new WorkspaceConfig(WORKSPACE_FOLDER);
-
-    await Promise.all([
-      config.updateRunTrigger('onSave'),
-      config.updateConfigPath('./somewhere'),
-      config.updateTsConfigPath('./tsconfig.json'),
-      config.updateUnusedDisableDirectives('deny'),
-      config.updateTypeAware(true),
-      config.updateDisableNestedConfig(true),
-      config.updateFixKind(FixKind.DangerousFix),
-      config.updateFormattingConfigPath('./oxfmt.json'),
-    ]);
-
-    const lsConfig = config.toLanguageServerConfig();
-
-    strictEqual(lsConfig.run, 'onSave');
-    strictEqual(lsConfig.configPath, './somewhere');
-    strictEqual(lsConfig.tsConfigPath, './tsconfig.json');
-    strictEqual(lsConfig.unusedDisableDirectives, 'deny');
-    strictEqual(lsConfig.typeAware, true);
-    strictEqual(lsConfig.disableNestedConfig, true);
-    strictEqual(lsConfig.fixKind, 'dangerous_fix');
-    strictEqual(lsConfig['fmt.configPath'], './oxfmt.json');
-  });
-
   test('toOxlintConfig method', async () => {
     const config = new WorkspaceConfig(WORKSPACE_FOLDER);
 


### PR DESCRIPTION
> This PR removes the internal oxc_language_server binary from the VS Code extension package, transitioning to using separate oxlint and oxfmt binaries exclusively. This is a breaking change that simplifies the extension's architecture.

closes https://github.com/oxc-project/oxc/issues/16988