### PR TITLE
feat(oxlint/lsp): support `textDocument/diagnostic`

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -12,8 +12,10 @@ use tower_lsp_server::{
         CodeActionParams, CodeActionResponse, ConfigurationItem, Diagnostic,
         DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
         DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams, DocumentFormattingParams, ExecuteCommandParams,
-        InitializeParams, InitializeResult, InitializedParams, ServerInfo, TextEdit, Uri,
+        DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+        DocumentDiagnosticReportKind, DocumentDiagnosticReportResult, DocumentFormattingParams,
+        ExecuteCommandParams, FullDocumentDiagnosticReport, InitializeParams, InitializeResult,
+        InitializedParams, RelatedFullDocumentDiagnosticReport, ServerInfo, TextEdit, Uri,
     },
 };
 
@@ -101,14 +103,18 @@ impl LanguageServer for Backend {
             None
         });
 
+        let capabilities = Capabilities::from(params.capabilities);
+
         info!("initialize: {options:?}");
         info!(
             "{} version: {}",
             self.server_info.name,
             self.server_info.version.as_deref().unwrap_or("unknown")
         );
-
-        let capabilities = Capabilities::from(params.capabilities);
+        debug!(
+            "diagnostic model: {}",
+            if capabilities.use_push_diagnostics() { "push" } else { "pull" }
+        );
 
         // client sent workspace folders
         let workers = if let Some(workspace_folders) = params.workspace_folders {
@@ -148,7 +154,7 @@ impl LanguageServer for Backend {
 
         let mut server_capabilities = server_capabilities();
         for tool_builder in &self.tool_builders {
-            tool_builder.server_capabilities(&mut server_capabilities);
+            tool_builder.server_capabilities(&mut server_capabilities, &capabilities);
         }
 
         self.capabilities.set(capabilities).map_err(|err| {
@@ -253,9 +259,14 @@ impl LanguageServer for Backend {
             clearing_diagnostics.extend(uris);
             removed_registrations.extend(unregistrations);
         }
-        if !clearing_diagnostics.is_empty() {
+
+        // only clear diagnostics when we are using push diagnostics
+        if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics)
+            && !clearing_diagnostics.is_empty()
+        {
             self.clear_diagnostics(clearing_diagnostics).await;
         }
+
         if self.capabilities.get().unwrap().dynamic_watchers
             && !removed_registrations.is_empty()
             && let Err(err) = self.client.unregister_capability(removed_registrations).await
@@ -331,6 +342,12 @@ impl LanguageServer for Backend {
             return;
         };
 
+        let mut needs_diagnostics_refresh = false;
+        let is_push_diagnostics =
+            self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics);
+        let fs_guard = if is_push_diagnostics { Some(self.file_system.read().await) } else { None };
+        let fs_ref = fs_guard.as_deref();
+
         for option in resolved_options {
             let Some(worker) =
                 workers.iter().find(|worker| worker.is_responsible_for_uri(&option.workspace_uri))
@@ -339,7 +356,7 @@ impl LanguageServer for Backend {
             };
 
             let (diagnostics, registrations, unregistrations) = worker
-                .did_change_configuration(option.options, &*self.file_system.read().await)
+                .did_change_configuration(option.options, &mut needs_diagnostics_refresh, fs_ref)
                 .await;
 
             if let Some(diagnostics) = diagnostics {
@@ -350,8 +367,15 @@ impl LanguageServer for Backend {
             adding_registrations.extend(registrations);
         }
 
-        if !new_diagnostics.is_empty() {
+        if is_push_diagnostics && !new_diagnostics.is_empty() {
             self.publish_all_diagnostics(new_diagnostics, ConcurrentHashMap::default()).await;
+        }
+
+        if !is_push_diagnostics && needs_diagnostics_refresh {
+            // In pull diagnostic model, we ask the client to refresh diagnostics
+            if let Err(err) = self.client.workspace_diagnostic_refresh().await {
+                warn!("sending workspace/diagnostic/refresh failed: {err}");
+            }
         }
 
         if !removing_registrations.is_empty()
@@ -379,6 +403,12 @@ impl LanguageServer for Backend {
         let mut removing_registrations = vec![];
         let mut adding_registrations = vec![];
 
+        let mut needs_diagnostics_refresh = false;
+        let is_push_diagnostics =
+            self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics);
+        let fs_guard = if is_push_diagnostics { Some(self.file_system.read().await) } else { None };
+        let fs_ref = fs_guard.as_deref();
+
         for file_event in &params.changes {
             // We do not expect multiple changes from the same workspace folder.
             // If we should consider it, we need to map the events to the workers first,
@@ -388,8 +418,9 @@ impl LanguageServer for Backend {
             else {
                 continue;
             };
-            let (diagnostics, registrations, unregistrations) =
-                worker.did_change_watched_files(file_event, &*self.file_system.read().await).await;
+            let (diagnostics, registrations, unregistrations) = worker
+                .did_change_watched_files(file_event, &mut needs_diagnostics_refresh, fs_ref)
+                .await;
 
             if let Some(diagnostics) = diagnostics {
                 new_diagnostics.extend(diagnostics);
@@ -398,8 +429,15 @@ impl LanguageServer for Backend {
             adding_registrations.extend(registrations);
         }
 
-        if !new_diagnostics.is_empty() {
+        if is_push_diagnostics && !new_diagnostics.is_empty() {
             self.publish_all_diagnostics(new_diagnostics, ConcurrentHashMap::default()).await;
+        }
+
+        if !is_push_diagnostics && needs_diagnostics_refresh {
+            // In pull diagnostic model, we ask the client to refresh diagnostics
+            if let Err(err) = self.client.workspace_diagnostic_refresh().await {
+                warn!("sending workspace/diagnostic/refresh failed: {err}");
+            }
         }
 
         if self.capabilities.get().is_some_and(|capabilities| capabilities.dynamic_watchers) {
@@ -443,7 +481,9 @@ impl LanguageServer for Backend {
             workers.remove(index);
         }
 
-        self.clear_diagnostics(cleared_diagnostics).await;
+        if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
+            self.clear_diagnostics(cleared_diagnostics).await;
+        }
 
         // client support `workspace/configuration` request
         if self.capabilities.get().is_some_and(|capabilities| capabilities.workspace_configuration)
@@ -502,9 +542,11 @@ impl LanguageServer for Backend {
             return;
         };
 
-        let diagnostics = worker.run_diagnostic_on_save(&uri, params.text.as_deref()).await;
-        if !diagnostics.is_empty() {
-            self.publish_all_diagnostics(diagnostics, ConcurrentHashMap::default()).await;
+        if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
+            let diagnostics = worker.run_diagnostic_on_save(&uri, params.text.as_deref()).await;
+            if !diagnostics.is_empty() {
+                self.publish_all_diagnostics(diagnostics, ConcurrentHashMap::default()).await;
+            }
         }
     }
     /// It will update the in-memory file content if the client supports dynamic formatting.
@@ -523,11 +565,13 @@ impl LanguageServer for Backend {
             self.file_system.write().await.set(uri.clone(), content.clone());
         }
 
-        let diagnostics = worker.run_diagnostic_on_change(&uri, content.as_deref()).await;
-        if !diagnostics.is_empty() {
-            let version_map = ConcurrentHashMap::default();
-            version_map.pin().insert(uri.clone(), params.text_document.version);
-            self.publish_all_diagnostics(diagnostics, version_map).await;
+        if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
+            let diagnostics = worker.run_diagnostic_on_change(&uri, content.as_deref()).await;
+            if !diagnostics.is_empty() {
+                let version_map = ConcurrentHashMap::default();
+                version_map.pin().insert(uri.clone(), params.text_document.version);
+                self.publish_all_diagnostics(diagnostics, version_map).await;
+            }
         }
     }
 
@@ -546,11 +590,13 @@ impl LanguageServer for Backend {
 
         self.file_system.write().await.set(uri.clone(), content.clone());
 
-        let diagnostics = worker.run_diagnostic(&uri, Some(&content)).await;
-        if !diagnostics.is_empty() {
-            let version_map = ConcurrentHashMap::default();
-            version_map.pin().insert(uri.clone(), params.text_document.version);
-            self.publish_all_diagnostics(diagnostics, version_map).await;
+        if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
+            let diagnostics = worker.run_diagnostic(&uri, Some(&content)).await;
+            if !diagnostics.is_empty() {
+                let version_map = ConcurrentHashMap::default();
+                version_map.pin().insert(uri.clone(), params.text_document.version);
+                self.publish_all_diagnostics(diagnostics, version_map).await;
+            }
         }
     }
 
@@ -618,6 +664,59 @@ impl LanguageServer for Backend {
         }
 
         Ok(None)
+    }
+
+    async fn diagnostic(
+        &self,
+        params: DocumentDiagnosticParams,
+    ) -> Result<DocumentDiagnosticReportResult> {
+        let uri = &params.text_document.uri;
+        let workers = self.workspace_workers.read().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
+            return Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
+                RelatedFullDocumentDiagnosticReport::default(),
+            )));
+        };
+        let diagnostics =
+            worker.run_diagnostic(uri, self.file_system.read().await.get(uri).as_deref()).await;
+
+        let uri_diagnostics = diagnostics
+            .iter()
+            .filter(|(diag_uri, _)| diag_uri == uri)
+            .flat_map(|(_, diags)| diags.clone())
+            .collect::<Vec<_>>();
+
+        let related_diagnostics =
+            diagnostics.into_iter().filter(|(diag_uri, _)| diag_uri != uri).collect::<Vec<_>>();
+
+        Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    items: uri_diagnostics,
+                    ..Default::default()
+                },
+                related_documents: if related_diagnostics.is_empty() {
+                    None
+                } else {
+                    Some(
+                        related_diagnostics
+                            .into_iter()
+                            .map(|(diag_uri, diags)| {
+                                (
+                                    diag_uri,
+                                    DocumentDiagnosticReportKind::Full(
+                                        FullDocumentDiagnosticReport {
+                                            items: diags,
+                                            ..Default::default()
+                                        },
+                                    ),
+                                )
+                            })
+                            .collect(),
+                    )
+                },
+            },
+        )))
     }
 
     /// It will return text edits to format the document if formatting is enabled for the workspace.

--- a/crates/oxc_language_server/src/formatter/server_formatter.rs
+++ b/crates/oxc_language_server/src/formatter/server_formatter.rs
@@ -12,6 +12,7 @@ use oxc_parser::Parser;
 use tower_lsp_server::ls_types::{Pattern, Position, Range, ServerCapabilities, TextEdit, Uri};
 
 use crate::{
+    capabilities::Capabilities,
     formatter::{FORMAT_CONFIG_FILES, options::FormatOptions as LSPFormatOptions},
     tool::{Tool, ToolBuilder, ToolRestartChanges},
     utils::normalize_path,
@@ -53,7 +54,11 @@ impl ServerFormatterBuilder {
 }
 
 impl ToolBuilder for ServerFormatterBuilder {
-    fn server_capabilities(&self, capabilities: &mut ServerCapabilities) {
+    fn server_capabilities(
+        &self,
+        capabilities: &mut ServerCapabilities,
+        _backend_capabilities: &Capabilities,
+    ) {
         capabilities.document_formatting_provider =
             Some(tower_lsp_server::ls_types::OneOf::Left(true));
     }
@@ -366,7 +371,7 @@ fn load_ignore_paths(cwd: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests_builder {
-    use crate::{ServerFormatterBuilder, ToolBuilder};
+    use crate::{ServerFormatterBuilder, ToolBuilder, capabilities::Capabilities};
 
     #[test]
     fn test_server_capabilities() {
@@ -375,7 +380,7 @@ mod tests_builder {
         let builder = ServerFormatterBuilder;
         let mut capabilities = ServerCapabilities::default();
 
-        builder.server_capabilities(&mut capabilities);
+        builder.server_capabilities(&mut capabilities, &Capabilities::default());
 
         assert_eq!(capabilities.document_formatting_provider, Some(OneOf::Left(true)));
     }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -88,9 +88,7 @@ impl Tool for FakeTool {
         root_uri: &Uri,
         options: serde_json::Value,
     ) -> ToolRestartChanges {
-        if changed_uri.as_str().ends_with("tool.config")
-            || changed_uri.as_str().ends_with("diagnostics.config")
-        {
+        if changed_uri.as_str().ends_with("tool.config") {
             return ToolRestartChanges {
                 tool: Some(FakeToolBuilder.build_boxed(root_uri, options)),
                 watch_patterns: None,
@@ -300,15 +298,27 @@ fn initialize_request_workspace_folders(
     workspace_configuration: bool,
     dynamic_watchers: bool,
     workspace_edit: bool,
+    pull_mode: bool,
     initialization_options: Option<Value>,
     workspace_folders: Vec<WorkspaceFolder>,
 ) -> Request {
     let params = InitializeParams {
         workspace_folders: Some(workspace_folders),
         capabilities: ClientCapabilities {
+            text_document: Some(TextDocumentClientCapabilities {
+                diagnostic: if pull_mode {
+                    Some(DiagnosticClientCapabilities::default())
+                } else {
+                    None
+                },
+                ..Default::default()
+            }),
             workspace: Some(WorkspaceClientCapabilities {
                 apply_edit: Some(workspace_edit),
                 configuration: Some(workspace_configuration),
+                diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                    refresh_support: Some(pull_mode),
+                }),
                 did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
                     dynamic_registration: Some(dynamic_watchers),
                     ..Default::default()
@@ -330,12 +340,14 @@ fn initialize_request(
     workspace_configuration: bool,
     dynamic_watchers: bool,
     workspace_edit: bool,
+    pull_mode: bool,
     initialization_options: Option<Value>,
 ) -> Request {
     initialize_request_workspace_folders(
         workspace_configuration,
         dynamic_watchers,
         workspace_edit,
+        pull_mode,
         initialization_options,
         vec![WorkspaceFolder { uri: WORKSPACE.parse().unwrap(), name: "workspace".to_string() }],
     )
@@ -387,6 +399,12 @@ async fn acknowledge_unregistrations(server: &mut TestServer) {
 
     // Acknowledge the unregistration
     server.send_ack(unregister_request.id().unwrap()).await;
+}
+
+async fn acknowledge_diagnostic_refresh(server: &mut TestServer) {
+    let diagnostic_refresh_request = server.recv_notification().await;
+    assert_eq!(diagnostic_refresh_request.method(), "workspace/diagnostic/refresh");
+    server.send_ack(diagnostic_refresh_request.id().unwrap()).await;
 }
 
 async fn response_to_configuration(
@@ -481,6 +499,18 @@ fn test_configuration_request(id: i64) -> Request {
     Request::build("test/configuration").id(id).params(json!(null)).finish()
 }
 
+fn diagnostic(id: i64, uri: &str) -> Request {
+    let params = DocumentDiagnosticParams {
+        text_document: TextDocumentIdentifier { uri: uri.parse().unwrap() },
+        identifier: None,
+        previous_result_id: None,
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+
+    Request::build("textDocument/diagnostic").id(id).params(json!(params)).finish()
+}
+
 #[cfg(test)]
 mod test_suite {
     use serde_json::{Value, json};
@@ -496,11 +526,12 @@ mod test_suite {
         backend::Backend,
         tests::{
             FAKE_COMMAND, FakeToolBuilder, TestServer, WORKSPACE, WORKSPACE_2,
-            acknowledge_registrations, acknowledge_unregistrations, code_action, did_change,
-            did_change_configuration, did_change_watched_files, did_close, did_open, did_save,
-            execute_command_request, initialize_request, initialize_request_workspace_folders,
-            initialized_notification, response_to_configuration, shutdown_request,
-            test_configuration_request, workspace_folders_changed,
+            acknowledge_diagnostic_refresh, acknowledge_registrations, acknowledge_unregistrations,
+            code_action, diagnostic, did_change, did_change_configuration,
+            did_change_watched_files, did_close, did_open, did_save, execute_command_request,
+            initialize_request, initialize_request_workspace_folders, initialized_notification,
+            response_to_configuration, shutdown_request, test_configuration_request,
+            workspace_folders_changed,
         },
     };
 
@@ -512,7 +543,7 @@ mod test_suite {
     async fn test_basic_start_and_shutdown_flow() {
         let mut server = TestServer::new(|client| Backend::new(client, server_info(), vec![]));
         // initialize request
-        server.send_request(initialize_request(false, false, false, None)).await;
+        server.send_request(initialize_request(false, false, false, false, None)).await;
         let initialize_result = server.recv_response().await;
 
         assert!(initialize_result.is_ok());
@@ -551,7 +582,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![]),
-            initialize_request(false, false, false, Some(init_options.clone())),
+            initialize_request(false, false, false, false, Some(init_options.clone())),
         )
         .await;
 
@@ -585,7 +616,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![]),
-            initialize_request(false, false, false, Some(init_options)),
+            initialize_request(false, false, false, false, Some(init_options)),
         )
         .await;
 
@@ -610,7 +641,7 @@ mod test_suite {
     async fn test_workspace_configuration_on_initialized() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![]),
-            initialize_request(true, false, false, None),
+            initialize_request(true, false, false, false, None),
         )
         .await;
 
@@ -648,7 +679,7 @@ mod test_suite {
     async fn test_dynamic_watched_files_registration() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
 
@@ -714,7 +745,7 @@ mod test_suite {
     async fn test_execute_workspace_command_with_apply_edit() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, true, None),
+            initialize_request(false, false, true, false, None),
         )
         .await;
 
@@ -784,6 +815,7 @@ mod test_suite {
                 false,
                 false,
                 false,
+                false,
                 Some(init_options.clone()),
                 vec![
                     WorkspaceFolder {
@@ -828,7 +860,7 @@ mod test_suite {
     async fn test_execute_workspace_command_with_no_edit() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -850,7 +882,7 @@ mod test_suite {
     async fn test_execute_workspace_command_with_invalid_command() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -880,7 +912,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
         server.send_request(folders_changed_notification).await;
@@ -902,7 +934,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -926,7 +958,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(true, false, false, None),
+            initialize_request(true, false, false, false, None),
         )
         .await;
         // workspace configuration request expected, one for initial workspace
@@ -953,7 +985,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
         server.send_request(folders_changed_notification).await;
@@ -975,7 +1007,7 @@ mod test_suite {
 
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -991,7 +1023,7 @@ mod test_suite {
     async fn test_watched_file_changed_unknown() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -1011,7 +1043,7 @@ mod test_suite {
     async fn test_watched_file_changed_new_watchers() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -1030,10 +1062,69 @@ mod test_suite {
     }
 
     #[tokio::test]
+    async fn test_watched_file_changed_revalidate_diagnostics() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, true, false, false, None),
+        )
+        .await;
+        acknowledge_registrations(&mut server).await;
+
+        let uri = format!("{WORKSPACE}/diagnostics.config");
+        let content = "some text";
+        server.send_request(did_open(&uri, content)).await;
+        let diagnostic_response = server.recv_notification().await;
+        assert_eq!(diagnostic_response.method(), "textDocument/publishDiagnostics");
+
+        // Simulate a watched file change notification for "tool.config"
+        let file_change_notification =
+            did_change_watched_files(format!("{WORKSPACE}/tool.config").as_str());
+        server.send_request(file_change_notification).await;
+
+        // expecting diagnostics to be re-validated
+        let diagnostic_response = server.recv_notification().await;
+        assert_eq!(diagnostic_response.method(), "textDocument/publishDiagnostics");
+        let params: PublishDiagnosticsParams =
+            serde_json::from_value(diagnostic_response.params().unwrap().clone()).unwrap();
+        assert_eq!(params.uri, uri.parse().unwrap());
+        assert_eq!(params.diagnostics.len(), 1);
+        assert_eq!(
+            params.diagnostics[0].message,
+            format!("Fake diagnostic for content: {content}")
+        );
+
+        server.shutdown_with_watchers(3).await;
+    }
+
+    #[tokio::test]
+    async fn test_watched_file_changed_revalidate_diagnostics_pull_mode() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, true, false, true, None),
+        )
+        .await;
+        acknowledge_registrations(&mut server).await;
+
+        let uri = format!("{WORKSPACE}/diagnostics.config");
+        let content = "some text";
+        server.send_request(did_open(&uri, content)).await;
+
+        // Simulate a watched file change notification for "tool.config"
+        let file_change_notification =
+            did_change_watched_files(format!("{WORKSPACE}/tool.config").as_str());
+        server.send_request(file_change_notification).await;
+
+        // Acknowledge the refresh request
+        acknowledge_diagnostic_refresh(&mut server).await;
+
+        server.shutdown_with_watchers(3).await;
+    }
+
+    #[tokio::test]
     async fn test_did_change_configuration_no_changes() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -1051,7 +1142,7 @@ mod test_suite {
     async fn test_did_change_configuration_config_passed_new_watchers() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, true, false, None),
+            initialize_request(false, true, false, false, None),
         )
         .await;
         acknowledge_registrations(&mut server).await;
@@ -1077,7 +1168,7 @@ mod test_suite {
     async fn test_did_change_configuration_config_requested_new_watchers() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(true, true, false, None),
+            initialize_request(true, true, false, false, None),
         )
         .await;
         response_to_configuration(&mut server, vec![json!(null)]).await;
@@ -1099,10 +1190,73 @@ mod test_suite {
     }
 
     #[tokio::test]
+    async fn test_did_change_configuration_config_revalidate_diagnostics() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, false, false, false, None),
+        )
+        .await;
+        let uri = format!("{WORKSPACE}/diagnostics.config");
+        let content = "some text";
+        server.send_request(did_open(&uri, content)).await;
+        let diagnostic_response = server.recv_notification().await;
+        assert_eq!(diagnostic_response.method(), "textDocument/publishDiagnostics");
+
+        // Simulate a configuration change that affects diagnostics
+        let config_change_notification = did_change_configuration(Some(json!([
+            {
+                "workspaceUri": WORKSPACE,
+                "options": 3
+            }
+        ])));
+        server.send_request(config_change_notification).await;
+
+        // expecting diagnostics to be re-validated
+        let diagnostic_response = server.recv_notification().await;
+        assert_eq!(diagnostic_response.method(), "textDocument/publishDiagnostics");
+        let params: PublishDiagnosticsParams =
+            serde_json::from_value(diagnostic_response.params().unwrap().clone()).unwrap();
+        assert_eq!(params.uri, uri.parse().unwrap());
+        assert_eq!(params.diagnostics.len(), 1);
+        assert_eq!(
+            params.diagnostics[0].message,
+            format!("Fake diagnostic for content: {content}")
+        );
+
+        server.shutdown(3).await;
+    }
+
+    #[tokio::test]
+    async fn test_did_change_configuration_config_revalidate_diagnostics_pull_mode() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, false, false, true, None),
+        )
+        .await;
+        let uri = format!("{WORKSPACE}/diagnostics.config");
+        let content = "some text";
+        server.send_request(did_open(&uri, content)).await;
+
+        // Simulate a configuration change that affects diagnostics
+        let config_change_notification = did_change_configuration(Some(json!([
+            {
+                "workspaceUri": WORKSPACE,
+                "options": 3
+            }
+        ])));
+        server.send_request(config_change_notification).await;
+
+        // Acknowledge the refresh request
+        acknowledge_diagnostic_refresh(&mut server).await;
+
+        server.shutdown(3).await;
+    }
+
+    #[tokio::test]
     async fn test_file_notifications() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1119,7 +1273,7 @@ mod test_suite {
     async fn test_code_action_no_actions() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1141,7 +1295,7 @@ mod test_suite {
     async fn test_code_actions_with_actions() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1166,7 +1320,7 @@ mod test_suite {
     async fn test_diagnostic_on_open() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1192,7 +1346,7 @@ mod test_suite {
     async fn test_diagnostic_on_change() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1222,7 +1376,7 @@ mod test_suite {
     async fn test_diagnostic_on_save() {
         let mut server = TestServer::new_initialized(
             |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
-            initialize_request(false, false, false, None),
+            initialize_request(false, false, false, false, None),
         )
         .await;
 
@@ -1247,6 +1401,53 @@ mod test_suite {
         assert_eq!(params.diagnostics.len(), 1);
         assert_eq!(
             params.diagnostics[0].message,
+            format!("Fake diagnostic for content: {content}")
+        );
+
+        server.shutdown(4).await;
+    }
+
+    #[tokio::test]
+    async fn test_no_diagnostics_on_pull_mode_on_save() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, false, false, true, None),
+        )
+        .await;
+
+        let file = format!("{WORKSPACE}/diagnostics.config");
+        let content = "new text";
+        server.send_request(did_open(&file, "old text")).await;
+        server.send_request(did_change(&file, content)).await;
+        server.send_request(did_save(&file, content)).await;
+        server.shutdown(4).await;
+    }
+
+    #[tokio::test]
+    async fn test_diagnostics_pull_mode() {
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), vec![Box::new(FakeToolBuilder)]),
+            initialize_request(false, false, false, true, None),
+        )
+        .await;
+
+        let file = format!("{WORKSPACE}/diagnostics.config");
+        let content = "pull mode text";
+        server.send_request(did_open(&file, content)).await;
+
+        server.send_request(diagnostic(3, &file)).await;
+
+        let diagnostic_response = server.recv_response().await;
+        assert!(diagnostic_response.is_ok());
+        assert_eq!(diagnostic_response.id(), &Id::Number(3));
+
+        let report: serde_json::Value =
+            serde_json::from_value(diagnostic_response.result().unwrap().clone()).unwrap();
+
+        assert_eq!(report["kind"], "full");
+        assert_eq!(report["items"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            report["items"][0]["message"],
             format!("Fake diagnostic for content: {content}")
         );
 

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -6,9 +6,16 @@ use tower_lsp_server::{
     },
 };
 
+use crate::capabilities::Capabilities;
+
 pub trait ToolBuilder: Send + Sync {
     /// Modify the server capabilities to include capabilities provided by this tool.
-    fn server_capabilities(&self, _capabilities: &mut ServerCapabilities) {}
+    fn server_capabilities(
+        &self,
+        _capabilities: &mut ServerCapabilities,
+        _backend_capabilities: &Capabilities,
+    ) {
+    }
 
     /// Build a boxed instance of the tool for the given root URI and options.
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;


### PR DESCRIPTION
This PR introduces the support for `textDocument/diagnostics`. This will be preferred over the other way around `textDocument/publishDiagnostics`
It is a newer concept between language server and the clients (editors).


> Diagnostics are currently published by the server to the client using a notification. This model has the advantage that for workspace wide diagnostics the server has the freedom to compute them at a server preferred point in time. On the other hand the approach has the disadvantage that the server can’t prioritize the computation for the file in which the user types or which are visible in the editor. Inferring the client’s UI state from the [textDocument/didOpen](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen) and [textDocument/didChange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange) notifications might lead to false positives since these notifications are ownership transfer notifications.

> The specification therefore introduces the concept of diagnostic pull requests to give a client more control over the documents for which diagnostics should be computed and at which point in time.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics

For our server, we need one more feature.

> The [workspace/diagnostic/refresh](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic_refresh) request is sent from the server to the client. Servers can use it to ask clients to refresh all needed document and workspace diagnostics. This is useful if a server detects a project wide configuration change which requires a re-calculation of all diagnostics.

This is needed because in the current implementation we re-lint the opened files when some `.oxlintrc.json` configuration is changed or `fix_kind` server configuration. Instead of re-linting, the server will send this request to the client.

----

This will be a breaking change for other clients which are sending the `run = onType | onSave` configuration, but are supporting all needed specs for the pull diagnostics mode. The client should instead implement their own configuration and sending the `textDocument/diagnostics` to the server when needed.