### PR TITLE
fix(formatter): wrongly added an indentation for an union type when there is a leading line comment

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts
@@ -1,0 +1,30 @@
+// TSTypeParameterInstantiation
+export class ClassTest extends Modal<
+  // comment
+  string | number | undefined
+> {
+}
+
+Math.random<
+  // comment
+  string | number | undefined
+>;
+
+Math.random<
+  // comment
+  string | number | undefined
+>();
+
+
+// TypeAssertion
+<
+  // comment
+  string | number | undefined
+>0;
+
+console.log(
+  <
+    // comment
+    string | number | undefined
+  >0
+);

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts.snap
@@ -1,0 +1,97 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// TSTypeParameterInstantiation
+export class ClassTest extends Modal<
+  // comment
+  string | number | undefined
+> {
+}
+
+Math.random<
+  // comment
+  string | number | undefined
+>;
+
+Math.random<
+  // comment
+  string | number | undefined
+>();
+
+
+// TypeAssertion
+<
+  // comment
+  string | number | undefined
+>0;
+
+console.log(
+  <
+    // comment
+    string | number | undefined
+  >0
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// TSTypeParameterInstantiation
+export class ClassTest extends Modal<
+  // comment
+  string | number | undefined
+> {}
+
+Math.random<
+  // comment
+  string | number | undefined
+>;
+
+Math.random<
+  // comment
+  string | number | undefined
+>();
+
+// TypeAssertion
+<
+  // comment
+  string | number | undefined
+>0;
+
+console.log(<
+    // comment
+    string | number | undefined
+  >0);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// TSTypeParameterInstantiation
+export class ClassTest extends Modal<
+  // comment
+  string | number | undefined
+> {}
+
+Math.random<
+  // comment
+  string | number | undefined
+>;
+
+Math.random<
+  // comment
+  string | number | undefined
+>();
+
+// TypeAssertion
+<
+  // comment
+  string | number | undefined
+>0;
+
+console.log(<
+    // comment
+    string | number | undefined
+  >0);
+
+===================== End =====================


### PR DESCRIPTION
close: #16902

The case below's output is incorrect, but it's not related to this issue, and was fixed in #17254
Input
```ts
console.log(
  <
    // comment
    string | number | undefined
  >0
);
```
Expect output:
```ts
console.log(
  <
    // comment
    string | number | undefined
  >0
);
```

Actual output
```ts
console.log(<
    // comment
    string | number | undefined
  >0);
```

