### PR TITLE
fix(formatter): Count emoji sequences correctly

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js
+++ b/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js
@@ -1,0 +1,16 @@
+//345678901234567890123456789012345678901234567890123456789012345678901234567890
+//                                                                           80|
+export async function deleteTestWorkspaceAPI() {
+  // THIS SHOULD BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+export async function deleteTestWorkspaceAPI2() {
+  // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+
+// Emoji with variation selector (U+1F5D1 + U+FE0F) has width 2, not 1.
+// const _ = "..."; = 13 chars
+// + 34 emojis = width 68,
+// Total 81 chars, should break with `printWidth: 80`.
+const _ = "🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️";

--- a/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+//345678901234567890123456789012345678901234567890123456789012345678901234567890
+//                                                                           80|
+export async function deleteTestWorkspaceAPI() {
+  // THIS SHOULD BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+export async function deleteTestWorkspaceAPI2() {
+  // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+
+// Emoji with variation selector (U+1F5D1 + U+FE0F) has width 2, not 1.
+// const _ = "..."; = 13 chars
+// + 34 emojis = width 68,
+// Total 81 chars, should break with `printWidth: 80`.
+const _ = "🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️";
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+//345678901234567890123456789012345678901234567890123456789012345678901234567890
+//                                                                           80|
+export async function deleteTestWorkspaceAPI() {
+  // THIS SHOULD BREAK WITH PRINT WIDTH 80
+  console.log(
+    `🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`,
+  );
+}
+export async function deleteTestWorkspaceAPI2() {
+  // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+
+// Emoji with variation selector (U+1F5D1 + U+FE0F) has width 2, not 1.
+// const _ = "..."; = 13 chars
+// + 34 emojis = width 68,
+// Total 81 chars, should break with `printWidth: 80`.
+const _ =
+  "🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️";
+
+-------------------
+{ printWidth: 100 }
+-------------------
+//345678901234567890123456789012345678901234567890123456789012345678901234567890
+//                                                                           80|
+export async function deleteTestWorkspaceAPI() {
+  // THIS SHOULD BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+export async function deleteTestWorkspaceAPI2() {
+  // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
+  console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
+}
+
+// Emoji with variation selector (U+1F5D1 + U+FE0F) has width 2, not 1.
+// const _ = "..."; = 13 chars
+// + 34 emojis = width 68,
+// Total 81 chars, should break with `printWidth: 80`.
+const _ = "🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️🗑️";
+
+===================== End =====================


### PR DESCRIPTION
Fixes #17271

It seems `U+FE0F` is not counted as 1 by char. Please see https://github.com/oxc-project/oxc/pull/17331/changes#diff-68ae34cbf2a12b1e38d6edaa09bda33717157a1c90311e2adcd8f060eed45223R572-R579 for explanation.