### PR TITLE
refactor(linter): Improvements for react version setting.

### DIFF
--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -668,6 +668,7 @@ expression: json
             "string",
             "null"
           ],
+          "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }
       },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -664,6 +664,7 @@
             "string",
             "null"
           ],
+          "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }
       },


### PR DESCRIPTION
This enforces a version regex for the react version setting, to provide feedback to users and make sure it's not set to a value that isn't Semver-compatible.

<img width="906" height="538" alt="Screenshot 2025-12-20 at 5 08 37 PM" src="https://github.com/user-attachments/assets/ced2e3a4-41f2-4e63-9c94-fa396e26728d" />

<img width="1052" height="546" alt="Screenshot 2025-12-20 at 5 08 46 PM" src="https://github.com/user-attachments/assets/83b2fe6a-e2f5-4092-827c-e53f90987093" />

Technically this regex _does_ disallow any pre-1.0 version, like `0.15.0`, but anyone on a react version that old is probably not worth worrying about.

Right now, the error message you get in the CLI is fairly generic:

```
oxlint-issue-repro-template % node ../oxc/apps/oxlint/dist/cli.js
Failed to parse configuration file.

  × Failed to parse config with error Error("invalid major version", line: 0, column: 0)
```

And this will help ensure that the config file shows the user that there's a problem via JSON Schema validation, rather than failing like this without many clues.

I have also updated the error messages for react version validation to be more specific about the problem:

```
% node ../oxc/apps/oxlint/dist/cli.js
Failed to parse configuration file.

  × Failed to parse config with error Error("invalid major version in settings.react.version", line: 0, column: 0)
```