### PR TITLE
fix(codegen): output trailing legal comments on same line

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -246,6 +246,15 @@ impl Comment {
             && self.is_leading()
     }
 
+    /// Returns `true` if this comment has legal content (regardless of position).
+    ///
+    /// Unlike `is_legal()`, this does not require the comment to be in a leading position.
+    /// Use this to check if a trailing comment contains legal content.
+    #[inline]
+    pub fn has_legal_content(self) -> bool {
+        matches!(self.content, CommentContent::Legal | CommentContent::JsdocLegal)
+    }
+
     /// Is `/* @__PURE__*/`.
     #[inline]
     pub fn is_pure(self) -> bool {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -646,9 +646,18 @@ impl<'a> Codegen<'a> {
             first.print(self, ctx);
         }
 
-        for stmt in rest {
+        // Print trailing comments for the first statement
+        let first_end = first.span().end;
+        let next_start = rest.first().map_or(u32::MAX, |s| s.span().start);
+        self.print_trailing_comments_after(first_end, next_start);
+
+        for (i, stmt) in rest.iter().enumerate() {
             self.print_semicolon_if_needed();
             stmt.print(self, ctx);
+            // Print trailing comments for this statement
+            let stmt_end = stmt.span().end;
+            let next_start = rest.get(i + 1).map_or(u32::MAX, |s| s.span().start);
+            self.print_trailing_comments_after(stmt_end, next_start);
         }
     }
 

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -1,6 +1,15 @@
 use crate::tester::{test, test_same};
 
 #[test]
+fn test_trailing_legal_comment() {
+    // Issue #17301: trailing legal comments should be output
+    test(
+        "//! Copyright notice 1\nconsole.log('in a') //! Copyright notice 2",
+        "//! Copyright notice 1\nconsole.log(\"in a\"); //! Copyright notice 2\n",
+    );
+}
+
+#[test]
 fn test_comment_at_top_of_file() {
     use oxc_allocator::Allocator;
     use oxc_ast::CommentPosition;

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -255,6 +255,18 @@ impl CodeBuffer {
         self.peek_nth_char_back(0)
     }
 
+    /// Remove and return the last byte from the buffer.
+    ///
+    /// Returns `None` if the buffer is empty.
+    ///
+    /// # Safety
+    /// The caller must ensure that after this call, the buffer still represents
+    /// a valid UTF-8 string. This is guaranteed if popping an ASCII byte.
+    #[inline]
+    pub fn pop(&mut self) -> Option<u8> {
+        self.buf.pop()
+    }
+
     /// Push a single ASCII byte into the buffer.
     ///
     /// # Panics


### PR DESCRIPTION
## Summary
Fixes #17301

This PR adds support for outputting trailing legal comments on the same line as the statement they follow.

**Before:**
```js
console.log('hello') //! Copyright notice
```
was output as:
```js
console.log("hello");
```

**After:**
```js
console.log("hello"); //! Copyright notice
```

## Changes
- Add `has_legal_content()` method to Comment for checking legal content without position requirement
- Handle trailing legal comments in `build_comments()` using span.start as key
- Add `print_trailing_comments_after()` to find and print trailing comments between statement end and next statement start
- Modify `print_directives_and_statements()` to print trailing comments after each statement
- Add `pop()` method to CodeBuffer for removing trailing newlines

## Test plan
- Added test case `test_trailing_legal_comment`
- All existing codegen tests pass