### PR TITLE
feat(linter/eslint-plugin-vitest): Implemented consistent-test-filename

### DIFF
--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 103 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3957,6 +3957,11 @@ impl RuleRunner for crate::rules::unicorn::throw_new_error::ThrowNewError {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vitest::consistent_test_filename::ConsistentTestFilename {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::vitest::no_conditional_tests::NoConditionalTests {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -661,6 +661,7 @@ pub(crate) mod promise {
 }
 
 pub(crate) mod vitest {
+    pub mod consistent_test_filename;
     pub mod no_conditional_tests;
     pub mod no_import_node_test;
     pub mod prefer_called_times;
@@ -1314,6 +1315,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::switch_case_braces,
     unicorn::text_encoding_identifier_case,
     unicorn::throw_new_error,
+    vitest::consistent_test_filename,
     vitest::no_conditional_tests,
     vitest::no_import_node_test,
     vitest::prefer_called_times,

--- a/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
@@ -74,7 +74,6 @@ impl std::ops::Deref for ConsistentTestFilename {
     }
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -98,7 +97,7 @@ declare_oxc_lint!(
     ///
     ConsistentTestFilename,
     vitest,
-    correctness,
+    style,
     config = ConsistentTestFilenameConfig,
 );
 
@@ -135,13 +134,9 @@ impl Rule for ConsistentTestFilename {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let Some(file_path) = ctx.file_path().to_str() else {
-            return;
-        };
+        let Some(file_path) = ctx.file_path().to_str() else { return };
 
-        let Some(file_name) = ctx.file_path().file_name().and_then(OsStr::to_str) else {
-            return;
-        };
+        let Some(file_name) = ctx.file_path().file_name().and_then(OsStr::to_str) else { return };
 
         if !self.all_test_pattern.is_match(file_path) {
             return;

--- a/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
@@ -1,0 +1,185 @@
+use std::ffi::OsStr;
+
+use lazy_regex::Regex;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn consistent_test_filename_diagnostic(file_path: &str, pattern: &str) -> OxcDiagnostic {
+    let message = format!("The {file_path} is a test file but his name is not allowed");
+    let help = format!("Rename the file that match the pattern {pattern}");
+
+    OxcDiagnostic::warn(message).with_help(help)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentTestFilename(Box<ConsistentTestFilenameConfig>);
+
+#[derive(Debug, Clone, JsonSchema)]
+pub struct CompiledAllTestPattern(lazy_regex::Regex);
+
+impl Default for CompiledAllTestPattern {
+    fn default() -> Self {
+        let default_regex = Regex::new(r".*\.(test|spec)\.[tj]sx?$");
+
+        Self(default_regex.unwrap())
+    }
+}
+
+impl std::ops::Deref for CompiledAllTestPattern {
+    type Target = lazy_regex::Regex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, JsonSchema)]
+pub struct CompiledTestPatternName(lazy_regex::Regex);
+
+impl Default for CompiledTestPatternName {
+    fn default() -> Self {
+        let default_regex = Regex::new(r".*\.test\.[tj]sx?$");
+
+        Self(default_regex.unwrap())
+    }
+}
+
+impl std::ops::Deref for CompiledTestPatternName {
+    type Target = lazy_regex::Regex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ConsistentTestFilenameConfig {
+    /// Regex pattern to ensure we are linting only test filenames.
+    /// Decides whether a file is a testing file.
+    all_test_pattern: CompiledAllTestPattern,
+    /// Required regex to check if a test filename have a valid formart.
+    /// Pattern doesn't have a default value, you must provide one.
+    pattern: CompiledTestPatternName,
+}
+
+impl std::ops::Deref for ConsistentTestFilename {
+    type Target = ConsistentTestFilenameConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule triggers an error when a file is considered a test file, but their name
+    /// don't match an expected filename format.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Files that are tests but has an unexpected filename make hard to distintc between
+    /// source code files and test files.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** file path for this rule configure as {"allTestPattern": "__tests__",  "pattern": r".*\.spec\.ts$"}:
+    ///
+    /// __tests__/2.ts
+    ///
+    /// Examples of **correct** file path for this rule configure as {"allTestPattern": "__tests__",  "pattern": r".*\.spec\.ts$"}:
+    ///
+    /// __tests__/2.spec.ts
+    ///
+    ConsistentTestFilename,
+    vitest,
+    correctness,
+    config = ConsistentTestFilenameConfig,
+);
+
+fn compile_matcher_pattern(matcher_pattern: &serde_json::Value) -> Option<lazy_regex::Regex> {
+    matcher_pattern.as_str().and_then(|regex_str| {
+        if let Some(stripped) = regex_str.strip_prefix('/')
+            && let Some(end) = stripped.rfind('/')
+        {
+            let (pat, _flags) = stripped.split_at(end);
+            // For now, ignore flags and just use the pattern
+            return Regex::new(pat).ok();
+        }
+
+        let reg_str = format!("(?u){regex_str}");
+        Regex::new(&reg_str).ok()
+    })
+}
+
+impl Rule for ConsistentTestFilename {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config = value.get(0);
+
+        let all_test_pattern = config
+            .and_then(|v| v.get("allTestPattern"))
+            .and_then(|value| compile_matcher_pattern(value).map(CompiledAllTestPattern))
+            .unwrap_or_default();
+
+        let pattern = config
+            .and_then(|v| v.get("pattern"))
+            .and_then(|value| compile_matcher_pattern(value).map(CompiledTestPatternName))
+            .unwrap_or_default();
+
+        Self(Box::new(ConsistentTestFilenameConfig { all_test_pattern, pattern }))
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        let Some(file_path) = ctx.file_path().to_str() else {
+            return;
+        };
+
+        let Some(file_name) = ctx.file_path().file_name().and_then(OsStr::to_str) else {
+            return;
+        };
+
+        if !self.all_test_pattern.is_match(file_path) {
+            return;
+        }
+
+        if !self.pattern.is_match(file_path) {
+            ctx.diagnostic(consistent_test_filename_diagnostic(file_name, self.pattern.as_str()));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        ("export {}", None, None, Some(PathBuf::from("1.test.ts"))),
+        (
+            "export {}",
+            Some(serde_json::json!([{ "pattern": r".*\.spec\.ts$" }])),
+            None,
+            Some(PathBuf::from("1.spec.ts")),
+        ),
+    ];
+
+    let fail = vec![
+        ("export {}", None, None, Some(PathBuf::from("1.spec.ts"))),
+        (
+            "export {}",
+            Some(
+                serde_json::json!([  {  "allTestPattern": "__tests__",  "pattern": r".*\.spec\.ts$",  },  ]),
+            ),
+            None,
+            Some(PathBuf::from("__tests__/2.ts")),
+        ),
+    ];
+
+    Tester::new(ConsistentTestFilename::NAME, ConsistentTestFilename::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_test_filename.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_test_filename.snap
@@ -1,0 +1,8 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(consistent-test-filename): The 1.spec.ts is a test file but his name is not allowed
+  help: Rename the file that match the pattern .*\.test\.[tj]sx?$
+
+  ⚠ eslint-plugin-vitest(consistent-test-filename): The 2.ts is a test file but his name is not allowed
+  help: Rename the file that match the pattern (?u).*\.spec\.ts$


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Implement `consistent-test-filename` vitest rule