### PR TITLE
feat(website_linter): Add a count of rules with fixes available to rules table.

### DIFF
--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -8,6 +8,7 @@ pub struct RuleTable {
     pub sections: Vec<RuleTableSection>,
     pub total: usize,
     pub turned_on_by_default_count: usize,
+    pub rules_with_fixes: usize,
 }
 
 pub struct RuleTableSection {
@@ -17,6 +18,7 @@ pub struct RuleTableSection {
     pub plugin_column_width: usize,
 }
 
+#[derive(Debug, Clone)]
 pub struct RuleTableRow {
     pub name: &'static str,
     pub plugin: String,
@@ -75,6 +77,8 @@ impl RuleTable {
 
         rows.sort_by_key(|row| (row.plugin.clone(), row.name));
 
+        let rules_with_fixes = rows.iter().filter(|r| r.autofix.has_fix()).count();
+
         let mut rows_by_category = rows.into_iter().fold(
             FxHashMap::default(),
             |mut map: FxHashMap<RuleCategory, Vec<RuleTableRow>>, row| {
@@ -101,7 +105,12 @@ impl RuleTable {
         })
         .collect::<Vec<_>>();
 
-        RuleTable { total, sections, turned_on_by_default_count: default_rules.len() }
+        RuleTable {
+            total,
+            sections,
+            turned_on_by_default_count: default_rules.len(),
+            rules_with_fixes,
+        }
     }
 }
 

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -18,7 +18,6 @@ pub struct RuleTableSection {
     pub plugin_column_width: usize,
 }
 
-#[derive(Debug, Clone)]
 pub struct RuleTableRow {
     pub name: &'static str,
     pub plugin: String,

--- a/tasks/website_linter/src/rules/table.rs
+++ b/tasks/website_linter/src/rules/table.rs
@@ -10,7 +10,7 @@ use oxc_linter::table::RuleTable;
 pub fn render_rules_table(table: &RuleTable, docs_prefix: &str) -> String {
     let total = table.total;
     let turned_on_by_default_count = table.turned_on_by_default_count;
-
+    let rules_with_fixes = table.rules_with_fixes;
     let body = table
         .sections
         .iter()
@@ -28,6 +28,7 @@ The progress of all rule implementations is tracked [here](https://github.com/ox
 
 - Total number of rules: {total}
 - Rules turned on by default: {turned_on_by_default_count}
+- Rules with fixes available: {rules_with_fixes}
 
 **Legend for 'Fixable?' column:**
 - 🛠️: an auto-fix is available for this rule


### PR DESCRIPTION
Simple enough change:

<img width="900" height="372" alt="Screenshot 2025-12-29 at 8 34 57 PM" src="https://github.com/user-attachments/assets/f5a558ef-118b-4d07-baac-69d340350fad" />
