### PR TITLE
chore(all): enable tsconfig `noUnusedLocals` compiler option

### DIFF
--- a/apps/oxfmt/tsconfig.json
+++ b/apps/oxfmt/tsconfig.json
@@ -5,7 +5,8 @@
     "noEmit": true,
     "target": "ESNext",
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": true
   },
   "include": ["src-js", "test/**/*.ts"],
   "exclude": ["test/fixtures"]

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -7,7 +7,8 @@
     "allowImportingTsExtensions": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": true
   },
   "exclude": ["node_modules", "fixtures", "test/fixtures/*/files", "conformance/submodules"]
 }

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -44,8 +44,6 @@ export default class LinterTool implements ToolInterface {
   // LSP client instance
   private client: LanguageClient | undefined;
 
-  private linterVersion: string | undefined;
-
   async getBinary(
     outputChannel: LogOutputChannel,
     configService: ConfigService,

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "sourceMap": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": true
   },
   "include": ["./client", "./tests"],
   "exclude": ["node_modules", ".vscode-test"]

--- a/napi/minify/tsconfig.json
+++ b/napi/minify/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "noUnusedLocals": true
   }
 }

--- a/napi/parser/tsconfig.json
+++ b/napi/parser/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "target": "ESNext",
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true
   }
 }

--- a/napi/transform/tsconfig.json
+++ b/napi/transform/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "noUnusedLocals": true
   }
 }

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -7,6 +7,7 @@
     "allowImportingTsExtensions": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": true
   }
 }

--- a/tasks/e2e/tsconfig.json
+++ b/tasks/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "module": "esnext"
+    "module": "esnext",
+    "noUnusedLocals": true
   }
 }


### PR DESCRIPTION
Unused local variables did not get reported by `@typescript-eslint/no-unused-vars`.  
Added `noUnusedLocals` check for every tsconfig, so `pnpm lint` will report them.
Example of failed CI: https://github.com/oxc-project/oxc/actions/runs/20626453016/job/59237769046?pr=17541