### PR TITLE
refactor(linter/plugins): add error messages to debug assertions

### DIFF
--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -87,7 +87,7 @@ export function initBuffer() {
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
 
   // Store in `buffers`, at index 0
-  debugAssert(buffers.length === 0);
+  debugAssert(buffers.length === 0, "`buffers` array should be empty");
   buffers.push(buffer);
 }
 

--- a/apps/oxlint/src-js/plugins/globals.ts
+++ b/apps/oxlint/src-js/plugins/globals.ts
@@ -54,7 +54,10 @@ export function initGlobals(): void {
   }
 
   debugAssertIsNonNull(globals);
-  debugAssert(typeof globals === "object" && !Array.isArray(globals));
+  debugAssert(
+    typeof globals === "object" && !Array.isArray(globals),
+    "`globals` should be an object",
+  );
 }
 
 /**

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -121,10 +121,16 @@ export function lintFileImpl(
   typeAssertIs<BufferWithArrays>(buffer);
 
   // Debug asserts that input is valid
-  debugAssert(typeof filePath === "string" && filePath.length > 0);
-  debugAssert(Array.isArray(ruleIds) && ruleIds.length > 0);
-  debugAssert(Array.isArray(optionsIds));
-  debugAssert(ruleIds.length === optionsIds.length);
+  debugAssert(
+    typeof filePath === "string" && filePath.length > 0,
+    "`filePath` should be a non-empty string",
+  );
+  debugAssert(Array.isArray(ruleIds) && ruleIds.length > 0, "`ruleIds` should be non-empty array");
+  debugAssert(Array.isArray(optionsIds), "`optionsIds` should be an array");
+  debugAssert(
+    ruleIds.length === optionsIds.length,
+    "`ruleIds` and `optionsIds` should be same length",
+  );
 
   // Pass file path to context module, so `Context`s know what file is being linted
   setupFileContext(filePath);

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -84,8 +84,11 @@ export function initLines(): void {
 
   // `lineStartIndices` starts as `[0]`, and is reset to length 1 in `resetLines`.
   // Debug check that `lines` and `lineStartIndices` are not already initialized.
-  debugAssert(lines.length === 0);
-  debugAssert(lineStartIndices.length === 1);
+  debugAssert(lines.length === 0, "`lines` should be empty at start of `initLines`");
+  debugAssert(
+    lineStartIndices.length === 1,
+    "`lineStartIndices` should have length 1 at start of `initLines`",
+  );
 
   let lastOffset = 0,
     offset,
@@ -105,8 +108,11 @@ export function initLines(): void {
  * No-op in release build - TSDown will remove this function and all calls to it.
  */
 function debugAssertLinesIsInitialized(): void {
-  debugAssert(lines.length > 0);
-  debugAssert(lines.length === lineStartIndices.length);
+  debugAssert(lines.length > 0, "`lines` should be initialized");
+  debugAssert(
+    lines.length === lineStartIndices.length,
+    "`lines` and `lineStartIndices` should be same length",
+  );
 }
 
 /**

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -135,7 +135,10 @@ function analyzeSelector(
 ): NodeTypeId[] | null {
   switch (esquerySelector.type) {
     case "identifier": {
-      debugAssert(identifierCount(selector.specificity) < IDENTIFIER_COUNT_MAX);
+      debugAssert(
+        identifierCount(selector.specificity) < IDENTIFIER_COUNT_MAX,
+        "Exceeded maximum identifier count in selector",
+      );
       selector.specificity += IDENTIFIER_COUNT_INCREMENT;
 
       const typeId = NODE_TYPE_IDS_MAP.get(esquerySelector.value);
@@ -208,7 +211,10 @@ function analyzeSelector(
     case "nth-child":
     case "nth-last-child":
       selector.isComplex = true;
-      debugAssert(attributeCount(selector.specificity) < ATTRIBUTE_COUNT_MAX);
+      debugAssert(
+        attributeCount(selector.specificity) < ATTRIBUTE_COUNT_MAX,
+        "Exceeded maximum attribute count in selector",
+      );
       selector.specificity += ATTRIBUTE_COUNT_INCREMENT;
       return null;
 

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -261,7 +261,7 @@ export function initTokensAndComments() {
     } while (commentStart < tokenStart);
   }
 
-  debugAssert(false, "Unreachable");
+  debugAssert(false, "End of `initTokensAndComments` should be unreachable");
 }
 
 /**

--- a/apps/oxlint/src-js/plugins/tokens_parse.ts
+++ b/apps/oxlint/src-js/plugins/tokens_parse.ts
@@ -67,7 +67,7 @@ export function parseTokens(): Token[] {
 
   // Check that TypeScript hasn't altered source text.
   // If it had, token ranges would be incorrect.
-  debugAssert(tsAst.text === sourceText);
+  debugAssert(tsAst.text === sourceText, "TS AST text and source text should match");
 
   // Extract tokens from TypeScript AST
   return convertTokens(tsAst);

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -449,7 +449,7 @@ const visitFns: VisitFn[] = [];
 function mergeVisitFns(visitProps: VisitProp[]): VisitFn {
   const numVisitFns = visitProps.length;
 
-  debugAssert(numVisitFns > 0);
+  debugAssert(numVisitFns > 0, "`visitProps` should have at least 1 element");
 
   let mergedFn: VisitFn;
   if (numVisitFns === 1) {
@@ -488,7 +488,7 @@ function mergeVisitFns(visitProps: VisitProp[]): VisitFn {
     // Merge functions.
     // Reuse a temporary array to avoid creating a new array for each merge.
     // TODO: Make merger functions take an array of `VisitProp`s to avoid this operation?
-    debugAssert(visitFns.length === 0);
+    debugAssert(visitFns.length === 0, "`visitFns` should be empty");
 
     for (let i = 0; i < numVisitFns; i++) {
       debugAssertIsNonNull(visitProps[i].fn);


### PR DESCRIPTION
Add error messages to all `debugAssert()` calls, for easier debugging.

When running Oxlint normally, we can easily figure out where errors are coming from stack traces, but in conformance test snapshot, line and column are removed from errors in the snapshot, so it's less easy.