### PR TITLE
fix(formatter): shouldn't treat `TaggedTemplateExpression` as a simple argument in the member chain

### DIFF
--- a/crates/oxc_formatter/src/utils/member_chain/simple_argument.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/simple_argument.rs
@@ -74,9 +74,6 @@ impl<'a, 'b> SimpleArgument<'a, 'b> {
                 Expression::TemplateLiteral(template) => {
                     is_simple_template_literal(template, depth + 1)
                 }
-                Expression::TaggedTemplateExpression(template) => {
-                    is_simple_template_literal(&template.quasi, depth + 1)
-                }
                 Expression::ObjectExpression(object) => Self::is_simple_object(object, depth),
                 Expression::ArrayExpression(array) => Self::is_simple_array(array, depth),
                 Expression::UnaryExpression(unary_expression) => {

--- a/crates/oxc_formatter/tests/fixtures/js/member-chains/simple-arguments.js
+++ b/crates/oxc_formatter/tests/fixtures/js/member-chains/simple-arguments.js
@@ -1,0 +1,5 @@
+// `TaggedTemplateExpression` shouldn't be treated as a simple argument
+// https://github.com/oxc-project/oxc/issues/16956
+utc("time_updated")
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)`)

--- a/crates/oxc_formatter/tests/fixtures/js/member-chains/simple-arguments.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/member-chains/simple-arguments.js.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `TaggedTemplateExpression` shouldn't be treated as a simple argument
+// https://github.com/oxc-project/oxc/issues/16956
+utc("time_updated")
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)`)
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `TaggedTemplateExpression` shouldn't be treated as a simple argument
+// https://github.com/oxc-project/oxc/issues/16956
+utc("time_updated")
+  .notNull()
+  .default(sql`CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)`);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `TaggedTemplateExpression` shouldn't be treated as a simple argument
+// https://github.com/oxc-project/oxc/issues/16956
+utc("time_updated")
+  .notNull()
+  .default(sql`CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)`);
+
+===================== End =====================


### PR DESCRIPTION
Part of #16956

Follow https://github.com/prettier/prettier/blob/a9de2a128cc8eea84ddd90efdc210378a894ab6b/src/language-js/utils/index.js#L802-L886