### PR TITLE
fix(ci): workaround `make_latest: false` bug in release_crates.yml

### DIFF
--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -60,3 +60,9 @@ jobs:
           target_commitish: ${{ github.sha }}
           draft: false
           make_latest: false # latest is reserved for apps
+
+      # Workaround for https://github.com/softprops/action-gh-release/issues/703
+      - name: Mark release as not latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ steps.run.outputs.TAG }} --latest=false


### PR DESCRIPTION
## Summary

- Add `gh release edit` step to explicitly mark crates releases as not latest
- The `make_latest: false` option in `softprops/action-gh-release` does not work reliably

See: https://github.com/softprops/action-gh-release/issues/703

🤖 Generated with [Claude Code](https://claude.com/claude-code)