### PR TITLE
refactor(linter/plugins, parser/napi): generate type IDs maps as variants

### DIFF
--- a/apps/oxlint/src-js/generated/type_ids.ts
+++ b/apps/oxlint/src-js/generated/type_ids.ts
@@ -3,7 +3,6 @@
 
 // Mapping from node type name to node type ID
 export const NODE_TYPE_IDS_MAP = new Map([
-  // Leaf nodes
   ["DebuggerStatement", 0],
   ["EmptyStatement", 1],
   ["Literal", 2],
@@ -31,7 +30,6 @@ export const NODE_TYPE_IDS_MAP = new Map([
   ["TSUndefinedKeyword", 24],
   ["TSUnknownKeyword", 25],
   ["TSVoidKeyword", 26],
-  // Non-leaf nodes
   ["AccessorProperty", 27],
   ["ArrayExpression", 28],
   ["ArrayPattern", 29],
@@ -173,5 +171,7 @@ export const NODE_TYPE_IDS_MAP = new Map([
 ]);
 
 export const NODE_TYPES_COUNT = 165;
+
 export const LEAF_NODE_TYPES_COUNT = 27;
+
 export const FUNCTION_NODE_TYPE_IDS = [30, 55, 56];

--- a/napi/parser/src-js/generated/visit/type_ids.js
+++ b/napi/parser/src-js/generated/visit/type_ids.js
@@ -3,7 +3,6 @@
 
 // Mapping from node type name to node type ID
 export const NODE_TYPE_IDS_MAP = new Map([
-  // Leaf nodes
   ["DebuggerStatement", 0],
   ["EmptyStatement", 1],
   ["Literal", 2],
@@ -31,7 +30,6 @@ export const NODE_TYPE_IDS_MAP = new Map([
   ["TSUndefinedKeyword", 24],
   ["TSUnknownKeyword", 25],
   ["TSVoidKeyword", 26],
-  // Non-leaf nodes
   ["AccessorProperty", 27],
   ["ArrayExpression", 28],
   ["ArrayPattern", 29],
@@ -173,4 +171,5 @@ export const NODE_TYPE_IDS_MAP = new Map([
 ]);
 
 export const NODE_TYPES_COUNT = 165;
+
 export const LEAF_NODE_TYPES_COUNT = 27;


### PR DESCRIPTION
Pure refactor. Generate the JS files containing `NODE_TYPE_IDS_MAP` as variants of a single source code file, instead of constructing to two different versions for parser and linter manually.

This makes changes in further PRs to come easier to implement.