### PR TITLE
chore(linter): Add more test cases for import/extensions rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/import_extensions.snap
+++ b/crates/oxc_linter/src/snapshots/import_extensions.snap
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import barjs from ".";
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import barjs from ".";
  3 │                 import barjs2 from "..";
@@ -116,7 +116,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import thing from "@name/pkg/test";
@@ -134,7 +134,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:4:17]
  3 │                 import bar from './bar.json';
  4 │                 import Component from './Component';
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:7:17]
  6 │                 import baw from '@scoped/baw/import';
  7 │                 import chart from '@/configs/chart';
@@ -152,7 +152,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:4:17]
  3 │                 import bar from './bar.json';
  4 │                 import Component from './Component';
@@ -161,7 +161,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:7:17]
  6 │                 import baw from '@scoped/baw/import';
  7 │                 import chart from '@/configs/chart';
@@ -206,7 +206,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 export { foo } from "./foo";
@@ -231,14 +231,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import withoutExtension from "./foo?a=True.ext";
    · ────────────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:33]
  1 │ 
  2 │                 const { foo } = require("./foo");
@@ -256,7 +256,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import foo from "@/ImNotAScopedModule";
@@ -265,7 +265,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import foo from "@/ImNotAScopedModule";
  3 │                 import chart from "@/configs/chart";
@@ -274,7 +274,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 export { foo } from "./foo";
@@ -292,7 +292,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this export.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 export * from "./foo";
@@ -328,7 +328,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import * as test from ".";
@@ -337,7 +337,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import * as test from "..";
@@ -346,7 +346,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import type { MyType } from "./typescript-declare";
@@ -355,7 +355,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in export declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 export type { MyType } from "./typescript-declare";
@@ -364,7 +364,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this export.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import x from '.';
@@ -373,7 +373,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import y from '..';
@@ -418,7 +418,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import Component from './Component';
@@ -436,7 +436,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import utils from './utils';
@@ -463,7 +463,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import Component from './App';
@@ -472,7 +472,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import Component from './App';
  3 │                 import utils from './utils';
@@ -490,7 +490,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the file extension from this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import Component from './App.vue';
  3 │                 import utils from './utils';
@@ -499,28 +499,28 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import { x } from 'rootverse+debug:src';
    · ────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import { x } from 'rootverse+debug:src';
    · ────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import { x } from 'custom+protocol:module';
    · ───────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import { a } from './standard';
  3 │                 import { b } from 'custom+protocol:module';
@@ -529,7 +529,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:2:17]
  1 │ 
  2 │                 import { a } from './standard';
@@ -538,42 +538,42 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import { x } from 'workspace:packages/core/src';
    · ────────────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import { x } from 'MyCustom+Protocol:src';
    · ──────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import x from './foo?v=1';
    · ──────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import x from './foo#section';
    · ──────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import x from '@/components/Button';
    · ────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:3:17]
  2 │                 import a from '@/utils.js';
  3 │                 import b from '~/config';
@@ -582,14 +582,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import x from 'workspace:packages/core';
    · ────────────────────────────────────────
    ╰────
   help: Add a file extension to this import.
 
-  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
    ╭─[extensions.tsx:1:1]
  1 │ import x from '@/utils/';
    · ─────────────────────────
@@ -607,5 +607,61 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[extensions.tsx:1:1]
  1 │ import x from './foo.Ts';
    · ─────────────────────────
+   ╰────
+  help: Remove the file extension from this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import React from 'react';
+   · ──────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import crypto from 'node_crypto';
+   · ─────────────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import fs from 'some-package';
+   · ──────────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import fs from '@fs/some-package';
+   · ──────────────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import { default as crypto } from '@fs/some-package';
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): Missing file extension in import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import * as fs from '@fs/some-package';
+   · ───────────────────────────────────────
+   ╰────
+  help: Add a file extension to this import.
+
+  ⚠ eslint-plugin-import(extensions): File extension "ts" should not be included in the import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import useState from 'react/useState.ts';
+   · ─────────────────────────────────────────
+   ╰────
+  help: Remove the file extension from this import.
+
+  ⚠ eslint-plugin-import(extensions): File extension "ts" should not be included in the import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import useState from '@foo/bar/useState.ts';
+   · ────────────────────────────────────────────
    ╰────
   help: Remove the file extension from this import.


### PR DESCRIPTION
Some of these may be _technically_ duplicative of the existing test cases, but I think that's fine to confirm the behavior for such a complex rule. I did this as part of investigating #17501 and confirming the behavior is working as-expected in most cases.

There is one case I've left commented-out as the test fails, but it needs to be investigated as to whether that behavior matches the original ESLint rule or not.