### PR TITLE
fix(linter): Merge env when extending configs

### DIFF
--- a/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1341,4 +1341,29 @@ mod test {
         .build(&mut external_plugin_store)
         .unwrap()
     }
+
+    #[test]
+    fn test_extends_env_merge() {
+        // Test that env is merged when extending configs
+        let config = config_store_from_str(
+            r#"
+            {
+                "extends": ["fixtures/extends_config/merge/env_parent.json"],
+                "env": {
+                    "node": true,
+                    "es6": false
+                }
+            }
+            "#,
+        );
+
+        let env = config.env();
+
+        // Parent values should be preserved
+        assert!(env.contains("browser"), "browser from parent should be preserved");
+        // Child values should be added
+        assert!(env.contains("node"), "node from child should be added");
+        // Child should override parent
+        assert!(!env.contains("es6"), "es6 should be false (child overrides parent's true)");
+    }
 }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -111,6 +111,10 @@ impl Config {
         self.base.config.plugins
     }
 
+    pub fn env(&self) -> &OxlintEnv {
+        &self.base.config.env
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
     }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -292,7 +292,8 @@ impl Oxlintrc {
             .collect::<Vec<_>>();
 
         let settings = self.settings.clone();
-        let env = self.env.clone();
+        // Merge env: self (child) values override other (parent), parent values preserved if not in child
+        let env = self.env.clone().merge(other.env.clone());
         let globals = self.globals.clone();
 
         let mut overrides = other.overrides;


### PR DESCRIPTION
## Summary
- Adds `merge()` and `is_empty()` methods to `OxlintEnv`
- Updates config extension logic to merge env fields instead of replacing
- Child env values override parent values (ESLint-compatible behavior)

This is part of splitting #14940 into smaller PRs for easier review.

## Test plan
- [x] Unit test added for merge behavior
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)