### PR TITLE
fix(formatter): should expand call arguments group when the argument will break

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-16902.ts.snap
@@ -59,10 +59,12 @@ Math.random<
   string | number | undefined
 >0;
 
-console.log(<
+console.log(
+  <
     // comment
     string | number | undefined
-  >0);
+  >0,
+);
 
 -------------------
 { printWidth: 100 }
@@ -89,9 +91,11 @@ Math.random<
   string | number | undefined
 >0;
 
-console.log(<
+console.log(
+  <
     // comment
     string | number | undefined
-  >0);
+  >0,
+);
 
 ===================== End =====================


### PR DESCRIPTION
Fix an incorrect output that was found in https://github.com/oxc-project/oxc/pull/17252#issue-3752523578

Biome has the same incorrect output and ended up fixing it by aligning the [Prettier implementation](https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/call-arguments.js#L193-L195).