### PR TITLE
fix(linter/no-unused-vars): handle non-null assertion in update expressions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -996,6 +996,22 @@ fn test_arguments() {
         ("items.reduce((acc, item) => (acc[item.action]--, acc), {})", None),
         ("items.reduce((acc, item) => (++acc[item.action], acc), {})", None),
         ("items.reduce((acc, item) => (--acc[item.action], acc), {})", None),
+        (
+            "export function fn(array: number[], index: number) { const array2 = array.slice(); array2[index]!++; return array2; }",
+            None,
+        ),
+        (
+            "export function fn(array: number[], index: number) { const array2 = array.slice(); ++array2[index]!; return array2; }",
+            None,
+        ),
+        (
+            "export function fn(array: number[], index: number) { const array2 = array.slice(); (array2[index]!)++; return array2; }",
+            None,
+        ),
+        (
+            "export function fn(array: number[], index: number) { const array2 = array.slice(); (array2[index] as number)++; return array2; }",
+            None,
+        ),
         // AssignmentExpression cases
         ("items.reduce((acc, item) => (acc[item.action] = 1, acc), {})", None),
         ("items.reduce((acc, item) => (acc.x[item.action] = 1, acc), {})", None),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -434,7 +434,11 @@ impl<'a> Symbol<'_, 'a> {
                     // `for (let x = 0; x++; ) {}` is valid usage, as the loop body running is a side-effect
                     if !self.is_in_for_loop_test_or_update(node.id(), ref_span) {
                         // `a.b++` or `a[b] + 1` are not reassignment of `a`
-                        if !argument.is_member_expression() {
+                        let is_member_expr = argument.is_member_expression()
+                            || argument
+                                .get_expression()
+                                .is_some_and(|e| e.get_inner_expression().is_member_expression());
+                        if !is_member_expr {
                             is_used_by_others = false;
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/17280