### PR TITLE
fix(linter): Deep merge settings when extending configs

### DIFF
--- a/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
@@ -1,0 +1,6 @@
+{
+  "globals": {
+    "ParentGlobal": "readonly",
+    "SharedGlobal": "writable"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
@@ -1,0 +1,14 @@
+{
+  "settings": {
+    "next": {
+      "rootDir": "parent/app"
+    },
+    "react": {
+      "linkComponents": ["ParentLink"]
+    },
+    "custom-plugin": {
+      "setting1": "parent-value",
+      "setting2": "parent-only"
+    }
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1366,4 +1366,32 @@ mod test {
         // Child should override parent
         assert!(!env.contains("es6"), "es6 should be false (child overrides parent's true)");
     }
+
+    #[test]
+    fn test_extends_globals_merge() {
+        // Test that globals are merged when extending configs
+        let config = config_store_from_str(
+            r#"
+            {
+                "extends": ["fixtures/extends_config/merge/globals_parent.json"],
+                "globals": {
+                    "ChildGlobal": "writable",
+                    "SharedGlobal": "off"
+                }
+            }
+            "#,
+        );
+
+        let globals = config.globals();
+
+        // Parent values should be preserved
+        assert!(globals.is_enabled("ParentGlobal"), "ParentGlobal from parent should be preserved");
+        // Child values should be added
+        assert!(globals.is_enabled("ChildGlobal"), "ChildGlobal from child should be added");
+        // Child should override parent
+        assert!(
+            !globals.is_enabled("SharedGlobal"),
+            "SharedGlobal should be off (child overrides parent's writable)"
+        );
+    }
 }

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1341,4 +1341,29 @@ mod test {
         .build(&mut external_plugin_store)
         .unwrap()
     }
+
+    #[test]
+    fn test_extends_env_merge() {
+        // Test that env is merged when extending configs
+        let config = config_store_from_str(
+            r#"
+            {
+                "extends": ["fixtures/extends_config/merge/env_parent.json"],
+                "env": {
+                    "node": true,
+                    "es6": false
+                }
+            }
+            "#,
+        );
+
+        let env = config.env();
+
+        // Parent values should be preserved
+        assert!(env.contains("browser"), "browser from parent should be preserved");
+        // Child values should be added
+        assert!(env.contains("node"), "node from child should be added");
+        // Child should override parent
+        assert!(!env.contains("es6"), "es6 should be false (child overrides parent's true)");
+    }
 }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -111,6 +111,10 @@ impl Config {
         self.base.config.plugins
     }
 
+    pub fn env(&self) -> &OxlintEnv {
+        &self.base.config.env
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
     }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -115,6 +115,10 @@ impl Config {
         &self.base.config.env
     }
 
+    pub fn globals(&self) -> &OxlintGlobals {
+        &self.base.config.globals
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
     }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -292,7 +292,8 @@ impl Oxlintrc {
             .collect::<Vec<_>>();
 
         let settings = self.settings.clone();
-        let env = self.env.clone();
+        // Merge env: self (child) values override other (parent), parent values preserved if not in child
+        let env = self.env.clone().merge(other.env.clone());
         let globals = self.globals.clone();
 
         let mut overrides = other.overrides;

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -294,7 +294,8 @@ impl Oxlintrc {
         let settings = self.settings.clone();
         // Merge env: self (child) values override other (parent), parent values preserved if not in child
         let env = self.env.clone().merge(other.env.clone());
-        let globals = self.globals.clone();
+        // Merge globals: self (child) values override other (parent), parent values preserved if not in child
+        let globals = self.globals.clone().merge(other.globals.clone());
 
         let mut overrides = other.overrides;
         overrides.extend(self.overrides.clone());

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -291,7 +291,8 @@ impl Oxlintrc {
             .map(|rule| (**rule).clone())
             .collect::<Vec<_>>();
 
-        let settings = self.settings.clone();
+        // Deep merge settings: child values override parent, nested objects merged recursively
+        let settings = self.settings.clone().merge(other.settings.clone());
         // Merge env: self (child) values override other (parent), parent values preserved if not in child
         let env = self.env.clone().merge(other.env.clone());
         // Merge globals: self (child) values override other (parent), parent values preserved if not in child

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -178,6 +178,25 @@ impl JSDocPluginSettings {
             _ => original_name,
         }
     }
+
+    /// Check if all settings have default values (empty/unset).
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Merge self into other (self takes priority).
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+
+        // Merge tag_name_preference: self takes priority
+        for (key, value) in other.tag_name_preference {
+            self.tag_name_preference.entry(key).or_insert(value);
+        }
+
+        self
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/crates/oxc_linter/src/config/settings/jsx_a11y.rs
+++ b/crates/oxc_linter/src/config/settings/jsx_a11y.rs
@@ -64,3 +64,33 @@ pub struct JSXA11yPluginSettings {
     #[serde(default)]
     pub attributes: FxHashMap<CompactStr, Vec<CompactStr>>,
 }
+
+impl JSXA11yPluginSettings {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.polymorphic_prop_name.is_none()
+            && self.components.is_empty()
+            && self.attributes.is_empty()
+    }
+
+    /// Deep merge self into other (self takes priority).
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+
+        // Primitives: self takes priority
+        if self.polymorphic_prop_name.is_none() {
+            self.polymorphic_prop_name = other.polymorphic_prop_name;
+        }
+
+        // HashMaps: merge entries, self takes priority on conflict
+        for (key, value) in other.components {
+            self.components.entry(key).or_insert(value);
+        }
+        for (key, value) in other.attributes {
+            self.attributes.entry(key).or_insert(value);
+        }
+
+        self
+    }
+}

--- a/crates/oxc_linter/src/config/settings/next.rs
+++ b/crates/oxc_linter/src/config/settings/next.rs
@@ -34,6 +34,19 @@ impl NextPluginSettings {
             OneOrMany::Many(vec) => Cow::Borrowed(vec),
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(&self.root_dir, OneOrMany::Many(vec) if vec.is_empty())
+    }
+
+    /// Merge self into other (self takes priority).
+    /// Arrays are replaced, not merged (ESLint v9 behavior).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -67,6 +67,19 @@ impl ReactPluginSettings {
     pub fn get_link_component_attrs(&self, name: &str) -> Option<ComponentAttrs<'_>> {
         get_component_attrs_by_name(&self.link_components, name)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.form_components.is_empty() && self.link_components.is_empty()
+    }
+
+    /// Merge self into other (self takes priority).
+    /// Arrays are replaced, not merged (ESLint v9 behavior).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -13,3 +13,17 @@ pub struct VitestPluginSettings {
     #[serde(default)]
     pub typecheck: bool,
 }
+
+impl VitestPluginSettings {
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.typecheck
+    }
+
+    /// Merge self into other (self takes priority).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `merge()` and `is_empty()` methods to all plugin settings structs (jsx-a11y, next, react, jsdoc, vitest)
- Adds `deep_merge()` helper for arbitrary JSON settings (external/JS plugins)
- Updates config extension logic to deep merge settings instead of replacing
- Child settings take priority; nested objects are merged recursively, arrays are replaced (ESLint v9 behavior)

**Depends on:** #17153

This is part of splitting #14940 into smaller PRs for easier review.

## Test plan
- [x] Unit tests added for merge behavior (including arbitrary JSON settings)
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)