### PR TITLE
fix(formatter): Handle more test functions

### DIFF
--- a/crates/oxc_formatter/src/utils/call_expression.rs
+++ b/crates/oxc_formatter/src/utils/call_expression.rs
@@ -161,9 +161,12 @@ pub fn callee_name_iterator<'b>(expr: &'b Expression<'_>) -> Option<impl Iterato
 /// - `test`
 /// - `test.only`
 /// - `test.skip`
+/// - `test.fixme`
 /// - `test.step`
 /// - `test.describe`
 /// - `test.describe.only`
+/// - `test.describe.skip`
+/// - `test.describe.fixme`
 /// - `test.describe.parallel`
 /// - `test.describe.parallel.only`
 /// - `test.describe.serial`
@@ -191,10 +194,10 @@ pub fn contains_a_test_pattern(expr: &Expression<'_>) -> bool {
         },
         Some("test") => match names.next() {
             None => true,
-            Some("only" | "skip" | "step") => names.next().is_none(),
+            Some("only" | "skip" | "step" | "fixme") => names.next().is_none(),
             Some("describe") => match names.next() {
                 None => true,
-                Some("only") => names.next().is_none(),
+                Some("only" | "skip" | "fixme") => names.next().is_none(),
                 Some("parallel" | "serial") => match names.next() {
                     None => true,
                     Some("only") => names.next().is_none(),

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js
@@ -45,3 +45,11 @@ global().longcalllongcall().property
   .only('foobarbazqux', async () => {
     //
   })
+
+// https://github.com/oxc-project/oxc/issues/17272
+test.fixme("C[TBD] Create automation - Priority changes triggers action @regression-standalone-qa-env @regression @automations-squad", async ({
+  page: _page,
+}, testInfo) => {
+  // TODO
+});
+

--- a/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/test.js.snap
@@ -50,6 +50,14 @@ global().longcalllongcall().property
     //
   })
 
+// https://github.com/oxc-project/oxc/issues/17272
+test.fixme("C[TBD] Create automation - Priority changes triggers action @regression-standalone-qa-env @regression @automations-squad", async ({
+  page: _page,
+}, testInfo) => {
+  // TODO
+});
+
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -108,6 +116,13 @@ global()
     //
   });
 
+// https://github.com/oxc-project/oxc/issues/17272
+test.fixme("C[TBD] Create automation - Priority changes triggers action @regression-standalone-qa-env @regression @automations-squad", async ({
+  page: _page,
+}, testInfo) => {
+  // TODO
+});
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -163,5 +178,12 @@ global()
   .property.test.only("foobarbazqux", async () => {
     //
   });
+
+// https://github.com/oxc-project/oxc/issues/17272
+test.fixme("C[TBD] Create automation - Priority changes triggers action @regression-standalone-qa-env @regression @automations-squad", async ({
+  page: _page,
+}, testInfo) => {
+  // TODO
+});
 
 ===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 735/761 (96.58%)
+js compatibility: 736/761 (96.71%)
 
 # Failed
 
@@ -26,7 +26,6 @@ js compatibility: 735/761 (96.58%)
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
 | js/test-declarations/angularjs_inject.js | 💥💥 | 91.53% |
-| js/test-declarations/test_declarations.js | 💥💥 | 95.88% |
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |


### PR DESCRIPTION
Fixes #17272

---

This PR adds our missing test functions vs Prettier.

However, Prettier only supports:

https://github.com/prettier/prettier/blob/cd0c3292d303f3e0cbab2530045cfc06d6609d25/src/language-js/utilities/index.js#L298-L325

And we(Biome) already support extra variants like `Deno.test()`.

I also noticed that Biome has added more variants, such as Vitest test functions.
I think it's OK to follow these, but it means the difference with Prettier becomes wider.

How do you think? (draft: #17340)