### PR TITLE
feat(vscode): support diagnostic pull mode

### DIFF
--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -148,6 +148,12 @@ export default class LinterTool implements ToolInterface {
       initializationOptions: configService.oxlintServerConfig,
       outputChannel,
       traceOutputChannel: outputChannel,
+      diagnosticPullOptions: {
+        onChange: true,
+        onSave: true,
+        onTabs: false,
+        filter: (document, mode) => !configService.shouldRequestDiagnostics(document.uri, mode),
+      },
       middleware: {
         handleDiagnostics: (uri, diagnostics, next) => {
           for (const diag of diagnostics) {

--- a/editors/vscode/tests/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/WorkspaceConfig.spec.ts
@@ -1,5 +1,6 @@
 import { strictEqual } from 'assert';
 import { ConfigurationTarget, workspace } from 'vscode';
+import { DiagnosticPullMode } from 'vscode-languageclient';
 import { FixKind, WorkspaceConfig } from '../client/WorkspaceConfig.js';
 import { WORKSPACE_FOLDER } from './test-helpers.js';
 
@@ -65,7 +66,7 @@ suite('WorkspaceConfig', () => {
     const config = new WorkspaceConfig(WORKSPACE_FOLDER);
 
     await Promise.all([
-      config.updateRunTrigger('onSave'),
+      config.updateRunTrigger(DiagnosticPullMode.onSave),
       config.updateConfigPath('./somewhere'),
       config.updateTsConfigPath('./tsconfig.json'),
       config.updateUnusedDisableDirectives('deny'),
@@ -91,7 +92,7 @@ suite('WorkspaceConfig', () => {
     const config = new WorkspaceConfig(WORKSPACE_FOLDER);
 
     await Promise.all([
-      config.updateRunTrigger('onSave'),
+      config.updateRunTrigger(DiagnosticPullMode.onSave),
       config.updateConfigPath('./somewhere'),
       config.updateTsConfigPath('./tsconfig.json'),
       config.updateUnusedDisableDirectives('deny'),


### PR DESCRIPTION
The editor implementation for `textDocument/diagnostic`.  
The client auto enables this request when the server responded with the `DocumentDiagnosticProvider` in `initialize` request.
This change only aligns the new pull mode with the extension configuration.