### PR TITLE
ci(bench): add real-world linter benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,6 +90,14 @@ jobs:
           mv target/release/deps/${{ matrix.component }}-* target/codspeed/simulation/oxc_benchmark
           rm target/codspeed/simulation/oxc_benchmark/*.d
 
+      # Download github.com/calcom/cal.com repository for linter benchmark
+      - name: Download files for benchmark
+        if: ${{ matrix.component == 'linter' }}
+        run: |
+          REPOSITORY="https://github.com/calcom/cal.com"
+          git clone --depth 1 $REPOSITORY calcom
+          echo "CALCOM_PATH=$(pwd)/calcom/apps/web" >> $GITHUB_ENV
+
       - name: Run benchmark
         uses: CodSpeedHQ/action@972e3437949c89e1357ebd1a2dbc852fcbc57245 # v4.5.1
         timeout-minutes: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ version = "0.0.0"
 dependencies = [
  "cow-utils",
  "criterion2",
+ "ignore",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -82,6 +82,9 @@ criterion2 = { workspace = true }
 # Only for lexer benchmark
 cow-utils = { workspace = true, optional = true }
 
+# Only for linter benchmark
+ignore = { workspace = true, optional = true }
+
 # Only for NAPI benchmark
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -117,6 +120,7 @@ linter = [
   "dep:oxc_semantic",
   "dep:oxc_span",
   "dep:oxc_tasks_common",
+  "dep:ignore",
   "oxc_semantic/cfg",
 ]
 

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,5 +1,9 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
 
+use oxc_span::SourceType;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::Allocator;
@@ -15,7 +19,7 @@ use oxc_tasks_common::TestFiles;
 fn bench_linter(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("linter");
 
-    for file in TestFiles::minimal().files() {
+    for file in TestFiles::linter().files() {
         let id = BenchmarkId::from_parameter(&file.file_name);
         let source_text = &file.source_text;
         let source_type = file.source_type;
@@ -61,5 +65,114 @@ fn bench_linter(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(linter, bench_linter);
+#[derive(Debug)]
+struct RepoTestFile {
+    path: PathBuf,
+    source_type: SourceType,
+    source_text: String,
+}
+
+impl RepoTestFile {
+    fn new(path: PathBuf) -> Self {
+        let source_type = SourceType::from_path(&path).expect("invalid source type");
+        let source_text = std::fs::read_to_string(&path).expect("Failed to read source file");
+        Self { path, source_type, source_text }
+    }
+}
+
+fn bench_linter_real_world(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("linter_real_world");
+
+    let calcom_path = std::env::var("CALCOM_PATH").expect("CALCOM_PATH env var not set");
+
+    // TODO: Enable walker to lint whole repository
+    let walker = ignore::WalkBuilder::new(&calcom_path)
+        .ignore(false)
+        .git_global(false)
+        .git_ignore(true)
+        .follow_links(true)
+        .hidden(false)
+        .require_git(false)
+        .build_parallel();
+
+    // Read source files once, outside of the benchmark
+    let test_files = Arc::new(Mutex::new(Vec::new()));
+    walker.run(|| {
+        let test_files = Arc::clone(&test_files);
+        Box::new(move |result| {
+            if let Ok(entry) = result {
+                let path = entry.path();
+                if let Some(extension) = path.extension() {
+                    let extension = extension.to_string_lossy();
+                    if ["js", "jsx", "ts", "tsx"].contains(&extension.as_ref()) {
+                        test_files.lock().unwrap().push(RepoTestFile::new(path.to_path_buf()));
+                    }
+                }
+            }
+            ignore::WalkState::Continue
+        })
+    });
+    let test_files = Arc::try_unwrap(test_files).unwrap().into_inner().unwrap();
+
+    // Build the linter config once, outside of the benchmark
+    let mut external_plugin_store = ExternalPluginStore::default();
+    let lint_config = ConfigStoreBuilder::all().build(&mut external_plugin_store).unwrap();
+    let linter = Linter::new(
+        LintOptions::default(),
+        ConfigStore::new(lint_config, FxHashMap::default(), external_plugin_store),
+        None,
+    )
+    .with_fix(FixKind::None);
+
+    // Create allocator outside of bench_function so same allocator is used for
+    // both the warmup and measurement phases
+    let mut allocator = Allocator::default();
+
+    // Group all of the files together as a single benchmark for cal.com
+    group.bench_function("calcom_repo", |b| {
+        b.iter_with_setup_wrapper(|runner| {
+            // Reset allocator at start of each iteration to reclaim memory
+            allocator.reset();
+
+            // Step 1: Parse all files first
+            let parser_results: Vec<_> = test_files
+                .iter()
+                .map(|test_file| {
+                    Parser::new(&allocator, &test_file.source_text, test_file.source_type).parse()
+                })
+                .collect();
+
+            // Step 2: Build semantic analysis for each file
+            let lint_inputs: Vec<_> = test_files
+                .iter()
+                .zip(parser_results.iter())
+                .map(|(test_file, parser_ret)| {
+                    let semantic_ret = SemanticBuilder::new()
+                        .with_scope_tree_child_ids(true)
+                        .with_cfg(true)
+                        .build(&parser_ret.program);
+                    let semantic = semantic_ret.semantic;
+                    let module_record = Arc::new(ModuleRecord::new(
+                        &test_file.path,
+                        &parser_ret.module_record,
+                        &semantic,
+                    ));
+                    (&test_file.path, semantic, module_record)
+                })
+                .collect();
+
+            runner.run(|| {
+                for (path, semantic, module_record) in lint_inputs {
+                    linter.run(
+                        path,
+                        vec![ContextSubHost::new(semantic, Arc::clone(&module_record), 0)],
+                        &allocator,
+                    );
+                }
+            });
+        });
+    });
+}
+
+criterion_group!(linter, bench_linter, bench_linter_real_world);
 criterion_main!(linter);

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -59,6 +59,17 @@ impl TestFiles {
         }
     }
 
+    pub fn linter() -> Self {
+        Self {
+            files: [
+                // cal.com is excluded, since we benchmark it separately as the entire repository
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+                "https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.development.js",
+                "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/binder.ts",
+            ].into_iter().map(TestFile::new).collect(),
+        }
+    }
+
     pub fn minimal() -> Self {
         Self {
             files: [


### PR DESCRIPTION
- related to https://github.com/oxc-project/oxc/issues/13708

> [!warning]
> this is a work in progress.

this is an experimental PR (for now, until I mark as ready for review) to add some slightly more realistic usage of the linter. namely that means:

- linting multiple files at the same time
- not running with fixes (as this is less common for things like CI or pre-push hooks)
- maybe: running with only the most common plugins?