### PR TITLE
ci(vscode): fix release script

### DIFF
--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Package Extension
         working-directory: editors/vscode
         run: |
-          ls ./target/release
           pnpm exec vsce package -o "../../oxc_language_server-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
 
       - name: Upload VSCode extension artifact


### PR DESCRIPTION
there is no language server to build anymore. Bug was introduced in https://github.com/oxc-project/oxc/pull/17133