### PR TITLE
feat(linter/eslint-plugin-vitest): Implement consistent-vitest-vi rule

### DIFF
--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+Finished in <variable>ms on 1 file with 103 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 103 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3982,6 +3982,12 @@ impl RuleRunner for crate::rules::vitest::consistent_test_filename::ConsistentTe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::consistent_vitest_vi::ConsistentVitestVi {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ImportDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vitest::no_conditional_tests::NoConditionalTests {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -664,6 +664,7 @@ pub(crate) mod promise {
 
 pub(crate) mod vitest {
     pub mod consistent_test_filename;
+    pub mod consistent_vitest_vi;
     pub mod no_conditional_tests;
     pub mod no_import_node_test;
     pub mod prefer_called_times;
@@ -1322,6 +1323,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::text_encoding_identifier_case,
     unicorn::throw_new_error,
     vitest::consistent_test_filename,
+    vitest::consistent_vitest_vi,
     vitest::no_conditional_tests,
     vitest::no_import_node_test,
     vitest::prefer_called_times,

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -101,7 +101,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentVitestVi {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<ConsistentVitestVi>>(value)
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value)
             .unwrap_or_default()
             .into_inner()
     }

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -1,0 +1,274 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{CompactStr, GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, parse_general_jest_fn_call},
+};
+
+fn consistent_vitest_vi_diagnostic(span: Span, fn_value: &VitestFnName) -> OxcDiagnostic {
+    let message = format!(
+        "Prefer using `{}` instead of `{}`.",
+        fn_value.get_string(),
+        fn_value.get_opposite_accessor()
+    );
+
+    OxcDiagnostic::warn("The vitest function accessor used is not allowed")
+        .with_help(message)
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentVitestVi(Box<ConsistentVitestConfig>);
+
+impl std::ops::Deref for ConsistentVitestVi {
+    type Target = ConsistentVitestConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, JsonSchema, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VitestFnName {
+    #[default]
+    Vi,
+    Vitest,
+}
+
+impl VitestFnName {
+    fn get_opposite_accessor(&self) -> CompactStr {
+        match self {
+            VitestFnName::Vi => CompactStr::new("vitest"),
+            VitestFnName::Vitest => CompactStr::new("vi"),
+        }
+    }
+
+    fn get_string(&self) -> CompactStr {
+        match self {
+            VitestFnName::Vi => CompactStr::new("vi"),
+            VitestFnName::Vitest => CompactStr::new("vitest"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct ConsistentVitestConfig {
+    /// Decides whether to prefer vitest function accessor
+    #[serde(rename = "fn", default)]
+    function: VitestFnName,
+}
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule triggers an error when a not expected vitest accessor is used.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Not having a consistent vitest accessor can lead to confusion on why
+    /// on some contexts `vi` is used, and on other `vitest` is used.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// vitest.mock('./src/calculator.ts', { spy: true })
+    ///
+    /// vi.stubEnv('NODE_ENV', 'production')
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// vi.mock('./src/calculator.ts', { spy: true })
+    ///
+    /// vi.stubEnv('NODE_ENV', 'production')
+    /// ```
+    ConsistentVitestVi,
+    vitest,
+    correctness,
+    fix,
+    config = ConsistentVitestConfig,
+);
+
+impl Rule for ConsistentVitestVi {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let config: ConsistentVitestConfig =
+            value.get(0).and_then(|v| serde_json::from_value(v.clone()).ok()).unwrap_or_default();
+
+        Self(Box::new(config))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ImportDeclaration(import) => {
+                if import.source.value != "vitest" {
+                    return;
+                }
+
+                let Some(vitest_import) = import.specifiers.as_ref().and_then(|specs| {
+                    specs.iter().find(|spec| spec.name() == self.function.get_opposite_accessor())
+                }) else {
+                    return;
+                };
+
+                ctx.diagnostic_with_fix(
+                    consistent_vitest_vi_diagnostic(vitest_import.span(), &self.function),
+                    |fixer| {
+                        let mut specifiers_without_opposite_accessor = import
+                            .specifiers
+                            .as_ref()
+                            .map(|specs| {
+                                specs
+                                    .iter()
+                                    .map(|spec| CompactStr::from(spec.name()))
+                                    .filter(|spec_name| {
+                                        *spec_name != self.function.get_opposite_accessor()
+                                    })
+                                    .collect::<Vec<CompactStr>>()
+                            })
+                            .unwrap_or(vec![]);
+
+                        if specifiers_without_opposite_accessor.is_empty() {
+                            match self.function {
+                                VitestFnName::Vi => fixer.replace(vitest_import.local().span, "vi"),
+                                VitestFnName::Vitest => {
+                                    fixer.replace(vitest_import.local().span, "vitest")
+                                }
+                            }
+                        } else {
+                            if !specifiers_without_opposite_accessor
+                                .contains(&self.function.get_string())
+                            {
+                                specifiers_without_opposite_accessor
+                                    .push(self.function.get_string());
+                            }
+
+                            let import_text = specifiers_without_opposite_accessor.join(", ");
+
+                            let Some(first_specifier) =
+                                import.specifiers.as_ref().and_then(|specs| specs.first())
+                            else {
+                                return fixer.noop();
+                            };
+
+                            let Some(last_specifier) =
+                                import.specifiers.as_ref().and_then(|specs| specs.last())
+                            else {
+                                return fixer.noop();
+                            };
+
+                            let specifiers_span = Span::new(
+                                first_specifier.local().span.start,
+                                last_specifier.local().span.end,
+                            );
+
+                            fixer.replace(specifiers_span, import_text)
+                        }
+                    },
+                );
+            }
+            AstKind::CallExpression(call_expr) => {
+                let Some(vitest_fn) = parse_general_jest_fn_call(
+                    call_expr,
+                    &PossibleJestNode { node, original: None },
+                    ctx,
+                ) else {
+                    return;
+                };
+
+                if vitest_fn.kind != JestFnKind::General(JestGeneralFnKind::Vitest) {
+                    return;
+                }
+
+                if vitest_fn.name == self.function.get_opposite_accessor() {
+                    let Some(member_expression) = call_expr.callee.as_member_expression() else {
+                        return;
+                    };
+
+                    ctx.diagnostic_with_fix(
+                        consistent_vitest_vi_diagnostic(
+                            member_expression.object().span(),
+                            &self.function,
+                        ),
+                        |fixer| {
+                            fixer.replace(
+                                member_expression.object().span(),
+                                self.function.get_string(),
+                            )
+                        },
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"import { expect, it } from "vitest";"#, None),
+        (r#"import { vi } from "vitest";"#, None),
+        (r#"import { vitest } from "vitest";"#, Some(serde_json::json!([{ "fn": "vitest" }]))),
+        (
+            r#"import { vi } from "vitest";
+			vi.stubEnv("NODE_ENV", "production");"#,
+            None,
+        ),
+        (r#"vi.stubEnv("NODE_ENV", "production");"#, None),
+    ];
+
+    let fail = vec![
+        (r#"import { vitest } from "vitest";"#, None),
+        (r#"import { expect, vi, vitest } from "vitest";"#, None),
+        (
+            r#"import { vitest } from "vitest";
+			vitest.stubEnv("NODE_ENV", "production");"#,
+            None,
+        ),
+        (
+            r#"vi.stubEnv("NODE_ENV", "production");
+			vi.clearAllMocks();"#,
+            Some(serde_json::json!([{ "fn": "vitest" }])),
+        ),
+    ];
+
+    let fix = vec![
+        (r#"import { vitest } from "vitest";"#, r#"import { vi } from "vitest";"#, None), // WORKING
+        (
+            r#"import { expect, vi, vitest } from "vitest";"#,
+            r#"import { expect, vi } from "vitest";"#,
+            None,
+        ),
+        (
+            r#"import { vitest } from "vitest";
+			vitest.stubEnv("NODE_ENV", "production");"#,
+            r#"import { vi } from "vitest";
+			vi.stubEnv("NODE_ENV", "production");"#,
+            None,
+        ),
+        (
+            r#"vi.stubEnv("NODE_ENV", "production");
+			vi.clearAllMocks();"#,
+            r#"vitest.stubEnv("NODE_ENV", "production");
+			vitest.clearAllMocks();"#,
+            Some(serde_json::json!([{ "fn": "vitest" }])),
+        ),
+    ];
+    Tester::new(ConsistentVitestVi::NAME, ConsistentVitestVi::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, ast::ImportDeclarationSpecifier};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -70,12 +70,12 @@ pub struct ConsistentVitestConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule triggers an error when a not expected vitest accessor is used.
+    /// This rule triggers an error when an unexpected vitest accessor is used.
     ///
     /// ### Why is this bad?
     ///
-    /// Not having a consistent vitest accessor can lead to confusion on why
-    /// on some contexts `vi` is used, and on other `vitest` is used.
+    /// Not having a consistent vitest accessor can lead to confusion
+    /// when `vi` and `vitest` are used interchangeably.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -100,8 +100,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConsistentVitestVi {
-    fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner()
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+            .unwrap_or_default()
+            .into_inner())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -101,9 +101,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentVitestVi {
     fn from_configuration(value: serde_json::Value) -> Self {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner()
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:10]
+ 1 │ import { vitest } from "vitest";
+   ·          ──────
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:22]
+ 1 │ import { expect, vi, vitest } from "vitest";
+   ·                      ──────
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:10]
+ 1 │ import { vitest } from "vitest";
+   ·          ──────
+ 2 │             vitest.stubEnv("NODE_ENV", "production");
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:2:4]
+ 1 │ import { vitest } from "vitest";
+ 2 │             vitest.stubEnv("NODE_ENV", "production");
+   ·             ──────
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:1]
+ 1 │ vi.stubEnv("NODE_ENV", "production");
+   · ──
+ 2 │             vi.clearAllMocks();
+   ╰────
+  help: Prefer using `vitest` instead of `vi`.
+
+  ⚠ eslint-plugin-vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:2:4]
+ 1 │ vi.stubEnv("NODE_ENV", "production");
+ 2 │             vi.clearAllMocks();
+   ·             ──
+   ╰────
+  help: Prefer using `vitest` instead of `vi`.

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -54,7 +54,7 @@ impl JestFnKind {
         match name {
             "expect" => Self::Expect,
             "expectTypeOf" => Self::ExpectTypeOf,
-            "vi" => Self::General(JestGeneralFnKind::Vitest),
+            "vi" | "vitest" => Self::General(JestGeneralFnKind::Vitest),
             "bench" => Self::General(JestGeneralFnKind::Bench),
             "jest" => Self::General(JestGeneralFnKind::Jest),
             "describe" | "fdescribe" | "xdescribe" => Self::General(JestGeneralFnKind::Describe),

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -274,7 +274,7 @@ fn parse_jest_jest_fn_call<'a>(
 ) -> Option<ParsedJestFnCall<'a>> {
     let lowercase_name = name.cow_to_ascii_lowercase();
 
-    if !(lowercase_name == "jest" || lowercase_name == "vi") {
+    if !(lowercase_name == "jest" || lowercase_name == "vi" || lowercase_name == "vitest") {
         return None;
     }
 


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Implement `consistent-vitest-vi` vitest rule