### PR TITLE
fix(oxfmt,oxlint): disable mimalloc for 32-bit Arm targets

### DIFF
--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -9,6 +9,9 @@ pub mod stdin;
 #[cfg(feature = "napi")]
 pub use main_napi::*;
 
-#[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]
+#[cfg(all(
+    feature = "allocator",
+    not(any(target_arch = "arm", miri, target_os = "freebsd", target_family = "wasm"))
+))]
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -38,6 +38,9 @@ mod js_plugins;
 // Use Mimalloc as the global allocator if `--features allocator` is enabled.
 // Mimalloc has better performance, but this is feature-gated because it's slow to compile.
 // `--features allocator` is only used in release builds.
-#[cfg(all(feature = "allocator", not(miri), not(target_family = "wasm")))]
+#[cfg(all(
+    feature = "allocator",
+    not(any(target_arch = "arm", miri, target_os = "freebsd", target_family = "wasm"))
+))]
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;


### PR DESCRIPTION
This makes the condition for enabling mimalloc the same across the
entire codebase. The condition for enabling mimalloc dependency was the
same across all the projects, but wasn't the same when actually enabling
it.
~Not sure if removing the miri condition is fine. But if we are rewriting this, let's just do this as well and test it on CI~ (miri condition added back after maintainer request)