### PR TITLE
fix(semantic): do not reuse catch variable symbol for var declarations

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -66,6 +66,15 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                     if let Some(symbol_id) =
                         builder.check_redeclaration(scope_id, span, &name, excludes, true)
                     {
+                        // https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks
+                        // A var declaration with the same name as the catch parameter
+                        // should NOT reuse the catch parameter's symbol. Instead, it should
+                        // create a new binding in the function/global scope that the catch
+                        // parameter shadows within the catch block.
+                        if builder.scoping.symbol_flags(symbol_id).is_catch_variable() {
+                            continue;
+                        }
+
                         builder.add_redeclare_variable(symbol_id, includes, span);
                         declared_symbol_id = Some(symbol_id);
 

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/nested-catch-with-var.js
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/nested-catch-with-var.js
@@ -1,0 +1,9 @@
+// https://github.com/oxc-project/oxc/issues/17307
+// var declaration in nested catch block should create hoisted binding
+try {} catch (e) {
+  try {} catch (e) {
+    var e = "e";
+    console.log(e === "e");
+  }
+}
+console.log(e === undefined);

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/nested-catch-with-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/nested-catch-with-var.snap
@@ -1,0 +1,97 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/nested-catch-with-var.js
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "BlockStatement",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [],
+                "flags": "ScopeFlags(StrictMode)",
+                "id": 4,
+                "node": "BlockStatement",
+                "symbols": []
+              },
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "flags": "ScopeFlags(StrictMode)",
+                    "id": 6,
+                    "node": "BlockStatement",
+                    "symbols": [
+                      {
+                        "flags": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
+                        "id": 1,
+                        "name": "e",
+                        "node": "CatchParameter",
+                        "references": [
+                          {
+                            "flags": "ReferenceFlags(Read)",
+                            "id": 1,
+                            "name": "e",
+                            "node_id": 23
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "flags": "ScopeFlags(StrictMode | CatchClause)",
+                "id": 5,
+                "node": "CatchClause",
+                "symbols": []
+              }
+            ],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "BlockStatement",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
+                "id": 0,
+                "name": "e",
+                "node": "CatchParameter",
+                "references": []
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | CatchClause)",
+        "id": 2,
+        "node": "CatchClause",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(FunctionScopedVariable)",
+        "id": 2,
+        "name": "e",
+        "node": "VariableDeclarator(e)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 3,
+            "name": "e",
+            "node_id": 31
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
When a var declaration inside a catch block has the same name as the
catch parameter, the var should create a separate hoisted binding in
the function/global scope rather than reusing the catch parameter symbol.

This matches ECMAScript spec section B.3.4 (VariableStatements in Catch Blocks)
and TypeScript behavior where var declarations go to the function scope
while catch parameters remain in the catch clause scope.

Closes #17307