### PR TITLE
test(rust): disable empty test and doctest targets

### DIFF
--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [lib]
 proc-macro = true
+test = false
 doctest = false
 
 [dependencies]

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -18,7 +18,10 @@ workspace = true
 
 [[bin]]
 name = "oxc_language_server"
-test = true
+test = false
+doctest = false
+
+[lib]
 doctest = false
 
 [dependencies]

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -17,6 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
+test = false
 doctest = false
 crate-type = ["lib", "cdylib"]
 

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = true
+doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/tasks/compat_data/Cargo.toml
+++ b/tasks/compat_data/Cargo.toml
@@ -12,6 +12,10 @@ workspace = true
 test = false
 doctest = false
 
+[[bin]]
+name = "oxc_compat_data"
+test = false
+
 [dependencies]
 oxc_tasks_common = { workspace = true }
 oxc_transformer = { workspace = true }

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -14,6 +14,7 @@ description.workspace = true
 workspace = true
 
 [lib]
+test = false
 doctest = false
 
 [[bin]]

--- a/tasks/linter_codegen/Cargo.toml
+++ b/tasks/linter_codegen/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [[bin]]
 name = "oxc_linter_codegen"
-test = true
+test = false
 doctest = false
 
 [dependencies]

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -14,6 +14,7 @@ description.workspace = true
 workspace = true
 
 [lib]
+test = false
 doctest = false
 
 [[bin]]

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -14,6 +14,7 @@ description.workspace = true
 workspace = true
 
 [lib]
+test = false
 doctest = false
 
 [[bin]]

--- a/tasks/vscode_docs/Cargo.toml
+++ b/tasks/vscode_docs/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [[bin]]
 name = "vscode_docs"
+test = false
 doctest = false
 
 [dependencies]

--- a/tasks/website_common/Cargo.toml
+++ b/tasks/website_common/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [lints]
 workspace = true
 
+[lib]
+doctest = false
+test = false
+
 [dependencies]
 handlebars = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
## Summary

- Disable `test = false` and `doctest = false` for crates that have no tests
- Reduces CI noise from "0 passed; 0 failed" output
- Saves compilation time for empty test targets

**Affected crates:**
- `oxc_ast_macros` - lib test
- `oxc_language_server` - bin test, lib doctest
- `oxc_napi` - lib test
- `oxc_syntax` - lib doctest
- `oxc_compat_data` - bin test
- `oxc_coverage` - lib test
- `oxc_linter_codegen` - bin test
- `oxc_prettier_conformance` - lib test
- `oxc_transform_conformance` - lib test
- `vscode_docs` - bin test
- `website_common` - lib test, lib doctest

## Test plan

- [x] `cargo test` passes with no empty test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)