### PR TITLE
perf(linter): avoid multiple `to_string_lossy` calls in loop

### DIFF
--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -122,7 +122,9 @@ impl Walk {
             return false;
         }
         let Some(file_name) = dir_entry.path().file_name() else { return false };
-        if [".min.", "-min.", "_min."].iter().any(|e| file_name.to_string_lossy().contains(e)) {
+        let file_name = file_name.to_string_lossy();
+        let file_name = file_name.as_ref();
+        if [".min.", "-min.", "_min."].iter().any(|e| file_name.contains(e)) {
             return false;
         }
         let Some(extension) = dir_entry.path().extension() else { return false };


### PR DESCRIPTION
Small optimization: Call `to_string_lossy` only once, rather than 3 times in a loop.