### PR TITLE
docs(linter): Update not_supported rules list with two stylistic react rules

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -165,6 +165,8 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "react/jsx-props-no-multi-spaces",
   "react/jsx-tag-spacing",
   "react/jsx-space-before-closing",
+  "react/jsx-closing-tag-location",
+  "react/jsx-closing-bracket-location",
 
   // React Compiler rules will not be implemented in oxlint for now,
   // as they require integration with the react compiler itself.


### PR DESCRIPTION
These two rules will conflict with oxfmt's styling and should not be implemented by oxlint as native rules.

Docs for these two rules:

- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md