### PR TITLE
fix(rust): rename binaries to avoid PDB filename collision on Windows

### DIFF
--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -20,8 +20,9 @@ crate-type = ["lib", "cdylib"]
 path = "src/lib.rs"
 doctest = false
 
+# Differs from lib, see https://github.com/rust-lang/cargo/issues/6313
 [[bin]]
-name = "oxfmt"
+name = "oxfmt_cli"
 path = "src/main.rs"
 test = false
 doctest = false

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -20,8 +20,9 @@ crate-type = ["cdylib", "lib"]
 path = "src/lib.rs"
 doctest = false
 
+# Differs from lib, see https://github.com/rust-lang/cargo/issues/6313
 [[bin]]
-name = "oxlint"
+name = "oxlint_cli"
 path = "src/main.rs"
 test = false
 doctest = false


### PR DESCRIPTION
## Summary
- Rename `oxlint` binary to `oxlint_cli` to avoid collision with `oxlint` library
- Rename `oxfmt` binary to `oxfmt_cli` to avoid collision with `oxfmt` library

This fixes the Cargo warning about output filename collision on Windows where both the lib and bin targets produce `.pdb` files with the same name.

See https://github.com/rust-lang/cargo/issues/6313

🤖 Generated with [Claude Code](https://claude.com/claude-code)