### PR TITLE
docs(linter): Add a few more stylistic react rules to NOT_SUPPORTED_RULE_NAMES.

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -167,6 +167,11 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "react/jsx-space-before-closing",
   "react/jsx-closing-tag-location",
   "react/jsx-closing-bracket-location",
+  "react/jsx-first-prop-new-line",
+  "react/jsx-max-props-per-line",
+  "react/jsx-curly-newline",
+  "react/jsx-child-element-spacing",
+  "react/jsx-one-expression-per-line",
 
   // React Compiler rules will not be implemented in oxlint for now,
   // as they require integration with the react compiler itself.


### PR DESCRIPTION
These rules are stylistic and would conflict with oxfmt/prettier-based formatting. As such, we should not implement them.

These additional rules were sourced from the eslint-config-prettier lib https://github.com/prettier/eslint-config-prettier/blob/07829b4912d173986610a4985247896b09f9fcaf/index.js#L197

This should hopefully finish up the list of not-supported react rules for good, and we won't need to add any more.