### PR TITLE
refactor(lsp): cache sent diagnostics uri for shutdown inside workspace worker

### DIFF
--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -20,7 +20,7 @@ use crate::backend::Backend;
 pub use crate::formatter::ServerFormatterBuilder;
 #[cfg(feature = "linter")]
 pub use crate::linter::ServerLinterBuilder;
-pub use crate::tool::{Tool, ToolBuilder, ToolRestartChanges, ToolShutdownChanges};
+pub use crate::tool::{Tool, ToolBuilder, ToolRestartChanges};
 
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -34,7 +34,7 @@ use crate::{
         isolated_lint_handler::{IsolatedLintHandler, IsolatedLintHandlerOptions},
         options::{LintOptions as LSPLintOptions, Run, UnusedDisableDirectives},
     },
-    tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges, ToolShutdownChanges},
+    tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges},
     utils::normalize_path,
 };
 
@@ -323,10 +323,6 @@ impl Tool for ServerLinter {
         "linter"
     }
 
-    fn shutdown(&self) -> ToolShutdownChanges {
-        ToolShutdownChanges { uris_to_clear_diagnostics: Some(self.get_cached_uris()) }
-    }
-
     /// # Panics
     /// Panics if the root URI cannot be converted to a file path.
     fn handle_configuration_change(
@@ -567,10 +563,6 @@ impl ServerLinter {
             extended_paths,
             code_actions: Arc::new(ConcurrentHashMap::default()),
         }
-    }
-
-    fn get_cached_uris(&self) -> Vec<Uri> {
-        self.code_actions.pin().keys().cloned().collect()
     }
 
     fn get_code_actions_for_uri(&self, uri: &Uri) -> Option<Vec<LinterCodeAction>> {

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -128,9 +128,9 @@ pub trait Tool: Send + Sync {
         // Default implementation does nothing.
     }
 
-    /// Shutdown the tool and return any necessary changes to be made after shutdown.
-    fn shutdown(&self) -> ToolShutdownChanges {
-        ToolShutdownChanges { uris_to_clear_diagnostics: None }
+    /// Shutdown hook for the tool. Implementors may perform any necessary cleanup here.
+    fn shutdown(&self) {
+        // Default implementation does nothing.
     }
 }
 
@@ -141,9 +141,4 @@ pub struct ToolRestartChanges {
     /// The patterns that were added during the tool restart
     /// Old patterns will be automatically unregistered
     pub watch_patterns: Option<Vec<Pattern>>,
-}
-
-pub struct ToolShutdownChanges {
-    /// The URIs that need to have their diagnostics removed after the tool shutdown
-    pub uris_to_clear_diagnostics: Option<Vec<Uri>>,
 }


### PR DESCRIPTION
> This PR refactors how the language server tracks and clears diagnostics on shutdown by moving the responsibility from individual tools to the workspace worker. The diagnostics are now cached at the workspace level only in push mode, eliminating the need for tools to track their own URIs.