### PR TITLE
feat(linter/eslint-plugin-vitest): Implement valid-title eslint rule

### DIFF
--- a/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -45,7 +45,8 @@ working directory:
       "tagNamePreference": {}
     },
     "vitest": {
-      "typecheck": false
+      "typecheck": false,
+      "vitestImports": []
     }
   },
   "env": {

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -38,7 +38,8 @@ working directory: fixtures
       "tagNamePreference": {}
     },
     "vitest": {
-      "typecheck": false
+      "typecheck": false,
+      "vitestImports": []
     }
   },
   "env": {

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -1,3 +1,4 @@
+use oxc_span::CompactStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -12,4 +13,6 @@ pub struct VitestPluginSettings {
     /// to accommodate TypeScript type checking scenarios.
     #[serde(default)]
     pub typecheck: bool,
+    #[serde(rename = "vitestImports", default)]
+    pub vitest_imports: Vec<CompactStr>,
 }

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -13,6 +13,8 @@ pub struct VitestPluginSettings {
     /// to accommodate TypeScript type checking scenarios.
     #[serde(default)]
     pub typecheck: bool,
+    /// When user provided an array of custom fixtures, those functions
+    /// will be linted as well.
     #[serde(rename = "vitestImports", default)]
     pub vitest_imports: Vec<CompactStr>,
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -268,7 +268,10 @@ impl Linter {
                     }
 
                     if should_run_on_jest_node {
-                        for jest_node in iter_possible_jest_call_node(semantic) {
+                        for jest_node in iter_possible_jest_call_node(
+                            semantic,
+                            &ctx_host.settings().vitest.vitest_imports,
+                        ) {
                             for (rule, ctx) in &rules {
                                 if !with_runtime_optimization
                                     || rule.run_info().is_run_on_jest_node_implemented()
@@ -306,7 +309,10 @@ impl Linter {
                             && (!with_runtime_optimization
                                 || run_info.is_run_on_jest_node_implemented())
                         {
-                            for jest_node in iter_possible_jest_call_node(semantic) {
+                            for jest_node in iter_possible_jest_call_node(
+                                semantic,
+                                &ctx.settings().vitest.vitest_imports,
+                            ) {
                                 rule.run_on_jest_node(&jest_node, ctx);
                             }
                         }

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -58,7 +58,7 @@ impl Rule for NoExport {
         // `iter_possible_jest_call_node` yields uses of `JEST_METHOD_NAMES`.
         // We focus on "fit", "it", "test", "xit", and "xtest" (JestGeneralFnKind::Test).
         // Presence of any of these is taken to mean the module has tests, and the rule should enforce no exports.
-        let has_tests = iter_possible_jest_call_node(ctx).any(|possible_node| {
+        let has_tests = iter_possible_jest_call_node(ctx, &[]).any(|possible_node| {
             let AstKind::CallExpression(call_expr) = possible_node.node.kind() else {
                 return false;
             };

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -198,7 +198,7 @@ impl Rule for NoLargeSnapshots {
                 }
             }
         } else {
-            for possible_jest_node in iter_possible_jest_call_node(ctx.semantic()) {
+            for possible_jest_node in iter_possible_jest_call_node(ctx.semantic(), &[]) {
                 self.run(&possible_jest_node, ctx);
             }
         }

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -136,6 +136,17 @@ declare_oxc_lint!(
     ///     mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
     /// }
     /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///      "vitest/valid-title": "error"
+    ///   }
+    /// }
+    /// ```
     ValidTitle,
     jest,
     correctness,
@@ -670,6 +681,7 @@ fn test() {
         ),
     ];
 
+    // TODO handle `vitestImports` config option
     let fail = vec![
         (
             "describe('the correct way to do things', function () {})",

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -499,40 +499,47 @@ fn test() {
     use crate::tester::Tester;
 
     let mut pass = vec![
-        ("describe('the correct way to properly handle all the things', () => {});", None),
-        ("test('that all is as it should be', () => {});", None),
+        ("describe('the correct way to properly handle all the things', () => {});", None, None),
+        ("test('that all is as it should be', () => {});", None, None),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([
               { "ignoreTypeOfDescribeName": false, "disallowedWords": ["correct"] },
             ])),
+            None,
         ),
-        ("it('correctly sets the value', () => {});", Some(serde_json::json!([]))),
-        ("describe('the correct way to properly handle all the things', () => {});", None),
-        ("test('that all is as it should be', () => {});", None),
+        ("it('correctly sets the value', () => {});", Some(serde_json::json!([])), None),
+        ("describe('the correct way to properly handle all the things', () => {});", None, None),
+        ("test('that all is as it should be', () => {});", None, None),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([{ "mustMatch": {} }])),
+            None,
         ),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([{ "mustMatch": " " }])),
+            None,
         ),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([{ "mustMatch": [" "] }])),
+            None,
         ),
         (
             "it('correctly sets the value #unit', () => {});",
             Some(serde_json::json!([{ "mustMatch": "#(?:unit|integration|e2e)" }])),
+            None,
         ),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([{ "mustMatch": "^[^#]+$|(?:#(?:unit|e2e))" }])),
+            None,
         ),
         (
             "it('correctly sets the value', () => {});",
             Some(serde_json::json!([{ "mustMatch": { "test": "#(?:unit|integration|e2e)" } }])),
+            None,
         ),
         (
             "
@@ -549,62 +556,66 @@ fn test() {
             });
             ",
             Some(serde_json::json!([{ "mustMatch": { "test": "^[^#]+$|(?:#(?:unit|e2e))" } }])),
+            None,
         ),
-        ("it('is a string', () => {});", None),
-        ("it('is' + ' a ' + ' string', () => {});", None),
-        ("it(1 + ' + ' + 1, () => {});", None),
-        ("test('is a string', () => {});", None),
-        ("xtest('is a string', () => {});", None),
-        ("xtest(`${myFunc} is a string`, () => {});", None),
-        ("describe('is a string', () => {});", None),
-        ("describe.skip('is a string', () => {});", None),
-        ("describe.skip(`${myFunc} is a string`, () => {});", None),
-        ("fdescribe('is a string', () => {});", None),
+        ("it('is a string', () => {});", None, None),
+        ("it('is' + ' a ' + ' string', () => {});", None, None),
+        ("it(1 + ' + ' + 1, () => {});", None, None),
+        ("test('is a string', () => {});", None, None),
+        ("xtest('is a string', () => {});", None, None),
+        ("xtest(`${myFunc} is a string`, () => {});", None, None),
+        ("describe('is a string', () => {});", None, None),
+        ("describe.skip('is a string', () => {});", None, None),
+        ("describe.skip(`${myFunc} is a string`, () => {});", None, None),
+        ("fdescribe('is a string', () => {});", None, None),
         (
             "describe(String(/.+/), () => {});",
             Some(serde_json::json!([{ "ignoreTypeOfDescribeName": true }])),
+            None,
         ),
         (
             "describe(myFunction, () => {});",
             Some(serde_json::json!([{ "ignoreTypeOfDescribeName": true }])),
+            None,
         ),
         (
             "xdescribe(skipFunction, () => {});",
             Some(serde_json::json!([{ "ignoreTypeOfDescribeName": true, "disallowedWords": [] }])),
+            None,
         ),
-        ("describe()", None),
-        ("someFn('', function () {})", None),
-        ("describe('foo', function () {})", None),
-        ("describe('foo', function () { it('bar', function () {}) })", None),
-        ("test('foo', function () {})", None),
-        ("test.concurrent('foo', function () {})", None),
-        ("test(`foo`, function () {})", None),
-        ("test.concurrent(`foo`, function () {})", None),
-        ("test(`${foo}`, function () {})", None),
-        ("test.concurrent(`${foo}`, function () {})", None),
-        ("it('foo', function () {})", None),
-        ("it.each([])()", None),
-        ("it.concurrent('foo', function () {})", None),
-        ("xdescribe('foo', function () {})", None),
-        ("xit('foo', function () {})", None),
-        ("xtest('foo', function () {})", None),
-        ("it()", None),
-        ("it.concurrent()", None),
-        ("describe()", None),
-        ("it.each()()", None),
-        ("describe('foo', function () {})", None),
-        ("fdescribe('foo', function () {})", None),
-        ("xdescribe('foo', function () {})", None),
-        ("it('foo', function () {})", None),
-        ("it.concurrent('foo', function () {})", None),
-        ("fit('foo', function () {})", None),
-        ("fit.concurrent('foo', function () {})", None),
-        ("xit('foo', function () {})", None),
-        ("test('foo', function () {})", None),
-        ("test.concurrent('foo', function () {})", None),
-        ("xtest('foo', function () {})", None),
-        ("xtest(`foo`, function () {})", None),
-        ("someFn('foo', function () {})", None),
+        ("describe()", None, None),
+        ("someFn('', function () {})", None, None),
+        ("describe('foo', function () {})", None, None),
+        ("describe('foo', function () { it('bar', function () {}) })", None, None),
+        ("test('foo', function () {})", None, None),
+        ("test.concurrent('foo', function () {})", None, None),
+        ("test(`foo`, function () {})", None, None),
+        ("test.concurrent(`foo`, function () {})", None, None),
+        ("test(`${foo}`, function () {})", None, None),
+        ("test.concurrent(`${foo}`, function () {})", None, None),
+        ("it('foo', function () {})", None, None),
+        ("it.each([])()", None, None),
+        ("it.concurrent('foo', function () {})", None, None),
+        ("xdescribe('foo', function () {})", None, None),
+        ("xit('foo', function () {})", None, None),
+        ("xtest('foo', function () {})", None, None),
+        ("it()", None, None),
+        ("it.concurrent()", None, None),
+        ("describe()", None, None),
+        ("it.each()()", None, None),
+        ("describe('foo', function () {})", None, None),
+        ("fdescribe('foo', function () {})", None, None),
+        ("xdescribe('foo', function () {})", None, None),
+        ("it('foo', function () {})", None, None),
+        ("it.concurrent('foo', function () {})", None, None),
+        ("fit('foo', function () {})", None, None),
+        ("fit.concurrent('foo', function () {})", None, None),
+        ("xit('foo', function () {})", None, None),
+        ("test('foo', function () {})", None, None),
+        ("test.concurrent('foo', function () {})", None, None),
+        ("xtest('foo', function () {})", None, None),
+        ("xtest(`foo`, function () {})", None, None),
+        ("someFn('foo', function () {})", None, None),
         (
             "
                 describe('foo', () => {
@@ -612,33 +623,36 @@ fn test() {
                 })
             ",
             None,
+            None,
         ),
         (
             "it(`GIVEN...
             `, () => {});",
             Some(serde_json::json!([{ "ignoreSpaces": true }])),
+            None,
         ),
-        ("describe('foo', function () {})", None),
-        ("fdescribe('foo', function () {})", None),
-        ("xdescribe('foo', function () {})", None),
-        ("xdescribe(`foo`, function () {})", None),
-        ("test('foo', function () {})", None),
-        ("test('foo', function () {})", None),
-        ("xtest('foo', function () {})", None),
-        ("xtest(`foo`, function () {})", None),
-        ("test('foo test', function () {})", None),
-        ("xtest('foo test', function () {})", None),
-        ("it('foo', function () {})", None),
-        ("fit('foo', function () {})", None),
-        ("xit('foo', function () {})", None),
-        ("xit(`foo`, function () {})", None),
-        ("it('foos it correctly', function () {})", None),
+        ("describe('foo', function () {})", None, None),
+        ("fdescribe('foo', function () {})", None, None),
+        ("xdescribe('foo', function () {})", None, None),
+        ("xdescribe(`foo`, function () {})", None, None),
+        ("test('foo', function () {})", None, None),
+        ("test('foo', function () {})", None, None),
+        ("xtest('foo', function () {})", None, None),
+        ("xtest(`foo`, function () {})", None, None),
+        ("test('foo test', function () {})", None, None),
+        ("xtest('foo test', function () {})", None, None),
+        ("it('foo', function () {})", None, None),
+        ("fit('foo', function () {})", None, None),
+        ("xit('foo', function () {})", None, None),
+        ("xit(`foo`, function () {})", None, None),
+        ("it('foos it correctly', function () {})", None, None),
         (
             "
                 describe('foo', () => {
                 it('bar', () => {})
                 })
             ",
+            None,
             None,
         ),
         (
@@ -648,20 +662,26 @@ fn test() {
                 })
             ",
             None,
+            None,
         ),
-        ("it(abc, function () {})", Some(serde_json::json!([{ "ignoreTypeOfTestName": true }]))),
+        (
+            "it(abc, function () {})",
+            Some(serde_json::json!([{ "ignoreTypeOfTestName": true }])),
+            None,
+        ),
         // Vitest-specific tests with allowArguments option
-        ("it(foo, () => {});", Some(serde_json::json!([{ "allowArguments": true }]))),
-        ("describe(bar, () => {});", Some(serde_json::json!([{ "allowArguments": true }]))),
-        ("test(baz, () => {});", Some(serde_json::json!([{ "allowArguments": true }]))),
+        ("it(foo, () => {});", Some(serde_json::json!([{ "allowArguments": true }])), None),
+        ("describe(bar, () => {});", Some(serde_json::json!([{ "allowArguments": true }])), None),
+        ("test(baz, () => {});", Some(serde_json::json!([{ "allowArguments": true }])), None),
         // Vitest-specific tests with .extend()
         (
             "export const myTest = test.extend({
                 archive: []
             })",
             None,
+            None,
         ),
-        ("const localTest = test.extend({})", None),
+        ("const localTest = test.extend({})", None, None),
         (
             "import { it } from 'vitest'
 
@@ -678,30 +698,35 @@ fn test() {
 
             test('', () => {})",
             None,
+            None,
         ),
     ];
 
-    // TODO handle `vitestImports` config option
-    let fail = vec![
+    let mut fail = vec![
         (
             "describe('the correct way to do things', function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["correct"] }])),
+            None,
         ),
         (
             "it('has ALL the things', () => {})",
             Some(serde_json::json!([{ "disallowedWords": ["all"] }])),
+            None,
         ),
         (
             "xdescribe('every single one of them', function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["every"] }])),
+            None,
         ),
         (
             "describe('Very Descriptive Title Goes Here', function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["descriptive"] }])),
+            None,
         ),
         (
             "test(`that the value is set properly`, function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["properly"] }])),
+            None,
         ),
         // TODO: The regex `(?:#(?!unit|e2e))\w+` in those test cases is not valid in Rust
         // (
@@ -874,46 +899,52 @@ fn test() {
         (
             "test('the correct way to properly handle all things', () => {});",
             Some(serde_json::json!([{ "mustMatch": "#(?:unit|integration|e2e)" }])),
+            None,
         ),
         (
             "describe('the test', () => {});",
             Some(serde_json::json!([
               { "mustMatch": { "describe": "#(?:unit|integration|e2e)" } },
             ])),
+            None,
         ),
         (
             "xdescribe('the test', () => {});",
             Some(serde_json::json!([
               { "mustMatch": { "describe": "#(?:unit|integration|e2e)" } },
             ])),
+            None,
         ),
         (
             "describe.skip('the test', () => {});",
             Some(serde_json::json!([
               { "mustMatch": { "describe": "#(?:unit|integration|e2e)" } },
             ])),
+            None,
         ),
-        ("it.each([])(1, () => {});", None),
-        ("it.skip.each([])(1, () => {});", None),
-        ("it.skip.each``(1, () => {});", None),
-        ("it(123, () => {});", None),
-        ("it.concurrent(123, () => {});", None),
-        ("it(1 + 2 + 3, () => {});", None),
-        ("it.concurrent(1 + 2 + 3, () => {});", None),
+        ("it.each([])(1, () => {});", None, None),
+        ("it.skip.each([])(1, () => {});", None, None),
+        ("it.skip.each``(1, () => {});", None, None),
+        ("it(123, () => {});", None, None),
+        ("it.concurrent(123, () => {});", None, None),
+        ("it(1 + 2 + 3, () => {});", None, None),
+        ("it.concurrent(1 + 2 + 3, () => {});", None, None),
         (
             "test.skip(123, () => {});",
             Some(serde_json::json!([{ "ignoreTypeOfDescribeName": true }])),
+            None,
         ),
-        ("describe(String(/.+/), () => {});", None),
+        ("describe(String(/.+/), () => {});", None, None),
         (
             "describe(myFunction, () => 1);",
             Some(serde_json::json!([{ "ignoreTypeOfDescribeName": false }])),
+            None,
         ),
-        ("describe(myFunction, () => {});", None),
-        ("xdescribe(myFunction, () => {});", None),
-        ("describe(6, function () {})", None),
-        ("describe.skip(123, () => {});", None),
-        ("describe('', function () {})", None),
+        ("describe(myFunction, () => {});", None, None),
+        ("xdescribe(myFunction, () => {});", None, None),
+        ("describe(6, function () {})", None, None),
+        ("describe.skip(123, () => {});", None, None),
+        ("describe('', function () {})", None, None),
         (
             "
                 describe('foo', () => {
@@ -921,30 +952,31 @@ fn test() {
                 });
             ",
             None,
+            None,
         ),
-        ("it('', function () {})", None),
-        ("it.concurrent('', function () {})", None),
-        ("test('', function () {})", None),
-        ("test.concurrent('', function () {})", None),
-        ("test(``, function () {})", None),
-        ("test.concurrent(``, function () {})", None),
-        ("xdescribe('', () => {})", None),
-        ("xit('', () => {})", None),
-        ("xtest('', () => {})", None),
-        ("describe(' foo', function () {})", None),
-        ("describe.each()(' foo', function () {})", None),
-        ("describe.only.each()(' foo', function () {})", None),
-        ("describe(' foo foe fum', function () {})", None),
-        ("describe('foo foe fum ', function () {})", None),
-        ("fdescribe(' foo', function () {})", None),
-        ("fdescribe(' foo', function () {})", None),
-        ("xdescribe(' foo', function () {})", None),
-        ("it(' foo', function () {})", None),
-        ("it.concurrent(' foo', function () {})", None),
-        ("fit(' foo', function () {})", None),
-        ("it.skip(' foo', function () {})", None),
-        ("fit('foo ', function () {})", None),
-        ("it.skip('foo ', function () {})", None),
+        ("it('', function () {})", None, None),
+        ("it.concurrent('', function () {})", None, None),
+        ("test('', function () {})", None, None),
+        ("test.concurrent('', function () {})", None, None),
+        ("test(``, function () {})", None, None),
+        ("test.concurrent(``, function () {})", None, None),
+        ("xdescribe('', () => {})", None, None),
+        ("xit('', () => {})", None, None),
+        ("xtest('', () => {})", None, None),
+        ("describe(' foo', function () {})", None, None),
+        ("describe.each()(' foo', function () {})", None, None),
+        ("describe.only.each()(' foo', function () {})", None, None),
+        ("describe(' foo foe fum', function () {})", None, None),
+        ("describe('foo foe fum ', function () {})", None, None),
+        ("fdescribe(' foo', function () {})", None, None),
+        ("fdescribe(' foo', function () {})", None, None),
+        ("xdescribe(' foo', function () {})", None, None),
+        ("it(' foo', function () {})", None, None),
+        ("it.concurrent(' foo', function () {})", None, None),
+        ("fit(' foo', function () {})", None, None),
+        ("it.skip(' foo', function () {})", None, None),
+        ("fit('foo ', function () {})", None, None),
+        ("it.skip('foo ', function () {})", None, None),
         (
             "
                 import { test as testThat } from '@jest/globals';
@@ -952,24 +984,26 @@ fn test() {
                 testThat('foo works ', () => {});
             ",
             None,
+            None,
         ),
-        ("xit(' foo', function () {})", None),
-        ("test(' foo', function () {})", None),
-        ("test.concurrent(' foo', function () {})", None),
-        ("test(` foo`, function () {})", None),
-        ("test.concurrent(` foo`, function () {})", None),
-        ("test(` foo bar bang`, function () {})", None),
-        ("test.concurrent(` foo bar bang`, function () {})", None),
-        ("test(` foo bar bang  `, function () {})", None),
-        ("test.concurrent(` foo bar bang  `, function () {})", None),
-        ("xtest(' foo', function () {})", None),
-        ("xtest(' foo  ', function () {})", None),
+        ("xit(' foo', function () {})", None, None),
+        ("test(' foo', function () {})", None, None),
+        ("test.concurrent(' foo', function () {})", None, None),
+        ("test(` foo`, function () {})", None, None),
+        ("test.concurrent(` foo`, function () {})", None, None),
+        ("test(` foo bar bang`, function () {})", None, None),
+        ("test.concurrent(` foo bar bang`, function () {})", None, None),
+        ("test(` foo bar bang  `, function () {})", None, None),
+        ("test.concurrent(` foo bar bang  `, function () {})", None, None),
+        ("xtest(' foo', function () {})", None, None),
+        ("xtest(' foo  ', function () {})", None, None),
         (
             "
                 describe(' foo', () => {
                     it('bar', () => {})
                 })
             ",
+            None,
             None,
         ),
         (
@@ -979,26 +1013,28 @@ fn test() {
                 })
             ",
             None,
+            None,
         ),
-        ("describe('describe foo', function () {})", None),
-        ("fdescribe('describe foo', function () {})", None),
-        ("xdescribe('describe foo', function () {})", None),
-        ("describe('describe foo', function () {})", None),
-        ("fdescribe(`describe foo`, function () {})", None),
-        ("test('test foo', function () {})", None),
-        ("xtest('test foo', function () {})", None),
-        ("test(`test foo`, function () {})", None),
-        ("test(`test foo test`, function () {})", None),
-        ("it('it foo', function () {})", None),
-        ("fit('it foo', function () {})", None),
-        ("xit('it foo', function () {})", None),
-        ("it('it foos it correctly', function () {})", None),
+        ("describe('describe foo', function () {})", None, None),
+        ("fdescribe('describe foo', function () {})", None, None),
+        ("xdescribe('describe foo', function () {})", None, None),
+        ("describe('describe foo', function () {})", None, None),
+        ("fdescribe(`describe foo`, function () {})", None, None),
+        ("test('test foo', function () {})", None, None),
+        ("xtest('test foo', function () {})", None, None),
+        ("test(`test foo`, function () {})", None, None),
+        ("test(`test foo test`, function () {})", None, None),
+        ("it('it foo', function () {})", None, None),
+        ("fit('it foo', function () {})", None, None),
+        ("xit('it foo', function () {})", None, None),
+        ("it('it foos it correctly', function () {})", None, None),
         (
             "
                 describe('describe foo', () => {
                     it('bar', () => {})
                 })
             ",
+            None,
             None,
         ),
         (
@@ -1008,6 +1044,7 @@ fn test() {
                 })
             ",
             None,
+            None,
         ),
         (
             "
@@ -1016,10 +1053,11 @@ fn test() {
                 })
             ",
             None,
+            None,
         ),
-        ("it(abc, function () {})", None),
+        ("it(abc, function () {})", None, None),
         // Vitest-specific fail test with allowArguments: false
-        ("test(bar, () => {});", Some(serde_json::json!([{ "allowArguments": false }]))),
+        ("test(bar, () => {});", Some(serde_json::json!([{ "allowArguments": false }])), None),
     ];
 
     let fix = vec![
@@ -1154,9 +1192,39 @@ fn test() {
         ),
     ];
 
-    let pass_vitest = vec![("test.scoped({})", None), ("it.scoped({})", None)];
+    let pass_vitest = vec![("test.scoped({})", None, None), ("it.scoped({})", None, None)];
+    let fail_vitest = vec![
+        (
+            "import { test } from './test-extend'
+      			      test('the correct way to properly handle all things', () => {})
+      			      ",
+            Some(serde_json::json!([{ "disallowedWords": ["correct"] }])),
+            Some(
+                serde_json::json!({ "settings": { "vitest": { "vitestImports": ["./test-extend"], },} }),
+            ),
+        ),
+        (
+            "import { test } from '@/tests/fixtures'
+      			      test('the correct way to properly handle all things', () => {})
+      			      ",
+            Some(serde_json::json!([{ "disallowedWords": ["correct"] }])),
+            Some(
+                serde_json::json!({ "settings": { "vitest": { "vitestImports": ["@/tests/fixtures"], },} }),
+            ),
+        ),
+        (
+            "import { test } from '@/tests/fixtures'
+      			      test('the correct way to properly handle all things', () => {})
+      			      ",
+            Some(serde_json::json!([{ "disallowedWords": ["correct"] }])),
+            Some(
+                serde_json::json!({ "settings": { "vitest": { "vitestImports": [r"\/fixtures$"] },} }),
+            ),
+        ),
+    ];
 
     pass.extend(pass_vitest);
+    fail.extend(fail_vitest);
 
     Tester::new(ValidTitle::NAME, ValidTitle::PLUGIN, pass, fail)
         .with_jest_plugin(true)

--- a/crates/oxc_linter/src/snapshots/jest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_title.snap
@@ -574,3 +574,30 @@ source: crates/oxc_linter/src/tester.rs
    ·      ───
    ╰────
   help: Replace your title with a string
+
+  ⚠ eslint-plugin-jest(valid-title): correct is not allowed in test title
+   ╭─[valid_title.tsx:2:21]
+ 1 │ import { test } from './test-extend'
+ 2 │                       test('the correct way to properly handle all things', () => {})
+   ·                            ───────────────────────────────────────────────
+ 3 │                       
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ eslint-plugin-jest(valid-title): correct is not allowed in test title
+   ╭─[valid_title.tsx:2:21]
+ 1 │ import { test } from '@/tests/fixtures'
+ 2 │                       test('the correct way to properly handle all things', () => {})
+   ·                            ───────────────────────────────────────────────
+ 3 │                       
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ eslint-plugin-jest(valid-title): correct is not allowed in test title
+   ╭─[valid_title.tsx:2:21]
+ 1 │ import { test } from '@/tests/fixtures'
+ 2 │                       test('the correct way to properly handle all things', () => {})
+   ·                            ───────────────────────────────────────────────
+ 3 │                       
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title

--- a/crates/oxc_linter/src/snapshots/jest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_title.snap
@@ -2,13 +2,6 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-jest(valid-title): correct is not allowed in test title
-   ╭─[valid_title.tsx:1:6]
- 1 │ test('the correct way to properly handle all things', () => {});
-   ·      ───────────────────────────────────────────────
-   ╰────
-  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
-
-  ⚠ eslint-plugin-jest(valid-title): correct is not allowed in test title
    ╭─[valid_title.tsx:1:10]
  1 │ describe('the correct way to do things', function () {})
    ·          ──────────────────────────────

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -137,7 +137,8 @@ expression: json
           "tagNamePreference": {}
         },
         "vitest": {
-          "typecheck": false
+          "typecheck": false,
+          "vitestImports": []
         }
       },
       "allOf": [
@@ -628,7 +629,8 @@ expression: json
         },
         "vitest": {
           "default": {
-            "typecheck": false
+            "typecheck": false,
+            "vitestImports": []
           },
           "allOf": [
             {
@@ -719,6 +721,15 @@ expression: json
           "default": false,
           "type": "boolean",
           "markdownDescription": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios."
+        },
+        "vitestImports": {
+          "description": "When user provided an array of custom fixtures, those functions\nwill be linted as well.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "When user provided an array of custom fixtures, those functions\nwill be linted as well."
         }
       },
       "markdownDescription": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference."

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 /// List of Jest rules that have Vitest equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/2c336c67d75adb09a402ae66fb3099f1dedbe516/scripts/constants.ts
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 41] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 42] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -75,6 +75,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 41] = [
     "require-top-level-describe",
     "valid-describe-callback",
     "valid-expect",
+    "valid-title",
 ];
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -133,7 +133,8 @@
           "tagNamePreference": {}
         },
         "vitest": {
-          "typecheck": false
+          "typecheck": false,
+          "vitestImports": []
         }
       },
       "allOf": [
@@ -624,7 +625,8 @@
         },
         "vitest": {
           "default": {
-            "typecheck": false
+            "typecheck": false,
+            "vitestImports": []
           },
           "allOf": [
             {
@@ -715,6 +717,15 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios."
+        },
+        "vitestImports": {
+          "description": "When user provided an array of custom fixtures, those functions\nwill be linted as well.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "When user provided an array of custom fixtures, those functions\nwill be linted as well."
         }
       },
       "markdownDescription": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference."

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -784,3 +784,13 @@ default: `false`
 Whether to enable typecheck mode for Vitest rules.
 When enabled, some rules will skip certain checks for describe blocks
 to accommodate TypeScript type checking scenarios.
+
+
+#### settings.vitest.vitestImports
+
+type: `string[]`
+
+default: `[]`
+
+When user provided an array of custom fixtures, those functions
+will be linted as well.


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Set `valid-title` as a compatible vitest rule

https://github.com/oxc-project/oxlint-migrate/pull/301