### PR TITLE
chore(formatter): Remove a deprecated option from the repo vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
   "oxc.unusedDisableDirectives": "deny",
 
   // "oxc.path.oxfmt": "apps/oxfmt/dist/cli.js", // debug with local oxfmt build
-  "oxc.fmt.experimental": true,
   "oxc.fmt.configPath": "oxfmtrc.jsonc",
   "[javascript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"


### PR DESCRIPTION
Should maybe also update the list of languages that use oxfmt as the default formatter, but that's a problem for someone else to solve :)