### PR TITLE
chore(linter): Add a convenience script for printing a table of rule implementation stats

### DIFF
--- a/tasks/lint_rules/src/count-implemented.mjs
+++ b/tasks/lint_rules/src/count-implemented.mjs
@@ -1,0 +1,78 @@
+// oxlint-disable no-console
+
+import { ALL_TARGET_PLUGINS, createESLintLinter, loadTargetPluginRules } from "./eslint-rules.mjs";
+import {
+  createRuleEntries,
+  overrideTypeScriptPluginStatusWithEslintPluginStatus as syncTypeScriptPluginStatusWithEslintPluginStatus,
+  syncUnicornPluginStatusWithEslintPluginStatus,
+  syncVitestPluginStatusWithJestPluginStatus,
+  updateImplementedStatus,
+  updateNotSupportedStatus,
+  updatePendingFixStatus,
+} from "./oxlint-rules.mjs";
+
+// Initialize linter and load plugin rules
+const linter = createESLintLinter();
+// Include type-checked rules, for accurate counting of the total implemented number.
+loadTargetPluginRules(linter, true);
+
+// Build rule entries and update statuses
+const ruleEntries = createRuleEntries(linter.getRules());
+await updateImplementedStatus(ruleEntries);
+updateNotSupportedStatus(ruleEntries);
+await updatePendingFixStatus(ruleEntries);
+await syncTypeScriptPluginStatusWithEslintPluginStatus(ruleEntries);
+await syncVitestPluginStatusWithJestPluginStatus(ruleEntries);
+syncUnicornPluginStatusWithEslintPluginStatus(ruleEntries);
+
+// Helper to gather stats for a plugin
+const statsForPlugin = (pluginName) => {
+  const prefix = `${pluginName}/`;
+  const entries = Array.from(ruleEntries.entries()).filter(([name]) => name.startsWith(prefix));
+  const filtered = entries.filter(([_, e]) => !e.isNotSupported);
+  const total = filtered.length;
+  const implemented = filtered.filter(([_, e]) => e.isImplemented).length;
+  const notImplemented = total - implemented;
+  const notSupported = entries.length - filtered.length;
+  return { pluginName, total, implemented, notImplemented, notSupported };
+};
+
+// Compute per-plugin and overall stats
+const pluginNames = Array.from(ALL_TARGET_PLUGINS.keys());
+const perPlugin = pluginNames.map((name) => statsForPlugin(name));
+
+const overall = perPlugin.reduce(
+  (acc, cur) => ({
+    total: acc.total + cur.total,
+    implemented: acc.implemented + cur.implemented,
+    notImplemented: acc.notImplemented + cur.notImplemented,
+    notSupported: acc.notSupported + cur.notSupported,
+  }),
+  { total: 0, implemented: 0, notImplemented: 0, notSupported: 0 },
+);
+
+// print the numbers of rules that are implemented, not implemented, and not supported
+for (const { pluginName, total, implemented, notImplemented, notSupported } of perPlugin) {
+  const implementedPct = total === 0 ? "-" : `${((implemented / total) * 100).toFixed(2)}%`;
+  console.log(
+    `${pluginName.padEnd(12)} Implemented: ${implemented.toString().padStart(4)} / ${total
+      .toString()
+      .padStart(4)} (${implementedPct.padStart(7)}), Not Implemented: ${notImplemented
+      .toString()
+      .padStart(3)}, Not Supported: ${notSupported.toString().padStart(3)}`,
+  );
+}
+
+// Print overall summary
+const overallPct =
+  overall.total === 0 ? "-" : `${((overall.implemented / overall.total) * 100).toFixed(2)}%`;
+console.log(
+  "-----------------------------------------------------------------------------------------",
+);
+console.log(
+  `${"total".padEnd(12)} Implemented: ${overall.implemented.toString().padStart(4)} / ${overall.total
+    .toString()
+    .padStart(4)} (${overallPct.padStart(7)}), Not Implemented: ${overall.notImplemented
+    .toString()
+    .padStart(3)}, Not Supported: ${overall.notSupported.toString().padStart(3)}`,
+);

--- a/tasks/lint_rules/src/eslint-rules.mjs
+++ b/tasks/lint_rules/src/eslint-rules.mjs
@@ -63,14 +63,18 @@ const { rules: pluginNextAllRules } = pluginNext;
 const { configs: pluginVitestConfigs, rules: pluginVitestRules } = pluginVitest;
 const { configs: pluginVueConfigs, rules: pluginVueRules } = pluginVue;
 
-/** @param {import("eslint").Linter} linter */
-const loadPluginTypeScriptRules = (linter) => {
-  // We want to list all rules but not support type-checked rules
-  const pluginTypeScriptDisableTypeCheckedRules = new Map(
-    Object.entries(pluginTypeScriptConfigs["disable-type-checked"].rules),
-  );
+export const typescriptTypeCheckRules = new Map(
+  Object.entries(pluginTypeScriptConfigs["disable-type-checked"].rules),
+);
+
+/**
+ * @param {import("eslint").Linter} linter
+ * @param {boolean} includeTypeCheckRules
+ * @returns {void}
+ */
+const loadPluginTypeScriptRules = (linter, includeTypeCheckRules = false) => {
   for (const [name, rule] of Object.entries(pluginTypeScriptAllRules)) {
-    if (pluginTypeScriptDisableTypeCheckedRules.has(`@typescript-eslint/${name}`)) {
+    if (!includeTypeCheckRules && typescriptTypeCheckRules.has(`@typescript-eslint/${name}`)) {
       continue;
     }
 
@@ -309,9 +313,13 @@ export const createESLintLinter = () =>
     configType: "eslintrc",
   });
 
-/** @param {import("eslint").Linter} linter */
-export const loadTargetPluginRules = (linter) => {
-  loadPluginTypeScriptRules(linter);
+/**
+ * @param {import("eslint").Linter} linter
+ * @param {boolean} includeTypeCheckRules
+ * @returns {void}
+ */
+export const loadTargetPluginRules = (linter, includeTypeCheckRules = false) => {
+  loadPluginTypeScriptRules(linter, includeTypeCheckRules);
   loadPluginNRules(linter);
   loadPluginUnicornRules(linter);
   loadPluginJSDocRules(linter);

--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -1,6 +1,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import unsupportedRules from "./unsupported-rules.json" with { type: "json" };
+import { typescriptTypeCheckRules } from "./eslint-rules.mjs";
 
 const readAllImplementedRuleNames = async () => {
   const rulesFile = await readFile(resolve("crates/oxc_linter/src/rules.rs"), "utf8");
@@ -172,6 +173,14 @@ export const updateImplementedStatus = async (ruleEntries) => {
     if (rule) {
       rule.isImplemented = true;
     } else {
+      // Don't print the warning for rules that are type-check only and thus implemented via tsgolint.
+      if (name.startsWith("typescript/")) {
+        const tsRuleName = name.split("/").at(1);
+        if (tsRuleName && typescriptTypeCheckRules.has(`@typescript-eslint/${tsRuleName}`)) {
+          continue;
+        }
+      }
+
       // oxlint-disable-next-line no-console
       console.log(`👀 ${name} is implemented but not found in their rules`);
     }


### PR DESCRIPTION
AI Disclosure: Written with help from GitHub Copilot + Raptor mini, reviewed by me and confirmed to be functional and correct.

 Note that the reason for the # of implemented rules being higher than the actual # of rules listed on the rules page of the docs is due to jest-vitest rules, where we implement two rules as one. (there are also a few other rules that get counted this way, not just the jest-vitest rules).

This adds a script for listing the full progress report stats across all plugins/rules. This is not used for anything yet, but could be used in the future on the website, or just as an internal tracker for our own usage.

Command to install the dependencies/latest eslint plugins and then run the script: `cd tasks/lint_rules && npm install && cd ../.. && node tasks/lint_rules/src/count-implemented.mjs`

Output:

```
eslint       Implemented:  165 /  196 ( 84.18%), Not Implemented:  31, Not Supported:  96
typescript   Implemented:  102 /  130 ( 78.46%), Not Implemented:  28, Not Supported:   3
n            Implemented:    4 /   36 ( 11.11%), Not Implemented:  32, Not Supported:   5
unicorn      Implemented:  122 /  141 ( 86.52%), Not Implemented:  19, Not Supported:   3
jsdoc        Implemented:   18 /   75 ( 24.00%), Not Implemented:  57, Not Supported:   0
import       Implemented:   30 /   44 ( 68.18%), Not Implemented:  14, Not Supported:   2
jsx-a11y     Implemented:   30 /   36 ( 83.33%), Not Implemented:   6, Not Supported:   3
jest         Implemented:   52 /   68 ( 76.47%), Not Implemented:  16, Not Supported:   3
react        Implemented:   47 /   87 ( 54.02%), Not Implemented:  40, Not Supported:  45
react-perf   Implemented:    4 /    4 (100.00%), Not Implemented:   0, Not Supported:   0
nextjs       Implemented:   21 /   21 (100.00%), Not Implemented:   0, Not Supported:   0
promise      Implemented:   16 /   16 (100.00%), Not Implemented:   0, Not Supported:   1
vitest       Implemented:   49 /   78 ( 62.82%), Not Implemented:  29, Not Supported:   2
vue          Implemented:   14 /   83 ( 16.87%), Not Implemented:  69, Not Supported: 165
-----------------------------------------------------------------------------------------
total        Implemented:  674 / 1015 ( 66.40%), Not Implemented: 341, Not Supported: 328
```

This also fixes a bug (arguably not a bug I guess? 🤷) where the script to generate the rules lists would print a bunch of irrelevant messages because we had implemented type-checked rules (which are not included in the plugin issue in oxlint, as they are for tsgolint). So we'll no longer see a bunch of lines like this in the logs:

```
👀 typescript/no-for-in-array is implemented but not found in their rules
👀 typescript/no-implied-eval is implemented but not found in their rules
👀 typescript/no-meaningless-void-operator is implemented but not found in their rules
👀 typescript/no-misused-spread is implemented but not found in their rules
👀 typescript/no-mixed-enums is implemented but not found in their rules
👀 typescript/no-redundant-type-constituents is implemented but not found in their rules
👀 typescript/no-unnecessary-boolean-literal-compare is implemented but not found in their rules
👀 typescript/no-unnecessary-template-expression is implemented but not found in their rules
👀 typescript/no-unnecessary-type-arguments is implemented but not found in their rules
👀 typescript/no-unnecessary-type-assertion is implemented but not found in their rules
```