### PR TITLE
feat(transformer): export `ESFeature` from options

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -74,7 +74,7 @@ pub use crate::{
     es2026::ES2026Options,
     jsx::{JsxOptions, JsxRuntime, ReactRefreshOptions},
     options::{
-        ESTarget, Engine, EngineTargets, EnvOptions, Module, TransformOptions,
+        ESFeature, ESTarget, Engine, EngineTargets, EnvOptions, Module, TransformOptions,
         babel::{BabelEnvOptions, BabelOptions},
     },
     plugins::{PluginsOptions, StyledComponentsOptions},

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -28,7 +28,7 @@ mod module;
 use babel::BabelOptions;
 pub use env::EnvOptions;
 pub use module::Module;
-pub use oxc_compat::{Engine, EngineTargets};
+pub use oxc_compat::{ESFeature, Engine, EngineTargets};
 pub use oxc_syntax::es_target::ESTarget;
 
 /// <https://babel.dev/docs/options>


### PR DESCRIPTION
Rolldown need `EngineTargets::has_feature(ESFeature::ES2024UnicodeSetsRegex)` to detect js module whether need to be transformed.

See https://github.com/rolldown/rolldown/blob/1e462a32d8bf43178d87b348d930b106bd36a80b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs#L128-L131