### PR TITLE
fix(formatter): Complete `is_complex_type_arguments()` (take2)

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts
@@ -7,3 +7,14 @@ const emitter = createGlobalEmitter<{
 const emitter2 = createGlobalEmitter<{
   longlonglonglongKey: Extract<Event, { type: key }>
 }>()
+
+// Type argument is an `TSTypeReference`
+// https://github.com/oxc-project/oxc/issues/17275
+export class Test {
+  	readonly coordinates = model.required<
+		  Immutable<{
+		  	latitude: number;
+		  	longitude: number;
+		  }>
+	  >();
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts.snap
@@ -12,6 +12,17 @@ const emitter2 = createGlobalEmitter<{
   longlonglonglongKey: Extract<Event, { type: key }>
 }>()
 
+// Type argument is an `TSTypeReference`
+// https://github.com/oxc-project/oxc/issues/17275
+export class Test {
+  	readonly coordinates = model.required<
+		  Immutable<{
+		  	latitude: number;
+		  	longitude: number;
+		  }>
+	  >();
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -26,6 +37,17 @@ const emitter2 = createGlobalEmitter<{
   longlonglonglongKey: Extract<Event, { type: key }>;
 }>();
 
+// Type argument is an `TSTypeReference`
+// https://github.com/oxc-project/oxc/issues/17275
+export class Test {
+  readonly coordinates = model.required<
+    Immutable<{
+      latitude: number;
+      longitude: number;
+    }>
+  >();
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -38,5 +60,16 @@ const emitter = createGlobalEmitter<{
 const emitter2 = createGlobalEmitter<{
   longlonglonglongKey: Extract<Event, { type: key }>;
 }>();
+
+// Type argument is an `TSTypeReference`
+// https://github.com/oxc-project/oxc/issues/17275
+export class Test {
+  readonly coordinates = model.required<
+    Immutable<{
+      latitude: number;
+      longitude: number;
+    }>
+  >();
+}
 
 ===================== End =====================


### PR DESCRIPTION
Fixes #17275, without `memoized.inspect(f)`.
