### PR TITLE
refactor(vscode): improve statusbar item display

### DIFF
--- a/editors/vscode/client/StatusBarItemHandler.ts
+++ b/editors/vscode/client/StatusBarItemHandler.ts
@@ -2,8 +2,17 @@ import { MarkdownString, StatusBarAlignment, StatusBarItem, ThemeColor, window }
 
 type StatusBarTool = "linter" | "formatter";
 
+type ToolState = {
+  isEnabled: boolean;
+  content: string;
+  version?: string;
+};
+
 export default class StatusBarItemHandler {
-  private tooltipSections: Map<StatusBarTool, string> = new Map();
+  private tooltipSections: Map<StatusBarTool, ToolState> = new Map([
+    ["linter", { isEnabled: false, content: "", version: "unknown" }],
+    ["formatter", { isEnabled: false, content: "", version: "unknown" }],
+  ]);
 
   private statusBarItem: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
 
@@ -19,8 +28,11 @@ export default class StatusBarItemHandler {
     this.statusBarItem.show();
   }
 
-  public setColorAndIcon(bgColor: string, icon: string): void {
-    this.statusBarItem.backgroundColor = new ThemeColor(bgColor);
+  public setWarnBackground(): void {
+    this.statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
+  }
+
+  public setIcon(icon: string): void {
     this.statusBarItem.text = `$(${icon}) oxc`;
   }
 
@@ -28,14 +40,33 @@ export default class StatusBarItemHandler {
    * Updates the tooltip text for a specific tool section.
    * The tooltip can use markdown syntax and VSCode icons.
    */
-  public updateToolTooltip(toolId: StatusBarTool, text: string): void {
-    this.tooltipSections.set(toolId, text);
-    this.updateFullTooltip();
+  public updateTool(
+    toolId: StatusBarTool,
+    isEnabled: boolean,
+    text: string,
+    version?: string,
+  ): void {
+    const section = this.tooltipSections.get(toolId);
+    if (section) {
+      section.isEnabled = isEnabled;
+      section.content = text;
+      section.version = version ?? "unknown";
+      this.updateFullTooltip();
+    }
   }
 
   private updateFullTooltip(): void {
-    const text = [this.tooltipSections.get("linter"), this.tooltipSections.get("formatter")]
-      .filter(Boolean)
+    const sections: [string, ToolState][] = [
+      ["oxlint", this.tooltipSections.get("linter")!],
+      ["oxfmt", this.tooltipSections.get("formatter")!],
+    ];
+
+    const text = sections
+      .map(([tool, section]) => {
+        const version = section.version ? ` v${section.version}` : "unknown version";
+        const statusText = section.isEnabled ? `enabled (${version})` : "disabled";
+        return `**${tool} is ${statusText}**\n\n${section.content}`;
+      })
       .join("\n\n---\n\n");
 
     if (!(this.statusBarItem.tooltip instanceof MarkdownString)) {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -76,41 +76,24 @@ export async function activate(context: ExtensionContext) {
 
   await Promise.all(
     tools.map((tool): Promise<void> => {
+      const channel = tool instanceof Linter ? outputChannelLint : outputChannelFormat;
       const binaryPath = binaryPaths[tools.indexOf(tool)];
 
-      if (!binaryPath && tool instanceof Linter) {
-        statusBarItemHandler.setColorAndIcon("statusBarItem.errorBackground", "error");
-        statusBarItemHandler.updateToolTooltip(
-          "linter",
-          "**oxlint disabled**\n\nError: No valid oxlint binary found.",
-        );
-        return Promise.resolve();
-      }
-
-      if (!binaryPath && tool instanceof Formatter) {
-        // No valid binary found for the formatter.
-        statusBarItemHandler.updateToolTooltip(
-          "formatter",
-          "**oxfmt disabled**\n\nNo valid oxfmt binary found.",
-        );
-        outputChannelFormat.appendLine(
-          "No valid oxfmt binary found. Formatter will not be activated.",
-        );
-        return Promise.resolve();
-      }
-
-      // binaryPath is guaranteed to be defined here.
-      const binaryPathResolved = binaryPath!;
-
-      return tool.activate(
-        context,
-        binaryPathResolved,
-        tool instanceof Linter ? outputChannelLint : outputChannelFormat,
-        configService,
-        statusBarItemHandler,
-      );
+      return tool.activate(context, channel, configService, statusBarItemHandler, binaryPath);
     }),
   );
+
+  // No valid binaries found for any tool, show error background.
+  if (binaryPaths.every((path) => !path)) {
+    statusBarItemHandler.setWarnBackground();
+    statusBarItemHandler.setIcon("circle-slash");
+    // Every tool has a valid binary.
+  } else if (binaryPaths.every((path) => path)) {
+    statusBarItemHandler.setIcon("check-all");
+    // Some tools are missing binaries.
+  } else {
+    statusBarItemHandler.setIcon("check");
+  }
 
   // Finally show the status bar item.
   statusBarItemHandler.show();

--- a/editors/vscode/client/tools/ToolInterface.ts
+++ b/editors/vscode/client/tools/ToolInterface.ts
@@ -15,10 +15,10 @@ export default interface ToolInterface {
    */
   activate(
     context: ExtensionContext,
-    binaryPath: string,
     outputChannel: LogOutputChannel,
     configService: ConfigService,
     statusBarItemHandler: StatusBarItemHandler,
+    binaryPath?: string,
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
This PR refactors the VSCode extension's status bar item display logic .
- Double Checkmark: Both tools (oxlint / oxfmt) are found and can be used
- Single Checkmark: One of the tools binary could not be found and is deactivated
- Circle: None of tools binary could be found

The background color changed a bit too. The error background is not shown anymore, only the warning background when no binaries could be found.

closes https://github.com/oxc-project/oxc/issues/17483

<img width="204" height="271" alt="grafik" src="https://github.com/user-attachments/assets/95f180a0-34ec-4d59-bd89-477d4d5fe754" />

<img width="198" height="247" alt="grafik" src="https://github.com/user-attachments/assets/2155bff6-e7e6-46b5-8ebb-8ab5036fafbc" />

<img width="179" height="177" alt="grafik" src="https://github.com/user-attachments/assets/32ed59db-4caa-4a0a-89c9-65ca7caef171" />

<img width="184" height="287" alt="grafik" src="https://github.com/user-attachments/assets/759bd775-fa43-4371-a3db-ef668951aa6d" />

PS: the `v(version)` in the screenshots are outdated 😅 
