### PR TITLE
feat(minifier): add `invalid_import_side_effects` option

### DIFF
--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -188,6 +188,14 @@ pub struct TreeShakeOptions {
     ///
     /// Default `true`
     pub unknown_global_side_effects: bool,
+
+    /// Whether invalid import statements have side effects.
+    ///
+    /// Accessing a non-existing import name will throw an error.
+    /// Also import statements that cannot be resolved will throw an error.
+    ///
+    /// Default `true`
+    pub invalid_import_side_effects: bool,
 }
 
 impl Default for TreeShakeOptions {
@@ -197,6 +205,7 @@ impl Default for TreeShakeOptions {
             manual_pure_functions: vec![],
             property_read_side_effects: PropertyReadSideEffects::default(),
             unknown_global_side_effects: true,
+            invalid_import_side_effects: true,
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -157,7 +157,9 @@ impl<'a> PeepholeOptimizations {
     /// import 'b'
     /// ```
     pub fn remove_unused_import_specifiers(stmt: &mut Statement<'a>, ctx: &mut Ctx<'a, '_>) {
-        if ctx.state.options.unused == CompressOptionsUnused::Keep {
+        if ctx.options().treeshake.invalid_import_side_effects
+            || ctx.state.options.unused == CompressOptionsUnused::Keep
+        {
             return;
         }
 
@@ -214,7 +216,7 @@ mod test {
     use oxc_span::SourceType;
 
     use crate::{
-        CompressOptions,
+        CompressOptions, TreeShakeOptions,
         tester::{
             test_options, test_options_source_type, test_same_options,
             test_same_options_source_type,
@@ -345,7 +347,13 @@ mod test {
 
     #[test]
     fn remove_unused_import_specifiers() {
-        let options = CompressOptions::smallest();
+        let options = CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: false,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        };
 
         test_options("import a from 'a'", "import 'a';", &options);
         test_options("import a from 'a'; foo()", "import 'a'; foo();", &options);
@@ -414,7 +422,13 @@ mod test {
 
     #[test]
     fn remove_unused_import_source_statement() {
-        let options = CompressOptions::smallest();
+        let options = CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: false,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        };
 
         test_options("import source a from 'a'", "", &options);
         test_options("import source a from 'a'; if (false) { console.log(a) }", "", &options);
@@ -423,7 +437,13 @@ mod test {
 
     #[test]
     fn remove_unused_import_defer_statements() {
-        let options = CompressOptions::smallest();
+        let options = CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: false,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        };
 
         test_options("import defer * as a from 'a'", "", &options);
         test_options(

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -182,6 +182,15 @@ export interface TreeShakeOptions {
    * @default true
    */
   unknownGlobalSideEffects?: boolean
+  /**
+   * Whether invalid import statements have side effects.
+   *
+   * Accessing a non-existing import name will throw an error.
+   * Also import statements that cannot be resolved will throw an error.
+   *
+   * @default true
+   */
+  invalidImportSideEffects?: boolean
 }
 export interface Comment {
   type: 'Line' | 'Block'

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -32,6 +32,14 @@ pub struct TreeShakeOptions {
     ///
     /// @default true
     pub unknown_global_side_effects: Option<bool>,
+
+    /// Whether invalid import statements have side effects.
+    ///
+    /// Accessing a non-existing import name will throw an error.
+    /// Also import statements that cannot be resolved will throw an error.
+    ///
+    /// @default true
+    pub invalid_import_side_effects: Option<bool>,
 }
 
 impl TryFrom<&TreeShakeOptions> for oxc_minifier::TreeShakeOptions {
@@ -59,6 +67,9 @@ impl TryFrom<&TreeShakeOptions> for oxc_minifier::TreeShakeOptions {
             unknown_global_side_effects: o
                 .unknown_global_side_effects
                 .unwrap_or(default.unknown_global_side_effects),
+            invalid_import_side_effects: o
+                .invalid_import_side_effects
+                .unwrap_or(default.invalid_import_side_effects),
         })
     }
 }

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,7 +4,7 @@ checker.ts                 | 2.92 MB        ||          83503 |          14179 |
 
 cal.com.tsx                | 1.06 MB        ||          40448 |           3032 ||          37138 |           4586
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             84 |              6 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             85 |              9 ||             30 |              6
 
 pdf.mjs                    | 567.30 kB      ||          20495 |           2899 ||          47453 |           7730
 


### PR DESCRIPTION
Added a new option (`invalid_import_side_effects`) to disable #16797 as it requires a new assumptions.

refs https://github.com/rolldown/rolldown/pull/7512#issuecomment-3682642929
