### PR TITLE
chore(linter): Add some unused fix tests for unicorn rules

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -319,6 +319,12 @@ fn test() {
         (r"(el as HTMLElement).onmouseenter = onAnchorMouseEnter;", None),
     ];
 
+    // TODO: Implement autofix and use these tests.
+    // let _fix = vec![(
+    //     "(el as HTMLElement).onmouseenter = onAnchorMouseEnter;",
+    //     "(el as HTMLElement).addEventListener('mouseenter', onAnchorMouseEnter);",
+    // )];
+
     Tester::new(PreferAddEventListener::NAME, PreferAddEventListener::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
@@ -605,6 +605,7 @@ fn test() {
         "array.filter(foo)?.pop()",
     ];
 
+    // TODO: Implement autofix and use these tests.
     let _fix: Vec<(&'static str, &'static str, Option<serde_json::Value>)> = vec![
         ("array.filter(foo)[0]", "array.find(foo)", None),
         ("array.filter(foo, thisArgument)[0]", "array.find(foo, thisArgument)", None),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -614,6 +614,7 @@ fn test() {
 }",
     ];
 
+    // TODO: Implement autofix and use these tests.
     let _fix = vec![
         (
             r"function abc(foo) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -132,6 +132,10 @@ fn test() {
         "await a ? (await (a)) : (foo)",
         "(await a) ? await (a) : (foo)",
         "(await a) ? (await (a)) : (foo)",
+        "const foo = [];
+         !+a ? b : +a",
+        "const foo = [];
+         a && b ? a && b : 1",
     ];
 
     Tester::new(

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -207,6 +207,83 @@ fn test() {
         ),
     ];
 
+    // TODO: Implement autofix and use these tests.
+    let _fix = vec![
+        (
+            "parentNode.replaceChild(newChildNode, oldChildNode);",
+            "oldChildNode.replaceWith(newChildNode);",
+        ),
+        ("parentNode.insertBefore(newNode, referenceNode);", "referenceNode.before(newNode);"),
+        (
+            r#"referenceNode.insertAdjacentText("beforebegin", "text");"#,
+            r#"referenceNode.before("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentText("afterbegin", "text");"#,
+            r#"referenceNode.prepend("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentText("beforeend", "text");"#,
+            r#"referenceNode.append("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentText("afterend", "text");"#,
+            r#"referenceNode.after("text");"#,
+        ),
+        (
+            r#"const foo = referenceNode.insertAdjacentText("beforebegin", "text");"#,
+            r#"const foo = referenceNode.before("text");"#,
+        ),
+        (
+            r#"foo = referenceNode.insertAdjacentText("beforebegin", "text");"#,
+            r#"foo = referenceNode.before("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement("beforebegin", newNode);"#,
+            "referenceNode.before(newNode);",
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement("afterbegin", "text");"#,
+            r#"referenceNode.prepend("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement("beforeend", "text");"#,
+            r#"referenceNode.append("text");"#,
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement("afterend", newNode);"#,
+            "referenceNode.after(newNode);",
+        ),
+        (
+            "parentNode.replaceChild(
+                newChildNode,
+                oldChildNode
+            );",
+            "oldChildNode.replaceWith(newChildNode);",
+        ),
+        (
+            "parentNode. replaceChild( // inline comments
+                newChildNode, // inline comments
+                oldChildNode // inline comments
+            );",
+            "oldChildNode.replaceWith(newChildNode);",
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement(
+                "afterend",
+                newNode
+            );"#,
+            "referenceNode.after(newNode);",
+        ),
+        (
+            r#"referenceNode.insertAdjacentElement( // inline comments
+                "afterend", // inline comments
+                newNode  // inline comments
+            ); // inline comments"#,
+            "referenceNode.after(newNode); // inline comments",
+        ),
+    ];
+
     Tester::new(PreferModernDomApis::NAME, PreferModernDomApis::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -409,6 +409,8 @@ fn test() {
 				);
 			}
 		",
+        // TODO: Fix this
+        // "Math.sqrt((( a ** 2 )) + (( b ** 2 + c ** 2 )) + (( d )) * (( d )) + (( e )) ** (( 2 )))",
     ];
 
     Tester::new(PreferModernMathApis::NAME, PreferModernMathApis::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_logical_operator_over_ternary.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_logical_operator_over_ternary.snap
@@ -126,3 +126,19 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────
    ╰────
   help: Switch to "||" or "??" operator
+
+  ⚠ eslint-plugin-unicorn(prefer-logical-operator-over-ternary): Prefer using a logical operator over a ternary.
+   ╭─[prefer_logical_operator_over_ternary.tsx:2:10]
+ 1 │ const foo = [];
+ 2 │          !+a ? b : +a
+   ·          ────────────
+   ╰────
+  help: Switch to "||" or "??" operator
+
+  ⚠ eslint-plugin-unicorn(prefer-logical-operator-over-ternary): Prefer using a logical operator over a ternary.
+   ╭─[prefer_logical_operator_over_ternary.tsx:2:10]
+ 1 │ const foo = [];
+ 2 │          a && b ? a && b : 1
+   ·          ───────────────────
+   ╰────
+  help: Switch to "||" or "??" operator


### PR DESCRIPTION
Basically just adding some minor changes from the upstream rules (found by deleting the rules and then re-generating them and looking through the diff in the tests). I had hoped to find more tests for pending fixes, but didn't really find many.