### PR TITLE
feat(parser): produce syntax error for `({ foo(bar) })`

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -233,7 +233,7 @@ impl<'a> ParserImpl<'a> {
         };
         self.ctx =
             self.ctx.and_in(ctx.has_in()).and_await(ctx.has_await()).and_yield(ctx.has_yield());
-        if !self.is_ts && body.is_none() {
+        if (!self.is_ts || matches!(func_kind, FunctionKind::ObjectMethod)) && body.is_none() {
             return self.fatal_error(diagnostics::expect_function_body(self.end_span(span)));
         }
         let function_type = match func_kind {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: b78f0899
 parser_typescript Summary:
 AST Parsed     : 9839/9840 (99.99%)
 Positive Passed: 9830/9840 (99.90%)
-Negative Passed: 1492/2549 (58.53%)
+Negative Passed: 1493/2549 (58.57%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -715,8 +715,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nonexistentP
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/nullKeyword.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/omitTypeTestErrors01.ts
 
@@ -2653,17 +2651,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  4 │ }
    ╰────
 
-  × Getters and setters must have an implementation.
-   ╭─[typescript/tests/cases/compiler/accessorWithoutBody1.ts:1:15]
+  × Expected function body
+   ╭─[typescript/tests/cases/compiler/accessorWithoutBody1.ts:1:18]
  1 │ var v = { get foo() }
-   ·               ───
+   ·                  ──
    ╰────
+  help: Add a function body (`{}`).
 
-  × Getters and setters must have an implementation.
-   ╭─[typescript/tests/cases/compiler/accessorWithoutBody2.ts:1:15]
+  × Expected function body
+   ╭─[typescript/tests/cases/compiler/accessorWithoutBody2.ts:1:18]
  1 │ var v = { set foo(a) }
-   ·               ───
+   ·                  ───
    ╰────
+  help: Add a function body (`{}`).
 
   × Unexpected token
     ╭─[typescript/tests/cases/compiler/aliasErrors.ts:13:12]
@@ -8817,6 +8817,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·         │    ╰── `,` or `}` expected
    ·         ╰── Opened here
    ╰────
+
+  × Expected function body
+   ╭─[typescript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts:1:14]
+ 1 │ var v = { foo(); }
+   ·              ──
+   ╰────
+  help: Add a function body (`{}`).
 
   × Expected `,` or `}` but found `;`
    ╭─[typescript/tests/cases/compiler/objectLiteralWithSemicolons1.ts:1:12]
@@ -26061,14 +26068,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  38 │ }
     ╰────
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers2.ts:20:15]
+  × Expected function body
+    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers2.ts:20:8]
  19 │ var b = {
  20 │     foo(x = 1), // error
-    ·               ▲
+    ·        ───────
  21 │     foo(x = 1) { }, // error
     ╰────
-  help: Try inserting a semicolon here
+  help: Add a function body (`{}`).
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:16:10]


### PR DESCRIPTION
closes #17265