### PR TITLE
fix(formatter): incorrect JSX text wrapping when the expression container is an arrow function that will break

### DIFF
--- a/crates/oxc_formatter/src/write/jsx/mod.rs
+++ b/crates/oxc_formatter/src/write/jsx/mod.rs
@@ -197,24 +197,26 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
                 let should_inline = !has_comment(f)
                     && (is_conditional_or_binary || should_inline_jsx_expression(self));
 
-                if should_inline {
-                    write!(f, ["{", self.expression(), line_suffix_boundary(), "}"]);
-                } else {
-                    write!(
-                        f,
-                        [group(&format_args!(
-                            "{",
+                let format_expression = format_with(|f| {
+                    if should_inline {
+                        write!(f, self.expression());
+                    } else {
+                        write!(
+                            f,
                             soft_block_indent(&format_with(|f| {
                                 write!(f, [self.expression()]);
                                 let comments =
                                     f.context().comments().comments_before(self.span.end);
                                 write!(f, [FormatTrailingComments::Comments(comments)]);
-                            })),
-                            line_suffix_boundary(),
-                            "}"
-                        ))]
-                    );
-                }
+                            }))
+                        );
+                    }
+                });
+
+                write!(
+                    f,
+                    [group(&format_args!("{", format_expression, line_suffix_boundary(), "}"))]
+                );
             }
         } else {
             // JSXAttributeValue

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/text-wrap.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/text-wrap.jsx
@@ -1,0 +1,5 @@
+<p>
+  Current usage for X is ${(() => {
+    // comment
+  })()}.
+</p>

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/text-wrap.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/text-wrap.jsx.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+<p>
+  Current usage for X is ${(() => {
+    // comment
+  })()}.
+</p>
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+<p>
+  Current usage for X is $
+  {(() => {
+    // comment
+  })()}
+  .
+</p>;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+<p>
+  Current usage for X is $
+  {(() => {
+    // comment
+  })()}
+  .
+</p>;
+
+===================== End =====================


### PR DESCRIPTION
close: #16956

The mismatch is caused by the expression container (which is an arrow function here) not being wrapped by a `group` compared to Prettier. After grouping, the output turns into the same.

Input:
```jsx
<p>
  Current usage for is ${(() => {
    //
  })()}.
</p>
```
Before output:
```jsx
<p>
  Current usage for is ${(() => {
    //
  })()}.
</p>;
```

After output:
```jsx
<p>
  Current usage for X is $
  {(() => {
    // comment
  })()}
  .
</p>;
```
[Prettier output](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeADgPgDpQAR4DCArgE6kIx7EDOAhgOZx4BmEpeAljXgCTAAKAQEo8AXkx5guAngD0cmXgC+wkcoB0uVHKwgANCAjoYnaDWSg65CAHcACtYQWUdADa26ATwuGARqR0YADWcDAAynQAtnAAMpxQcMgs7jRwhhB+AFZwYDAA6oHoyCDoFGmkAG5J-oEhYeHoQQkMyDCkxOkgaVGcbR1dcAAe6HCknDGw7gDyo4Ew7PYQNJym0CUIACYGIMNzE5TuACpjUNaccC4pbmmGK1AMbnAAisQQ8MmpXVk0Q+EtT1e7ySSGutxAAEc3vB7KRjC4QHQaABaRJwTbonbtOicNwtQgQKJROgldxuHb3R5wACCMHanD8xBhY3iiU+Ny6AAsYFE3PlOatLk0wHBws5VpxKqsvCUwDRfCBKp0AJJQDGwcJgcYmalq8IwLxPdngsrLOCFOjFFBlS5jao7LbTFiskEgNwsHYJCowWGMYnGrpNUgVEp+Oh+OBuZEwBVlBIFTibGCc5AARlTAAZDBQoZwKL6GP7QV9DDBw-lE8nkAAmQy0OBHcNXEu7KIRzYYzaxOgPYiMOAAMXYxLpLVJTIgIGUyiAA):

```js
<p>
  Current usage for is $
  {(() => {
    //
  })()}
  .
</p>;
```