### PR TITLE
refactor(semantic): consolidate diagnostics into single module

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -5,7 +5,6 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::GetAddress;
 use oxc_ast::{AstKind, ModuleDeclarationKind, ast::*};
-use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList, PropName};
 use oxc_span::{GetSpan, ModuleKind, Span};
 use oxc_syntax::{
@@ -16,12 +15,7 @@ use oxc_syntax::{
     symbol::{SymbolFlags, SymbolId},
 };
 
-use crate::{IsGlobalReference, builder::SemanticBuilder, diagnostics::redeclaration};
-
-#[cold]
-fn undefined_export(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Export '{x0}' is not defined")).with_label(span1)
-}
+use crate::{IsGlobalReference, builder::SemanticBuilder, diagnostics};
 
 /// It is a Syntax Error if any element of the ExportedBindings of ModuleItemList
 /// does not also occur in either the VarDeclaredNames of ModuleItemList, or the LexicallyDeclaredNames of ModuleItemList.
@@ -35,7 +29,9 @@ pub fn check_unresolved_exports(program: &Program<'_>, ctx: &SemanticBuilder<'_>
                 if let ModuleExportName::IdentifierReference(ident) = &specifier.local
                     && ident.is_global_reference(&ctx.scoping)
                 {
-                    ctx.errors.borrow_mut().push(undefined_export(&ident.name, ident.span));
+                    ctx.errors
+                        .borrow_mut()
+                        .push(diagnostics::undefined_export(&ident.name, ident.span));
                 }
             }
         }
@@ -71,21 +67,15 @@ pub fn check_duplicate_class_elements(ctx: &SemanticBuilder<'_>) {
                 };
 
                 if is_duplicate {
-                    ctx.error(redeclaration(&element.name, prev_element.span, element.span));
+                    ctx.error(diagnostics::redeclaration(
+                        &element.name,
+                        prev_element.span,
+                        element.span,
+                    ));
                 }
             }
         }
     });
-}
-
-#[cold]
-fn class_static_block_await(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Cannot use await in class static initialization block").with_label(span)
-}
-
-#[cold]
-fn reserved_keyword(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("The keyword '{x0}' is reserved")).with_label(span1)
 }
 
 pub const STRICT_MODE_NAMES: Set<&'static str> = phf_set! {
@@ -114,17 +104,17 @@ pub fn check_identifier(
     if name == "await" {
         // It is a Syntax Error if the goal symbol of the syntactic grammar is Module and the StringValue of IdentifierName is "await".
         if ctx.source_type.is_module() {
-            return ctx.error(reserved_keyword(name, span));
+            return ctx.error(diagnostics::reserved_keyword(name, span));
         }
         // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
         if ctx.scoping.scope_flags(ctx.current_scope_id).is_class_static_block() {
-            return ctx.error(class_static_block_await(span));
+            return ctx.error(diagnostics::class_static_block_await(span));
         }
     }
 
     // It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName is: "implements", "interface", "let", "package", "private", "protected", "public", "static", or "yield".
     if ctx.strict_mode() && STRICT_MODE_NAMES.contains(name) {
-        ctx.error(reserved_keyword(name, span));
+        ctx.error(diagnostics::reserved_keyword(name, span));
     }
 }
 
@@ -144,19 +134,6 @@ fn is_current_node_ambient_binding(symbol_id: Option<SymbolId>, ctx: &SemanticBu
     } else {
         false
     }
-}
-
-#[cold]
-fn unexpected_identifier_assign(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Cannot assign to '{x0}' in strict mode")).with_label(span1)
-}
-
-#[cold]
-fn invalid_let_declaration(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!(
-        "`let` cannot be declared as a variable name inside of a `{x0}` declaration"
-    ))
-    .with_label(span1)
 }
 
 pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder<'_>) {
@@ -206,7 +183,7 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
             };
 
             if !is_ok {
-                ctx.error(unexpected_identifier_assign(&ident.name, ident.span));
+                ctx.error(diagnostics::unexpected_identifier_assign(&ident.name, ident.span));
             }
         }
     } else {
@@ -217,7 +194,10 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
                 match node_kind {
                     AstKind::VariableDeclarator(decl) => {
                         if decl.kind.is_lexical() {
-                            ctx.error(invalid_let_declaration(decl.kind.as_str(), ident.span));
+                            ctx.error(diagnostics::invalid_let_declaration(
+                                decl.kind.as_str(),
+                                ident.span,
+                            ));
                         }
                         break;
                     }
@@ -227,13 +207,6 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
             }
         }
     }
-}
-
-#[cold]
-fn unexpected_arguments(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("'arguments' is not allowed in {x0}"))
-        .with_label(span1)
-        .with_help("Assign the 'arguments' variable to a temporary variable outside")
 }
 
 pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBuilder<'_>) {
@@ -247,7 +220,8 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
                 | AstKind::AssignmentTargetPropertyIdentifier(_)
                 | AstKind::UpdateExpression(_)
                 | AstKind::ArrayAssignmentTarget(_) => {
-                    return ctx.error(unexpected_identifier_assign(&ident.name, ident.span));
+                    return ctx
+                        .error(diagnostics::unexpected_identifier_assign(&ident.name, ident.span));
                 }
                 AstKind::AssignmentExpression(assign_expr) => {
                     // only throw error if arguments or eval are being assigned to
@@ -255,7 +229,10 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
                         &assign_expr.left
                         && target_ident.name == ident.name
                     {
-                        return ctx.error(unexpected_identifier_assign(&ident.name, ident.span));
+                        return ctx.error(diagnostics::unexpected_identifier_assign(
+                            &ident.name,
+                            ident.span,
+                        ));
                     }
                 }
                 m if m.is_member_expression_kind() => {
@@ -282,13 +259,17 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
                         .as_ref()
                         .is_some_and(|value| value.address() == previous_node_address)
                     {
-                        return ctx
-                            .error(unexpected_arguments("class field initializer", ident.span));
+                        return ctx.error(diagnostics::unexpected_arguments(
+                            "class field initializer",
+                            ident.span,
+                        ));
                     }
                 }
                 AstKind::StaticBlock(_) => {
-                    return ctx
-                        .error(unexpected_arguments("static initialization block", ident.span));
+                    return ctx.error(diagnostics::unexpected_arguments(
+                        "static initialization block",
+                        ident.span,
+                    ));
                 }
                 _ => {}
             }
@@ -297,25 +278,13 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
     }
 }
 
-#[cold]
-fn private_not_in_class(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Private identifier '#{x0}' is not allowed outside class bodies"))
-        .with_label(span1)
-}
-
 pub fn check_private_identifier_outside_class(
     ident: &PrivateIdentifier,
     ctx: &SemanticBuilder<'_>,
 ) {
     if ctx.class_table_builder.current_class_id.is_none() {
-        ctx.error(private_not_in_class(&ident.name, ident.span));
+        ctx.error(diagnostics::private_not_in_class(&ident.name, ident.span));
     }
-}
-
-#[cold]
-fn private_field_undeclared(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Private field '{x0}' must be declared in an enclosing class"))
-        .with_label(span1)
 }
 
 fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
@@ -324,24 +293,10 @@ fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
             if !ctx.class_table_builder.classes.ancestors(class_id).any(|class_id| {
                 ctx.class_table_builder.classes.has_private_definition(class_id, &reference.name)
             }) {
-                ctx.error(private_field_undeclared(&reference.name, reference.span));
+                ctx.error(diagnostics::private_field_undeclared(&reference.name, reference.span));
             }
         }
     }
-}
-
-#[cold]
-fn legacy_octal(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("'0'-prefixed octal literals and octal escape sequences are deprecated")
-        .with_help("for octal literals use the '0o' prefix instead")
-        .with_label(span)
-}
-
-#[cold]
-fn leading_zero_decimal(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Decimals with leading zeros are not allowed in strict mode")
-        .with_help("remove the leading zero")
-        .with_label(span)
 }
 
 pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
@@ -363,21 +318,14 @@ pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
     if ctx.strict_mode() {
         match lit.base {
             NumberBase::Octal if leading_zero(lit.raw) => {
-                ctx.error(legacy_octal(lit.span));
+                ctx.error(diagnostics::legacy_octal(lit.span));
             }
             NumberBase::Decimal | NumberBase::Float if leading_zero(lit.raw) => {
-                ctx.error(leading_zero_decimal(lit.span));
+                ctx.error(diagnostics::leading_zero_decimal(lit.span));
             }
             _ => {}
         }
     }
-}
-
-#[cold]
-fn non_octal_decimal_escape_sequence(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid escape sequence")
-        .with_help("\\8 and \\9 are not allowed in strict mode")
-        .with_label(span)
 }
 
 pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
@@ -394,31 +342,20 @@ pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
                 match chars.next() {
                     Some('0') => {
                         if chars.peek().is_some_and(char::is_ascii_digit) {
-                            return ctx.error(legacy_octal(lit.span));
+                            return ctx.error(diagnostics::legacy_octal(lit.span));
                         }
                     }
                     Some('1'..='7') => {
-                        return ctx.error(legacy_octal(lit.span));
+                        return ctx.error(diagnostics::legacy_octal(lit.span));
                     }
                     Some('8'..='9') => {
-                        return ctx.error(non_octal_decimal_escape_sequence(lit.span));
+                        return ctx.error(diagnostics::non_octal_decimal_escape_sequence(lit.span));
                     }
                     _ => {}
                 }
             }
         }
     }
-}
-
-#[cold]
-fn illegal_use_strict(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(
-        "Illegal 'use strict' directive in function with non-simple parameter list",
-    )
-    .with_label(span)
-    .with_help(
-        "Wrap this function with an IIFE with a 'use strict' directive that returns this function",
-    )
 }
 
 // It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true and IsSimpleParameterList of FormalParameters is false.
@@ -437,21 +374,8 @@ pub fn check_directive(directive: &Directive, ctx: &SemanticBuilder<'_>) {
         | AstKind::ArrowFunctionExpression(ArrowFunctionExpression { params, .. })
         if !params.is_simple_parameter_list())
     {
-        ctx.error(illegal_use_strict(directive.span));
+        ctx.error(diagnostics::illegal_use_strict(directive.span));
     }
-}
-
-#[cold]
-fn top_level(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!(
-        "'{x0}' declaration can only be used at the top level of a module"
-    ))
-    .with_label(span1)
-}
-
-#[cold]
-fn module_code(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Cannot use {x0} outside a module")).with_label(span1)
 }
 
 pub fn check_module_declaration(decl: &ModuleDeclarationKind, ctx: &SemanticBuilder<'_>) {
@@ -478,36 +402,22 @@ pub fn check_module_declaration(decl: &ModuleDeclarationKind, ctx: &SemanticBuil
             panic!("Technically unreachable, omit to avoid panic.");
         }
         ModuleKind::Script => {
-            ctx.error(module_code(text, span));
+            ctx.error(diagnostics::module_code(text, span));
         }
         ModuleKind::Module => {
             if matches!(ctx.nodes.parent_kind(ctx.current_node_id), AstKind::Program(_)) {
                 return;
             }
-            ctx.error(top_level(text, span));
+            ctx.error(diagnostics::top_level(text, span));
         }
     }
-}
-
-#[cold]
-fn new_target(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected new.target expression")
-        .with_help("new.target is only allowed in constructors and functions invoked using the `new` operator")
-        .with_label(span)
-}
-
-#[cold]
-fn import_meta(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected import.meta expression")
-        .with_help("import.meta is only allowed in module code")
-        .with_label(span)
 }
 
 pub fn check_meta_property(prop: &MetaProperty, ctx: &SemanticBuilder<'_>) {
     match prop.meta.name.as_str() {
         "import" => {
             if prop.property.name == "meta" && ctx.source_type.is_script() {
-                ctx.error(import_meta(prop.span));
+                ctx.error(diagnostics::import_meta(prop.span));
             }
         }
         "new" => {
@@ -525,28 +435,12 @@ pub fn check_meta_property(prop: &MetaProperty, ctx: &SemanticBuilder<'_>) {
                     }
                 }
                 if !in_function_scope {
-                    ctx.error(new_target(prop.span));
+                    ctx.error(diagnostics::new_target(prop.span));
                 }
             }
         }
         _ => {}
     }
-}
-
-#[cold]
-fn function_declaration_strict(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid function declaration")
-        .with_help(
-            "In strict mode code, functions can only be declared at top level or inside a block",
-        )
-        .with_label(span)
-}
-
-#[cold]
-fn function_declaration_non_strict(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid function declaration")
-.with_help("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement")
-.with_label(span)
 }
 
 pub fn check_function_declaration<'a>(
@@ -557,9 +451,9 @@ pub fn check_function_declaration<'a>(
     // Function declaration not allowed in statement position
     if let Statement::FunctionDeclaration(decl) = stmt {
         if ctx.strict_mode() {
-            ctx.error(function_declaration_strict(decl.span));
+            ctx.error(diagnostics::function_declaration_strict(decl.span));
         } else if !is_if_stmt_or_labeled_stmt {
-            ctx.error(function_declaration_non_strict(decl.span));
+            ctx.error(diagnostics::function_declaration_non_strict(decl.span));
         }
     }
 }
@@ -571,7 +465,7 @@ pub fn check_function_declaration_in_labeled_statement<'a>(
 ) {
     if let Statement::FunctionDeclaration(decl) = body {
         if ctx.strict_mode() {
-            ctx.error(function_declaration_strict(decl.span));
+            ctx.error(diagnostics::function_declaration_strict(decl.span));
         } else {
             // skip(1) for `LabeledStatement`
             for kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
@@ -588,7 +482,7 @@ pub fn check_function_declaration_in_labeled_statement<'a>(
                     _ => return,
                 }
             }
-            ctx.error(function_declaration_non_strict(decl.span));
+            ctx.error(diagnostics::function_declaration_non_strict(decl.span));
         }
     }
 }
@@ -612,7 +506,7 @@ pub fn check_variable_declarator_redeclaration(
 
         // `{ function f() {}; var f; }` is invalid in both strict and non-strict mode
         if rd.flags.is_function() {
-            ctx.error(redeclaration(&ident.name, rd.span, decl.span));
+            ctx.error(diagnostics::redeclaration(&ident.name, rd.span, decl.span));
         }
     });
 }
@@ -683,7 +577,7 @@ pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) 
         }
     }
 
-    ctx.error(redeclaration(&id.name, prev.span, id.span));
+    ctx.error(diagnostics::redeclaration(&id.name, prev.span, id.span));
 }
 
 pub fn check_class_redeclaration(class: &Class, ctx: &SemanticBuilder<'_>) {
@@ -697,18 +591,13 @@ pub fn check_class_redeclaration(class: &Class, ctx: &SemanticBuilder<'_>) {
     };
 
     if prev.flags.contains(SymbolFlags::Function) {
-        ctx.error(redeclaration(&id.name, prev.span, id.span));
+        ctx.error(diagnostics::redeclaration(&id.name, prev.span, id.span));
     }
-}
-
-#[cold]
-fn with_statement(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("'with' statements are not allowed").with_label(span)
 }
 
 pub fn check_with_statement(stmt: &WithStatement, ctx: &SemanticBuilder<'_>) {
     if ctx.strict_mode() || ctx.source_type.is_typescript() {
-        ctx.error(with_statement(Span::sized(stmt.span.start, 4)));
+        ctx.error(diagnostics::with_statement(Span::sized(stmt.span.start, 4)));
     }
 }
 
@@ -717,38 +606,12 @@ pub fn check_switch_statement<'a>(stmt: &SwitchStatement<'a>, ctx: &SemanticBuil
     for case in &stmt.cases {
         if case.test.is_none() {
             if let Some(previous_span) = previous_default {
-                ctx.error(redeclaration("default", previous_span, case.span));
+                ctx.error(diagnostics::redeclaration("default", previous_span, case.span));
                 break;
             }
             previous_default.replace(case.span);
         }
     }
-}
-
-#[cold]
-fn invalid_label_jump_target(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Jump target cannot cross function boundary.").with_label(span)
-}
-
-#[cold]
-fn invalid_label_target(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Use of undefined label").with_label(span)
-}
-
-#[cold]
-fn invalid_label_non_iteration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("A `{x0}` statement can only jump to a label of an enclosing `for`, `while` or `do while` statement."))
-        .with_labels([
-            span1.label("This is an non-iteration statement"),
-            span2.label("for this label")
-        ])
-}
-
-#[cold]
-fn invalid_break(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Illegal break statement")
-.with_help("A `break` statement can only be used within an enclosing iteration or switch statement.")
-.with_label(span)
 }
 
 pub fn check_break_statement(stmt: &BreakStatement, ctx: &SemanticBuilder<'_>) {
@@ -757,14 +620,14 @@ pub fn check_break_statement(stmt: &BreakStatement, ctx: &SemanticBuilder<'_>) {
         match node_kind {
             AstKind::Program(_) => {
                 return stmt.label.as_ref().map_or_else(
-                    || ctx.error(invalid_break(stmt.span)),
-                    |label| ctx.error(invalid_label_target(label.span)),
+                    || ctx.error(diagnostics::invalid_break(stmt.span)),
+                    |label| ctx.error(diagnostics::invalid_label_target(label.span)),
                 );
             }
             AstKind::Function(_) | AstKind::StaticBlock(_) => {
                 return stmt.label.as_ref().map_or_else(
-                    || ctx.error(invalid_break(stmt.span)),
-                    |label| ctx.error(invalid_label_jump_target(label.span)),
+                    || ctx.error(diagnostics::invalid_break(stmt.span)),
+                    |label| ctx.error(diagnostics::invalid_label_jump_target(label.span)),
                 );
             }
             AstKind::LabeledStatement(labeled_statement) => {
@@ -787,27 +650,20 @@ pub fn check_break_statement(stmt: &BreakStatement, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-#[cold]
-fn invalid_continue(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Illegal continue statement: no surrounding iteration statement")
-.with_help("A `continue` statement can only be used within an enclosing `for`, `while` or `do while` ")
-.with_label(span)
-}
-
 pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<'_>) {
     // It is a Syntax Error if this ContinueStatement is not nested, directly or indirectly (but not crossing function or static initialization block boundaries), within an IterationStatement.
     for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
         match node_kind {
             AstKind::Program(_) => {
                 return stmt.label.as_ref().map_or_else(
-                    || ctx.error(invalid_continue(stmt.span)),
-                    |label| ctx.error(invalid_label_target(label.span)),
+                    || ctx.error(diagnostics::invalid_continue(stmt.span)),
+                    |label| ctx.error(diagnostics::invalid_label_target(label.span)),
                 );
             }
             AstKind::Function(_) | AstKind::StaticBlock(_) => {
                 return stmt.label.as_ref().map_or_else(
-                    || ctx.error(invalid_continue(stmt.span)),
-                    |label| ctx.error(invalid_label_jump_target(label.span)),
+                    || ctx.error(diagnostics::invalid_continue(stmt.span)),
+                    |label| ctx.error(diagnostics::invalid_label_jump_target(label.span)),
                 );
             }
             AstKind::LabeledStatement(labeled_statement) => match &stmt.label {
@@ -823,7 +679,7 @@ pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<
                     ) {
                         break;
                     }
-                    return ctx.error(invalid_label_non_iteration(
+                    return ctx.error(diagnostics::invalid_label_non_iteration(
                         "continue",
                         labeled_statement.label.span,
                         label.span,
@@ -837,14 +693,6 @@ pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<
     }
 }
 
-#[cold]
-fn label_redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Label `{x0}` has already been declared")).with_labels([
-        span1.label(format!("`{x0}` has already been declared here")),
-        span2.label("It can not be redeclared here"),
-    ])
-}
-
 pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_>) {
     for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
         match node_kind {
@@ -854,7 +702,7 @@ pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_
             | AstKind::StaticBlock(_) => break,
             // check label name redeclaration
             AstKind::LabeledStatement(label_stmt) if stmt.label.name == label_stmt.label.name => {
-                return ctx.error(label_redeclaration(
+                return ctx.error(diagnostics::label_redeclaration(
                     stmt.label.name.as_str(),
                     label_stmt.label.span,
                     stmt.label.span,
@@ -863,20 +711,6 @@ pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_
             _ => {}
         }
     }
-}
-
-#[cold]
-fn multiple_declaration_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!(
-        "Only a single declaration is allowed in a `for...{x0}` statement"
-    ))
-    .with_label(span1)
-}
-
-#[cold]
-fn unexpected_initializer_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{x0} loop variable declaration may not have an initializer"))
-        .with_label(span1)
 }
 
 pub fn check_for_statement_left(
@@ -888,7 +722,7 @@ pub fn check_for_statement_left(
 
     // initializer is not allowed for for-in / for-of
     if decl.declarations.len() > 1 {
-        return ctx.error(multiple_declaration_in_for_loop_head(
+        return ctx.error(diagnostics::multiple_declaration_in_for_loop_head(
             if is_for_in { "in" } else { "of" },
             decl.span,
         ));
@@ -902,25 +736,12 @@ pub fn check_for_statement_left(
                 || decl.kind.is_lexical()
                 || !matches!(declarator.id, BindingPattern::BindingIdentifier(_)))
         {
-            ctx.error(unexpected_initializer_in_for_loop_head(
+            ctx.error(diagnostics::unexpected_initializer_in_for_loop_head(
                 if is_for_in { "for-in" } else { "for-of" },
                 decl.span,
             ));
         }
     }
-}
-
-#[cold]
-fn duplicate_constructor(span: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Multiple constructor implementations are not allowed.").with_labels([
-        LabeledSpan::new_with_span(Some("constructor has already been declared here".into()), span),
-        LabeledSpan::new_with_span(Some("it cannot be redeclared here".into()), span1),
-    ])
-}
-
-#[cold]
-fn require_class_name(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A class name is required.").with_label(span)
 }
 
 pub fn check_class(class: &Class, ctx: &SemanticBuilder<'_>) {
@@ -934,7 +755,7 @@ pub fn check_class(class: &Class, ctx: &SemanticBuilder<'_>) {
         )
     {
         let start = class.span.start;
-        ctx.error(require_class_name(Span::sized(start, 5)));
+        ctx.error(diagnostics::require_class_name(Span::sized(start, 5)));
     }
 
     // ClassBody : ClassElementList
@@ -952,32 +773,10 @@ pub fn check_class(class: &Class, ctx: &SemanticBuilder<'_>) {
     });
     for new_span in constructors {
         if let Some(prev_span) = prev_constructor {
-            return ctx.error(duplicate_constructor(prev_span, new_span));
+            return ctx.error(diagnostics::duplicate_constructor(prev_span, new_span));
         }
         prev_constructor = Some(new_span);
     }
-}
-
-#[cold]
-fn super_without_derived_class(span: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("'super' can only be referenced in a derived class.")
-        .with_help("either remove this super, or extend the class")
-        .with_labels([
-            span.into(),
-            LabeledSpan::new_with_span(Some("class does not have `extends`".into()), span1),
-        ])
-}
-
-#[cold]
-fn unexpected_super_call(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Super calls are not permitted outside constructors or in nested functions inside constructors.")
-.with_label(span)
-}
-
-#[cold]
-fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("'super' can only be referenced in members of derived classes or object literal expressions.")
-.with_label(span)
 }
 
 pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
@@ -1208,7 +1007,9 @@ pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
                         let class_node_id = ctx.class_table_builder.classes.get_node_id(class_id);
                         let class = ctx.nodes.kind(class_node_id).as_class().unwrap();
                         if class.super_class.is_none() {
-                            ctx.error(super_without_derived_class(sup.span, class.span));
+                            ctx.error(diagnostics::super_without_derived_class(
+                                sup.span, class.span,
+                            ));
                         }
                     }
                     return;
@@ -1224,9 +1025,9 @@ pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
 
     // `super` is in illegal position
     if let Some(super_call_span) = super_call_span {
-        ctx.error(unexpected_super_call(super_call_span));
+        ctx.error(diagnostics::unexpected_super_call(super_call_span));
     } else {
-        ctx.error(unexpected_super_reference(sup.span));
+        ctx.error(diagnostics::unexpected_super_reference(sup.span));
     }
 }
 
@@ -1243,11 +1044,6 @@ fn get_class_details(
     (Some(scope_id), class_id)
 }
 
-#[cold]
-fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
-}
-
 pub fn check_assignment_expression(assign_expr: &AssignmentExpression, ctx: &SemanticBuilder<'_>) {
     // AssignmentExpression :
     //     LeftHandSideExpression AssignmentOperator AssignmentExpression
@@ -1258,7 +1054,7 @@ pub fn check_assignment_expression(assign_expr: &AssignmentExpression, ctx: &Sem
     if assign_expr.operator != AssignmentOperator::Assign
         && !assign_expr.left.is_simple_assignment_target()
     {
-        ctx.error(assignment_is_not_simple(assign_expr.left.span()));
+        ctx.error(diagnostics::assignment_is_not_simple(assign_expr.left.span()));
     }
 }
 
@@ -1278,17 +1074,12 @@ pub fn check_object_expression(obj_expr: &ObjectExpression, ctx: &SemanticBuilde
                 && prop_name == "__proto__"
             {
                 if let Some(prev_span) = prev_proto {
-                    ctx.error(redeclaration("__proto__", prev_span, span));
+                    ctx.error(diagnostics::redeclaration("__proto__", prev_span, span));
                 }
                 prev_proto = Some(span);
             }
         }
     }
-}
-
-#[cold]
-fn super_private(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span)
 }
 
 pub fn check_private_field_expression(
@@ -1297,19 +1088,8 @@ pub fn check_private_field_expression(
 ) {
     // `super.#m`
     if private_expr.object.is_super() {
-        ctx.error(super_private(private_expr.span));
+        ctx.error(diagnostics::super_private(private_expr.span));
     }
-}
-
-#[cold]
-fn delete_of_unqualified(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span)
-}
-
-#[cold]
-fn delete_private_field(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("The operand of a 'delete' operator cannot be a private identifier.")
-        .with_label(span)
 }
 
 pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilder<'_>) {
@@ -1317,14 +1097,14 @@ pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilde
     if unary_expr.operator == UnaryOperator::Delete {
         match unary_expr.argument.get_inner_expression() {
             Expression::Identifier(ident) if ctx.strict_mode() => {
-                ctx.error(delete_of_unqualified(ident.span));
+                ctx.error(diagnostics::delete_of_unqualified(ident.span));
             }
             Expression::PrivateFieldExpression(expr) => {
-                ctx.error(delete_private_field(expr.span));
+                ctx.error(diagnostics::delete_private_field(expr.span));
             }
             Expression::ChainExpression(chain_expr) => {
                 if let ChainElement::PrivateFieldExpression(e) = &chain_expr.expression {
-                    ctx.error(delete_private_field(e.field.span));
+                    ctx.error(diagnostics::delete_private_field(e.field.span));
                 }
             }
             _ => {}
@@ -1345,25 +1125,19 @@ fn is_in_formal_parameters(ctx: &SemanticBuilder<'_>) -> bool {
     false
 }
 
-#[cold]
-fn await_or_yield_in_parameter(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{x0} expression not allowed in formal parameter"))
-        .with_label(span1.label(format!("{x0} expression not allowed in formal parameter")))
-}
-
 pub fn check_await_expression(expr: &AwaitExpression, ctx: &SemanticBuilder<'_>) {
     if is_in_formal_parameters(ctx) {
-        ctx.error(await_or_yield_in_parameter("await", expr.span));
+        ctx.error(diagnostics::await_or_yield_in_parameter("await", expr.span));
     }
     // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
     if ctx.scoping.scope_flags(ctx.current_scope_id).is_class_static_block() {
         let start = expr.span.start;
-        ctx.error(class_static_block_await(Span::sized(start, 5)));
+        ctx.error(diagnostics::class_static_block_await(Span::sized(start, 5)));
     }
 }
 
 pub fn check_yield_expression(expr: &YieldExpression, ctx: &SemanticBuilder<'_>) {
     if is_in_formal_parameters(ctx) {
-        ctx.error(await_or_yield_in_parameter("yield", expr.span));
+        ctx.error(diagnostics::await_or_yield_in_parameter("yield", expr.span));
     }
 }

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -4,25 +4,10 @@ use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{AstKind, ast::*};
-use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::BoundNames;
 use oxc_span::{Atom, GetSpan, Span};
 
-use crate::{builder::SemanticBuilder, diagnostics::redeclaration};
-
-#[cold]
-fn ts_error<M: Into<Cow<'static, str>>>(code: &'static str, message: M) -> OxcDiagnostic {
-    OxcDiagnostic::error(message).with_error_code("TS", code)
-}
-
-#[cold]
-fn can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
-    modifier: &str,
-    span: Span,
-) -> OxcDiagnostic {
-    ts_error("1274", format!("'{modifier}' modifier can only appear on a type parameter of a class, interface or type alias."))
-        .with_label(span)
-}
+use crate::{builder::SemanticBuilder, diagnostics};
 
 pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBuilder<'a>) {
     check_type_name_is_reserved(&param.name, ctx, "Type parameter");
@@ -38,35 +23,17 @@ pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBu
         );
         if !is_allowed_node {
             if param.r#in {
-                ctx.error(can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
+                ctx.error(diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
                     "in", param.span,
                 ));
             }
             if param.out {
-                ctx.error(can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
+                ctx.error(diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
                     "out", param.span,
                 ));
             }
         }
     }
-}
-
-/// '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | null | undefined'?(17019)
-#[cold]
-fn jsdoc_type_in_annotation(
-    modifier: char,
-    is_start: bool,
-    span: Span,
-    suggested_type: &str,
-) -> OxcDiagnostic {
-    let (code, start_or_end) = if is_start { ("17020", "start") } else { ("17019", "end") };
-
-    ts_error(
-        code,
-        format!("'{modifier}' at the {start_or_end} of a type is not valid TypeScript syntax.",),
-    )
-    .with_label(span)
-    .with_help(format!("Did you mean to write '{suggested_type}'?"))
 }
 
 pub fn check_ts_type_annotation(annotation: &TSTypeAnnotation<'_>, ctx: &SemanticBuilder<'_>) {
@@ -91,7 +58,7 @@ pub fn check_ts_type_annotation(annotation: &TSTypeAnnotation<'_>, ctx: &Semanti
         Cow::Borrowed(suggestion)
     };
 
-    ctx.error(jsdoc_type_in_annotation(
+    ctx.error(diagnostics::jsdoc_type_in_annotation(
         modifier,
         is_start,
         span_with_illegal_modifier,
@@ -106,11 +73,6 @@ pub fn check_ts_type_alias_declaration<'a>(
     check_type_name_is_reserved(&decl.id, ctx, "Type alias");
 }
 
-#[cold]
-fn required_parameter_after_optional_parameter(span: Span) -> OxcDiagnostic {
-    ts_error("1016", "A required parameter cannot follow an optional parameter.").with_label(span)
-}
-
 pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {
     if params.kind == FormalParameterKind::Signature && params.items.len() > 1 {
         check_duplicate_bound_names(params, ctx);
@@ -123,7 +85,7 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
         if param.optional {
             has_optional = true;
         } else if has_optional && param.initializer.is_none() {
-            ctx.error(required_parameter_after_optional_parameter(param.span));
+            ctx.error(diagnostics::required_parameter_after_optional_parameter(param.span));
         }
     }
 }
@@ -132,18 +94,9 @@ fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &Sem
     let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
         if let Some(old_span) = idents.insert(ident.name, ident.span) {
-            ctx.error(redeclaration(&ident.name, old_span, ident.span));
+            ctx.error(diagnostics::redeclaration(&ident.name, old_span, ident.span));
         }
     });
-}
-
-#[cold]
-fn not_allowed_namespace_declaration(span: Span) -> OxcDiagnostic {
-    ts_error(
-        "1235",
-        "A namespace declaration is only allowed at the top level of a namespace or module.",
-    )
-    .with_label(span)
 }
 
 pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
@@ -151,20 +104,13 @@ pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &Sem
     check_ts_export_assignment_in_module_decl(decl, ctx);
 }
 
-#[cold]
-fn global_scope_augmentation_should_have_declare_modifier(span: Span) -> OxcDiagnostic {
-    ts_error(
-        "2670",
-        "Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context.",
-    )
-    .with_label(span)
-}
-
 pub fn check_ts_global_declaration<'a>(decl: &TSGlobalDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
     check_ts_module_or_global_declaration(decl.span, ctx);
 
     if !decl.declare && !ctx.in_declare_scope() {
-        ctx.error(global_scope_augmentation_should_have_declare_modifier(decl.global_span));
+        ctx.error(diagnostics::global_scope_augmentation_should_have_declare_modifier(
+            decl.global_span,
+        ));
     }
 }
 
@@ -182,15 +128,10 @@ fn check_ts_module_or_global_declaration(span: Span, ctx: &SemanticBuilder<'_>) 
                 // We need to check the parent of the parent
             }
             _ => {
-                ctx.error(not_allowed_namespace_declaration(span));
+                ctx.error(diagnostics::not_allowed_namespace_declaration(span));
             }
         }
     }
-}
-
-#[cold]
-fn enum_member_must_have_initializer(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Enum member must have initializer.").with_label(span)
 }
 
 pub fn check_ts_enum_declaration<'a>(decl: &TSEnumDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
@@ -213,17 +154,11 @@ pub fn check_ts_enum_declaration<'a>(decl: &TSEnumDeclaration<'a>, ctx: &Semanti
                     | Expression::UnaryExpression(_)
             );
         } else if need_initializer {
-            ctx.error(enum_member_must_have_initializer(member.span));
+            ctx.error(diagnostics::enum_member_must_have_initializer(member.span));
         }
     });
 
     check_type_name_is_reserved(&decl.id, ctx, "Enum");
-}
-
-/// TS(1392)
-#[cold]
-fn import_alias_cannot_use_import_type(span: Span) -> OxcDiagnostic {
-    ts_error("1392", "An import alias cannot use 'import type'").with_label(span)
 }
 
 pub fn check_ts_import_equals_declaration<'a>(
@@ -233,31 +168,8 @@ pub fn check_ts_import_equals_declaration<'a>(
     // `import type Foo = require('./foo')` is allowed
     // `import { Foo } from './foo'; import type Bar = Foo.Bar` is not allowed
     if decl.import_kind.is_type() && !decl.module_reference.is_external() {
-        ctx.error(import_alias_cannot_use_import_type(decl.span));
+        ctx.error(diagnostics::import_alias_cannot_use_import_type(decl.span));
     }
-}
-
-/// - Abstract properties can only appear within an abstract class. (1253)
-/// - Abstract methods can only appear within an abstract class. (1244)
-#[cold]
-fn abstract_elem_in_concrete_class(is_property: bool, span: Span) -> OxcDiagnostic {
-    let (code, elem_kind) = if is_property { ("1253", "properties") } else { ("1244", "methods") };
-    ts_error(code, format!("Abstract {elem_kind} can only appear within an abstract class."))
-        .with_label(span)
-}
-
-#[cold]
-fn constructor_implementation_missing(span: Span) -> OxcDiagnostic {
-    ts_error("2390", "Constructor implementation is missing.").with_label(span)
-}
-
-#[cold]
-fn function_implementation_missing(span: Span) -> OxcDiagnostic {
-    ts_error(
-        "2391",
-        "Function implementation is missing or not immediately following the declaration.",
-    )
-    .with_label(span)
 }
 
 pub fn check_class<'a>(class: &Class<'a>, ctx: &SemanticBuilder<'a>) {
@@ -265,7 +177,7 @@ pub fn check_class<'a>(class: &Class<'a>, ctx: &SemanticBuilder<'a>) {
         for elem in &class.body.body {
             if elem.is_abstract() {
                 let span = elem.property_key().map_or_else(|| elem.span(), GetSpan::span);
-                ctx.error(abstract_elem_in_concrete_class(elem.is_property(), span));
+                ctx.error(diagnostics::abstract_elem_in_concrete_class(elem.is_property(), span));
             }
         }
     }
@@ -285,9 +197,9 @@ pub fn check_class<'a>(class: &Class<'a>, ctx: &SemanticBuilder<'a>) {
                 })
             {
                 if a.kind.is_constructor() {
-                    ctx.error(constructor_implementation_missing(a.key.span()));
+                    ctx.error(diagnostics::constructor_implementation_missing(a.key.span()));
                 } else {
-                    ctx.error(function_implementation_missing(a.key.span()));
+                    ctx.error(diagnostics::function_implementation_missing(a.key.span()));
                 }
             }
         }
@@ -332,39 +244,10 @@ fn check_type_name_is_reserved<'a>(
     match id.name.as_str() {
         "any" | "unknown" | "never" | "number" | "bigint" | "boolean" | "string" | "symbol"
         | "void" | "object" | "undefined" => {
-            ctx.error(reserved_type_name(id.span, id.name.as_str(), syntax_name));
+            ctx.error(diagnostics::reserved_type_name(id.span, id.name.as_str(), syntax_name));
         }
         _ => {}
     }
-}
-
-#[cold]
-fn reserved_type_name(span: Span, reserved_name: &str, syntax_name: &str) -> OxcDiagnostic {
-    ts_error("2414", format!("{syntax_name} name cannot be '{reserved_name}'")).with_label(span)
-}
-
-/// 'abstract' modifier can only appear on a class, method, or property declaration. (1242)
-#[cold]
-fn illegal_abstract_modifier(span: Span) -> OxcDiagnostic {
-    ts_error(
-        "1242",
-        "'abstract' modifier can only appear on a class, method, or property declaration.",
-    )
-    .with_label(span)
-}
-
-/// A parameter property is only allowed in a constructor implementation.ts(2369)
-#[cold]
-fn parameter_property_only_in_constructor_impl(span: Span) -> OxcDiagnostic {
-    ts_error("2369", "A parameter property is only allowed in a constructor implementation.")
-        .with_label(span)
-}
-
-/// Getter or setter without a body. There is no corresponding TS error code,
-/// since in TSC this is a parse error.
-#[cold]
-fn accessor_without_body(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Getters and setters must have an implementation.").with_label(span)
 }
 
 pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &SemanticBuilder<'a>) {
@@ -386,7 +269,7 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     if is_abstract {
         // constructors cannot be abstract, no matter what
         if method.kind.is_constructor() {
-            ctx.error(illegal_abstract_modifier(method.key.span()));
+            ctx.error(diagnostics::illegal_abstract_modifier(method.key.span()));
         }
     }
 
@@ -395,14 +278,14 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     if method.kind.is_constructor() && is_empty_body {
         for param in &method.value.params.items {
             if param.has_modifier() {
-                ctx.error(parameter_property_only_in_constructor_impl(param.span));
+                ctx.error(diagnostics::parameter_property_only_in_constructor_impl(param.span));
             }
         }
     }
 
     // Illegal to have `get foo();` or `set foo(a)`
     if method.kind.is_accessor() && is_empty_body && !is_abstract && !is_declare {
-        ctx.error(accessor_without_body(method.key.span()));
+        ctx.error(diagnostics::accessor_without_body(method.key.span()));
     }
 }
 
@@ -411,20 +294,8 @@ pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
         && prop.kind.is_accessor()
         && matches!(func.r#type, FunctionType::TSEmptyBodyFunctionExpression)
     {
-        ctx.error(accessor_without_body(prop.key.span()));
+        ctx.error(diagnostics::accessor_without_body(prop.key.span()));
     }
-}
-
-/// The left-hand side of a 'for...of' statement cannot use a type annotation. (2483)
-#[cold]
-fn type_annotation_in_for_left(span: Span, is_for_in: bool) -> OxcDiagnostic {
-    let for_of_or_in = if is_for_in { "for...in" } else { "for...of" };
-    ts_error(
-        "2483",
-        format!(
-            "The left-hand side of a '{for_of_or_in}' statement cannot use a type annotation.",
-        ),
-    ).with_label(span).with_help("This iterator's type will be inferred from the iterable. You can safely remove the type annotation.")
 }
 
 pub fn check_for_statement_left(left: &ForStatementLeft, is_for_in: bool, ctx: &SemanticBuilder) {
@@ -435,16 +306,9 @@ pub fn check_for_statement_left(left: &ForStatementLeft, is_for_in: bool, ctx: &
     for decl in &decls.declarations {
         if decl.type_annotation.is_some() {
             let span = decl.id.span();
-            ctx.error(type_annotation_in_for_left(span, is_for_in));
+            ctx.error(diagnostics::type_annotation_in_for_left(span, is_for_in));
         }
     }
-}
-
-#[cold]
-fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
-    ts_error("18007", "JSX expressions may not use the comma operator")
-        .with_help("Did you mean to write an array?")
-        .with_label(span)
 }
 
 pub fn check_jsx_expression_container(
@@ -452,15 +316,10 @@ pub fn check_jsx_expression_container(
     ctx: &SemanticBuilder<'_>,
 ) {
     if matches!(container.expression, JSXExpression::SequenceExpression(_)) {
-        ctx.error(jsx_expressions_may_not_use_the_comma_operator(container.expression.span()));
+        ctx.error(diagnostics::jsx_expressions_may_not_use_the_comma_operator(
+            container.expression.span(),
+        ));
     }
-}
-
-#[cold]
-fn ts_export_assignment_cannot_be_used_with_other_exports(span: Span) -> OxcDiagnostic {
-    ts_error("2309", "An export assignment cannot be used in a module with other exported elements")
-        .with_label(span)
-        .with_help("If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.")
 }
 
 pub fn check_ts_export_assignment_in_program<'a>(program: &Program<'a>, ctx: &SemanticBuilder<'a>) {
@@ -515,7 +374,7 @@ fn check_ts_export_assignment_in_statements<'a>(
 
     if has_other_exports {
         for span in export_assignment_spans {
-            ctx.error(ts_export_assignment_cannot_be_used_with_other_exports(span));
+            ctx.error(diagnostics::ts_export_assignment_cannot_be_used_with_other_exports(span));
         }
     }
 }

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -1,5 +1,12 @@
+use std::borrow::Cow;
+
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
+
+#[cold]
+fn ts_error<M: Into<Cow<'static, str>>>(code: &'static str, message: M) -> OxcDiagnostic {
+    OxcDiagnostic::error(message).with_error_code("TS", code)
+}
 
 #[cold]
 pub fn redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
@@ -7,4 +14,386 @@ pub fn redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
         span1.label(format!("`{x0}` has already been declared here")),
         span2.label("It can not be redeclared here"),
     ])
+}
+
+#[cold]
+pub fn undefined_export(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Export '{x0}' is not defined")).with_label(span1)
+}
+
+#[cold]
+pub fn class_static_block_await(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Cannot use await in class static initialization block").with_label(span)
+}
+
+#[cold]
+pub fn reserved_keyword(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("The keyword '{x0}' is reserved")).with_label(span1)
+}
+
+#[cold]
+pub fn unexpected_identifier_assign(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Cannot assign to '{x0}' in strict mode")).with_label(span1)
+}
+
+#[cold]
+pub fn invalid_let_declaration(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!(
+        "`let` cannot be declared as a variable name inside of a `{x0}` declaration"
+    ))
+    .with_label(span1)
+}
+
+#[cold]
+pub fn unexpected_arguments(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("'arguments' is not allowed in {x0}"))
+        .with_label(span1)
+        .with_help("Assign the 'arguments' variable to a temporary variable outside")
+}
+
+#[cold]
+pub fn private_not_in_class(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Private identifier '#{x0}' is not allowed outside class bodies"))
+        .with_label(span1)
+}
+
+#[cold]
+pub fn private_field_undeclared(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Private field '{x0}' must be declared in an enclosing class"))
+        .with_label(span1)
+}
+
+#[cold]
+pub fn legacy_octal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'0'-prefixed octal literals and octal escape sequences are deprecated")
+        .with_help("for octal literals use the '0o' prefix instead")
+        .with_label(span)
+}
+
+#[cold]
+pub fn leading_zero_decimal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Decimals with leading zeros are not allowed in strict mode")
+        .with_help("remove the leading zero")
+        .with_label(span)
+}
+
+#[cold]
+pub fn non_octal_decimal_escape_sequence(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid escape sequence")
+        .with_help("\\8 and \\9 are not allowed in strict mode")
+        .with_label(span)
+}
+
+#[cold]
+pub fn illegal_use_strict(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(
+        "Illegal 'use strict' directive in function with non-simple parameter list",
+    )
+    .with_label(span)
+    .with_help(
+        "Wrap this function with an IIFE with a 'use strict' directive that returns this function",
+    )
+}
+
+#[cold]
+pub fn top_level(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!(
+        "'{x0}' declaration can only be used at the top level of a module"
+    ))
+    .with_label(span1)
+}
+
+#[cold]
+pub fn module_code(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Cannot use {x0} outside a module")).with_label(span1)
+}
+
+#[cold]
+pub fn new_target(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected new.target expression")
+        .with_help("new.target is only allowed in constructors and functions invoked using the `new` operator")
+        .with_label(span)
+}
+
+#[cold]
+pub fn import_meta(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected import.meta expression")
+        .with_help("import.meta is only allowed in module code")
+        .with_label(span)
+}
+
+#[cold]
+pub fn function_declaration_strict(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid function declaration")
+        .with_help(
+            "In strict mode code, functions can only be declared at top level or inside a block",
+        )
+        .with_label(span)
+}
+
+#[cold]
+pub fn function_declaration_non_strict(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid function declaration")
+        .with_help("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement")
+        .with_label(span)
+}
+
+#[cold]
+pub fn with_statement(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'with' statements are not allowed").with_label(span)
+}
+
+#[cold]
+pub fn invalid_label_jump_target(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Jump target cannot cross function boundary.").with_label(span)
+}
+
+#[cold]
+pub fn invalid_label_target(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Use of undefined label").with_label(span)
+}
+
+#[cold]
+pub fn invalid_label_non_iteration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("A `{x0}` statement can only jump to a label of an enclosing `for`, `while` or `do while` statement."))
+        .with_labels([
+            span1.label("This is an non-iteration statement"),
+            span2.label("for this label")
+        ])
+}
+
+#[cold]
+pub fn invalid_break(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Illegal break statement")
+        .with_help("A `break` statement can only be used within an enclosing iteration or switch statement.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn invalid_continue(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Illegal continue statement: no surrounding iteration statement")
+        .with_help("A `continue` statement can only be used within an enclosing `for`, `while` or `do while` ")
+        .with_label(span)
+}
+
+#[cold]
+pub fn label_redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Label `{x0}` has already been declared")).with_labels([
+        span1.label(format!("`{x0}` has already been declared here")),
+        span2.label("It can not be redeclared here"),
+    ])
+}
+
+#[cold]
+pub fn multiple_declaration_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!(
+        "Only a single declaration is allowed in a `for...{x0}` statement"
+    ))
+    .with_label(span1)
+}
+
+#[cold]
+pub fn unexpected_initializer_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{x0} loop variable declaration may not have an initializer"))
+        .with_label(span1)
+}
+
+#[cold]
+pub fn duplicate_constructor(span: Span, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Multiple constructor implementations are not allowed.").with_labels([
+        span.label("constructor has already been declared here"),
+        span1.label("it cannot be redeclared here"),
+    ])
+}
+
+#[cold]
+pub fn require_class_name(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A class name is required.").with_label(span)
+}
+
+#[cold]
+pub fn super_without_derived_class(span: Span, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'super' can only be referenced in a derived class.")
+        .with_help("either remove this super, or extend the class")
+        .with_labels([span.into(), span1.label("class does not have `extends`")])
+}
+
+#[cold]
+pub fn unexpected_super_call(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Super calls are not permitted outside constructors or in nested functions inside constructors.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'super' can only be referenced in members of derived classes or object literal expressions.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
+}
+
+#[cold]
+pub fn super_private(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span)
+}
+
+#[cold]
+pub fn delete_of_unqualified(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span)
+}
+
+#[cold]
+pub fn delete_private_field(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("The operand of a 'delete' operator cannot be a private identifier.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn await_or_yield_in_parameter(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{x0} expression not allowed in formal parameter"))
+        .with_label(span1.label(format!("{x0} expression not allowed in formal parameter")))
+}
+
+// TypeScript diagnostics
+
+#[cold]
+pub fn can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
+    modifier: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    ts_error("1274", format!("'{modifier}' modifier can only appear on a type parameter of a class, interface or type alias."))
+        .with_label(span)
+}
+
+/// '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | null | undefined'?(17019)
+#[cold]
+pub fn jsdoc_type_in_annotation(
+    modifier: char,
+    is_start: bool,
+    span: Span,
+    suggested_type: &str,
+) -> OxcDiagnostic {
+    let (code, start_or_end) = if is_start { ("17020", "start") } else { ("17019", "end") };
+
+    ts_error(
+        code,
+        format!("'{modifier}' at the {start_or_end} of a type is not valid TypeScript syntax.",),
+    )
+    .with_label(span)
+    .with_help(format!("Did you mean to write '{suggested_type}'?"))
+}
+
+#[cold]
+pub fn required_parameter_after_optional_parameter(span: Span) -> OxcDiagnostic {
+    ts_error("1016", "A required parameter cannot follow an optional parameter.").with_label(span)
+}
+
+#[cold]
+pub fn not_allowed_namespace_declaration(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1235",
+        "A namespace declaration is only allowed at the top level of a namespace or module.",
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn global_scope_augmentation_should_have_declare_modifier(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "2670",
+        "Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context.",
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn enum_member_must_have_initializer(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Enum member must have initializer.").with_label(span)
+}
+
+/// TS(1392)
+#[cold]
+pub fn import_alias_cannot_use_import_type(span: Span) -> OxcDiagnostic {
+    ts_error("1392", "An import alias cannot use 'import type'").with_label(span)
+}
+
+/// - Abstract properties can only appear within an abstract class. (1253)
+/// - Abstract methods can only appear within an abstract class. (1244)
+#[cold]
+pub fn abstract_elem_in_concrete_class(is_property: bool, span: Span) -> OxcDiagnostic {
+    let (code, elem_kind) = if is_property { ("1253", "properties") } else { ("1244", "methods") };
+    ts_error(code, format!("Abstract {elem_kind} can only appear within an abstract class."))
+        .with_label(span)
+}
+
+#[cold]
+pub fn constructor_implementation_missing(span: Span) -> OxcDiagnostic {
+    ts_error("2390", "Constructor implementation is missing.").with_label(span)
+}
+
+#[cold]
+pub fn function_implementation_missing(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "2391",
+        "Function implementation is missing or not immediately following the declaration.",
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn reserved_type_name(span: Span, reserved_name: &str, syntax_name: &str) -> OxcDiagnostic {
+    ts_error("2414", format!("{syntax_name} name cannot be '{reserved_name}'")).with_label(span)
+}
+
+/// 'abstract' modifier can only appear on a class, method, or property declaration. (1242)
+#[cold]
+pub fn illegal_abstract_modifier(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1242",
+        "'abstract' modifier can only appear on a class, method, or property declaration.",
+    )
+    .with_label(span)
+}
+
+/// A parameter property is only allowed in a constructor implementation.ts(2369)
+#[cold]
+pub fn parameter_property_only_in_constructor_impl(span: Span) -> OxcDiagnostic {
+    ts_error("2369", "A parameter property is only allowed in a constructor implementation.")
+        .with_label(span)
+}
+
+/// Getter or setter without a body. There is no corresponding TS error code,
+/// since in TSC this is a parse error.
+#[cold]
+pub fn accessor_without_body(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Getters and setters must have an implementation.").with_label(span)
+}
+
+/// The left-hand side of a 'for...of' statement cannot use a type annotation. (2483)
+#[cold]
+pub fn type_annotation_in_for_left(span: Span, is_for_in: bool) -> OxcDiagnostic {
+    let for_of_or_in = if is_for_in { "for...in" } else { "for...of" };
+    ts_error(
+        "2483",
+        format!(
+            "The left-hand side of a '{for_of_or_in}' statement cannot use a type annotation.",
+        ),
+    ).with_label(span).with_help("This iterator's type will be inferred from the iterable. You can safely remove the type annotation.")
+}
+
+#[cold]
+pub fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
+    ts_error("18007", "JSX expressions may not use the comma operator")
+        .with_help("Did you mean to write an array?")
+        .with_label(span)
+}
+
+#[cold]
+pub fn ts_export_assignment_cannot_be_used_with_other_exports(span: Span) -> OxcDiagnostic {
+    ts_error("2309", "An export assignment cannot be used in a module with other exported elements")
+        .with_label(span)
+        .with_help("If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.")
 }


### PR DESCRIPTION
Diagnostic functions for semantic were previously spread across 3x files, with `diagnostics.rs` only containing a single diagnostic. This PR refactors it to have all diagnostics in a single file. When diagnostics are needded, they are referenced via `diagnostic::my_diagnostic` to be clear and precise as to where the diagnostic is coming from.

I **think** this is better than how it was before - but if you disagree Boshen, feel free to close.