### PR TITLE
fix(linter): include JS plugin rules when calculating total rule count

### DIFF
--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 90 rules using X threads.
+Finished in Xms on 1 file with 91 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
@@ -264,7 +264,7 @@
   help: Remove the debugger statement
 
 Found 20 warnings and 20 errors.
-Finished in Xms on 20 files with 55 rules using X threads.
+Finished in Xms on 20 files with 56 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
@@ -33,7 +33,7 @@
    `----
 
 Found 1 warning and 3 errors.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 4 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 Found 0 warnings and 0 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/cfg/output.snap.md
+++ b/apps/oxlint/test/fixtures/cfg/output.snap.md
@@ -21,7 +21,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/comments/output.snap.md
@@ -456,7 +456,7 @@
     `----
 
 Found 0 warnings and 32 errors.
-Finished in Xms on 3 files with 0 rules using X threads.
+Finished in Xms on 3 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -46,7 +46,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
@@ -64,7 +64,7 @@
    `----
 
 Found 0 warnings and 10 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -352,7 +352,7 @@
    `----
 
 Found 0 warnings and 58 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 6 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 7 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 7 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -259,7 +259,7 @@
    `----
 
 Found 0 warnings and 35 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 7 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
@@ -33,7 +33,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/disable_directives/output.snap.md
@@ -43,7 +43,7 @@
     `----
 
 Found 0 warnings and 5 errors.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -146,7 +146,7 @@
     `----
 
 Found 0 warnings and 9 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 Found 0 warnings and 0 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/fixes/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/output.snap.md
@@ -98,7 +98,7 @@
     `----
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
+++ b/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
@@ -356,7 +356,7 @@
    `----
 
 Found 0 warnings and 45 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/globals/output.snap.md
+++ b/apps/oxlint/test/fixtures/globals/output.snap.md
@@ -66,7 +66,7 @@
    `----
 
 Found 0 warnings and 3 errors.
-Finished in Xms on 3 files with 0 rules using X threads.
+Finished in Xms on 3 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -213,7 +213,7 @@
    `----
 
 Found 0 warnings and 13 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/languageOptions/output.snap.md
+++ b/apps/oxlint/test/fixtures/languageOptions/output.snap.md
@@ -814,7 +814,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 3 files with 0 rules using X threads.
+Finished in Xms on 3 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at after (<fixture>/plugin.ts:13:19)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at before (<fixture>/plugin.ts:12:19)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at Object.create (<fixture>/plugin.ts:10:15)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
@@ -10,7 +10,7 @@
   |     at Identifier (<fixture>/plugin.ts:12:21)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
@@ -21,7 +21,7 @@
    `----
 
 Found 0 warnings and 3 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
@@ -15,7 +15,7 @@
    `----
 
 Found 0 warnings and 2 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -107,7 +107,7 @@
    `----
 
 Found 1 warning and 16 errors.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 17 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_error/output.snap.md
@@ -9,7 +9,7 @@
   |     at DebuggerStatement (<fixture>/plugin.ts:18:21)
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
@@ -58,7 +58,7 @@
    `----
 
 Found 0 warnings and 7 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
@@ -18,7 +18,7 @@
    `----
 
 Found 0 warnings and 2 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
@@ -58,7 +58,7 @@
    `----
 
 Found 0 warnings and 7 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
@@ -10,7 +10,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -268,7 +268,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 8 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/parent/output.snap.md
+++ b/apps/oxlint/test/fixtures/parent/output.snap.md
@@ -100,7 +100,7 @@
    `----
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/parser_services/output.snap.md
+++ b/apps/oxlint/test/fixtures/parser_services/output.snap.md
@@ -11,7 +11,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/plugin_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name/output.snap.md
@@ -89,7 +89,7 @@
   help: Add `@param` tag with name.
 
 Found 0 warnings and 12 errors.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 12 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/scope_manager/output.snap.md
+++ b/apps/oxlint/test/fixtures/scope_manager/output.snap.md
@@ -87,7 +87,7 @@
     `----
 
 Found 0 warnings and 6 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/selector/output.snap.md
+++ b/apps/oxlint/test/fixtures/selector/output.snap.md
@@ -193,7 +193,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -261,7 +261,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
@@ -138,7 +138,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
@@ -292,7 +292,7 @@
     `----
 
 Found 0 warnings and 33 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
@@ -422,7 +422,7 @@
     `----
 
 Found 0 warnings and 23 errors.
-Finished in Xms on 2 files with 0 rules using X threads.
+Finished in Xms on 2 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -162,7 +162,7 @@
    `----
 
 Found 0 warnings and 16 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
@@ -129,7 +129,7 @@
     `----
 
 Found 0 warnings and 11 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
+++ b/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
@@ -50,7 +50,7 @@
    `----
 
 Found 0 warnings and 4 errors.
-Finished in Xms on 1 file with 0 rules using X threads.
+Finished in Xms on 1 file with 1 rules using X threads.
 ```
 
 # stderr


### PR DESCRIPTION
This ensures that we print the expected number of rules for users that are using JS Plugins.

Fix #17519.

Based on #17517, because otherwise we'd end up with weird snapshot differences when trying to merge these anyway.

AI Disclosure: The fix here was generated with Copilot + GitHub's Raptor mini model.