### PR TITLE
refactor(oxfmt,oxlint): replace OXC_VERSION with `env!("CARGO_PKG_VERSION")`

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -86,7 +86,6 @@ jobs:
     name: Build Oxlint ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     env:
-      OXC_VERSION: ${{ needs.check.outputs.oxlint_version }} # Required for `--version` to work.
       TARGET_CC: clang # for mimalloc
     defaults:
       run:
@@ -253,7 +252,6 @@ jobs:
     name: Build Oxfmt ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     env:
-      OXC_VERSION: ${{ needs.check.outputs.oxfmt_version }} # Required for `--version` to work.
       TARGET_CC: clang # for mimalloc
     defaults:
       run:

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,5 +2,4 @@
 passthrough = [
   "CI", # for crates/oxc_traverse/build.rs
   "JEMALLOC_SYS_WITH_LG_PAGE",
-  "OXC_VERSION",
 ]

--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -4,10 +4,7 @@ use bpaf::{Bpaf, Parser};
 #[cfg(feature = "napi")]
 use cow_utils::CowUtils;
 
-const VERSION: &str = match option_env!("OXC_VERSION") {
-    Some(v) => v,
-    None => "dev",
-};
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[expect(clippy::ptr_arg)]
 fn validate_paths(paths: &Vec<PathBuf>) -> bool {

--- a/apps/oxlint/src/command/mod.rs
+++ b/apps/oxlint/src/command/mod.rs
@@ -10,10 +10,7 @@ pub use self::{
     lint::{LintCommand, OutputOptions, ReportUnusedDirectives, WarningOptions, lint_command},
 };
 
-const VERSION: &str = match option_env!("OXC_VERSION") {
-    Some(v) => v,
-    None => "dev",
-};
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Miscellaneous
 #[derive(Debug, Clone, Bpaf)]


### PR DESCRIPTION
I didn't know this env variable existed when I built the first version
of the CLI :-)