### PR TITLE
fix(oxlint): do not enable external plugin store when no external linter is passed

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -178,7 +178,7 @@ impl CliRunner {
             paths.sort_unstable();
         }
 
-        let mut external_plugin_store = ExternalPluginStore::default();
+        let mut external_plugin_store = ExternalPluginStore::new(self.external_linter.is_some());
 
         let search_for_nested_configs = !disable_nested_config &&
             // If the `--config` option is explicitly passed, we should not search for nested config files


### PR DESCRIPTION
somehow the refactoring in #17463 shows some js plugin errors for CLI tests.
See https://github.com/oxc-project/oxc/actions/runs/20587373437/job/59126059421

The reason was this code part:
https://github.com/oxc-project/oxc/blob/0222857e629cc286aabb388adf418c24299b1896/crates/oxc_linter/src/config/config_builder.rs#L166-L176
