### PR TITLE
perf(semantic): use `split_at_mut` instead of iterator in `current_and_parent_mut`

### DIFF
--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -89,7 +89,6 @@ impl<'a> UnresolvedReferencesStack<'a> {
         &mut self,
     ) -> (&mut TempUnresolvedReferences<'a>, &mut TempUnresolvedReferences<'a>) {
         // Assert invariants to remove bounds checks in code below.
-        // https://godbolt.org/z/vv5Wo5csv
         // SAFETY: `current_scope_depth` starts at 1, and is only decremented
         // in `decrement_scope_depth` which checks it doesn't go below 1.
         unsafe { assert_unchecked!(self.current_scope_depth > 0) };
@@ -99,9 +98,9 @@ impl<'a> UnresolvedReferencesStack<'a> {
         // and it grows `stack` to ensure `stack.len()` always exceeds `current_scope_depth`.
         unsafe { assert_unchecked!(self.stack.len() > self.current_scope_depth) };
 
-        let mut iter = self.stack.iter_mut();
-        let parent = iter.nth(self.current_scope_depth - 1).unwrap();
-        let current = iter.next().unwrap();
+        let (head, tail) = self.stack.split_at_mut(self.current_scope_depth);
+        let parent = &mut head[self.current_scope_depth - 1];
+        let current = &mut tail[0];
         (current, parent)
     }
 


### PR DESCRIPTION
Before:

```rs
impl Stack {
    #[inline]
    pub fn current_and_parent_iter(&mut self) -> (&mut Map, &mut Map) {
        // Assert invariants
        if self.depth == 0 {
            unsafe { unreachable_unchecked() };
        }
        if self.stack.len() <= self.depth {
            unsafe { unreachable_unchecked() };
        }
        let mut iter = self.stack.iter_mut();
        let parent = iter.nth(self.depth - 1).unwrap();
        let current = iter.next().unwrap();
        (current, parent)
    }
}

pub fn use_iter(s: &mut Stack) -> (&mut Map, &mut Map) {
    s.current_and_parent_iter()
}
```

```asm
use_iter:
        mov     rax, qword ptr [rdi + 24]
        movabs  rcx, 1152921504606846975
        and     rcx, rax
        cmp     rcx, qword ptr [rdi + 16]
        je      .LBB0_2
        lea     rcx, [rax + 2*rax]
        shl     rcx, 4
        mov     rdx, qword ptr [rdi + 8]
        lea     rax, [rdx + rcx]
        add     rdx, rcx
        add     rdx, -48
        ret
.LBB0_2:
        push    rax
        lea     rdi, [rip + .Lanon.f6daf3c64be0965473887c7779875594.1]
        call    qword ptr [rip + core::option::unwrap_failed::hc7ed8ec7fd6c106d@GOTPCREL]

.Lanon.f6daf3c64be0965473887c7779875594.0:
        .asciz  "/app/example.rs"

.Lanon.f6daf3c64be0965473887c7779875594.1:
        .quad   .Lanon.f6daf3c64be0965473887c7779875594.0
        .asciz  "\017\000\000\000\000\000\000\000\025\000\000\000#\000\000"
```

After:

```rs
impl Stack {
    #[inline]
    pub fn current_and_parent_split(&mut self) -> (&mut Map, &mut Map) {
        // Assert invariants
        if self.depth == 0 {
            unsafe { unreachable_unchecked() };
        }
        if self.stack.len() <= self.depth {
            unsafe { unreachable_unchecked() };
        }
        let (head, tail) = self.stack.split_at_mut(self.depth);
        let parent = &mut head[self.depth - 1] ;
        let current = &mut tail[0];
        (current, parent)
    }
}

pub fn use_split(s: &mut Stack) -> (&mut Map, &mut Map) {
    s.current_and_parent_split()
}
```

```asm
use_split:
        mov     rcx, qword ptr [rdi + 8]
        mov     rax, qword ptr [rdi + 24]
        lea     rdx, [rax + 2*rax]
        shl     rdx, 4
        lea     rax, [rcx + rdx]
        add     rdx, rcx
        add     rdx, -48
        ret
```