### PR TITLE
fix(formatter): JSXFragment missed a leading semicolon when semicolon is disabled

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -553,6 +553,7 @@ fn expression_statement_needs_semicolon<'a>(
                     | Expression::TSTypeAssertion(_)
                     | Expression::ArrowFunctionExpression(_)
                     | Expression::JSXElement(_)
+                    | Expression::JSXFragment(_)
                     | Expression::TemplateLiteral(_) => true,
                     Expression::UnaryExpression(unary) => {
                         matches!(

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -2,7 +2,7 @@ commit: 2dfdbbab
 
 formatter_typescript Summary:
 AST Parsed     : 9840/9840 (100.00%)
-Positive Passed: 9781/9840 (99.40%)
+Positive Passed: 9787/9840 (99.46%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
@@ -18,14 +18,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignment
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
-Unexpected token
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
-Unexpected token
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryErrorNotIdentifier.tsx
-Unexpected token
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryNull.tsx
-Unexpected token
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryButNoJsxFragmentFactory.tsx
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
 Expected `{` but found `Identifier`
@@ -109,10 +101,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeReso
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
-Unexpected token
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
-Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts


### PR DESCRIPTION
Add a leading `;` for the `JSXFragment` to solve a syntax error caused by the semicolon being disabled.