### PR TITLE
fix(linter): print total rule # when using a single nested config

### DIFF
--- a/apps/oxlint/fixtures/auto_config_detection/.oxlintrc.json
+++ b/apps/oxlint/fixtures/auto_config_detection/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
     "no-debugger": "error"
   }

--- a/apps/oxlint/fixtures/cross_module_extended_config/config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cross_module_extended_config/config/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "plugins": [
     "import"
   ],

--- a/apps/oxlint/fixtures/ignore_file_current_dir/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_file_current_dir/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "ignorePatterns": [
     "foo.js",
     "a/bar.js"

--- a/apps/oxlint/fixtures/ignore_patterns_relative/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_relative/.oxlintrc.json
@@ -1,3 +1,9 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "warn"
+  },
   "ignorePatterns": ["nested/*.ts"]
 }

--- a/apps/oxlint/fixtures/ignore_patterns_whitelist/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_patterns_whitelist/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
     "no-debugger": "error"
   },

--- a/apps/oxlint/fixtures/import/.oxlintrc-import-x.json
+++ b/apps/oxlint/fixtures/import/.oxlintrc-import-x.json
@@ -1,5 +1,8 @@
 {
     "plugins": ["import"],
+    "categories": {
+      "correctness": "off"
+    },
     "rules": {
         "import-x/no-default-export": "error",
         "import-x/namespace": "allow"

--- a/apps/oxlint/fixtures/import/.oxlintrc.json
+++ b/apps/oxlint/fixtures/import/.oxlintrc.json
@@ -1,5 +1,8 @@
 {
     "plugins": ["import"],
+    "categories": {
+      "correctness": "off"
+    },
     "rules": {
         "import/no-default-export": "error",
         "import/namespace": "allow"

--- a/apps/oxlint/fixtures/output_formatter_diagnostic/.oxlintrc.json
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
-    "rules": {
-        "no-debugger": "error",
-        "no-unused-vars": "warn"
-    }
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "error",
+    "no-unused-vars": "warn"
+  }
 }

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/auto_config_detection
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
@@ -29,7 +29,7 @@ working directory: fixtures/cross_module_extended_config
         -> ./dep-b.ts - fixtures/cross_module_extended_config/dep-b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
@@ -29,7 +29,7 @@ working directory: fixtures/cross_module_nested_config
         -> ./folder-dep-b.ts - fixtures/cross_module_nested_config/folder/folder-dep-b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 4 files using 1 threads.
+Finished in <variable>ms on 4 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__disable_directive_issue_13311_test.jsx test2.d.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_directive_issue_13311_test.jsx test2.d.ts@oxlint.snap
@@ -6,7 +6,7 @@ arguments: test.jsx test2.d.ts
 working directory: fixtures/disable_directive_issue_13311
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 3 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -40,7 +40,7 @@ working directory: fixtures/extends_config
   help: Provide an `href` for the `a` element.
 
 Found 1 warning and 3 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files using 1 threads.
+Finished in <variable>ms on 0 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/ignore_file_current_dir
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files using 1 threads.
+Finished in <variable>ms on 0 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
@@ -21,7 +21,7 @@ working directory: fixtures/ignore_patterns_relative
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -46,7 +46,7 @@ working directory: fixtures/ignore_patterns_relative
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_symlink_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_symlink_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files using 1 threads.
+Finished in <variable>ms on 0 files with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/ignore_patterns_whitelist
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -32,7 +32,7 @@ working directory: fixtures/ignore_patterns_whitelist
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 55 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -34,7 +34,7 @@ working directory: fixtures/import
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 55 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/output_formatter_diagnostic
   help: Remove the debugger statement
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
@@ -9,7 +9,7 @@ working directory: fixtures/output_formatter_diagnostic
 {"message": "Function 'foo' is declared but never used.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this declaration.","filename": "test.js","labels": [{"label": "'foo' is declared here","span": {"offset": 9,"length": 3,"line": 1,"column": 10}}],"related": []},
 {"message": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this parameter.","filename": "test.js","labels": [{"label": "'b' is declared here","span": {"offset": 16,"length": 1,"line": 1,"column": 17}}],"related": []}],
               "number_of_files": 1,
-              "number_of_rules": null,
+              "number_of_rules": 2,
               "threads_count": 1,
               "start_time": <variable>
             }

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware --silent@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware --silent@oxlint.snap
@@ -7,7 +7,7 @@ working directory: fixtures/tsgolint
 ----------
 
 Found 0 warnings and 51 errors.
-Finished in <variable>ms on 45 files using 1 threads.
+Finished in <variable>ms on 45 files with 44 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware test.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware test.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/tsgolint
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 44 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
@@ -397,7 +397,7 @@ working directory: fixtures/tsgolint
    `----
 
 Found 0 warnings and 51 errors.
-Finished in <variable>ms on 45 files using 1 threads.
+Finished in <variable>ms on 45 files with 44 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
@@ -39,7 +39,7 @@ working directory: fixtures/tsgolint_rule_options
     `----
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 1 file using 1 threads.
+Finished in <variable>ms on 1 file with 6 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_type_error_--type-aware --type-check@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_type_error_--type-aware --type-check@oxlint.snap
@@ -13,7 +13,7 @@ working directory: fixtures/tsgolint_type_error
    `----
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 2 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
@@ -27,7 +27,7 @@ working directory: fixtures
         -> ./b - fixtures/issue_10054/b.ts
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files using 1 threads.
+Finished in <variable>ms on 2 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 90 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_many_files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_many_files/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "warn" // explicitly enable this so we can ensure import rules are enabled.
+  },
   "jsPlugins": ["./plugin.ts"],
   "plugins": ["import"],
   "rules": {

--- a/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
@@ -264,7 +264,7 @@
   help: Remove the debugger statement
 
 Found 20 warnings and 20 errors.
-Finished in Xms on 20 files using X threads.
+Finished in Xms on 20 files with 55 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/.oxlintrc.json
@@ -1,8 +1,12 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "jsPlugins": ["./plugin.ts"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error",
     "basic-custom-plugin/no-debugger-2": "error",
-    "basic-custom-plugin/no-identifiers-named-foo": "error"
+    "basic-custom-plugin/no-identifiers-named-foo": "error",
+    "eslint/no-debugger": "warn"
   }
 }

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
@@ -32,16 +32,8 @@
    : ^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
-   ,-[files/index.js:3:1]
- 2 | 
- 3 | foo;
-   : ^^^^
-   `----
-  help: Consider using this expression or removing it
-
-Found 2 warnings and 3 errors.
-Finished in Xms on 1 file using X threads.
+Found 1 warning and 3 errors.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_no_errors/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_no_errors/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "jsPlugins": ["./plugin.ts"],
   "rules": {
     "basic-custom-plugin/no-debugger": "error"

--- a/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 Found 0 warnings and 0 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_warn_severity/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/.oxlintrc.json
@@ -1,6 +1,10 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "jsPlugins": ["./plugin.ts"],
   "rules": {
-    "basic-custom-plugin/no-debugger": "warn"
+    "basic-custom-plugin/no-debugger": "warn",
+    "eslint/no-debugger": "warn"
   }
 }

--- a/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/built_in_no_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_no_errors/output.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 Found 0 warnings and 0 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/cfg/output.snap.md
+++ b/apps/oxlint/test/fixtures/cfg/output.snap.md
@@ -21,7 +21,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/comments/output.snap.md
@@ -456,7 +456,7 @@
     `----
 
 Found 0 warnings and 32 errors.
-Finished in Xms on 3 files using X threads.
+Finished in Xms on 3 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -46,7 +46,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
@@ -64,7 +64,7 @@
    `----
 
 Found 0 warnings and 10 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -352,7 +352,7 @@
    `----
 
 Found 0 warnings and 58 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
@@ -33,7 +33,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/disable_directives/output.snap.md
@@ -43,7 +43,7 @@
     `----
 
 Found 0 warnings and 5 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -146,7 +146,7 @@
     `----
 
 Found 0 warnings and 9 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 Found 0 warnings and 0 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/fixes/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/output.snap.md
@@ -98,7 +98,7 @@
     `----
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
+++ b/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
@@ -356,7 +356,7 @@
    `----
 
 Found 0 warnings and 45 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/globals/output.snap.md
+++ b/apps/oxlint/test/fixtures/globals/output.snap.md
@@ -66,7 +66,7 @@
    `----
 
 Found 0 warnings and 3 errors.
-Finished in Xms on 3 files using X threads.
+Finished in Xms on 3 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -213,7 +213,7 @@
    `----
 
 Found 0 warnings and 13 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/languageOptions/output.snap.md
+++ b/apps/oxlint/test/fixtures/languageOptions/output.snap.md
@@ -814,7 +814,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 3 files using X threads.
+Finished in Xms on 3 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at after (<fixture>/plugin.ts:13:19)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at before (<fixture>/plugin.ts:12:19)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at Object.create (<fixture>/plugin.ts:10:15)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
@@ -10,7 +10,7 @@
   |     at Identifier (<fixture>/plugin.ts:12:21)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
@@ -21,7 +21,7 @@
    `----
 
 Found 0 warnings and 3 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
@@ -15,7 +15,7 @@
    `----
 
 Found 0 warnings and 2 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/load_paths/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "jsPlugins": [
     "./plugins/plugin1.js",
     "./plugins/plugin2.cjs",
@@ -33,6 +36,7 @@
     "plugin13/no-debugger": "error",
     "plugin14/no-debugger": "error",
     "plugin15/no-debugger": "error",
-    "plugin16/no-debugger": "error"
+    "plugin16/no-debugger": "error",
+    "eslint/no-debugger": "warn"
   }
 }

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -107,7 +107,7 @@
    `----
 
 Found 1 warning and 16 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at DebuggerStatement (<fixture>/plugin.ts:18:21)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
@@ -58,7 +58,7 @@
    `----
 
 Found 0 warnings and 7 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
@@ -18,7 +18,7 @@
    `----
 
 Found 0 warnings and 2 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
@@ -58,7 +58,7 @@
    `----
 
 Found 0 warnings and 7 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
@@ -10,7 +10,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -268,7 +268,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/overrides/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/overrides/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "overrides": [
     {
       "files": ["*.js"],

--- a/apps/oxlint/test/fixtures/overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/overrides/output.snap.md
@@ -9,15 +9,8 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[files/index.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
-   `----
-  help: Remove the debugger statement
-
-Found 1 warning and 1 error.
-Finished in Xms on 1 file using X threads.
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/parent/output.snap.md
+++ b/apps/oxlint/test/fixtures/parent/output.snap.md
@@ -100,7 +100,7 @@
    `----
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/parser_services/output.snap.md
+++ b/apps/oxlint/test/fixtures/parser_services/output.snap.md
@@ -11,7 +11,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/plugin_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name/output.snap.md
@@ -89,7 +89,7 @@
   help: Add `@param` tag with name.
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/scope_manager/output.snap.md
+++ b/apps/oxlint/test/fixtures/scope_manager/output.snap.md
@@ -87,7 +87,7 @@
     `----
 
 Found 0 warnings and 6 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/selector/output.snap.md
+++ b/apps/oxlint/test/fixtures/selector/output.snap.md
@@ -193,7 +193,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -261,7 +261,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
@@ -138,7 +138,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
@@ -292,7 +292,7 @@
     `----
 
 Found 0 warnings and 33 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
@@ -422,7 +422,7 @@
     `----
 
 Found 0 warnings and 23 errors.
-Finished in Xms on 2 files using X threads.
+Finished in Xms on 2 files with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -162,7 +162,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
@@ -129,7 +129,7 @@
     `----
 
 Found 0 warnings and 11 errors.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/utf16_offsets/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "jsPlugins": ["./plugin.ts"],
   "rules": {
     "utf16-plugin/no-debugger": "error"

--- a/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
+++ b/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
@@ -3,14 +3,6 @@
 
 # stdout
 ```
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[files/index.js:1:1]
- 1 | debugger;
-   : ^^^^^^^^^
- 2 | // £
-   `----
-  help: Remove the debugger statement
-
   x utf16-plugin(no-debugger): debugger:
   | start/end: [0,9]
   | range: [0,9]
@@ -35,15 +27,6 @@
  7 | `-> }
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[files/index.js:3:1]
- 2 | // £
- 3 | debugger;
-   : ^^^^^^^^^
- 4 | // 🤨
-   `----
-  help: Remove the debugger statement
-
   x utf16-plugin(no-debugger): debugger:
   | start/end: [15,24]
   | range: [15,24]
@@ -54,15 +37,6 @@
    : ^^^^^^^^^
  4 | // 🤨
    `----
-
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[files/index.js:6:3]
- 5 | {
- 6 |   debugger;
-   :   ^^^^^^^^^
- 7 | }
-   `----
-  help: Remove the debugger statement
 
   x utf16-plugin(no-debugger): debugger:
   | start/end: [35,44]
@@ -75,8 +49,8 @@
  7 | }
    `----
 
-Found 3 warnings and 4 errors.
-Finished in Xms on 1 file using X threads.
+Found 0 warnings and 4 errors.
+Finished in Xms on 1 file with 0 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -202,10 +202,16 @@ function normalizeStdout(stdout: string, fixtureName: string, isESLint: boolean)
 
   let lines = stdout.split("\n");
 
-  // Remove timing and thread count info which can vary between runs
+  // Remove timing and thread count info which can vary between runs.
+  //
+  // Examples, all need to be handled:
+  // `Finished in 123ms on 4 files with 10 rules using 2 threads.`
+  // `Finished in 1.23s on 1 file using 8 threads.`
+  // `Finished in 456us on 2 files with 5 rules using 4 threads.`
   lines[lines.length - 1] = lines[lines.length - 1].replace(
-    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?) using \d+ threads.$/,
-    "Finished in Xms on $1 file$2 using X threads.",
+    /^Finished in \d+(?:\.\d+)?(?:s|ms|us|ns) on (\d+) file(s?) (?:with (\d+) rule(?:s?) )?using \d+ threads.$/,
+    (_match, filesCount, filePlural, rulesCount) =>
+      `Finished in Xms on ${filesCount} file${filePlural}${rulesCount ? ` with ${rulesCount} rules` : ""} using X threads.`,
   );
 
   // Remove lines from stack traces which are outside `fixtures` directory.


### PR DESCRIPTION
For a while, we've been skipping the printing of rule runs unless `--disable-nested-config` was passed. This was a result of the nested_configs value including the base config (see #16356). When we were checking whether that value was empty, it would always have at least 1 item (unless nested configs were entirely disabled).

As part of this, I've updated some configs in the fixtures to disable correctness rules, otherwise we will end up with a bunch of fixture snapshots needing updates every time a new default rule is added.

It's probably easiest to review this one commit at a time.