### PR TITLE
fix(formatter): method signature missed a semicolon when it is on the same line with a property

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts
@@ -2,3 +2,7 @@ export interface MethodSignatures {
   (arg: string): void;
   (arg: number): null;
 }
+
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true }

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/method-signatures.ts.snap
@@ -7,6 +7,10 @@ export interface MethodSignatures {
   (arg: number): null;
 }
 
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true }
+
 ==================== Output ====================
 -------------------------------
 { printWidth: 80, semi: false }
@@ -16,6 +20,10 @@ export interface MethodSignatures {
   (arg: number): null
 }
 
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true }
+
 --------------------------------
 { printWidth: 100, semi: false }
 --------------------------------
@@ -23,6 +31,10 @@ export interface MethodSignatures {
   (arg: string): void
   (arg: number): null
 }
+
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true }
 
 ------------------------------
 { printWidth: 80, semi: true }
@@ -32,6 +44,10 @@ export interface MethodSignatures {
   (arg: number): null;
 }
 
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true };
+
 -------------------------------
 { printWidth: 100, semi: true }
 -------------------------------
@@ -39,5 +55,9 @@ export interface MethodSignatures {
   (arg: string): void;
   (arg: number): null;
 }
+
+export type MethodSignaturesAndPropertyOnSameLine =
+  | { json(): never; ok: false }
+  | { json(): Promise<any>; ok: true };
 
 ===================== End =====================


### PR DESCRIPTION
close: #17151