### PR TITLE
refactor(formatter): improve the code that was made for removing the binding pattern

### DIFF
--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -172,20 +172,27 @@ impl<'a> AssignmentLike<'a, '_> {
         match self {
             AssignmentLike::VariableDeclarator(declarator) => {
                 if let Some(init) = &declarator.init {
-                    write!(f, [FormatNodeWithoutTrailingComments(&declarator.id())]);
-                    if let Some(type_annotation) = declarator.type_annotation() {
-                        write!(f, type_annotation);
-                    }
+                    write!(
+                        f,
+                        [
+                            FormatNodeWithoutTrailingComments(&declarator.id()),
+                            declarator.type_annotation()
+                        ]
+                    );
                     format_left_trailing_comments(
                         declarator.id.span().end,
                         should_print_as_leading(init),
                         f,
                     );
                 } else {
-                    write!(f, declarator.id());
-                    if let Some(type_annotation) = declarator.type_annotation() {
-                        write!(f, type_annotation);
-                    }
+                    write!(
+                        f,
+                        [
+                            declarator.id(),
+                            declarator.definite.then_some("!"),
+                            declarator.type_annotation()
+                        ]
+                    );
                 }
                 false
             }

--- a/crates/oxc_formatter/tests/fixtures/ts/parameters/hug.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parameters/hug.ts
@@ -1,4 +1,11 @@
  const assertFilteringFor = (expected: {
    [T in TestFilterTerm]?: boolean;
  }) => {};
- 
+
+// Should not hug
+export async function update(
+  options: {
+    eventKey?: ConfigEvent.ConfigEventKey;
+  } = {},
+): Promise<void> {
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/parameters/hug.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parameters/hug.ts.snap
@@ -5,7 +5,15 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
  const assertFilteringFor = (expected: {
    [T in TestFilterTerm]?: boolean;
  }) => {};
- 
+
+// Should not hug
+export async function update(
+  options: {
+    eventKey?: ConfigEvent.ConfigEventKey;
+  } = {},
+): Promise<void> {
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -14,11 +22,25 @@ const assertFilteringFor = (expected: {
   [T in TestFilterTerm]?: boolean;
 }) => {};
 
+// Should not hug
+export async function update(
+  options: {
+    eventKey?: ConfigEvent.ConfigEventKey;
+  } = {},
+): Promise<void> {}
+
 -------------------
 { printWidth: 100 }
 -------------------
 const assertFilteringFor = (expected: {
   [T in TestFilterTerm]?: boolean;
 }) => {};
+
+// Should not hug
+export async function update(
+  options: {
+    eventKey?: ConfigEvent.ConfigEventKey;
+  } = {},
+): Promise<void> {}
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/definite.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/definite.ts
@@ -1,0 +1,2 @@
+let A!: never;
+var B!: string;

--- a/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/definite.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/variable-declarations/definite.ts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+let A!: never;
+var B!: string;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+let A!: never;
+var B!: string;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+let A!: never;
+var B!: string;
+
+===================== End =====================


### PR DESCRIPTION
Follow up on https://github.com/oxc-project/oxc/pull/15925. Improved slightly to make it simpler.