### PR TITLE
docs(linter): Mark `react/jsx-uses-vars` as not-supported, it is handled by no-unused-vars already

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -285,6 +285,8 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "eslint/wrap-regex",
   "eslint/yield-star-spacing",
 
+  "react/jsx-uses-vars", // handled by eslint/no-unused-vars, which already evaluates whether vars are used in JSX
+
   "unicorn/no-named-default", // implemented via import/no-named-default
 
   // not supported as it requires parsing the vue template


### PR DESCRIPTION
This rule is redundant with eslint/no-unused-vars, which already checks for variables used in JSX. So, no need to implement it.

I swear this is the last update I'll need to do for react rules in this list.

Probably.

Maybe.

See also #17312.