### PR TITLE
test(linter/plugins): add ability to lint files in deterministic order

### DIFF
--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -72,4 +72,7 @@ lazy-regex = { workspace = true }
 default = ["napi"]
 napi = ["dep:napi", "dep:napi-derive"]
 allocator = ["dep:mimalloc-safe"]
-force_test_reporter = ["oxc_linter/force_test_reporter"]
+# For use in NAPI tests.
+# - Enables test reporter.
+# - Sorts file paths before linting if oxlint is run with `--threads 1`.
+testing = ["oxc_linter/force_test_reporter"]

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -15,7 +15,7 @@
     "build-test": "pnpm run build-napi-test && cross-env DEBUG=true pnpm run build-js",
     "build-conformance": "pnpm run build-napi-test && cross-env CONFORMANCE=true pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
-    "build-napi-test": "pnpm run build-napi --features force_test_reporter",
+    "build-napi-test": "pnpm run build-napi --features testing",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.ts",
     "test": "vitest --dir ./test run",

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -77,7 +77,7 @@ impl CliRunner {
             }
         };
 
-        let handler = if cfg!(any(test, feature = "force_test_reporter")) {
+        let handler = if cfg!(any(test, feature = "testing")) {
             GraphicalReportHandler::new_themed(miette::GraphicalTheme::none())
         } else {
             GraphicalReportHandler::new()
@@ -165,7 +165,18 @@ impl CliRunner {
         }
 
         let walker = Walk::new(&paths, &ignore_options, override_builder);
-        let paths = walker.paths();
+        let mut paths = walker.paths();
+
+        // NAPI tests build `oxlint` with `testing` feature enabled.
+        // In NAPI tests, sort file paths if oxlint is run with `--threads 1`.
+        // This guarantees files are linted in a deterministic order.
+        //
+        // Note: Sorting paths would not be sufficient to guarantee deterministic linting order unless
+        // `--threads 1` is also used, because otherwise linting happens in parallel on multiple threads,
+        // which also produces non-determinism.
+        if cfg!(feature = "testing") && misc_options.threads == Some(1) {
+            paths.sort_unstable();
+        }
 
         let mut external_plugin_store = ExternalPluginStore::default();
 

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -40,12 +40,12 @@ impl InternalFormatter for DefaultOutputFormatter {
         }
     }
 
-    #[cfg(not(any(test, feature = "force_test_reporter")))]
+    #[cfg(not(any(test, feature = "testing")))]
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
         Box::new(GraphicalReporter::default())
     }
 
-    #[cfg(any(test, feature = "force_test_reporter"))]
+    #[cfg(any(test, feature = "testing"))]
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
         use crate::output_formatter::default::test_implementation::GraphicalReporterTester;
 
@@ -63,7 +63,7 @@ impl DefaultOutputFormatter {
 /// Pretty-prints diagnostics. Primarily meant for human-readable output in a terminal.
 ///
 /// See [`GraphicalReportHandler`] for how to configure colors, context lines, etc.
-#[cfg_attr(all(not(test), feature = "force_test_reporter"), expect(dead_code))]
+#[cfg_attr(all(not(test), feature = "testing"), expect(dead_code))]
 struct GraphicalReporter {
     handler: GraphicalReportHandler,
 }
@@ -114,7 +114,7 @@ fn get_diagnostic_result_output(result: &DiagnosticResult) -> String {
     output
 }
 
-#[cfg(any(test, feature = "force_test_reporter"))]
+#[cfg(any(test, feature = "testing"))]
 mod test_implementation {
     use oxc_diagnostics::{
         Error, GraphicalReportHandler, GraphicalTheme,

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -45,7 +45,7 @@ async function runFixture(fixture: Fixture, expect: ExpectStatic): Promise<void>
   // Run Oxlint without `--fix` option
   await testFixtureWithCommand({
     command: NODE_BIN_PATH,
-    args: [CLI_PATH, "files"],
+    args: [CLI_PATH, ...(fixture.options.singleThread ? ["--threads", "1"] : []), "files"],
     fixture,
     snapshotName: "output",
     isESLint: false,
@@ -56,7 +56,12 @@ async function runFixture(fixture: Fixture, expect: ExpectStatic): Promise<void>
   if (fixture.options.fix) {
     await testFixtureWithCommand({
       command: NODE_BIN_PATH,
-      args: [CLI_PATH, "--fix", "files"],
+      args: [
+        CLI_PATH,
+        "--fix",
+        ...(fixture.options.singleThread ? ["--threads", "1"] : []),
+        "files",
+      ],
       fixture,
       snapshotName: "fix",
       isESLint: false,

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -28,10 +28,17 @@ export interface Fixture {
     eslint: boolean;
     // Run Oxlint with fixes. Default: `false`.
     fix: boolean;
+    // Run Oxlint single-threaded. Default: `false`.
+    singleThread: boolean;
   };
 }
 
-const DEFAULT_OPTIONS: Fixture["options"] = { oxlint: true, eslint: false, fix: false };
+const DEFAULT_OPTIONS: Fixture["options"] = {
+  oxlint: true,
+  eslint: false,
+  fix: false,
+  singleThread: false,
+};
 
 /**
  * Get all fixtures in `test/fixtures`, and their options.
@@ -64,10 +71,11 @@ export function getFixtures(): Fixture[] {
     if (
       typeof options.oxlint !== "boolean" ||
       typeof options.eslint !== "boolean" ||
-      typeof options.fix !== "boolean"
+      typeof options.fix !== "boolean" ||
+      typeof options.singleThread !== "boolean"
     ) {
       throw new TypeError(
-        "`oxlint`, `eslint`, and `fix` properties in `options.json` must be booleans",
+        "`oxlint`, `eslint`, `fix`, and `singleThread` properties in `options.json` must be booleans",
       );
     }
 


### PR DESCRIPTION
In JS plugins tests, it's sometimes required to ensure that files are linted in deterministic order.

For example, #17207 fixes a bug where some internal global state was not reset correctly after an error is thrown during visiting the AST. This affects what happens when linting the *next* file.

In order to write a test for this, and produces deterministic output in the snapshot file, the order files are linted in needs to be deterministic.

This PR provides this determinism by:

1. Adding a `force_deterministic_order` cargo feature which is enabled in test build.
2. When this feature is enabled *and* Oxlint is run with `--threads 1`, file paths are sorted before linting.
3. Adding an option for test fixtures `singleThread`. When `true`, the fixture is run with `--threads 1`.

Aim is to only enable deterministic ordering in test fixtures which *need* determinism, so that most test fixtures are still testing Oxlint running as it does usually for a user.