### PR TITLE
feat(linter): PoC to Enforce config option validity for many rules

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -15,8 +15,8 @@ use crate::{
 
 pub trait Rule: Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
-    fn from_configuration(_value: serde_json::Value) -> Self {
-        Self::default()
+    fn from_configuration(_value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        Ok(Self::default())
     }
 
     /// Serialize rule configuration to JSON. Only used for sending rule configurations
@@ -82,7 +82,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
 ///
 /// ```ignore
 /// impl Rule for MyRule {
-///     fn from_configuration(value: serde_json::Value) -> Self {
+///     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
 ///         serde_json::from_value::<DefaultRuleConfig<MyRule>>(value)
 ///             .unwrap_or_default()
 ///             .into_inner()

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -125,7 +125,7 @@ where
                 .unwrap_or_else(T::default);
             Ok(DefaultRuleConfig(config))
         } else if value == serde_json::Value::Null {
-            return Ok(DefaultRuleConfig(T::default()));
+            Ok(DefaultRuleConfig(T::default()))
         } else {
             Err(D::Error::custom("Expected array for rule configuration"))
         }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -124,6 +124,8 @@ where
                 .and_then(|v| serde_json::from_value(v).ok())
                 .unwrap_or_else(T::default);
             Ok(DefaultRuleConfig(config))
+        } else if value == serde_json::Value::Null {
+            return Ok(DefaultRuleConfig(T::default()));
         } else {
             Err(D::Error::custom("Expected array for rule configuration"))
         }

--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -121,8 +121,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for AccessorPairs {
-    fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<AccessorPairs>>(value).unwrap().into_inner()
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -32,7 +32,7 @@ fn getter_without_setter_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AccessorPairsConfig {
     /// Report a setter without a getter.
     set_without_get: bool,

--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -122,9 +122,7 @@ declare_oxc_lint!(
 
 impl Rule for AccessorPairs {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<AccessorPairs>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<AccessorPairs>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -83,7 +83,7 @@ declare_oxc_lint!(
 impl Rule for ArrayCallbackReturn {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ArrayCallbackReturn>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -35,7 +35,7 @@ fn expect_no_return(method_name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ArrayCallbackReturn {
     /// When set to true, rule will also report forEach callbacks that return a value.
     check_for_each: bool,

--- a/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
@@ -184,7 +184,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ArrowBodyStyle {
-    fn from_configuration(value: Value) -> Self {
+    fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
         let mode = value.get(0).and_then(Value::as_str).map(Mode::from).unwrap_or_default();
 
         let require_return_for_object_literal = value
@@ -193,7 +193,7 @@ impl Rule for ArrowBodyStyle {
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
-        Self { mode, require_return_for_object_literal }
+        Ok(Self { mode, require_return_for_object_literal })
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for GetterReturn {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<GetterReturn>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<GetterReturn>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -32,7 +32,7 @@ fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct GetterReturn {
     /// When set to `true`, allows getters to implicitly return `undefined` with a `return` statement containing no expression.
     pub allow_implicit: bool,

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -21,7 +21,7 @@ fn max_classes_per_file_diagnostic(total: usize, max: usize, span: Span) -> OxcD
 pub struct MaxClassesPerFile(Box<MaxClassesPerFileConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxClassesPerFileConfig {
     /// The maximum number of classes allowed per file.
     pub max: usize,

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -87,7 +87,7 @@ impl Rule for MaxClassesPerFile {
             Self(Box::new(MaxClassesPerFileConfig { max, ignore_expressions: false }))
         } else {
             serde_json::from_value::<DefaultRuleConfig<MaxClassesPerFile>>(value)
-                .unwrap_or_default()
+                .unwrap()
                 .into_inner()
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -104,9 +104,7 @@ impl Rule for MaxDepth {
         {
             MaxDepth { max }
         } else {
-            serde_json::from_value::<DefaultRuleConfig<MaxDepth>>(value)
-                .unwrap_or_default()
-                .into_inner()
+            serde_json::from_value::<DefaultRuleConfig<MaxDepth>>(value).unwrap().into_inner()
         }
     }
 

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -73,9 +73,7 @@ impl Rule for MaxLines {
         {
             Self(Box::new(MaxLinesConfig { max, skip_comments: false, skip_blank_lines: false }))
         } else {
-            serde_json::from_value::<DefaultRuleConfig<MaxLines>>(value)
-                .unwrap_or_default()
-                .into_inner()
+            serde_json::from_value::<DefaultRuleConfig<MaxLines>>(value).unwrap().into_inner()
         }
     }
 

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -21,7 +21,7 @@ fn max_lines_diagnostic(count: usize, max: usize, span: Span) -> OxcDiagnostic {
 pub struct MaxLines(Box<MaxLinesConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxLinesConfig {
     /// Maximum number of lines allowed per file.
     max: usize,

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -24,7 +24,7 @@ fn max_params_diagnostic(message: &str, span: Span) -> OxcDiagnostic {
 pub struct MaxParams(Box<MaxParamsConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxParamsConfig {
     /// Maximum number of parameters allowed in function definitions.
     max: usize,

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -106,9 +106,7 @@ impl Rule for MaxParams {
         {
             Self(Box::new(MaxParamsConfig { max, count_void_this: false }))
         } else {
-            serde_json::from_value::<DefaultRuleConfig<MaxParams>>(value)
-                .unwrap_or_default()
-                .into_inner()
+            serde_json::from_value::<DefaultRuleConfig<MaxParams>>(value).unwrap().into_inner()
         }
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -99,9 +99,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBitwise {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoBitwise>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoBitwise>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -23,7 +23,7 @@ fn no_bitwise_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
 pub struct NoBitwise(Box<NoBitwiseConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBitwiseConfig {
     /// The `allow` option permits the given list of bitwise operators to be used
     /// as exceptions to this rule.

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -73,9 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoCondAssign {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoCondAssign>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoCondAssign>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for NoConsole {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoConsole>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoConsole>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -26,7 +26,7 @@ fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
 pub struct NoConsole(Box<NoConsoleConfig>);
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoConsoleConfig {
     /// The `allow` option permits the given list of console methods to be used as exceptions to
     /// this rule.

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -140,9 +140,7 @@ enum ModuleType {
 
 impl Rule for NoDuplicateImports {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoDuplicateImports>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoDuplicateImports>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -39,7 +39,7 @@ fn no_duplicate_exports_diagnostic(
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicateImports {
     /// When `true` this rule will also look at exports to see if there is both a re-export of a
     /// module as in `export ... from 'module'` and also a standard import statement for the same

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -22,7 +22,7 @@ fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagno
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoElseReturn {
     /// Whether to allow `else if` blocks after a return statement.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -18,7 +18,7 @@ fn no_empty_diagnostic(stmt_kind: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEmpty {
     /// If set to `true`, allows an empty `catch` block without triggering the linter.
     allow_empty_catch: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -18,7 +18,7 @@ fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEval {
     /// This `allowIndirect` option allows indirect `eval()` calls.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct NoExtendNative(Box<NoExtendNativeConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtendNativeConfig {
     /// A list of objects which are allowed to be exceptions to the rule.
     exceptions: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -80,9 +80,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExtendNative {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoExtendNative>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoExtendNative>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -32,7 +32,7 @@ fn no_extra_boolean_cast_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtraBooleanCast {
     /// when set to `true`, in addition to checking default contexts, checks
     /// whether extra boolean casts are present in expressions whose result is

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -87,9 +87,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExtraBooleanCast {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoExtraBooleanCast>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoExtraBooleanCast>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -19,7 +19,7 @@ fn no_global_assign_diagnostic(global_name: &str, span: Span) -> OxcDiagnostic {
 pub struct NoGlobalAssign(Box<NoGlobalAssignConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoGlobalAssignConfig {
     /// List of global variable names to exclude from this rule.
     /// Globals listed here can be assigned to without triggering warnings.

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -57,9 +57,7 @@ declare_oxc_lint!(
 
 impl Rule for NoGlobalAssign {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoGlobalAssign>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoGlobalAssign>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -180,9 +180,7 @@ declare_oxc_lint!(
 
 impl Rule for NoImplicitCoercion {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoImplicitCoercion>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoImplicitCoercion>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -51,7 +51,7 @@ fn report_coercion(ctx: &LintContext, span: Span, kind: CoercionKind, operand: &
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoImplicitCoercionConfig {
     /// When `true`, warns on implicit boolean coercion (e.g., `!!foo`).
     boolean: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -71,9 +71,7 @@ struct NoInvalidRegexpConfig {
 
 impl Rule for NoInvalidRegexp {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoInvalidRegexp>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoInvalidRegexp>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoInvalidRegexpConfig {
     /// Case-sensitive array of flags that will be allowed.
     allow_constructor_flags: Vec<char>,

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -120,9 +120,7 @@ declare_oxc_lint!(
 
 impl Rule for NoLabels {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoLabels>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoLabels>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -20,7 +20,7 @@ fn no_labels_diagnostic(message: &'static str, label_span: Span) -> OxcDiagnosti
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoLabels {
     /// If set to `true`, this rule ignores labels which are sticking to loop statements.
     /// Examples of **correct** code with this option set to `true`:

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -37,7 +37,7 @@ fn zwj_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMisleadingCharacterClass {
     /// When set to `true`, the rule allows any grouping of code points
     /// inside a character class as long as they are written using escape sequences.

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -151,7 +151,7 @@ impl<'ast> Visit<'ast> for CharacterSequenceCollector<'ast> {
 impl Rule for NoMisleadingCharacterClass {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoMisleadingCharacterClass>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
@@ -109,9 +109,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMultiAssign {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoMultiAssign>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoMultiAssign>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
@@ -18,7 +18,7 @@ fn no_multi_assign_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMultiAssign {
     /// When set to `true`, the rule allows chains that don't include initializing a variable in a declaration or initializing a class field.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -95,9 +95,7 @@ declare_oxc_lint!(
 
 impl Rule for NoPlusplus {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoPlusplus>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoPlusplus>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -29,7 +29,7 @@ fn no_plusplus_diagnostic(span: Span, operator: UpdateOperator) -> OxcDiagnostic
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoPlusplus {
     /// Whether to allow `++` and `--` in for loop afterthoughts.
     allow_for_loop_afterthoughts: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
@@ -26,7 +26,7 @@ fn no_promise_executor_return_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoPromiseExecutorReturn(Box<NoPromiseExecutorReturnConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoPromiseExecutorReturnConfig {
     /// If `true`, allows returning `void` expressions (e.g., `return void resolve()`).
     allow_void: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
@@ -122,7 +122,7 @@ declare_oxc_lint!(
 impl Rule for NoPromiseExecutorReturn {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoPromiseExecutorReturn>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -68,9 +68,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRedeclare {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoRedeclare>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoRedeclare>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -24,7 +24,7 @@ fn no_redeclare_as_builtin_in_diagnostic(name: &str, span: Span) -> OxcDiagnosti
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRedeclare {
     /// When set `true`, it flags redeclaring built-in globals (e.g., `let Object = 1;`).
     builtin_globals: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -73,9 +73,7 @@ fn is_sentinel_node(ast_kind: AstKind) -> bool {
 
 impl Rule for NoReturnAssign {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoReturnAssign>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoReturnAssign>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -24,7 +24,7 @@ fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoSelfAssign {
     /// The `props` option when set to `false`, disables the checking of properties.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -104,9 +104,7 @@ declare_oxc_lint!(
 
 impl Rule for NoSelfAssign {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoSelfAssign>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoSelfAssign>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -14,7 +14,7 @@ fn no_sequences_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoSequences {
     /// If this option is set to `false`, this rule disallows the comma operator
     /// even when the expression sequence is explicitly wrapped in parentheses.

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -22,7 +22,7 @@ fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> Oxc
 pub struct NoShadowRestrictedNames(Box<NoShadowRestrictedNamesConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoShadowRestrictedNamesConfig {
     /// If true, also report shadowing of `globalThis`.
     report_global_this: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -92,7 +92,7 @@ declare_oxc_lint!(
 impl Rule for NoShadowRestrictedNames {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoShadowRestrictedNames>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
@@ -26,7 +26,7 @@ fn no_unneeded_ternary_conditional_expression_diagnostic(span: Span) -> OxcDiagn
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnneededTernary {
     /// Whether to allow the default assignment pattern `x ? x : y`.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
@@ -81,9 +81,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnneededTernary {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUnneededTernary>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUnneededTernary>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -24,7 +24,7 @@ fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeNegation {
     /// The `enforceForOrderingRelations` option determines whether negation is allowed
     /// on the left-hand side of ordering relational operators (<, >, <=, >=).

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -73,9 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeNegation {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUnsafeNegation>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUnsafeNegation>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -28,7 +28,7 @@ fn no_unsafe_arithmetic_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeOptionalChaining {
     /// Disallow arithmetic operations on optional chaining expressions.
     /// If this is true, this rule warns arithmetic operations on optional chaining expressions, which possibly result in NaN.

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 impl Rule for NoUnsafeOptionalChaining {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUnsafeOptionalChaining>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -25,7 +25,7 @@ fn no_unused_expressions_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoUnusedExpressions(Box<NoUnusedExpressionsConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnusedExpressionsConfig {
     /// When set to `true`, allows short circuit evaluations in expressions.
     allow_short_circuit: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -81,7 +81,7 @@ impl Rule for NoUnusedExpressions {
 
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUnusedExpressions>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -22,7 +22,7 @@ fn no_useless_computed_key_diagnostic(span: Span, raw: Option<Atom>) -> OxcDiagn
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessComputedKey {
     /// The `enforceForClassMembers` option controls whether the rule applies to
     /// class members (methods and properties).

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -120,7 +120,7 @@ declare_oxc_lint!(
 impl Rule for NoUselessComputedKey {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUselessComputedKey>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -26,7 +26,7 @@ fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoUselessRename(Box<NoUselessRenameConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessRenameConfig {
     /// When set to `true`, allows using the same name in destructurings.
     ignore_destructuring: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -76,9 +76,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessRename {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUselessRename>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUselessRename>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -20,7 +20,7 @@ fn no_void_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoVoid {
     /// If set to `true`, using `void` as a standalone statement is allowed.
     pub allow_as_statement: bool,

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -83,7 +83,7 @@ declare_oxc_lint!(
 impl Rule for PreferPromiseRejectErrors {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferPromiseRejectErrors>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -306,7 +306,7 @@ impl PreserveCaughtError {
 impl Rule for PreserveCaughtError {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreserveCaughtError>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -38,7 +38,7 @@ fn missing_catch_parameter_diagnostic(span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(rename_all = "camelCase")]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct PreserveCaughtErrorOptions {
     /// When set to `true`, requires that catch clauses always have a parameter.
     require_catch_parameter: bool,

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -35,7 +35,7 @@ fn invalid_radix(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct Radix(RadixType);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for UnicodeBom {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<UnicodeBom>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<UnicodeBom>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -42,7 +42,7 @@ fn index_of_na_n(method_name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct UseIsnan {
     /// Whether to disallow NaN in switch cases and discriminants
     enforce_for_switch_case: bool,

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -144,9 +144,7 @@ impl Rule for UseIsnan {
     }
 
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<UseIsnan>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<UseIsnan>>(value).unwrap().into_inner()
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -159,9 +159,7 @@ impl Rule for ValidTypeof {
     }
 
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ValidTypeof>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<ValidTypeof>>(value).unwrap().into_inner()
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -30,7 +30,7 @@ fn invalid_value(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ValidTypeof {
     /// The `requireStringLiterals` option when set to `true`, allows the comparison of `typeof`
     /// expressions with only string literals or other `typeof` expressions, and disallows

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -102,7 +102,7 @@ declare_oxc_lint!(
 impl Rule for ConsistentTypeSpecifierStyle {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ConsistentTypeSpecifierStyle>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -92,7 +92,7 @@ impl Rule for MaxDependencies {
             Self(Box::new(MaxDependenciesConfig { max, ignore_type_imports: false }))
         } else {
             serde_json::from_value::<DefaultRuleConfig<MaxDependencies>>(value)
-                .unwrap_or_default()
+                .unwrap()
                 .into_inner()
         }
     }

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -26,7 +26,7 @@ fn max_dependencies_diagnostic<S: Into<Cow<'static, str>>>(
 pub struct MaxDependencies(Box<MaxDependenciesConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxDependenciesConfig {
     /// Maximum number of dependencies allowed in a module.
     max: usize,

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -49,7 +49,7 @@ fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct Namespace {
     /// Whether to allow computed references to an imported namespace.
     allow_computed: bool,

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -113,9 +113,7 @@ declare_oxc_lint!(
 
 impl Rule for Namespace {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Namespace>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<Namespace>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -108,9 +108,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAbsolutePath {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoAbsolutePath>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoAbsolutePath>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -24,7 +24,7 @@ fn no_absolute_path_diagnostic(span: Span) -> OxcDiagnostic {
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoAbsolutePath {
     /// If set to `true`, dependency paths for ES module import statements will be resolved:
     ///

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -21,7 +21,7 @@ fn no_anonymous_default_export_diagnostic(span: Span, msg: &'static str) -> OxcD
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoAnonymousDefaultExport {
     /// Allow anonymous array as default export.
     allow_array: bool,

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -123,7 +123,7 @@ declare_oxc_lint!(
 impl Rule for NoAnonymousDefaultExport {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoAnonymousDefaultExport>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -130,9 +130,7 @@ fn is_conditional(parent_node: &AstNode, ctx: &LintContext) -> bool {
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-commonjs.md>
 impl Rule for NoCommonjs {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoCommonjs>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoCommonjs>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -21,7 +21,7 @@ fn no_commonjs_diagnostic(span: Span, name: &str, actual: &str) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoCommonjs {
     /// If `allowPrimitiveModules` option is set to true, the following is valid:
     ///

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -22,7 +22,7 @@ fn no_cycle_diagnostic(span: Span, paths: &str) -> OxcDiagnostic {
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-cycle.md>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoCycle {
     /// Maximum dependency depth to traverse
     max_depth: u32,

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -93,9 +93,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicates {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoDuplicates>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoDuplicates>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -39,7 +39,7 @@ where
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-duplicates.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicates {
     /// When set to `true`, prefer inline type imports instead of separate type import
     /// statements for TypeScript code.

--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -58,9 +58,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDynamicRequire {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoDynamicRequire>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoDynamicRequire>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -18,7 +18,7 @@ fn no_dnyamic_require_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDynamicRequire {
     /// When `true`, also check `import()` expressions for dynamic module specifiers.
     esmodule: bool,

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -22,7 +22,7 @@ fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoNamespace(Box<NoNamespaceConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNamespaceConfig {
     /// An array of glob strings for modules that should be ignored by the rule.
     /// For example, `["*.json"]` will ignore all JSON imports.

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-namespace.md>
 impl Rule for NoNamespace {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoNamespace>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoNamespace>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnassignedImport {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUnassignedImport>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUnassignedImport>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/prefer_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/prefer_default_export.rs
@@ -29,7 +29,7 @@ enum Target {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferDefaultExport {
     /// Configuration option to specify the target type for preferring default exports.
     /// - `"single"`: Prefer default export when there is only one export in the module.

--- a/crates/oxc_linter/src/rules/import/prefer_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/prefer_default_export.rs
@@ -80,7 +80,7 @@ declare_oxc_lint!(
 impl Rule for PreferDefaultExport {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferDefaultExport>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxExpects {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<MaxExpects>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<MaxExpects>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -20,7 +20,7 @@ fn exceeded_max_assertion(count: usize, max: usize, span: Span) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxExpects {
     /// Maximum number of `expect()` assertion calls allowed within a single test.
     pub max: usize,

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -138,9 +138,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxNestedDescribe {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<MaxNestedDescribe>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<MaxNestedDescribe>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -24,7 +24,6 @@ fn exceeded_max_depth(current: usize, max: usize, span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-#[schemars(default)]
 pub struct MaxNestedDescribe {
     /// Maximum allowed depth of nested describe calls.
     pub max: usize,

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -23,7 +23,7 @@ fn exceeded_max_depth(current: usize, max: usize, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[schemars(default)]
 pub struct MaxNestedDescribe {
     /// Maximum allowed depth of nested describe calls.

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -20,7 +20,7 @@ fn unexpected_hook_diagonsitc(span: Span) -> OxcDiagnostic {
 pub struct NoHooks(Box<NoHooksConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoHooksConfig {
     /// An array of hook function names that are permitted for use.
     allow: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -32,7 +32,7 @@ fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoStandaloneExpect(Box<NoStandaloneExpectConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoStandaloneExpectConfig {
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for NoStandaloneExpect {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoStandaloneExpect>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoStandaloneExpect>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -172,7 +172,7 @@ declare_oxc_lint!(
 impl Rule for PreferLowercaseTitle {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferLowercaseTitle>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -23,7 +23,7 @@ fn prefer_lowercase_title_diagnostic(title: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferLowercaseTitleConfig {
     /// This array option allows specifying prefixes, which contain capitals that titles
     /// can start with. This can be useful when writing tests for API endpoints, where

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -26,7 +26,7 @@ fn use_hook(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireHookConfig {
     /// An array of function names that are allowed to be called outside of hooks.
     allowed_function_calls: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -178,9 +178,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireHook {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<RequireHook>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<RequireHook>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -37,7 +37,7 @@ fn unexpected_hook(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireTopLevelDescribe {
     /// The maximum number of top-level `describe` blocks allowed in a test file.
     pub max_number_of_top_level_describes: usize,

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -120,7 +120,7 @@ declare_oxc_lint!(
 impl Rule for RequireTopLevelDescribe {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<RequireTopLevelDescribe>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -232,9 +232,7 @@ const OUTSIDE_AMBIENT_INVALID_TAGS_IF_TYPED: [&str; 27] = [
 
 impl Rule for CheckTagNames {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<CheckTagNames>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<CheckTagNames>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct CheckTagNamesConfig {
     /// Additional tag names to allow.
     defined_tags: Vec<String>,

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -96,9 +96,7 @@ struct EmptyTagsConfig {
 
 impl Rule for EmptyTags {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<EmptyTags>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<EmptyTags>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -88,7 +88,7 @@ const EMPTY_TAGS: [&str; 18] = [
 ];
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct EmptyTagsConfig {
     /// Additional tags to check for their descriptions.
     tags: Vec<String>,

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -61,9 +61,7 @@ struct NoDefaultsConfig {
 
 impl Rule for NoDefaults {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoDefaults>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoDefaults>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoDefaultsConfig {
     /// If true, report the presence of optional param names (square brackets) on `@param` tags.
     no_optional_param_names: bool,

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -99,9 +99,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireReturns {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<RequireReturns>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<RequireReturns>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -36,7 +36,7 @@ fn duplicate_returns_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct RequireReturns(Box<RequireReturnsConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct RequireReturnsConfig {
     /// Tags that exempt functions from requiring `@returns`.
     exempted_by: Vec<String>,

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -105,9 +105,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireYields {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<RequireYields>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<RequireYields>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -49,7 +49,7 @@ impl Deref for RequireYields {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireYieldsConfig {
     /// Functions with these tags will be exempted from the lint rule.
     exempted_by: Vec<String>,

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -98,7 +98,7 @@ declare_oxc_lint!(
 impl Rule for AnchorAmbiguousText {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<AnchorAmbiguousText>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -32,7 +32,7 @@ fn anchor_has_ambiguous_text(span: Span, text: &CompactStr) -> OxcDiagnostic {
 pub struct AnchorAmbiguousText(Box<AnchorAmbiguousTextConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AnchorAmbiguousTextConfig {
     /// List of ambiguous words or phrases that should be flagged in anchor text.
     words: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -103,9 +103,7 @@ declare_oxc_lint!(
 
 impl Rule for AriaRole {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<AriaRole>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<AriaRole>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -28,7 +28,7 @@ fn aria_role_diagnostic(span: Span, help_suffix: &str) -> OxcDiagnostic {
 pub struct AriaRole(Box<AriaRoleConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AriaRoleConfig {
     /// Determines if developer-created components are checked.
     #[serde(rename = "ignoreNonDOM")]

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -28,7 +28,7 @@ fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnosti
 pub struct AutocompleteValid(Box<AutocompleteValidConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AutocompleteValidConfig {
     /// List of custom component names that should be treated as input elements.
     input_components: FxHashSet<CompactStr>,

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -24,7 +24,7 @@ fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct HeadingHasContent(Box<HeadingHasContentConfig>);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct HeadingHasContentConfig {
     /// Additional custom component names to treat as heading elements.
     /// These will be validated in addition to the standard h1-h6 elements.

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -75,9 +75,7 @@ const DEFAULT_COMPONENTS: [&str; 6] = ["h1", "h2", "h3", "h4", "h5", "h6"];
 
 impl Rule for HeadingHasContent {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<HeadingHasContent>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<HeadingHasContent>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -20,7 +20,7 @@ fn no_process_env_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoProcessEnvConfig {
     /// Variable names which are allowed to be accessed on `process.env`.
     allowed_variables: FxHashSet<CompactStr>,

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -71,9 +71,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
 
 impl Rule for NoProcessEnv {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoProcessEnv>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoProcessEnv>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -75,9 +75,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBarrelFile {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoBarrelFile>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoBarrelFile>>(value).unwrap().into_inner()
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -19,7 +19,7 @@ fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> O
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBarrelFile {
     /// The maximum number of modules that can be re-exported via `export *`
     /// before the rule is triggered.

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -319,9 +319,7 @@ const MAP_FN_NAMES: [&str; 2] = ["map", "flatMap"];
 
 impl Rule for NoMapSpread {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoMapSpread>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoMapSpread>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -73,9 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoOptionalChaining {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoOptionalChaining>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoOptionalChaining>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -24,7 +24,7 @@ fn no_optional_chaining_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
 pub struct NoOptionalChaining(Box<NoOptionalChainingConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoOptionalChainingConfig {
     /// A custom help message to display when optional chaining is found.
     /// For example, "Our output target is ES2016, and optional chaining results in verbose

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -67,7 +67,7 @@ declare_oxc_lint!(
 impl Rule for NoRestSpreadProperties {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoRestSpreadProperties>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -22,7 +22,7 @@ fn no_rest_spread_properties_diagnostic(
 pub struct NoRestSpreadProperties(Box<NoRestSpreadPropertiesOptions>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRestSpreadPropertiesOptions {
     /// A message to display when object spread properties are found.
     object_spread_message: String,

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -33,7 +33,7 @@ fn always_return_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct AlwaysReturn(Box<AlwaysReturnConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AlwaysReturnConfig {
     /// You can pass an `{ ignoreLastCallback: true }` as an option to this rule so that
     /// the last `then()` callback in a promise chain does not warn if it does not have

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -190,9 +190,7 @@ const PROCESS_METHODS: [&str; 2] = ["exit", "abort"];
 
 impl Rule for AlwaysReturn {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<AlwaysReturn>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<AlwaysReturn>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -137,9 +137,7 @@ declare_oxc_lint!(
 
 impl Rule for NoReturnWrap {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoReturnWrap>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoReturnWrap>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -30,7 +30,7 @@ fn no_return_wrap_diagnostic(span: Span, issue: &ReturnWrapper) -> OxcDiagnostic
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoReturnWrap {
     /// `allowReject` allows returning `Promise.reject` inside a promise handler.
     ///

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -74,9 +74,7 @@ fn is_inside_yield_or_await(node: &AstNode) -> bool {
 
 impl Rule for PreferAwaitToThen {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<PreferAwaitToThen>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<PreferAwaitToThen>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -28,7 +28,7 @@ impl std::ops::Deref for PreferAwaitToThen {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferAwaitToThenConfig {
     /// If true, enforces the rule even after an `await` or `yield` expression.
     strict: bool,

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -21,7 +21,7 @@ fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
 pub struct SpecOnly(Box<SpecOnlyConfig>);
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SpecOnlyConfig {
     /// List of Promise static methods that are allowed to be used.
     allowed_methods: Option<FxHashSet<CompactStr>>,

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for SpecOnly {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<SpecOnly>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<SpecOnly>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -32,7 +32,7 @@ fn invalid_type_prop(span: Span, allowed_types: &str) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ButtonHasType {
     /// If true, allow `type="button"`.
     button: bool,

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -80,9 +80,7 @@ declare_oxc_lint!(
 
 impl Rule for ButtonHasType {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ButtonHasType>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<ButtonHasType>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -194,7 +194,7 @@ impl Rule for CheckedRequiresOnchangeOrReadonly {
 
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<CheckedRequiresOnchangeOrReadonly>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 }

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -28,7 +28,7 @@ fn exclusive_checked_attribute(checked_span: Span, default_checked_span: Span) -
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct CheckedRequiresOnchangeOrReadonly {
     /// Ignore the requirement to provide either `onChange` or `readOnly` when the `checked` prop is present.
     ignore_missing_properties: bool,

--- a/crates/oxc_linter/src/rules/react/jsx_fragments.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_fragments.rs
@@ -107,9 +107,7 @@ impl Rule for JsxFragments {
     // Generally we should prefer the string-only syntax for compatibility with the original ESLint rule,
     // but we originally implemented the rule with only the object syntax, so we support both now.
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<JsxFragments>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<JsxFragments>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -57,7 +57,7 @@ fn duplicate_key_prop(key_value: &str, span: Span) -> OxcDiagnostic {
 pub struct JsxKey(Box<JsxKeyConfig>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[derive(Default)]
 pub struct JsxKeyConfig {
     /// When true, require key prop to be placed before any spread props

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -145,9 +145,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxNoTargetBlank {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<JsxNoTargetBlank>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<JsxNoTargetBlank>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -38,7 +38,7 @@ fn explicit_props_in_spread_attributes(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxNoTargetBlank {
     /// Whether to enforce dynamic links or enforce static links.
     enforce_dynamic_links: EnforceDynamicLinksEnum,

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -29,7 +29,7 @@ fn child_of_html_element(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxNoUselessFragment {
     /// Allow fragments with a single expression child.
     allow_expressions: bool,

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -111,9 +111,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxPascalCase {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<JsxPascalCase>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<JsxPascalCase>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -30,7 +30,7 @@ fn jsx_pascal_case_diagnostic(
 pub struct JsxPascalCase(Box<JsxPascalCaseConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxPascalCaseConfig {
     /// Whether to allow all-caps component names.
     pub allow_all_caps: bool,

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -29,7 +29,7 @@ enum IgnoreEnforceOption {
 }
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxPropsNoSpreadingConfig {
     /// `html` set to `ignore` will ignore all html jsx tags like `div`, `img` etc. Default is set to `enforce`.
     html: IgnoreEnforceOption,

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -92,7 +92,7 @@ declare_oxc_lint!(
 impl Rule for JsxPropsNoSpreading {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<JsxPropsNoSpreading>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -115,9 +115,7 @@ fn is_literal_ref_attribute(attr: &JSXAttribute, no_template_literals: bool) -> 
 
 impl Rule for NoStringRefs {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoStringRefs>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoStringRefs>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -31,7 +31,7 @@ fn string_in_ref_deprecated(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoStringRefs {
     /// Disallow template literals in addition to string literals.
     no_template_literals: bool,

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -474,9 +474,7 @@ fn has_uppercase(name: &str) -> bool {
 
 impl Rule for NoUnknownProperty {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUnknownProperty>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUnknownProperty>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -52,7 +52,7 @@ fn unknown_prop(span: Span) -> OxcDiagnostic {
 pub struct NoUnknownProperty(Box<NoUnknownPropertyConfig>);
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnknownPropertyConfig {
     /// List of properties to ignore.
     ignore: FxHashSet<Cow<'static, str>>,

--- a/crates/oxc_linter/src/rules/react/no_unsafe.rs
+++ b/crates/oxc_linter/src/rules/react/no_unsafe.rs
@@ -89,9 +89,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafe {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUnsafe>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUnsafe>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unsafe.rs
+++ b/crates/oxc_linter/src/rules/react/no_unsafe.rs
@@ -32,7 +32,7 @@ fn no_unsafe_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(rename_all = "camelCase")]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[derive(Default)]
 struct NoUnsafeConfig {
     #[serde(default)]

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferEs6Class {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<PreferEs6Class>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<PreferEs6Class>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -22,7 +22,7 @@ fn self_closing_comp_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SelfClosingComp {
     /// Whether to enforce self-closing for custom components.
     component: bool,

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -77,9 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for SelfClosingComp {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<SelfClosingComp>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<SelfClosingComp>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -129,9 +129,7 @@ declare_oxc_lint!(
 
 impl Rule for StateInConstructor {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<StateInConstructor>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<StateInConstructor>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -146,9 +146,7 @@ fn is_invalid_style_attribute<'a>(attribute: &JSXAttribute<'a>, ctx: &LintContex
 
 impl Rule for StylePropObject {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<StylePropObject>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<StylePropObject>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -27,7 +27,7 @@ fn style_prop_object_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct StylePropObject(Box<StylePropObjectConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct StylePropObjectConfig {
     /// List of component names on which to allow `style` prop values of any type.
     allow: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -22,7 +22,7 @@ use crate::{
 pub struct ArrayType(Box<ArrayTypeConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ArrayTypeConfig {
     /// The array type expected for mutable cases.
     default: ArrayOption,

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -138,9 +138,7 @@ fn array_simple(
 
 impl Rule for ArrayType {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ArrayType>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<ArrayType>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -110,7 +110,7 @@ declare_oxc_lint!(
 impl Rule for ConsistentIndexedObjectStyle {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ConsistentIndexedObjectStyle>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -93,7 +93,7 @@ declare_oxc_lint!(
 impl Rule for ConsistentTypeDefinitions {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ConsistentTypeDefinitions>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -174,7 +174,7 @@ declare_oxc_lint!(
 impl Rule for ConsistentTypeImports {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ConsistentTypeImports>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -51,7 +51,7 @@ impl Deref for ConsistentTypeImports {
 
 // <https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ConsistentTypeImportsConfig {
     /// Disallow using `import()` in type annotations, like `type T = import('foo')`
     disallow_type_annotations: bool,

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -148,7 +148,7 @@ fn explicit_function_return_type_diagnostic(span: Span) -> OxcDiagnostic {
 impl Rule for ExplicitFunctionReturnType {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ExplicitFunctionReturnType>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct ExplicitFunctionReturnType(Box<ExplicitFunctionReturnTypeConfig>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExplicitFunctionReturnTypeConfig {
     /// Whether to allow expressions as function return types. When `true`, allows functions that immediately return an expression without a return type annotation.
     allow_expressions: bool,

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -46,7 +46,7 @@ impl Deref for ExplicitModuleBoundaryTypes {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExplicitModuleBoundaryTypesConfig {
     /// Whether to ignore arguments that are explicitly typed as `any`.
     allow_arguments_explicitly_typed_as_any: bool,

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -164,7 +164,7 @@ declare_oxc_lint!(
 impl Rule for ExplicitModuleBoundaryTypes {
     fn from_configuration(value: Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ExplicitModuleBoundaryTypes>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoBaseToString(Box<NoBaseToStringConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBaseToStringConfig {
     /// Whether to also check values of type `unknown`.
     /// When `true`, calling toString on `unknown` values will be flagged.

--- a/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBaseToString {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoBaseToString>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoBaseToString>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -75,7 +75,7 @@ declare_oxc_lint!(
 impl Rule for NoConfusingVoidExpression {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoConfusingVoidExpression>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoConfusingVoidExpression(Box<NoConfusingVoidExpressionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoConfusingVoidExpressionConfig {
     /// Whether to ignore arrow function shorthand that returns void.
     /// When true, allows expressions like `() => someVoidFunction()`.

--- a/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoDeprecated(Box<NoDeprecatedConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDeprecatedConfig {
     /// An array of type or value specifiers that are allowed to be used even if deprecated.
     /// Use this to allow specific deprecated APIs that you intentionally want to continue using.

--- a/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
@@ -67,9 +67,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDeprecated {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoDeprecated>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoDeprecated>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
 impl Rule for NoDuplicateTypeConstituents {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoDuplicateTypeConstituents>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoDuplicateTypeConstituents(Box<NoDuplicateTypeConstituentsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicateTypeConstituentsConfig {
     /// Whether to ignore duplicate types in intersection types.
     /// When true, allows `type T = A & A`.

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -22,7 +22,7 @@ fn no_empty_interface_extend_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEmptyInterface {
     /// When set to `true`, allows empty interfaces that extend a single interface.
     #[serde(alias = "allow_single_extends")]

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -66,9 +66,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyInterface {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoEmptyInterface>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoEmptyInterface>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -19,7 +19,7 @@ fn no_explicit_any_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExplicitAny {
     /// Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type.
     fix_to_unknown: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -78,9 +78,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExplicitAny {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoExplicitAny>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoExplicitAny>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -114,9 +114,7 @@ fn only_constructor_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic 
 
 impl Rule for NoExtraneousClass {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoExtraneousClass>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoExtraneousClass>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtraneousClass {
     /// Allow classes that only have a constructor.
     allow_constructor_only: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoFloatingPromises(Box<NoFloatingPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoFloatingPromisesConfig {
     /// Allows specific calls to be ignored, specified as type or value specifiers.
     pub allow_for_known_safe_calls: Vec<TypeOrValueSpecifier>,

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -112,9 +112,7 @@ declare_oxc_lint!(
 
 impl Rule for NoFloatingPromises {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoFloatingPromises>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoFloatingPromises>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -67,9 +67,7 @@ declare_oxc_lint!(
 
 impl Rule for NoInferrableTypes {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoInferrableTypes>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoInferrableTypes>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -24,7 +24,7 @@ fn no_inferrable_types_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoInferrableTypes {
     /// When set to `true`, ignores type annotations on function parameters.
     ignore_parameters: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct NoMeaninglessVoidOperator(Box<NoMeaninglessVoidOperatorConfig>);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMeaninglessVoidOperatorConfig {
     /// Whether to check `void` applied to expressions of type `never`.
     pub check_never: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 impl Rule for NoMeaninglessVoidOperator {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoMeaninglessVoidOperator>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -12,7 +12,7 @@ fn default_checks_void_return() -> ChecksVoidReturn {
 pub struct NoMisusedPromises(Box<NoMisusedPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[expect(clippy::struct_field_names)]
 pub struct NoMisusedPromisesConfig {
     /// Whether to check if Promises are used in conditionals.
@@ -45,7 +45,7 @@ pub enum ChecksVoidReturn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ChecksVoidReturnOptions {
     /// Whether to check Promise-returning functions passed as arguments to void-returning functions.
     pub arguments: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -131,9 +131,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMisusedPromises {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoMisusedPromises>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoMisusedPromises>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoMisusedSpread(Box<NoMisusedSpreadConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMisusedSpreadConfig {
     /// An array of type or value specifiers that are allowed to be spread
     /// even if they would normally be flagged as misused.

--- a/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
@@ -71,9 +71,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMisusedSpread {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoMisusedSpread>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoMisusedSpread>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
@@ -150,9 +150,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRestrictedTypes {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoRestrictedTypes>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoRestrictedTypes>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnnecessaryBooleanLiteralCompare(Box<NoUnnecessaryBooleanLiteralCompareConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnnecessaryBooleanLiteralCompareConfig {
     /// Whether to allow comparing nullable boolean expressions to `false`.
     /// When false, `x === false` where x is `boolean | null` will be flagged.

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -93,7 +93,7 @@ declare_oxc_lint!(
 impl Rule for NoUnnecessaryBooleanLiteralCompare {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryBooleanLiteralCompare>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnnecessaryTypeAssertion(Box<NoUnnecessaryTypeAssertionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnnecessaryTypeAssertionConfig {
     /// Whether to check literal const assertions like `'foo' as const`.
     /// When `false` (default), const assertions on literal types are not flagged.

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
@@ -73,7 +73,7 @@ declare_oxc_lint!(
 impl Rule for NoUnnecessaryTypeAssertion {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUnnecessaryTypeAssertion>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
@@ -69,7 +69,7 @@ declare_oxc_lint!(
 impl Rule for NoUnsafeMemberAccess {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUnsafeMemberAccess>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnsafeMemberAccess(Box<NoUnsafeMemberAccessConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeMemberAccessConfig {
     /// Whether to allow `?.` optional chains on `any` values.
     /// When `true`, optional chaining on `any` values will not be flagged.

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -87,9 +87,7 @@ declare_oxc_lint!(
 
 impl Rule for OnlyThrowError {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<OnlyThrowError>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<OnlyThrowError>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct OnlyThrowError(Box<OnlyThrowErrorConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct OnlyThrowErrorConfig {
     /// An array of type or value specifiers for additional types that are allowed to be thrown.
     /// Use this to allow throwing custom error types.

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -21,7 +21,7 @@ fn prefer_literal_enum_member_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferLiteralEnumMember {
     /// When set to `true`, allows bitwise expressions in enum member initializers.
     /// This includes bitwise NOT (`~`), AND (`&`), OR (`|`), XOR (`^`), and shift operators (`<<`, `>>`, `>>>`).

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 impl Rule for PreferLiteralEnumMember {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferLiteralEnumMember>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
@@ -9,7 +9,7 @@ pub struct PreferNullishCoalescing(Box<PreferNullishCoalescingConfig>);
 
 /// Options for ignoring specific primitive types.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct IgnorePrimitivesOptions {
     /// Ignore bigint primitive types.
     pub bigint: bool,
@@ -41,7 +41,7 @@ impl Default for IgnorePrimitives {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferNullishCoalescingConfig {
     /// Unless this is set to `true`, the rule will error on every file whose
     /// `tsconfig.json` does _not_ have the `strictNullChecks` compiler option

--- a/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
@@ -141,7 +141,7 @@ declare_oxc_lint!(
 impl Rule for PreferNullishCoalescing {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferNullishCoalescing>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -78,7 +78,7 @@ declare_oxc_lint!(
 impl Rule for PreferPromiseRejectErrors {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferPromiseRejectErrors>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct PreferPromiseRejectErrors(Box<PreferPromiseRejectErrorsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferPromiseRejectErrorsConfig {
     /// Whether to allow calling `Promise.reject()` with no arguments.
     pub allow_empty_reject: bool,

--- a/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
+++ b/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
@@ -110,7 +110,7 @@ declare_oxc_lint!(
 impl Rule for PromiseFunctionAsync {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PromiseFunctionAsync>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
+++ b/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct PromiseFunctionAsync(Box<PromiseFunctionAsyncConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PromiseFunctionAsyncConfig {
     /// Whether to allow functions returning `any` type without requiring `async`.
     pub allow_any: bool,

--- a/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct RequireArraySortCompare(Box<RequireArraySortCompareConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireArraySortCompareConfig {
     /// Whether to ignore arrays in which all elements are strings.
     pub ignore_string_arrays: bool,

--- a/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
@@ -80,7 +80,7 @@ declare_oxc_lint!(
 impl Rule for RequireArraySortCompare {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<RequireArraySortCompare>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
@@ -99,7 +99,7 @@ declare_oxc_lint!(
 impl Rule for RestrictPlusOperands {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<RestrictPlusOperands>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct RestrictPlusOperands(Box<RestrictPlusOperandsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RestrictPlusOperandsConfig {
     /// Whether to allow `any` type in plus operations.
     pub allow_any: bool,

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -129,7 +129,7 @@ declare_oxc_lint!(
 impl Rule for RestrictTemplateExpressions {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<RestrictTemplateExpressions>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -22,7 +22,7 @@ fn default_restrict_template_allow() -> Vec<TypeOrValueSpecifier> {
 pub struct RestrictTemplateExpressions(Box<RestrictTemplateExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RestrictTemplateExpressionsConfig {
     /// Whether to allow `any` typed values in template expressions.
     pub allow_any: bool,

--- a/crates/oxc_linter/src/rules/typescript/return_await.rs
+++ b/crates/oxc_linter/src/rules/typescript/return_await.rs
@@ -105,9 +105,7 @@ declare_oxc_lint!(
 
 impl Rule for ReturnAwait {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ReturnAwait>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<ReturnAwait>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -129,7 +129,7 @@ declare_oxc_lint!(
 impl Rule for StrictBooleanExpressions {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<StrictBooleanExpressions>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct StrictBooleanExpressions(Box<StrictBooleanExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct StrictBooleanExpressionsConfig {
     /// Whether to allow `any` type in boolean contexts.
     pub allow_any: bool,

--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct SwitchExhaustivenessCheck(Box<SwitchExhaustivenessCheckConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SwitchExhaustivenessCheckConfig {
     /// Whether to allow default cases on switches that are not exhaustive.
     /// When false, requires exhaustive switch statements without default cases.

--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -140,7 +140,7 @@ declare_oxc_lint!(
 impl Rule for SwitchExhaustivenessCheck {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<SwitchExhaustivenessCheck>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -21,7 +21,7 @@ fn triple_slash_reference_diagnostic(ref_kind: &str, span: Span) -> OxcDiagnosti
 pub struct TripleSlashReference(Box<TripleSlashReferenceConfig>);
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct TripleSlashReferenceConfig {
     /// What to enforce for `/// <reference lib="..." />` references.
     lib: LibOption,

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -103,7 +103,7 @@ declare_oxc_lint!(
 impl Rule for TripleSlashReference {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<TripleSlashReference>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/typescript/unbound_method.rs
+++ b/crates/oxc_linter/src/rules/typescript/unbound_method.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct UnboundMethod(Box<UnboundMethodConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct UnboundMethodConfig {
     /// Whether to ignore unbound methods that are static.
     /// When true, static methods can be referenced without binding.

--- a/crates/oxc_linter/src/rules/typescript/unbound_method.rs
+++ b/crates/oxc_linter/src/rules/typescript/unbound_method.rs
@@ -102,9 +102,7 @@ declare_oxc_lint!(
 
 impl Rule for UnboundMethod {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<UnboundMethod>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<UnboundMethod>>(value).unwrap().into_inner()
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -54,7 +54,7 @@ fn consistent_function_scoping(
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ConsistentFunctionScoping {
     /// Whether to check scoping with arrow functions.
     check_arrow_functions: bool,

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -162,7 +162,7 @@ declare_oxc_lint!(
 impl Rule for ConsistentFunctionScoping {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ConsistentFunctionScoping>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -267,7 +267,7 @@ impl ExplicitLengthCheck {
 impl Rule for ExplicitLengthCheck {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<ExplicitLengthCheck>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArrayReduce {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoArrayReduce>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoArrayReduce>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -25,7 +25,7 @@ fn no_array_reduce_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArrayReduce {
     /// When set to `true`, allows simple operations (like summing numbers) in `reduce` and `reduceRight` calls.
     pub allow_simple_operations: bool,

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
@@ -70,9 +70,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArrayReverse {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoArrayReverse>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoArrayReverse>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
@@ -22,7 +22,7 @@ fn no_array_reverse_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArrayReverse {
     /// This rule allows `array.reverse()` as an expression statement by default.
     /// Set to `false` to forbid `Array#reverse()` even if it's an expression statement.

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -70,9 +70,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArraySort {
     fn from_configuration(value: Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoArraySort>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoArraySort>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -22,7 +22,7 @@ fn no_array_sort_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArraySort {
     /// When set to `true` (default), allows `array.sort()` as an expression statement.
     /// Set to `false` to forbid `Array#sort()` even if it's an expression statement.

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -26,7 +26,7 @@ fn no_null_diagnostic(null: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNull {
     /// When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.
     check_strict_equality: bool,

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -19,7 +19,7 @@ fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoTypeofUndefined {
     /// If set to `true`, also report `typeof x === "undefined"` when `x` may be a global
     /// variable that is not declared (commonly checked via `typeof foo === "undefined"`).

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -89,9 +89,7 @@ impl Rule for NoTypeofUndefined {
     }
 
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoTypeofUndefined>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoTypeofUndefined>>(value).unwrap().into_inner()
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -32,7 +32,7 @@ fn reject(span: Span, preferred: &str) -> OxcDiagnostic {
 pub struct NoUselessPromiseResolveReject(Box<NoUselessPromiseResolveRejectOptions>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessPromiseResolveRejectOptions {
     /// If set to `true`, allows the use of `Promise.reject` in async functions and promise callbacks.
     pub allow_reject: bool,

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -68,7 +68,7 @@ declare_oxc_lint!(
 impl Rule for NoUselessPromiseResolveReject {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<NoUselessPromiseResolveReject>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -153,9 +153,7 @@ fn is_has_function_return_type(node: &AstNode, ctx: &LintContext<'_>) -> bool {
 
 impl Rule for NoUselessUndefined {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<NoUselessUndefined>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<NoUselessUndefined>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -29,7 +29,7 @@ fn no_useless_undefined_diagnostic_spans(spans: Vec<Span>) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessUndefined {
     /// Whether to check for useless `undefined` in function call arguments.
     check_arguments: bool,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -34,7 +34,7 @@ impl std::ops::Deref for PreferNumberProperties {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferNumberPropertiesConfig {
     /// If set to `true`, checks for usage of `Infinity` and `-Infinity` as global variables.
     check_infinity: bool,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -89,7 +89,7 @@ declare_oxc_lint!(
 impl Rule for PreferNumberProperties {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferNumberProperties>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -28,7 +28,7 @@ fn prefer_structured_clone_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct PreferStructuredClone(Box<PreferStructuredCloneConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferStructuredCloneConfig {
     /// List of functions that are allowed to be used for deep cloning instead of structuredClone.
     functions: Vec<String>,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -80,7 +80,7 @@ declare_oxc_lint!(
 impl Rule for PreferStructuredClone {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<PreferStructuredClone>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -96,9 +96,7 @@ declare_oxc_lint!(
 
 impl Rule for SwitchCaseBraces {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<SwitchCaseBraces>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<SwitchCaseBraces>>(value).unwrap().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
@@ -130,7 +130,7 @@ declare_oxc_lint!(
 impl Rule for DefineEmitsDeclaration {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<DefineEmitsDeclaration>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
 impl Rule for DefinePropsDeclaration {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<DefinePropsDeclaration>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
@@ -83,7 +83,7 @@ declare_oxc_lint!(
 impl Rule for DefinePropsDestructuring {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<DefinePropsDestructuring>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
@@ -35,7 +35,7 @@ enum Destructure {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct DefinePropsDestructuring {
     /// Require or prohibit destructuring.
     destructure: Destructure,

--- a/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
+++ b/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 impl Rule for MyRule {
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -66,10 +66,10 @@ declare_oxc_lint!(
 
 impl Rule for {{pascal_rule_name}} {
 {{#if rule_config}}
-    fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
             .unwrap()
-            .into_inner()
+            .into_inner())
     }
 
 {{/if}}

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -68,7 +68,7 @@ impl Rule for {{pascal_rule_name}} {
 {{#if rule_config}}
     fn from_configuration(value: serde_json::Value) -> Self {
         serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
+            .unwrap()
             .into_inner()
     }
 


### PR DESCRIPTION
Basically, a proof-of-concept to add `deny_unknown_fields` on config structs across the linter and replace `unwrap_or_default()` with `unwrap()` in `from_configuration`, so it raises an error if the unwrapping fails. As part of this, I added a check for `null` to ensure that an _unset_ value for config (e.g. `"plugin/rule-name: "error"`) does not cause a failure.

I've only done the `deny_unknown_fields` part for rules where the DefaultRuleConfig was used.

Part of the goal here is to see if we can use this to help users find invalid configs/unsupported config options that get migrated from ESLint more easily. Ideally we would also ship a fuller JSON Schema that outputs schema definitions for _all_ the lint rules' config options based on the config structs we've built out, but that is a bit more difficult than this change.

I think it may be worth seeing what effect this change has on the oxc-ecosystem-ci job. I definitely would not recommend merging this right now, though, as it'd be a bad idea to potentially break things right as JS plugins are going into alpha.