### PR TITLE
test(vscode): move unit tests into own test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ target/
 /editors/vscode/node_modules/
 /editors/vscode/icon.png
 /editors/vscode/out/
+/editors/vscode/out_test/
 /editors/vscode/*.vsix
 /editors/vscode/test_workspace/
 /editors/vscode/test_workspace_second/

--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -13,7 +13,7 @@ const multiRootWorkspaceConfig = {
 writeFileSync(multiRootWorkspaceFile, JSON.stringify(multiRootWorkspaceConfig, null, 2));
 
 const baseTest = {
-  files: "out/**/*.spec.js",
+  files: "out_test/integration/**/*.spec.js",
   workspaceFolder: "./test_workspace",
   launchArgs: [
     // This disables all extensions except the one being tested
@@ -25,6 +25,13 @@ const baseTest = {
 };
 
 const allTestSuites = new Map([
+  [
+    "unit",
+    {
+      ...baseTest,
+      files: "out_test/unit/**/*.spec.js",
+    },
+  ],
   [
     "oxlint-lsp",
     {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -41,6 +41,7 @@
     "oxfmt:build:debug": "pnpm -C ../../apps/oxfmt build-napi-test && pnpm -C ../../apps/oxfmt build-js",
     "oxfmt:build:release": "pnpm -C ../../apps/oxfmt build-napi && pnpm -C ../../apps/oxfmt build-js",
     "test": "cross-env TEST=true pnpm run compile && vscode-test",
+    "test:unit": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=unit vscode-test",
     "test:oxlint": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxlint-lsp vscode-test",
     "test:oxlint-multi-root": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxlint-lsp-multi-root vscode-test",
     "test:oxfmt": "cross-env TEST=true pnpm run compile && cross-env TEST_SUITE=oxfmt-lsp vscode-test"

--- a/editors/vscode/rolldown.config.ts
+++ b/editors/vscode/rolldown.config.ts
@@ -9,10 +9,13 @@ const output: RolldownOptions["output"] = {
   format: "cjs",
   banner: `"use strict";\n`,
   minify: true,
+  cleanDir: true,
 };
 
 if (process.env.TEST === "true") {
-  output.dir = "out";
+  output.dir = "out_test";
+  output.preserveModules = true;
+  output.preserveModulesRoot = "tests";
 } else {
   output.file = "out/main.js";
 }

--- a/editors/vscode/tests/integration/code_actions.spec.ts
+++ b/editors/vscode/tests/integration/code_actions.spec.ts
@@ -18,7 +18,7 @@ import {
   loadFixture,
   sleep,
   testSingleFolderMode
-} from './test-helpers';
+} from '../test-helpers';
 import assert = require('assert');
 
 suiteSetup(async () => {

--- a/editors/vscode/tests/integration/commands.spec.ts
+++ b/editors/vscode/tests/integration/commands.spec.ts
@@ -11,7 +11,7 @@ import {
   sleep,
   testSingleFolderMode,
   WORKSPACE_DIR
-} from './test-helpers';
+} from '../test-helpers';
 
 const fileUri = Uri.joinPath(WORKSPACE_DIR, 'debugger.js');
 

--- a/editors/vscode/tests/integration/e2e_server_formatter.spec.ts
+++ b/editors/vscode/tests/integration/e2e_server_formatter.spec.ts
@@ -10,7 +10,7 @@ import {
   fixturesWorkspaceUri,
   loadFixture,
   sleep,
-} from './test-helpers';
+} from '../test-helpers';
 
 suiteSetup(async () => {
   await activateExtension();

--- a/editors/vscode/tests/integration/e2e_server_linter.spec.ts
+++ b/editors/vscode/tests/integration/e2e_server_linter.spec.ts
@@ -24,7 +24,7 @@ import {
   WORKSPACE_DIR,
   WORKSPACE_SECOND_DIR,
   writeToFixtureFile
-} from './test-helpers';
+} from '../test-helpers';
 import assert = require('assert');
 
 const fileUri = Uri.joinPath(WORKSPACE_DIR, 'debugger.js');

--- a/editors/vscode/tests/integration/workspace_folders.spec.ts
+++ b/editors/vscode/tests/integration/workspace_folders.spec.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "assert";
 import { DiagnosticSeverity, Uri, workspace } from "vscode";
-import { activateExtension, getDiagnostics, loadFixture, sleep, testMultiFolderMode, WORKSPACE_DIR } from "./test-helpers";
+import { activateExtension, getDiagnostics, loadFixture, sleep, testMultiFolderMode, WORKSPACE_DIR } from "../test-helpers";
 import assert = require("assert");
 
 suiteSetup(async () => {

--- a/editors/vscode/tests/unit/ConfigService.spec.ts
+++ b/editors/vscode/tests/unit/ConfigService.spec.ts
@@ -1,7 +1,7 @@
 import { strictEqual } from 'assert';
 import { workspace } from 'vscode';
-import { ConfigService } from '../client/ConfigService.js';
-import { testSingleFolderMode, WORKSPACE_FOLDER } from './test-helpers.js';
+import { ConfigService } from '../../client/ConfigService.js';
+import { WORKSPACE_FOLDER } from '../test-helpers.js';
 
 const conf = workspace.getConfiguration('oxc');
 
@@ -30,7 +30,7 @@ suite('ConfigService', () => {
   };
 
   suite('getOxfmtServerBinPath', () => {
-    testSingleFolderMode('resolves relative server path with workspace folder', async () => {
+    test('resolves relative server path with workspace folder', async () => {
       const service = new ConfigService();
       const nonDefinedServerPath = await service.getOxfmtServerBinPath();
 
@@ -48,7 +48,7 @@ suite('ConfigService', () => {
       strictEqual(relativeServerPath, `${workspace_path}/relative/oxfmt`);
     });
 
-    testSingleFolderMode('returns undefined for unsafe server path', async () => {
+    test('returns undefined for unsafe server path', async () => {
       const service = new ConfigService();
       await conf.update('path.oxfmt', '../unsafe/oxfmt');
       const unsafeServerPath = await service.getOxfmtServerBinPath();
@@ -56,7 +56,7 @@ suite('ConfigService', () => {
       strictEqual(unsafeServerPath, undefined);
     });
 
-    testSingleFolderMode('returns backslashes path on Windows', async () => {
+    test('returns backslashes path on Windows', async () => {
       if (process.platform !== 'win32') {
         return;
       }
@@ -71,7 +71,7 @@ suite('ConfigService', () => {
   });
 
   suite('getOxlintServerBinPath', () => {
-    testSingleFolderMode('resolves relative server path with workspace folder', async () => {
+    test('resolves relative server path with workspace folder', async () => {
       const service = new ConfigService();
       const nonDefinedServerPath = await service.getOxlintServerBinPath();
 
@@ -89,7 +89,7 @@ suite('ConfigService', () => {
       strictEqual(relativeServerPath, `${workspace_path}/relative/oxlint`);
     });
 
-    testSingleFolderMode('returns undefined for unsafe server path', async () => {
+    test('returns undefined for unsafe server path', async () => {
       const service = new ConfigService();
       await conf.update('path.oxlint', '../unsafe/oxlint');
       const unsafeServerPath = await service.getOxlintServerBinPath();
@@ -97,7 +97,7 @@ suite('ConfigService', () => {
       strictEqual(unsafeServerPath, undefined);
     });
 
-    testSingleFolderMode('returns backslashes path on Windows', async () => {
+    test('returns backslashes path on Windows', async () => {
       if (process.platform !== 'win32') {
         return;
       }

--- a/editors/vscode/tests/unit/PathValidator.spec.ts
+++ b/editors/vscode/tests/unit/PathValidator.spec.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import { validateSafeBinaryPath } from '../client/PathValidator';
+import { validateSafeBinaryPath } from '../../client/PathValidator';
 
 suite('validateSafeBinaryPath', () => {
   test('should return true for valid binary paths', () => {

--- a/editors/vscode/tests/unit/VSCodeConfig.spec.ts
+++ b/editors/vscode/tests/unit/VSCodeConfig.spec.ts
@@ -1,7 +1,6 @@
 import { strictEqual } from 'assert';
 import { workspace } from 'vscode';
-import { VSCodeConfig } from '../client/VSCodeConfig.js';
-import { testSingleFolderMode } from './test-helpers.js';
+import { VSCodeConfig } from '../../client/VSCodeConfig.js';
 
 const conf = workspace.getConfiguration('oxc');
 
@@ -15,7 +14,7 @@ suite('VSCodeConfig', () => {
     await Promise.all(keys.map(key => conf.update(key, undefined)));
   });
 
-  testSingleFolderMode('default values on initialization', () => {
+  test('default values on initialization', () => {
     const config = new VSCodeConfig();
 
     strictEqual(config.enable, true);
@@ -27,14 +26,14 @@ suite('VSCodeConfig', () => {
     strictEqual(config.nodePath, '');
   });
 
-  testSingleFolderMode('deprecated values are respected', async () => {
+  test('deprecated values are respected', async () => {
     await conf.update('path.server', './deprecatedBinary');
     const config = new VSCodeConfig();
 
     strictEqual(config.binPathOxlint, './deprecatedBinary');
   });
 
-  testSingleFolderMode('updating values updates the workspace configuration', async () => {
+  test('updating values updates the workspace configuration', async () => {
     const config = new VSCodeConfig();
 
     await Promise.all([

--- a/editors/vscode/tests/unit/WorkspaceConfig.spec.ts
+++ b/editors/vscode/tests/unit/WorkspaceConfig.spec.ts
@@ -1,8 +1,8 @@
 import { strictEqual } from 'assert';
 import { ConfigurationTarget, workspace } from 'vscode';
 import { DiagnosticPullMode } from 'vscode-languageclient';
-import { FixKind, WorkspaceConfig } from '../client/WorkspaceConfig.js';
-import { WORKSPACE_FOLDER } from './test-helpers.js';
+import { FixKind, WorkspaceConfig } from '../../client/WorkspaceConfig.js';
+import { WORKSPACE_FOLDER } from '../test-helpers.js';
 
 const keys = [
   'lint.run',

--- a/editors/vscode/tests/unit/lsp_helper.spec.ts
+++ b/editors/vscode/tests/unit/lsp_helper.spec.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import { runExecutable } from '../client/tools/lsp_helper';
+import { runExecutable } from '../../client/tools/lsp_helper';
 
 suite('runExecutable', () => {
   const originalPlatform = process.platform;

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -32,7 +32,7 @@
   },
   "overrides": [
     {
-      "files": ["**/editors/vscode/tests/*.spec.ts"],
+      "files": ["**/editors/vscode/tests/**/*.spec.ts"],
       "rules": {
         // VSCode uses `vscode-test-cli`, which uses `mocha`.
         // Ignore specific rules, instead of copying the plugins array.


### PR DESCRIPTION
> This PR reorganizes the VSCode extension tests by separating unit tests into their own test suite, distinct from integration tests. This allows unit tests to run independently and faster without requiring LSP server initialization.