### PR TITLE
refactor(lsp): capability to send `showMessage` on diagnostics errors

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use futures::future::join_all;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use rustc_hash::FxBuildHasher;
 use serde_json::Value;
 use tokio::sync::{OnceCell, RwLock, SetError};
@@ -15,7 +15,8 @@ use tower_lsp_server::{
         DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
         DocumentDiagnosticReportKind, DocumentDiagnosticReportResult, DocumentFormattingParams,
         ExecuteCommandParams, FullDocumentDiagnosticReport, InitializeParams, InitializeResult,
-        InitializedParams, RelatedFullDocumentDiagnosticReport, ServerInfo, TextEdit, Uri,
+        InitializedParams, MessageType, RelatedFullDocumentDiagnosticReport, ServerInfo, TextEdit,
+        Uri,
     },
 };
 
@@ -227,7 +228,15 @@ impl LanguageServer for Backend {
                     }
                     let content = self.file_system.read().await.get(uri);
                     let diagnostics = worker.run_diagnostic(uri, content.as_deref()).await;
-                    new_diagnostics.extend(diagnostics);
+                    match diagnostics {
+                        Err(err) => {
+                            error!("running diagnostics for {} failed: {err}", uri.as_str());
+                            if self.capabilities.get().is_some_and(|cap| cap.show_message) {
+                                self.client.show_message(MessageType::ERROR, err).await;
+                            }
+                        }
+                        Ok(diagnostics) => new_diagnostics.extend(diagnostics),
+                    }
                 }
             }
 
@@ -543,9 +552,19 @@ impl LanguageServer for Backend {
         };
 
         if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
-            let diagnostics = worker.run_diagnostic_on_save(&uri, params.text.as_deref()).await;
-            if !diagnostics.is_empty() {
-                self.publish_all_diagnostics(diagnostics, ConcurrentHashMap::default()).await;
+            match worker.run_diagnostic_on_save(&uri, params.text.as_deref()).await {
+                Err(err) => {
+                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
+                        self.client.show_message(MessageType::ERROR, err).await;
+                    }
+                }
+                Ok(diagnostics) => {
+                    if !diagnostics.is_empty() {
+                        self.publish_all_diagnostics(diagnostics, ConcurrentHashMap::default())
+                            .await;
+                    }
+                }
             }
         }
     }
@@ -566,11 +585,20 @@ impl LanguageServer for Backend {
         }
 
         if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
-            let diagnostics = worker.run_diagnostic_on_change(&uri, content.as_deref()).await;
-            if !diagnostics.is_empty() {
-                let version_map = ConcurrentHashMap::default();
-                version_map.pin().insert(uri.clone(), params.text_document.version);
-                self.publish_all_diagnostics(diagnostics, version_map).await;
+            match worker.run_diagnostic_on_change(&uri, content.as_deref()).await {
+                Err(err) => {
+                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
+                        self.client.show_message(MessageType::ERROR, err).await;
+                    }
+                }
+                Ok(diagnostics) => {
+                    if !diagnostics.is_empty() {
+                        let version_map = ConcurrentHashMap::default();
+                        version_map.pin().insert(uri.clone(), params.text_document.version);
+                        self.publish_all_diagnostics(diagnostics, version_map).await;
+                    }
+                }
             }
         }
     }
@@ -591,11 +619,20 @@ impl LanguageServer for Backend {
         self.file_system.write().await.set(uri.clone(), content.clone());
 
         if self.capabilities.get().is_some_and(Capabilities::use_push_diagnostics) {
-            let diagnostics = worker.run_diagnostic(&uri, Some(&content)).await;
-            if !diagnostics.is_empty() {
-                let version_map = ConcurrentHashMap::default();
-                version_map.pin().insert(uri.clone(), params.text_document.version);
-                self.publish_all_diagnostics(diagnostics, version_map).await;
+            match worker.run_diagnostic(&uri, Some(&content)).await {
+                Err(err) => {
+                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
+                        self.client.show_message(MessageType::ERROR, err).await;
+                    }
+                }
+                Ok(diagnostics) => {
+                    if !diagnostics.is_empty() {
+                        let version_map = ConcurrentHashMap::default();
+                        version_map.pin().insert(uri.clone(), params.text_document.version);
+                        self.publish_all_diagnostics(diagnostics, version_map).await;
+                    }
+                }
             }
         }
     }
@@ -679,6 +716,18 @@ impl LanguageServer for Backend {
         };
         let diagnostics =
             worker.run_diagnostic(uri, self.file_system.read().await.get(uri).as_deref()).await;
+
+        let diagnostics = match diagnostics {
+            Err(err) => {
+                error!("running diagnostics for {} failed: {err}", uri.as_str());
+                return Err(Error {
+                    code: ErrorCode::ServerError(1),
+                    message: Cow::Owned(err),
+                    data: None,
+                });
+            }
+            Ok(diagnostics) => diagnostics,
+        };
 
         let uri_diagnostics = diagnostics
             .iter()

--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -9,6 +9,7 @@ pub struct Capabilities {
     pub workspace_apply_edit: bool,
     pub workspace_configuration: bool,
     pub dynamic_watchers: bool,
+    pub show_message: bool,
     /// Whether the client supports pull diagnostics.
     pull_diagnostics: bool,
     /// Whether the client supports the `workspace/diagnostic/refresh` request.
@@ -19,15 +20,20 @@ impl From<ClientCapabilities> for Capabilities {
     fn from(value: ClientCapabilities) -> Self {
         let workspace_apply_edit =
             value.workspace.as_ref().is_some_and(|workspace| workspace.apply_edit.is_some());
+
         let workspace_configuration = value
             .workspace
             .as_ref()
             .is_some_and(|workspace| workspace.configuration.is_some_and(|config| config));
+
         let dynamic_watchers = value.workspace.as_ref().is_some_and(|workspace| {
             workspace.did_change_watched_files.is_some_and(|watched_files| {
                 watched_files.dynamic_registration.is_some_and(|dynamic| dynamic)
             })
         });
+
+        let show_message =
+            value.window.as_ref().is_some_and(|window| window.show_message.is_some());
 
         let pull_diagnostics = value
             .text_document
@@ -44,6 +50,7 @@ impl From<ClientCapabilities> for Capabilities {
             workspace_apply_edit,
             workspace_configuration,
             dynamic_watchers,
+            show_message,
             pull_diagnostics,
             refresh_diagnostics,
         }

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -517,9 +517,9 @@ impl Tool for ServerLinter {
     /// - If the file is not lintable or ignored, an empty vector is returned
     fn run_diagnostic(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         let Some(diagnostics) = self.run_file(uri, content) else {
-            return vec![];
+            return Ok(vec![]);
         };
-        vec![(uri.clone(), diagnostics)]
+        Ok(vec![(uri.clone(), diagnostics)])
     }
 
     /// Lint a file with the current linter
@@ -527,7 +527,7 @@ impl Tool for ServerLinter {
     /// - If the linter is not set to `OnType`, an empty vector is returned
     fn run_diagnostic_on_change(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         if self.run != Run::OnType {
-            return vec![];
+            return Ok(vec![]);
         }
         self.run_diagnostic(uri, content)
     }
@@ -537,7 +537,7 @@ impl Tool for ServerLinter {
     /// - If the linter is not set to `OnSave`, an empty vector is returned
     fn run_diagnostic_on_save(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         if self.run != Run::OnSave {
-            return vec![];
+            return Ok(vec![]);
         }
         self.run_diagnostic(uri, content)
     }

--- a/crates/oxc_language_server/src/linter/tester.rs
+++ b/crates/oxc_language_server/src/linter/tester.rs
@@ -22,7 +22,7 @@ pub fn get_file_uri(relative_file_path: &str) -> Uri {
         .expect("failed to convert file path to URL")
 }
 
-fn get_snapshot_from_diagnostic_result(diagnostic_result: &DiagnosticResult) -> String {
+fn get_snapshot_from_diagnostic_result(diagnostic_result: &[(Uri, Vec<Diagnostic>)]) -> String {
     if diagnostic_result.is_empty() {
         return "No diagnostics / Files are ignored".to_string();
     }
@@ -148,7 +148,12 @@ fn get_snapshot_from_code_action_or_command(action_or_command: &CodeActionOrComm
 }
 
 fn get_snapshot_from_report(report: &FileResult) -> String {
-    if report.diagnostic.is_empty() {
+    let diagnostics = match &report.diagnostic {
+        Err(err) => return format!("Error running diagnostics: {err}"),
+        Ok(diagnostics) => diagnostics,
+    };
+
+    if diagnostics.is_empty() {
         return "No diagnostics / Files are ignored".to_string();
     }
 
@@ -157,7 +162,7 @@ fn get_snapshot_from_report(report: &FileResult) -> String {
 {}
 ########### Code Actions/Commands
 {}",
-        get_snapshot_from_diagnostic_result(&report.diagnostic),
+        get_snapshot_from_diagnostic_result(diagnostics),
         report
             .actions
             .iter()

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -124,7 +124,7 @@ impl Tool for FakeTool {
 
     fn run_diagnostic(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {
         if uri.as_str().ends_with("diagnostics.config") {
-            return vec![(
+            return Ok(vec![(
                 uri.clone(),
                 vec![Diagnostic {
                     message: format!(
@@ -133,9 +133,14 @@ impl Tool for FakeTool {
                     ),
                     ..Default::default()
                 }],
-            )];
+            )]);
         }
-        vec![]
+
+        if uri.as_str().ends_with("error.config") {
+            return Err("Fake diagnostic error".to_string());
+        }
+
+        Ok(Vec::new())
     }
 
     fn run_diagnostic_on_change(&self, uri: &Uri, content: Option<&str>) -> DiagnosticResult {

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -21,7 +21,7 @@ pub trait ToolBuilder: Send + Sync {
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;
 }
 
-pub type DiagnosticResult = Vec<(Uri, Vec<Diagnostic>)>;
+pub type DiagnosticResult = Result<Vec<(Uri, Vec<Diagnostic>)>, String>;
 
 pub trait Tool: Send + Sync {
     /// Get the name of the tool.
@@ -93,25 +93,34 @@ pub trait Tool: Send + Sync {
 
     /// Run diagnostics on the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
-    /// Not all tools will implement diagnostics, so the default implementation returns an empty vector.
+    /// Not all tools will implement diagnostics, so the default implementation returns [`Ok`] with an empty vector.
+    ///
+    /// # Errors
+    /// Return [`Err`] when an error occurs, ignoring diagnostics should return [`Ok`] with an empty vector.
     fn run_diagnostic(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
-        Vec::new()
+        Ok(Vec::new())
     }
 
     /// Run diagnostics on save for the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
     /// Returns a vector of a Uri-Diagnostic tuple representing the diagnostic results.
-    /// Not all tools will implement diagnostics on save, so the default implementation returns an empty vector.
+    /// Not all tools will implement diagnostics on save, so the default implementation returns [`Ok`] with an empty vector.
+    ///
+    /// # Errors
+    /// Return [`Err`] when an error occurs, ignoring diagnostics should return [`Ok`] with an empty vector.
     fn run_diagnostic_on_save(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
-        Vec::new()
+        Ok(Vec::new())
     }
 
     /// Run diagnostics on change for the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
     /// Returns a vector of a Uri-Diagnostic tuple representing the diagnostic results.
-    /// Not all tools will implement diagnostics on change, so the default implementation returns an empty vector.
+    /// Not all tools will implement diagnostics on change, so the default implementation returns [`Ok`] with an empty vector.
+    ///
+    /// # Errors
+    /// Return [`Err`] when an error occurs, ignoring diagnostics should return [`Ok`] with an empty vector.
     fn run_diagnostic_on_change(&self, _uri: &Uri, _content: Option<&str>) -> DiagnosticResult {
-        Vec::new()
+        Ok(Vec::new())
     }
 
     /// Remove internal cache for the given URI, if any.


### PR DESCRIPTION
With these changes, `oxlint --lsp` can now show a window message like:
<img width="462" height="57" alt="grafik" src="https://github.com/user-attachments/assets/78d86d8c-1e93-44c9-b4b0-dd53e1ed65da" />

For the pull mode, an `Err` is returned instead. Do not know how the client will handle this. 🤞 

Useful when an error (like tsoglint) occurs which has nothing to do with a file diagnostic 