### PR TITLE
perf(semantic): use SIMD for finding backslashes in `check_string_literal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -720,9 +720,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "fixedbitset"
@@ -2333,6 +2333,7 @@ version = "0.106.0"
 dependencies = [
  "insta",
  "itertools",
+ "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -32,6 +32,7 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 itertools = { workspace = true }
+memchr = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }


### PR DESCRIPTION
Profiling shows that `check_string_literal` is called fairly often. We use a naive byte-by-byte check here for finding backslashes for octal escape sequences. This should be optimized to something wider than processing a single byte at a time, but it's worth ensuring this actually happens.

This PR changes it so that when the minimum string length is met, we use the SIMD-optimized `memchr` crate to find backslashes instead.


<img width="696" height="352" alt="image" src="https://github.com/user-attachments/assets/58c67f78-7b91-4ab1-aa45-68a175c38e6c" />
