### PR TITLE
perf(linter): inline `is_function_node` into run functions

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -163,12 +163,14 @@ impl RuleRunner for crate::rules::eslint::max_lines::MaxLines {
 }
 
 impl RuleRunner for crate::rules::eslint::max_lines_per_function::MaxLinesPerFunction {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::eslint::max_nested_callbacks::MaxNestedCallbacks {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::{
     AstNode,
-    ast_util::{get_function_name_with_kind, is_function_node, iter_outer_expressions},
+    ast_util::{get_function_name_with_kind, iter_outer_expressions},
     context::LintContext,
     rule::Rule,
     utils::count_comment_lines,
@@ -162,7 +162,13 @@ impl Rule for MaxLinesPerFunction {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !is_function_node(node) || (!self.iifes && is_iife(node, ctx.semantic())) {
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() => {}
+            AstKind::Function(f) if f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
+        }
+        if !self.iifes && is_iife(node, ctx.semantic()) {
             return;
         }
         let span = node.span();

--- a/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
@@ -91,6 +91,13 @@ declare_oxc_lint!(
 
 impl Rule for MaxNestedCallbacks {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Function(f) if f.is_function_declaration() => {}
+            AstKind::Function(f) if f.is_expression() => {}
+            AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
+        }
+
         if is_callback(node, ctx) {
             let depth = 1 + ctx
                 .semantic()


### PR DESCRIPTION
Inlining the `is_function_node` function allows the linter codegen to do the static analysis more easily. I suppose this is slightly negative towards less maintainability, but I don't expect we'll have more types of functions added to JS anytime soon. And the +1-2% improvement is hard to pass up for being so easy:

<img width="723" height="436" alt="image" src="https://github.com/user-attachments/assets/7612c36e-3006-4cea-a038-d0e9b027ee04" />
