### PR TITLE
test(formatter): run conformance tests with different options

### DIFF
--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -2,4 +2,18 @@ commit: cbdc42fe
 
 formatter_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2235/2235 (100.00%)
+Positive Passed: 2228/2235 (99.69%)
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/async-arrow-function/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-method/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-private-method/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/function/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/object-method/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/sequence-expression/input.js
+
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-false-positive/input.ts
+Unexpected token

--- a/tasks/coverage/snapshots/formatter_test262.snap
+++ b/tasks/coverage/snapshots/formatter_test262.snap
@@ -2,10 +2,22 @@ commit: 9079aeef
 
 formatter_test262 Summary:
 AST Parsed     : 46472/46472 (100.00%)
-Positive Passed: 46469/46472 (99.99%)
+Positive Passed: 46463/46472 (99.98%)
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR-LF.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-LF.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/arrow-function/scope-paramsbody-var-close.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/call/scope-lex-close.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/call/scope-var-close.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/function/scope-paramsbody-var-close.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/generators/scope-paramsbody-var-close.js
+
+Mismatch: tasks/coverage/test262/test/language/statements/let/syntax/escaped-let.js
 

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,18 +2,122 @@ commit: 2dfdbbab
 
 formatter_typescript Summary:
 AST Parsed     : 9840/9840 (100.00%)
-Positive Passed: 9833/9840 (99.93%)
+Positive Passed: 9781/9840 (99.40%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterSpread.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsFunction.ts
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
+An implementation cannot be declared in ambient contexts.
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
 Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
+Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryErrorNotIdentifier.tsx
+Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryNull.tsx
+Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryButNoJsxFragmentFactory.tsx
+Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
+Expected `{` but found `Identifier`
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedExpressionInternalComments.ts
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
+An implementation cannot be declared in ambient contexts.
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
+An implementation cannot be declared in ambient contexts.
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringReassignsRightHandSide.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTempalteString4.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTempalteString4ES6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString1.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString1ES6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString2ES6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString3.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString3ES6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.14.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.7.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.8.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.11.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.5.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.6.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.7.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOpEmitParens.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandBooleanType.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandNumberType.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandStringType.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorsMultipleOperators.ts
+
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/letIdentifierInElementAccess01.ts
 Unexpected token
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
+
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkJsdocSatisfiesTag3.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
+
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
+Unexpected token
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
+Unexpected token
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts
 
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
+'static' modifier cannot appear on a type member.'static' modifier cannot appear on a type member.


### PR DESCRIPTION
Context: https://github.com/oxc-project/oxc/issues/17151#issuecomment-3680097759

We have to run conformance tests with different options from the defaults, especially those options (semicolon, quote props) that can cause a syntax error if there is a bug