### PR TITLE
test(vscode): remove diagnostic sleeps

### DIFF
--- a/editors/vscode/tests/e2e_server_linter.spec.ts
+++ b/editors/vscode/tests/e2e_server_linter.spec.ts
@@ -193,8 +193,8 @@ suite('E2E Server Linter', () => {
 
   test('nested configs severity', async () => {
     await loadFixture('nested_config');
-    const rootDiagnostics = await getDiagnostics('index.ts');
-    const nestedDiagnostics = await getDiagnostics('folder/index.ts');
+    const rootDiagnostics = await getDiagnostics('index.ts', undefined, 500);
+    const nestedDiagnostics = await getDiagnostics('folder/index.ts', undefined, 500);
 
     assert(typeof rootDiagnostics[0].code == 'object');
     strictEqual(rootDiagnostics[0].code.target.authority, 'oxc.rs');

--- a/editors/vscode/tests/test-helpers.ts
+++ b/editors/vscode/tests/test-helpers.ts
@@ -100,13 +100,13 @@ export async function loadFixture(fixture: string, workspaceDir: Uri = fixturesW
   await workspace.fs.copy(Uri.file(absolutePath), Uri.joinPath(workspaceDir, 'fixtures'), { overwrite: true });
 }
 
-export async function getDiagnostics(file: string, workspaceDir: Uri = fixturesWorkspaceUri(), sleepDuration = 250): Promise<Diagnostic[]> {
+export async function getDiagnostics(file: string, workspaceDir: Uri = fixturesWorkspaceUri(), sleepDuration = 0): Promise<Diagnostic[]> {
   const diagnostics = await getDiagnosticsWithoutClose(file, workspaceDir, sleepDuration);
   await commands.executeCommand('workbench.action.closeActiveEditor');
   return diagnostics;
 }
 
-export async function getDiagnosticsWithoutClose(file: string, workspaceDir: Uri = fixturesWorkspaceUri(), sleepDuration = 250): Promise<Diagnostic[]> {
+export async function getDiagnosticsWithoutClose(file: string, workspaceDir: Uri = fixturesWorkspaceUri(), sleepDuration = 0): Promise<Diagnostic[]> {
   const fileUri = Uri.joinPath(workspaceDir, 'fixtures', file);
   await window.showTextDocument(fileUri);
   await sleep(sleepDuration);


### PR DESCRIPTION
because `oxlint`  supports now pull diagnostics, VS Code will request the diagnostic.  
We do not need to wait for the internal process, the `languages.getDiagnostics` will handle the communication with the server.