### PR TITLE
feat(linter): Add settings support to overrides

### DIFF
--- a/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/env_parent.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/globals_parent.json
@@ -1,0 +1,6 @@
+{
+  "globals": {
+    "ParentGlobal": "readonly",
+    "SharedGlobal": "writable"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
+++ b/crates/oxc_linter/fixtures/extends_config/merge/settings_parent.json
@@ -1,0 +1,14 @@
+{
+  "settings": {
+    "next": {
+      "rootDir": "parent/app"
+    },
+    "react": {
+      "linkComponents": ["ParentLink"]
+    },
+    "custom-plugin": {
+      "setting1": "parent-value",
+      "setting2": "parent-only"
+    }
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1366,4 +1366,32 @@ mod test {
         // Child should override parent
         assert!(!env.contains("es6"), "es6 should be false (child overrides parent's true)");
     }
+
+    #[test]
+    fn test_extends_globals_merge() {
+        // Test that globals are merged when extending configs
+        let config = config_store_from_str(
+            r#"
+            {
+                "extends": ["fixtures/extends_config/merge/globals_parent.json"],
+                "globals": {
+                    "ChildGlobal": "writable",
+                    "SharedGlobal": "off"
+                }
+            }
+            "#,
+        );
+
+        let globals = config.globals();
+
+        // Parent values should be preserved
+        assert!(globals.is_enabled("ParentGlobal"), "ParentGlobal from parent should be preserved");
+        // Child values should be added
+        assert!(globals.is_enabled("ChildGlobal"), "ChildGlobal from child should be added");
+        // Child should override parent
+        assert!(
+            !globals.is_enabled("SharedGlobal"),
+            "SharedGlobal should be off (child overrides parent's writable)"
+        );
+    }
 }

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1341,4 +1341,29 @@ mod test {
         .build(&mut external_plugin_store)
         .unwrap()
     }
+
+    #[test]
+    fn test_extends_env_merge() {
+        // Test that env is merged when extending configs
+        let config = config_store_from_str(
+            r#"
+            {
+                "extends": ["fixtures/extends_config/merge/env_parent.json"],
+                "env": {
+                    "node": true,
+                    "es6": false
+                }
+            }
+            "#,
+        );
+
+        let env = config.env();
+
+        // Parent values should be preserved
+        assert!(env.contains("browser"), "browser from parent should be preserved");
+        // Child values should be added
+        assert!(env.contains("node"), "node from child should be added");
+        // Child should override parent
+        assert!(!env.contains("es6"), "es6 should be false (child overrides parent's true)");
+    }
 }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -111,6 +111,10 @@ impl Config {
         self.base.config.plugins
     }
 
+    pub fn env(&self) -> &OxlintEnv {
+        &self.base.config.env
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
     }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -115,6 +115,10 @@ impl Config {
         &self.base.config.env
     }
 
+    pub fn globals(&self) -> &OxlintGlobals {
+        &self.base.config.globals
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.rules
     }

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -7,7 +7,9 @@ use rustc_hash::FxHashSet;
 use schemars::{JsonSchema, r#gen, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};
+use crate::{
+    LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules, config::settings::OxlintSettings,
+};
 
 use super::external_plugins::{ExternalPluginEntry, external_plugins_schema};
 
@@ -90,6 +92,9 @@ pub struct OxlintOverride {
 
     /// Enabled or disabled specific global variables.
     pub globals: Option<OxlintGlobals>,
+
+    /// Plugin-specific settings for this override.
+    pub settings: Option<OxlintSettings>,
 
     /// Optionally change what plugins are enabled for this override. When
     /// omitted, the base config's plugins are used.

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -292,7 +292,8 @@ impl Oxlintrc {
             .collect::<Vec<_>>();
 
         let settings = self.settings.clone();
-        let env = self.env.clone();
+        // Merge env: self (child) values override other (parent), parent values preserved if not in child
+        let env = self.env.clone().merge(other.env.clone());
         let globals = self.globals.clone();
 
         let mut overrides = other.overrides;

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -294,7 +294,8 @@ impl Oxlintrc {
         let settings = self.settings.clone();
         // Merge env: self (child) values override other (parent), parent values preserved if not in child
         let env = self.env.clone().merge(other.env.clone());
-        let globals = self.globals.clone();
+        // Merge globals: self (child) values override other (parent), parent values preserved if not in child
+        let globals = self.globals.clone().merge(other.globals.clone());
 
         let mut overrides = other.overrides;
         overrides.extend(self.overrides.clone());

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -291,7 +291,8 @@ impl Oxlintrc {
             .map(|rule| (**rule).clone())
             .collect::<Vec<_>>();
 
-        let settings = self.settings.clone();
+        // Deep merge settings: child values override parent, nested objects merged recursively
+        let settings = self.settings.clone().merge(other.settings.clone());
         // Merge env: self (child) values override other (parent), parent values preserved if not in child
         let env = self.env.clone().merge(other.env.clone());
         // Merge globals: self (child) values override other (parent), parent values preserved if not in child

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -197,6 +197,27 @@ impl JSDocPluginSettings {
 
         self
     }
+
+    /// Merge self into base (for overrides). Self takes priority.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        if self.is_empty() {
+            return;
+        }
+
+        // All primitive fields: override if self has non-default values
+        base.ignore_private = self.ignore_private;
+        base.ignore_internal = self.ignore_internal;
+        base.ignore_replaces_docs = self.ignore_replaces_docs;
+        base.override_replaces_docs = self.override_replaces_docs;
+        base.augments_extends_replaces_docs = self.augments_extends_replaces_docs;
+        base.implements_replaces_docs = self.implements_replaces_docs;
+        base.exempt_destructured_roots_from_checks = self.exempt_destructured_roots_from_checks;
+
+        // Merge tag_name_preference: self takes priority
+        for (key, value) in &self.tag_name_preference {
+            base.tag_name_preference.insert(key.clone(), value.clone());
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -178,6 +178,25 @@ impl JSDocPluginSettings {
             _ => original_name,
         }
     }
+
+    /// Check if all settings have default values (empty/unset).
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Merge self into other (self takes priority).
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+
+        // Merge tag_name_preference: self takes priority
+        for (key, value) in other.tag_name_preference {
+            self.tag_name_preference.entry(key).or_insert(value);
+        }
+
+        self
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/crates/oxc_linter/src/config/settings/jsx_a11y.rs
+++ b/crates/oxc_linter/src/config/settings/jsx_a11y.rs
@@ -93,4 +93,24 @@ impl JSXA11yPluginSettings {
 
         self
     }
+
+    /// Merge self into base (for overrides). Self takes priority.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        if self.is_empty() {
+            return;
+        }
+
+        // Primitives: override if self has value
+        if self.polymorphic_prop_name.is_some() {
+            base.polymorphic_prop_name.clone_from(&self.polymorphic_prop_name);
+        }
+
+        // HashMaps: merge entries, self takes priority on conflict
+        for (key, value) in &self.components {
+            base.components.insert(key.clone(), value.clone());
+        }
+        for (key, value) in &self.attributes {
+            base.attributes.insert(key.clone(), value.clone());
+        }
+    }
 }

--- a/crates/oxc_linter/src/config/settings/jsx_a11y.rs
+++ b/crates/oxc_linter/src/config/settings/jsx_a11y.rs
@@ -64,3 +64,33 @@ pub struct JSXA11yPluginSettings {
     #[serde(default)]
     pub attributes: FxHashMap<CompactStr, Vec<CompactStr>>,
 }
+
+impl JSXA11yPluginSettings {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.polymorphic_prop_name.is_none()
+            && self.components.is_empty()
+            && self.attributes.is_empty()
+    }
+
+    /// Deep merge self into other (self takes priority).
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+
+        // Primitives: self takes priority
+        if self.polymorphic_prop_name.is_none() {
+            self.polymorphic_prop_name = other.polymorphic_prop_name;
+        }
+
+        // HashMaps: merge entries, self takes priority on conflict
+        for (key, value) in other.components {
+            self.components.entry(key).or_insert(value);
+        }
+        for (key, value) in other.attributes {
+            self.attributes.entry(key).or_insert(value);
+        }
+
+        self
+    }
+}

--- a/crates/oxc_linter/src/config/settings/next.rs
+++ b/crates/oxc_linter/src/config/settings/next.rs
@@ -34,6 +34,19 @@ impl NextPluginSettings {
             OneOrMany::Many(vec) => Cow::Borrowed(vec),
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(&self.root_dir, OneOrMany::Many(vec) if vec.is_empty())
+    }
+
+    /// Merge self into other (self takes priority).
+    /// Arrays are replaced, not merged (ESLint v9 behavior).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/next.rs
+++ b/crates/oxc_linter/src/config/settings/next.rs
@@ -47,6 +47,13 @@ impl NextPluginSettings {
         }
         self
     }
+
+    /// Merge self into base (for overrides). Self takes priority.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        if !self.is_empty() {
+            base.root_dir = self.root_dir.clone();
+        }
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -80,6 +80,14 @@ impl ReactPluginSettings {
         }
         self
     }
+
+    /// Merge self into base (for overrides). Self takes priority.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        if !self.is_empty() {
+            base.form_components.clone_from(&self.form_components);
+            base.link_components.clone_from(&self.link_components);
+        }
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -67,6 +67,19 @@ impl ReactPluginSettings {
     pub fn get_link_component_attrs(&self, name: &str) -> Option<ComponentAttrs<'_>> {
         get_component_attrs_by_name(&self.link_components, name)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.form_components.is_empty() && self.link_components.is_empty()
+    }
+
+    /// Merge self into other (self takes priority).
+    /// Arrays are replaced, not merged (ESLint v9 behavior).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
 }
 
 // Deserialize helper types

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -13,3 +13,17 @@ pub struct VitestPluginSettings {
     #[serde(default)]
     pub typecheck: bool,
 }
+
+impl VitestPluginSettings {
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.typecheck
+    }
+
+    /// Merge self into other (self takes priority).
+    pub(crate) fn merge(self, other: Self) -> Self {
+        if self.is_empty() {
+            return other;
+        }
+        self
+    }
+}

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -26,4 +26,11 @@ impl VitestPluginSettings {
         }
         self
     }
+
+    /// Merge self into base (for overrides). Self takes priority.
+    pub(crate) fn merge_into(&self, base: &mut Self) {
+        if !self.is_empty() {
+            base.typecheck = self.typecheck;
+        }
+    }
 }

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -556,6 +556,18 @@ expression: json
               "$ref": "#/definitions/OxlintRules"
             }
           ]
+        },
+        "settings": {
+          "description": "Plugin-specific settings for this override.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintSettings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Plugin-specific settings for this override."
         }
       },
       "additionalProperties": false

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -552,6 +552,18 @@
               "$ref": "#/definitions/OxlintRules"
             }
           ]
+        },
+        "settings": {
+          "description": "Plugin-specific settings for this override.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintSettings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Plugin-specific settings for this override."
         }
       },
       "additionalProperties": false

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -380,6 +380,333 @@ type: `object`
 See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
 
 
+#### overrides[n].settings
+
+type: `object | null`
+
+
+Plugin-specific settings for this override.
+
+
+##### overrides[n].settings.jsdoc
+
+type: `object`
+
+
+
+
+
+###### overrides[n].settings.jsdoc.augmentsExtendsReplacesDocs
+
+type: `boolean`
+
+default: `false`
+
+Only for `require-(yields|returns|description|example|param|throws)` rule
+
+
+###### overrides[n].settings.jsdoc.exemptDestructuredRootsFromChecks
+
+type: `boolean`
+
+default: `false`
+
+Only for `require-param-type` and `require-param-description` rule
+
+
+###### overrides[n].settings.jsdoc.ignoreInternal
+
+type: `boolean`
+
+default: `false`
+
+For all rules but NOT apply to `empty-tags` rule
+
+
+###### overrides[n].settings.jsdoc.ignorePrivate
+
+type: `boolean`
+
+default: `false`
+
+For all rules but NOT apply to `check-access` and `empty-tags` rule
+
+
+###### overrides[n].settings.jsdoc.ignoreReplacesDocs
+
+type: `boolean`
+
+default: `true`
+
+Only for `require-(yields|returns|description|example|param|throws)` rule
+
+
+###### overrides[n].settings.jsdoc.implementsReplacesDocs
+
+type: `boolean`
+
+default: `false`
+
+Only for `require-(yields|returns|description|example|param|throws)` rule
+
+
+###### overrides[n].settings.jsdoc.overrideReplacesDocs
+
+type: `boolean`
+
+default: `true`
+
+Only for `require-(yields|returns|description|example|param|throws)` rule
+
+
+###### overrides[n].settings.jsdoc.tagNamePreference
+
+type: `object`
+
+default: `{}`
+
+
+
+
+##### overrides[n].settings.jsx-a11y
+
+type: `object`
+
+
+Configure JSX A11y plugin rules.
+
+See
+[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s
+configuration for a full reference.
+
+
+###### overrides[n].settings.jsx-a11y.attributes
+
+type: `Record<string, array>`
+
+default: `{}`
+
+Map of attribute names to their DOM equivalents.
+This is useful for non-React frameworks that use different attribute names.
+
+Example:
+
+```json
+{
+"settings": {
+"jsx-a11y": {
+"attributes": {
+"for": ["htmlFor", "for"]
+}
+}
+}
+}
+```
+
+
+###### overrides[n].settings.jsx-a11y.components
+
+type: `Record<string, string>`
+
+default: `{}`
+
+To have your custom components be checked as DOM elements, you can
+provide a mapping of your component names to the DOM element name.
+
+Example:
+
+```json
+{
+"settings": {
+"jsx-a11y": {
+"components": {
+"Link": "a",
+"IconButton": "button"
+}
+}
+}
+}
+```
+
+
+###### overrides[n].settings.jsx-a11y.polymorphicPropName
+
+type: `string | null`
+
+
+An optional setting that define the prop your code uses to create polymorphic components.
+This setting will be used to determine the element type in rules that
+require semantic context.
+
+For example, if you set the `polymorphicPropName` to `as`, then this element:
+
+```jsx
+<Box as="h3">Hello</Box>
+```
+
+Will be treated as an `h3`. If not set, this component will be treated
+as a `Box`.
+
+
+##### overrides[n].settings.next
+
+type: `object`
+
+
+Configure Next.js plugin rules.
+
+
+###### overrides[n].settings.next.rootDir
+
+type: `array | string`
+
+
+
+
+
+####### overrides[n].settings.next.rootDir[n]
+
+type: `string`
+
+
+
+
+
+##### overrides[n].settings.react
+
+type: `object`
+
+
+Configure React plugin rules.
+
+Derived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)
+
+
+###### overrides[n].settings.react.formComponents
+
+type: `array`
+
+default: `[]`
+
+Components used as alternatives to `<form>` for forms, such as `<Formik>`.
+
+Example:
+
+```jsonc
+{
+"settings": {
+"react": {
+"formComponents": [
+"CustomForm",
+// OtherForm is considered a form component and has an endpoint attribute
+{ "name": "OtherForm", "formAttribute": "endpoint" },
+// allows specifying multiple properties if necessary
+{ "name": "Form", "formAttribute": ["registerEndpoint", "loginEndpoint"] }
+]
+}
+}
+}
+```
+
+
+####### overrides[n].settings.react.formComponents[n]
+
+type: `object | string`
+
+
+
+
+
+######## overrides[n].settings.react.formComponents[n].attribute
+
+type: `string`
+
+
+
+
+
+######## overrides[n].settings.react.formComponents[n].name
+
+type: `string`
+
+
+
+
+
+###### overrides[n].settings.react.linkComponents
+
+type: `array`
+
+default: `[]`
+
+Components used as alternatives to `<a>` for linking, such as `<Link>`.
+
+Example:
+
+```jsonc
+{
+"settings": {
+"react": {
+"linkComponents": [
+"HyperLink",
+// Use `linkAttribute` for components that use a different prop name
+// than `href`.
+{ "name": "MyLink", "linkAttribute": "to" },
+// allows specifying multiple properties if necessary
+{ "name": "Link", "linkAttribute": ["to", "href"] }
+]
+}
+}
+}
+```
+
+
+####### overrides[n].settings.react.linkComponents[n]
+
+type: `object | string`
+
+
+
+
+
+######## overrides[n].settings.react.linkComponents[n].attribute
+
+type: `string`
+
+
+
+
+
+######## overrides[n].settings.react.linkComponents[n].name
+
+type: `string`
+
+
+
+
+
+##### overrides[n].settings.vitest
+
+type: `object`
+
+
+Configure Vitest plugin rules.
+
+See [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s
+configuration for a full reference.
+
+
+###### overrides[n].settings.vitest.typecheck
+
+type: `boolean`
+
+default: `false`
+
+Whether to enable typecheck mode for Vitest rules.
+When enabled, some rules will skip certain checks for describe blocks
+to accommodate TypeScript type checking scenarios.
+
+
 ## plugins
 
 type: `array | null`


### PR DESCRIPTION
## Summary
- Adds `settings` field to `OxlintOverride` struct
- Adds `merge_into()` methods to all plugin settings structs for in-place mutation
- Updates `apply_overrides()` to merge settings from matching overrides into base config
- Settings from overrides take priority, with deep merge for nested objects

This enables file-specific plugin settings in override blocks, e.g.:
```json
{
  "settings": { "next": { "rootDir": "app" } },
  "overrides": [{
    "files": ["*.test.ts"],
    "settings": { "next": { "rootDir": "test-app" } }
  }]
}
```

**Depends on:** #17154

This is part of splitting #14940 into smaller PRs for easier review.

## Test plan
- [x] Unit test added for settings in overrides
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)