### PR TITLE
refactor(linter): arrow-body-style: add help messages to diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
@@ -16,12 +16,28 @@ use crate::{
     rule::Rule,
 };
 
-fn arrow_body_style_diagnostic(span: Span, msg: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(msg.to_string()).with_label(span)
+fn expected_block_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expected block statement surrounding arrow body.")
+        .with_help("Surround the arrow body with braces and use a return statement.")
+        .with_label(span)
 }
 
-const EXPECTED_BLOCK_MSG: &str = "Expected block statement surrounding arrow body.";
-const UNEXPECTED_BLOCK_SINGLE_MSG: &str = "Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.";
+fn unexpected_block_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected block statement surrounding arrow body.")
+        .with_help("Move the returned value to be immediately after the `=>`.")
+        .with_label(span)
+}
+
+fn unexpected_empty_block_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected empty block statement surrounding arrow body.")
+        .with_help("Put a value of `undefined` immediately after the `=>`.")
+        .with_label(span)
+}
+
+/// Diagnostic that is emitted when we don't have a specific help message to provide
+fn unexpected_block_with_unknown_help_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected block statement surrounding arrow body.").with_label(span)
+}
 
 #[derive(Debug, Default, PartialEq, Clone)]
 enum Mode {
@@ -218,7 +234,6 @@ impl ArrowBodyStyle {
         arrow_func_expr: &ArrowFunctionExpression<'a>,
         ctx: &LintContext<'a>,
     ) {
-        let body = &arrow_func_expr.body;
         let inner_expr = arrow_func_expr.get_expression().map(Expression::get_inner_expression);
 
         let should_report = self.mode == Mode::Always
@@ -230,10 +245,9 @@ impl ArrowBodyStyle {
             return;
         }
 
-        ctx.diagnostic_with_fix(
-            arrow_body_style_diagnostic(body.span, EXPECTED_BLOCK_MSG),
-            |fixer| Self::fix_concise_to_block(arrow_func_expr, fixer, ctx),
-        );
+        ctx.diagnostic_with_fix(expected_block_diagnostic(arrow_func_expr.body.span), |fixer| {
+            Self::fix_concise_to_block(arrow_func_expr, fixer, ctx)
+        });
     }
 
     /// Handle block arrow body: `() => { ... }`
@@ -253,10 +267,7 @@ impl ArrowBodyStyle {
                 // Mode::Never: report any block body
                 if body.statements.is_empty() {
                     // TODO: implement a fix for empty block bodies
-                    ctx.diagnostic(arrow_body_style_diagnostic(
-                        body.span,
-                        "Unexpected block statement surrounding arrow body; put a value of `undefined` immediately after the `=>`.",
-                    ));
+                    ctx.diagnostic(unexpected_empty_block_diagnostic(body.span));
                     return;
                 }
 
@@ -265,26 +276,14 @@ impl ArrowBodyStyle {
                     && let Statement::ReturnStatement(return_statement) = &body.statements[0]
                     && let Some(return_arg) = &return_statement.argument
                 {
-                    ctx.diagnostic_with_fix(
-                        arrow_body_style_diagnostic(body.span, UNEXPECTED_BLOCK_SINGLE_MSG),
-                        |fixer| {
-                            Self::fix_block_to_concise(
-                                arrow_func_expr,
-                                return_arg,
-                                node,
-                                fixer,
-                                ctx,
-                            )
-                        },
-                    );
+                    ctx.diagnostic_with_fix(unexpected_block_diagnostic(body.span), |fixer| {
+                        Self::fix_block_to_concise(arrow_func_expr, return_arg, node, fixer, ctx)
+                    });
                     return;
                 }
 
                 // Cannot auto-fix other cases
-                ctx.diagnostic(arrow_body_style_diagnostic(
-                    body.span,
-                    "Unexpected block statement surrounding arrow body.",
-                ));
+                ctx.diagnostic(unexpected_block_with_unknown_help_diagnostic(body.span));
             }
             Mode::AsNeeded if body.statements.len() == 1 => {
                 if let Statement::ReturnStatement(return_statement) = &body.statements[0] {
@@ -301,25 +300,13 @@ impl ArrowBodyStyle {
                     // Cannot fix if return has no argument (undefined return)
                     let Some(return_arg) = &return_statement.argument else {
                         // TODO: implement a fix for undefined return
-                        ctx.diagnostic(arrow_body_style_diagnostic(
-                            body.span,
-                            UNEXPECTED_BLOCK_SINGLE_MSG,
-                        ));
+                        ctx.diagnostic(unexpected_block_diagnostic(body.span));
                         return;
                     };
 
-                    ctx.diagnostic_with_fix(
-                        arrow_body_style_diagnostic(body.span, UNEXPECTED_BLOCK_SINGLE_MSG),
-                        |fixer| {
-                            Self::fix_block_to_concise(
-                                arrow_func_expr,
-                                return_arg,
-                                node,
-                                fixer,
-                                ctx,
-                            )
-                        },
-                    );
+                    ctx.diagnostic_with_fix(unexpected_block_diagnostic(body.span), |fixer| {
+                        Self::fix_block_to_concise(arrow_func_expr, return_arg, node, fixer, ctx)
+                    });
                 }
             }
             _ => {}

--- a/crates/oxc_linter/src/snapshots/eslint_arrow_body_style.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_arrow_body_style.snap
@@ -1,285 +1,286 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:22]
  1 │ for (var foo = () => { return a in b ? bar : () => {} } ;;);
    ·                      ──────────────────────────────────
    ╰────
-  help: Replace `{ return a in b ? bar : () => {} }` with `(a in b ? bar : () => {})`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:28]
  1 │ a in b; for (var f = () => { return c };;);
    ·                            ────────────
    ╰────
-  help: Replace `{ return c }` with `c`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:15]
  1 │ for (a = b => { return c in d ? e : f } ;;);
    ·               ─────────────────────────
    ╰────
-  help: Replace `{ return c in d ? e : f }` with `(c in d ? e : f)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:20]
  1 │ for (var f = () => { return a };;);
    ·                    ────────────
    ╰────
-  help: Replace `{ return a }` with `a`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:22]
  1 │ for (var f;f = () => { return a };);
    ·                      ────────────
    ╰────
-  help: Replace `{ return a }` with `a`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:20]
  1 │ for (var f = () => { return a in c };;);
    ·                    ─────────────────
    ╰────
-  help: Replace `{ return a in c }` with `(a in c)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:22]
  1 │ for (var f;f = () => { return a in c };);
    ·                      ─────────────────
    ╰────
-  help: Replace `{ return a in c }` with `a in c`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:24]
  1 │ for (;;){var f = () => { return a in c }}
    ·                        ─────────────────
    ╰────
-  help: Replace `{ return a in c }` with `a in c`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:15]
  1 │ for (a = b => { return c = d in e } ;;);
    ·               ─────────────────────
    ╰────
-  help: Replace `{ return c = d in e }` with `(c = d in e)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:22]
  1 │ for (var a;;a = b => { return c = d in e } );
    ·                      ─────────────────────
    ╰────
-  help: Replace `{ return c = d in e }` with `c = d in e`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:27]
  1 │ for (let a = (b, c, d) => { return vb && c in d; }; ;);
    ·                           ────────────────────────
    ╰────
-  help: Replace `{ return vb && c in d; }` with `(vb && c in d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:27]
  1 │ for (let a = (b, c, d) => { return v in b && c in d; }; ;);
    ·                           ────────────────────────────
    ╰────
-  help: Replace `{ return v in b && c in d; }` with `(v in b && c in d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:43]
  1 │ function foo(){ for (let a = (b, c, d) => { return v in b && c in d; }; ;); }
    ·                                           ────────────────────────────
    ╰────
-  help: Replace `{ return v in b && c in d; }` with `(v in b && c in d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:24]
  1 │ for ( a = (b, c, d) => { return v in b && c in d; }; ;);
    ·                        ────────────────────────────
    ╰────
-  help: Replace `{ return v in b && c in d; }` with `(v in b && c in d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:18]
  1 │ for ( a = (b) => { return (c in d) }; ;);
    ·                  ───────────────────
    ╰────
-  help: Replace `{ return (c in d) }` with `(c in d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:27]
  1 │ for (let a = (b, c, d) => { return vb in dd ; }; ;);
    ·                           ─────────────────────
    ╰────
-  help: Replace `{ return vb in dd ; }` with `(vb in dd)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:27]
  1 │ for (let a = (b, c, d) => { return vb in c in dd ; }; ;);
    ·                           ──────────────────────────
    ╰────
-  help: Replace `{ return vb in c in dd ; }` with `(vb in c in dd)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:18]
  1 │ do{let a = () => {return f in ff}}while(true){}
    ·                  ────────────────
    ╰────
-  help: Replace `{return f in ff}` with `f in ff`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:30]
  1 │ do{for (let a = (b, c, d) => { return vb in c in dd ; }; ;);}while(true){}
    ·                              ──────────────────────────
    ╰────
-  help: Replace `{ return vb in c in dd ; }` with `(vb in c in dd)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:21]
  1 │ scores.map(score => { return x in +(score / maxScore).toFixed(2)});
    ·                     ─────────────────────────────────────────────
    ╰────
-  help: Replace `{ return x in +(score / maxScore).toFixed(2)}` with `x in +(score / maxScore).toFixed(2)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:22]
  1 │ const fn = (a, b) => { return a + x in Number(b) };
    ·                      ─────────────────────────────
    ╰────
-  help: Replace `{ return a + x in Number(b) }` with `a + x in Number(b)`.
+  help: Move the returned value to be immediately after the `=>`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => 0
    ·                 ─
    ╰────
-  help: Replace `0` with `{return 0}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => 0;
    ·                 ─
    ╰────
-  help: Replace `0` with `{return 0}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ({});
    ·                 ────
    ╰────
-  help: Replace `({})` with `{return {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => (  {});
    ·                 ──────
    ╰────
-  help: Replace `(  {})` with `{return {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:8]
  1 │ (() => ({}))
    ·        ────
    ╰────
-  help: Replace `({})` with `{return {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:8]
  1 │ (() => ( {}))
    ·        ─────
    ╰────
-  help: Replace `( {})` with `{return {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return 0; };
    ·                 ─────────────
    ╰────
-  help: Replace `{ return 0; }` with `0`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return 0 };
    ·                 ────────────
    ╰────
-  help: Replace `{ return 0 }` with `0`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return bar(); };
    ·                 ─────────────────
    ╰────
-  help: Replace `{ return bar(); }` with `bar()`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; put a value of `undefined` immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected empty block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => {};
    ·                 ──
    ╰────
+  help: Put a value of `undefined` immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ ╭─▶ var foo = () => {
  2 │ │               return 0;
  3 │ ╰─▶             };
    ╰────
-  help: Replace `{
-                    return 0;
-                    }` with `0`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return { bar: 0 }; };
    ·                 ──────────────────────
    ╰────
-  help: Replace `{ return { bar: 0 }; }` with `({ bar: 0 })`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return ({ bar: 0 }); };
    ·                 ────────────────────────
    ╰────
-  help: Replace `{ return ({ bar: 0 }); }` with `({ bar: 0 })`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return a, b }
    ·                 ───────────────
    ╰────
-  help: Replace `{ return a, b }` with `(a, b)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return };
    ·                 ──────────
    ╰────
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return; };
    ·                 ───────────
    ╰────
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return ( /* a */ {ok: true} /* b */ ) };
    ·                 ─────────────────────────────────────────
    ╰────
-  help: Replace `{ return ( /* a */ {ok: true} /* b */ ) }` with `( /* a */ {ok: true} /* b */ )`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return '{' };
    ·                 ──────────────
    ╰────
-  help: Replace `{ return '{' }` with `'{'`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return { bar: 0 }.bar; };
    ·                 ──────────────────────────
    ╰────
-  help: Replace `{ return { bar: 0 }.bar; }` with `({ bar: 0 }.bar)`.
+  help: Move the returned value to be immediately after the `=>`.
 
   ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:27]
@@ -295,82 +296,78 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────
    ╰────
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return 0; };
    ·                 ─────────────
    ╰────
-  help: Replace `{ return 0; }` with `0`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return bar(); };
    ·                 ─────────────────
    ╰────
-  help: Replace `{ return bar(); }` with `bar()`.
+  help: Move the returned value to be immediately after the `=>`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ({});
    ·                 ────
    ╰────
-  help: Replace `({})` with `{return {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ({ bar: 0 });
    ·                 ────────────
    ╰────
-  help: Replace `({ bar: 0 })` with `{return { bar: 0 }}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => (((((((5)))))));
    ·                 ───────────────
    ╰────
-  help: Replace `(((((((5)))))))` with `{return (((((((5)))))))}`.
+  help: Surround the arrow body with braces and use a return statement.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:50]
  1 │ var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;
    ·                                                  ──────────────────────────────────────────────
    ╰────
-  help: Replace `{ /* e */ return /* f */ 5 /* g */ ; /* h */ }` with `5`.
+  help: Move the returned value to be immediately after the `=>`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:50]
  1 │ var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;
    ·                                                  ─────────────────────
    ╰────
-  help: Replace `( /* e */ 5 /* f */ )` with `{return ( /* e */ 5 /* f */ )}`.
+  help: Surround the arrow body with braces and use a return statement.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ ╭─▶ var foo = () => {
  2 │ │               return bar;
  3 │ ╰─▶             };
    ╰────
-  help: Replace `{
-                    return bar;
-                    }` with `bar`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ ╭─▶ var foo = () => {
  2 │ ╰─▶             return bar;};
    ╰────
-  help: Replace `{
-                    return bar;}` with `bar`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ ╭─▶ var foo = () => {return bar;
  2 │ ╰─▶             };
    ╰────
-  help: Replace `{return bar;
-                    }` with `bar`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:2:43]
  1 │     
  2 │ ╭─▶                           var foo = () => {
@@ -379,13 +376,9 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                           };
  6 │                             
    ╰────
-  help: Replace `{
-                                    return foo
-                                      .bar;
-                                  }` with `foo
-                                      .bar`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:2:43]
  1 │     
  2 │ ╭─▶                           var foo = () => {
@@ -396,36 +389,28 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                           };
  8 │                             
    ╰────
-  help: Replace `{
-                                    return {
-                                      bar: 1,
-                                      baz: 2
-                                    };
-                                  }` with `({
-                                      bar: 1,
-                                      baz: 2
-                                    })`.
+  help: Move the returned value to be immediately after the `=>`.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ({foo: 1}).foo();
    ·                 ────────────────
    ╰────
-  help: Replace `({foo: 1}).foo()` with `{return ({foo: 1}).foo()}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ({foo: 1}.foo());
    ·                 ────────────────
    ╰────
-  help: Replace `({foo: 1}.foo())` with `{return ({foo: 1}.foo())}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => ( {foo: 1} ).foo();
    ·                 ──────────────────
    ╰────
-  help: Replace `( {foo: 1} ).foo()` with `{return ( {foo: 1} ).foo()}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:2:43]
@@ -436,13 +421,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                             });
  6 │                             
    ╰────
-  help: Replace `({
-                                      bar: 1,
-                                      baz: 2
-                                    })` with `{return {
-                                      bar: 1,
-                                      baz: 2
-                                    }}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:2:63]
@@ -455,68 +434,60 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                           ));
  8 │                             
    ╰────
-  help: Replace `(
-                                      {
-                                          index : year,
-                                          title : splitYear(year)
-                                      }
-                                  )` with `{return {
-                                          index : year,
-                                          title : splitYear(year)
-                                      }}`.
+  help: Surround the arrow body with braces and use a return statement.
 
   ⚠ eslint(arrow-body-style): Expected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:33]
  1 │ const createMarker = (color) => ({ latitude, longitude }, index) => {};
    ·                                 ──────────────────────────────────────
    ╰────
-  help: Replace `({ latitude, longitude }, index) => {}` with `{return ({ latitude, longitude }, index) => {}}`.
+  help: Surround the arrow body with braces and use a return statement.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b + c };
    ·                 ───────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b + c }` with `({a: 1}.b + c)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b && c };
    ·                 ────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b && c }` with `({a: 1}.b && c)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b || c };
    ·                 ────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b || c }` with `({a: 1}.b || c)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b ? c : d };
    ·                 ───────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b ? c : d }` with `({a: 1}.b ? c : d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b + c && d };
    ·                 ────────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b + c && d }` with `({a: 1}.b + c && d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b.c + d };
    ·                 ─────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b.c + d }` with `({a: 1}.b.c + d)`.
+  help: Move the returned value to be immediately after the `=>`.
 
-  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
+  ⚠ eslint(arrow-body-style): Unexpected block statement surrounding arrow body.
    ╭─[arrow_body_style.tsx:1:17]
  1 │ var foo = () => { return {a: 1}.b() + c };
    ·                 ─────────────────────────
    ╰────
-  help: Replace `{ return {a: 1}.b() + c }` with `({a: 1}.b() + c)`.
+  help: Move the returned value to be immediately after the `=>`.


### PR DESCRIPTION
Split the diagnostics into separate functions and move the suggestions to be in the help field.