### PR TITLE
docs(linter): Ensure that the docs render default values for various rules that use enum config options

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -12,6 +12,7 @@ use schemars::JsonSchema;
 use crate::{AstNode, context::LintContext, rule::Rule};
 use icu_segmenter::GraphemeClusterSegmenter;
 use lazy_regex::Regex;
+use serde::Serialize;
 use serde_json::Value;
 
 fn id_length_is_too_short_diagnostic(span: Span, config_min: u64) -> OxcDiagnostic {
@@ -25,7 +26,7 @@ fn id_length_is_too_long_diagnostic(span: Span, config_max: u64) -> OxcDiagnosti
 const DEFAULT_MAX_LENGTH: u64 = u64::MAX;
 const DEFAULT_MIN_LENGTH: u64 = 2;
 
-#[derive(Debug, Default, Clone, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, PartialEq, JsonSchema, Serialize)]
 #[serde(rename_all = "lowercase")]
 enum PropertyKind {
     #[default]
@@ -55,7 +56,6 @@ impl Deref for IdLength {
 pub struct IdLengthConfig {
     /// An array of regex patterns for identifiers to exclude from the rule.
     /// For example, `["^x.*"]` would exclude all identifiers starting with "x".
-    #[schemars(with = "Vec<String>")]
     exception_patterns: Vec<Regex>,
     /// An array of identifier names that are excluded from the rule.
     /// For example, `["x", "y", "z"]` would allow single-letter identifiers "x", "y", and "z".

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -20,6 +20,7 @@ fn max_depth_diagnostic(num: usize, max: usize, span: Span) -> OxcDiagnostic {
 const DEFAULT_MAX_DEPTH: usize = 4;
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MaxDepth {
     /// The `max` enforces a maximum depth that blocks can be nested
     max: usize,

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
     AstKind,
@@ -20,8 +20,8 @@ fn jsx_props_no_spreading_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prop spreading is forbidden").with_label(span)
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 enum IgnoreEnforceOption {
     Ignore,
     #[default]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -13,7 +13,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{Reference, SymbolId};
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -71,7 +71,7 @@ impl Default for ConsistentTypeImportsConfig {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, JsonSchema, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, JsonSchema, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum FixStyle {
     /// Will add the type keyword after the import keyword `import type { A } from '...'`
@@ -81,7 +81,7 @@ enum FixStyle {
     InlineTypeImports,
 }
 
-#[derive(Default, Debug, Clone, JsonSchema, Deserialize)]
+#[derive(Default, Debug, Clone, JsonSchema, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum Prefer {
     /// Will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators.

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -69,7 +69,7 @@ pub struct NoEmptyObjectTypeConfig {
     allow_with_name: Option<Regex>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum AllowInterfaces {
     #[default]
@@ -88,7 +88,7 @@ impl From<&str> for AllowInterfaces {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum AllowObjectTypes {
     #[default]


### PR DESCRIPTION
Without the `Serialize` flag, the default values for the enum config options that are taken by these rules will not be shown in the docs. This fixes that problem. It also makes a few other minor tweaks.

Fixes #17189.