### PR TITLE
perf(allocator): use `Stack` in `AllocatorPool`s

### DIFF
--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -21,7 +21,7 @@ doctest = true
 
 [dependencies]
 oxc_ast_macros = { workspace = true, optional = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked", "stack"] }
 oxc_estree = { workspace = true, optional = true }
 
 allocator-api2 = { workspace = true }

--- a/crates/oxc_allocator/src/pool/standard.rs
+++ b/crates/oxc_allocator/src/pool/standard.rs
@@ -1,5 +1,7 @@
 use std::{iter, sync::Mutex};
 
+use oxc_data_structures::stack::Stack;
+
 use crate::Allocator;
 
 /// A thread-safe pool for reusing [`Allocator`] instances, that uses standard allocators.
@@ -7,7 +9,11 @@ use crate::Allocator;
 /// Unlike `FixedSizeAllocatorPool`, the `Allocator`s used in this pool are suitable for general use,
 /// but not for raw transfer.
 pub struct StandardAllocatorPool {
-    allocators: Mutex<Vec<Allocator>>,
+    /// Allocators currently in the pool.
+    /// We use a `Stack` because it's faster than `Vec` for `push` and `pop`,
+    /// and those are the operations we do while `Mutex` lock is held.
+    /// The shorter the time lock is held, the less contention there is.
+    allocators: Mutex<Stack<Allocator>>,
 }
 
 impl StandardAllocatorPool {


### PR DESCRIPTION
Replace `Vec` with `Stack` in `StandardAllocatorPool` and `FixedSizeAllocatorPool`.

`Stack` is faster than `Vec` for `push` and `pop`. These are the operations which pools do while the `Mutex` is locked, so reducing the work these operations do reduces contention.