### PR TITLE
feat(linter/plugins): add `getRange` and `getLoc` methods to `SourceCode`

### DIFF
--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -241,6 +241,29 @@ export function getOffsetFromLineColumn(loc: LineColumn): number {
 }
 
 /**
+ * Get the range of the given node or token.
+ * @param nodeOrToken - Node or token to get the range of
+ * @returns Range of the node or token
+ */
+export function getRange(nodeOrToken: NodeOrToken): Range {
+  return nodeOrToken.range;
+}
+
+/**
+ * Get the location of the given node or token.
+ * @param nodeOrToken - Node or token to get the location of
+ * @returns Location of the node or token
+ */
+// Note: We cannot expose `getNodeLoc` as public method, because it always recalculates the location,
+// and returns a new object each time. It would be misleading if `node.loc !== sourceCode.getLoc(node)`.
+export function getLoc(nodeOrToken: NodeOrToken): Location {
+  // If location is already calculated for this node or token, return it
+  if (Object.hasOwn(nodeOrToken, "loc")) return nodeOrToken.loc;
+  // Calculate location
+  return getNodeLoc(nodeOrToken);
+}
+
+/**
  * Calculate the `Location` for an AST node or token.
  *
  * Used in `loc` getters on AST nodes.

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -6,16 +6,8 @@ import { deserializeProgramOnly, resetBuffer } from "../generated/deserialize.js
 
 import visitorKeys from "../generated/keys.ts";
 import * as commentMethods from "./comments.ts";
-import {
-  getLineColumnFromOffset,
-  getNodeByRangeIndex,
-  getNodeLoc,
-  getOffsetFromLineColumn,
-  initLines,
-  lines,
-  lineStartIndices,
-  resetLines,
-} from "./location.ts";
+import * as locationMethods from "./location.ts";
+import { getNodeLoc, initLines, lines, lineStartIndices, resetLines } from "./location.ts";
 import { resetScopeManager, SCOPE_MANAGER } from "./scope.ts";
 import * as scopeMethods from "./scope.ts";
 import { resetTokens } from "./tokens.ts";
@@ -255,9 +247,11 @@ export const SOURCE_CODE = Object.freeze({
   },
 
   // Location methods
-  getNodeByRangeIndex,
-  getLocFromIndex: getLineColumnFromOffset,
-  getIndexFromLoc: getOffsetFromLineColumn,
+  getRange: locationMethods.getRange,
+  getLoc: locationMethods.getLoc,
+  getNodeByRangeIndex: locationMethods.getNodeByRangeIndex,
+  getLocFromIndex: locationMethods.getLineColumnFromOffset,
+  getIndexFromLoc: locationMethods.getOffsetFromLineColumn,
 
   // Comment methods
   getAllComments: commentMethods.getAllComments,

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -21,8 +21,20 @@ const testCommentsRule: Rule = {
     const { sourceCode } = context;
     const { ast } = sourceCode;
 
+    const comments = sourceCode.getAllComments();
+
+    for (const comment of comments) {
+      // Check getting `range` / `loc` properties twice results in same objects
+      const { range, loc } = comment;
+      assert(range === comment.range);
+      assert(loc === comment.loc);
+      // Check `getRange` and `getLoc` return the same objects too
+      assert(sourceCode.getRange(comment) === range);
+      assert(sourceCode.getLoc(comment) === loc);
+    }
+
     context.report({
-      message: `getAllComments: ${formatComments(sourceCode.getAllComments())}`,
+      message: `getAllComments: ${formatComments(comments)}`,
       node: ast,
     });
 

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -114,6 +114,8 @@
   | source with before: "t foo"
   | source with after: "foo,"
   | source with both: "t foo,"
+  | range: [4,7]
+  | loc: {"start":{"line":1,"column":4},"end":{"line":1,"column":7}}
   | start loc: {"line":1,"column":4}
   | end loc: {"line":1,"column":7}
    ,-[files/1.js:1:5]
@@ -140,6 +142,8 @@
   | source with before: ", bar"
   | source with after: "bar;"
   | source with both: ", bar;"
+  | range: [9,12]
+  | loc: {"start":{"line":1,"column":9},"end":{"line":1,"column":12}}
   | start loc: {"line":1,"column":9}
   | end loc: {"line":1,"column":12}
    ,-[files/1.js:1:10]
@@ -235,6 +239,8 @@
   | source with before: "t qux"
   | source with after: "qux;"
   | source with both: "t qux;"
+  | range: [4,7]
+  | loc: {"start":{"line":1,"column":4},"end":{"line":1,"column":7}}
   | start loc: {"line":1,"column":4}
   | end loc: {"line":1,"column":7}
    ,-[files/2.js:1:5]

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -69,6 +69,15 @@ const createRule: Rule = {
         assert(sourceCode.getIndexFromLoc(startLoc) === node.start);
         assert(sourceCode.getIndexFromLoc(endLoc) === node.end);
 
+        const { range, loc } = node;
+
+        // Check getting `range` / `loc` properties twice results in same objects
+        assert(range === node.range);
+        assert(loc === node.loc);
+        // Check `getRange` and `getLoc` return the same objects too
+        assert(sourceCode.getRange(node) === range);
+        assert(sourceCode.getLoc(node) === loc);
+
         context.report({
           message:
             `ident "${node.name}":\n` +
@@ -76,6 +85,8 @@ const createRule: Rule = {
             `source with before: "${sourceCode.getText(node, 2)}"\n` +
             `source with after: "${sourceCode.getText(node, null, 1)}"\n` +
             `source with both: "${sourceCode.getText(node, 2, 1)}"\n` +
+            `range: ${JSON.stringify(range)}\n` +
+            `loc: ${JSON.stringify(loc)}\n` +
             `start loc: ${JSON.stringify(startLoc)}\n` +
             `end loc: ${JSON.stringify(endLoc)}`,
           node,

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -11,6 +11,16 @@ const rule: Rule = {
 
     const { ast } = sourceCode;
 
+    for (const tokenOrComment of tokensAndComments) {
+      // Check getting `range` / `loc` properties twice results in same objects
+      const { range, loc } = tokenOrComment;
+      assert(range === tokenOrComment.range);
+      assert(loc === tokenOrComment.loc);
+      // Check `getRange` and `getLoc` return the same objects too
+      assert(sourceCode.getRange(tokenOrComment) === range);
+      assert(sourceCode.getLoc(tokenOrComment) === loc);
+    }
+
     // `ast.tokens` does not include comments
     context.report({
       message:


### PR DESCRIPTION
ESLint has undocumented `getRange` and `getLoc` methods on `SourceCode`. Add them.

These are the last 2 missing methods on `SourceCode` (according to Claude).

Also add more tests for correct functioning of `range` and `loc` properties.