### PR TITLE
perf(semantic): use match_module_declaration! macro instead of match guard

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, ast::*};
+use oxc_ast::{AstKind, ast::*, match_module_declaration};
 
 use crate::builder::SemanticBuilder;
 
@@ -30,10 +30,9 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::StringLiteral(lit) => js::check_string_literal(lit, ctx),
 
         AstKind::Directive(dir) => js::check_directive(dir, ctx),
-        m if m.is_module_declaration() => {
-            if let Some(mod_decl_kind) = m.as_module_declaration_kind() {
-                js::check_module_declaration(&mod_decl_kind, ctx);
-            }
+        match_module_declaration!(AstKind) => {
+            let mod_decl_kind = kind.as_module_declaration_kind().unwrap();
+            js::check_module_declaration(&mod_decl_kind, ctx);
         }
         AstKind::MetaProperty(prop) => js::check_meta_property(prop, ctx),
 


### PR DESCRIPTION
Replaces the match guard pattern that calls `is_module_declaration()` for every AST node with the `match_module_declaration!` macro for direct pattern matching.

Before:

```asm
example::check_before::hfc46178bb9b4d182:
        cmp     rdi, 7
        ja      .LBB1_11
        lea     rax, [rip + .LJTI1_0]
        movsxd  rcx, dword ptr [rax + 4*rdi]
        add     rcx, rax
        jmp     rcx
.LBB1_2:
        mov     rdi, rsi
        jmp     example::check_program::hdcbd5472c2f04f3b
.LBB1_3:
        mov     eax, 3
        jmp     .LBB1_10
.LBB1_4:
        mov     eax, 1
        jmp     .LBB1_10
.LBB1_5:
        mov     eax, 2
        jmp     .LBB1_10
.LBB1_7:
        xor     eax, eax
        jmp     .LBB1_10
.LBB1_8:
        mov     eax, 4
        jmp     .LBB1_10
.LBB1_9:
        mov     eax, 5
.LBB1_10:
        sub     rsp, 24
        mov     qword ptr [rsp + 8], rax
        mov     qword ptr [rsp + 16], rsi
        lea     rdi, [rsp + 8]
        call    example::check_module_declaration::h47851d60ce069a6b
        add     rsp, 24
.LBB1_11:
        ret
.LJTI1_0:
        .long   .LBB1_2-.LJTI1_0
        .long   .LBB1_7-.LJTI1_0
        .long   .LBB1_4-.LJTI1_0
        .long   .LBB1_5-.LJTI1_0
        .long   .LBB1_3-.LJTI1_0
        .long   .LBB1_8-.LJTI1_0
        .long   .LBB1_9-.LJTI1_0
        .long   .LBB1_2-.LJTI1_0

```

After:

```asm
example::check_after::h7e9549e143229746:
        lea     rax, [rdi - 1]
        cmp     rax, 6
        jae     .LBB0_1
        sub     rsp, 24
        mov     qword ptr [rsp + 8], rax
        mov     qword ptr [rsp + 16], rsi
        lea     rdi, [rsp + 8]
        call    example::check_module_declaration::h47851d60ce069a6b
        add     rsp, 24
.LBB0_5:
        ret
.LBB0_1:
        test    rdi, rdi
        je      .LBB0_3
        cmp     rdi, 7
        jne     .LBB0_5
.LBB0_3:
        mov     rdi, rsi
        jmp     example::check_program::hdcbd5472c2f04f3b

```