### PR TITLE
fix(linter): Improve the error message for when the oxlint config file is invalid.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -92,7 +92,7 @@ impl CliRunner {
                 print_and_flush_stdout(
                     stdout,
                     &format!(
-                        "Failed to parse configuration file.\n{}\n",
+                        "Failed to parse oxlint configuration file.\n{}\n",
                         render_report(&handler, &err)
                     ),
                 );
@@ -220,7 +220,7 @@ impl CliRunner {
                 print_and_flush_stdout(
                     stdout,
                     &format!(
-                        "Failed to parse configuration file.\n{}\n",
+                        "Failed to parse oxlint configuration file.\n{}\n",
                         render_report(&handler, &OxcDiagnostic::error(e.to_string()))
                     ),
                 );
@@ -580,7 +580,7 @@ impl CliRunner {
                     print_and_flush_stdout(
                         stdout,
                         &format!(
-                            "Failed to parse configuration file.\n{}\n",
+                            "Failed to parse oxlint configuration file.\n{}\n",
                             render_report(handler, &OxcDiagnostic::error(e.to_string()))
                         ),
                     );

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_parse_error_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_parse_error_debugger.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: debugger.js
 working directory: fixtures/auto_config_parse_error
 ----------
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to parse eslint config <cwd>/fixtures/auto_config_parse_error/.oxlintrc.json.
   | expected `:` at line 2 column 11

--- a/apps/oxlint/test/fixtures/import_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/import_error/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: whoops!

--- a/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: Whoops!

--- a/apps/oxlint/test/fixtures/missing_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_plugin/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.js
   |   Cannot find module './plugin.js'

--- a/apps/oxlint/test/fixtures/missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_rule/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Rule 'unknown-rule' not found in plugin 'basic-custom-plugin'
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Plugin alias 'eslint-plugin-invalid' is not valid. Must not start with 'eslint-plugin-', or be of form '@scope/eslint-plugin' or '@scope/eslint-plugin-name'.

--- a/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Plugin name 'jsdoc' is reserved, and cannot be used for JS plugins.
   | 

--- a/apps/oxlint/test/fixtures/plugin_name_missing/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_missing/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: Plugin must either define `meta.name`, be loaded from an NPM package with a `name` field in `package.json`, or be given an alias in config

--- a/apps/oxlint/test/fixtures/plugin_name_missing2/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_missing2/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: no_name
   |   Error: Plugin must either define `meta.name`, be loaded from an NPM package with a `name` field in `package.json`, or be given an alias in config

--- a/apps/oxlint/test/fixtures/plugin_name_reserved/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_reserved/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to parse configuration file.
+Failed to parse oxlint configuration file.
 
   x Plugin name 'import' is reserved, and cannot be used for JS plugins.
   | 


### PR DESCRIPTION
It'd be better if the path of the specific invalid config were printed when this happened, in case I'm using nested configs, but for now this improves things a bit, at least.