### PR TITLE
feat(data_structures): implement `Send` and `Sync` for stack types

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -442,6 +442,13 @@ impl<T: Default> Default for NonEmptyStack<T> {
     }
 }
 
+// SAFETY: `NonEmptyStack<T>` can be `Send` / `Sync` if `T` is `Send` / `Sync`.
+// It does not use interior mutability, and is essentially the same as `Vec<T>` in this respect,
+// which implements `Send` / `Sync` in the same way.
+unsafe impl<T: Send> Send for NonEmptyStack<T> {}
+// SAFETY: See above.
+unsafe impl<T: Sync> Sync for NonEmptyStack<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -421,6 +421,13 @@ impl<T> DerefMut for Stack<T> {
     }
 }
 
+// SAFETY: `Stack<T>` can be `Send` / `Sync` if `T` is `Send` / `Sync`.
+// It does not use interior mutability, and is essentially the same as `Vec<T>`,
+// which implements `Send` / `Sync` in the same way.
+unsafe impl<T: Send> Send for Stack<T> {}
+// SAFETY: See above.
+unsafe impl<T: Sync> Sync for Stack<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Implement `Send` and `Sync` for `Stack<T>` and `NonEmptyStack<T>` where `T` is `Send` / `Sync`.

This also makes `SparseStack<T>` implement `Send` / `Sync` with same bounds.

`Vec` also implements `Send` / `Sync` in the same way, and the stack types are all essentially the same as `Vec`, just with a different internal implementations, so it makes sense to follow `Vec`.