### PR TITLE
chore(linter): simplify fixture test case to avoid conflicts when new rules are added

### DIFF
--- a/apps/oxlint/fixtures/issue_11644/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_11644/.oxlintrc.json
@@ -1,26 +1,11 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "plugins": [
-    "eslint",
-    "import",
     "jsx-a11y",
-    "nextjs",
-    "node",
-    "oxc",
-    "promise",
-    "react",
-    "react-perf",
-    "typescript",
-    "unicorn"
   ],
   "rules": {
-    "import/no-default-export": 0,
-    "no-console": 1,
-    "react/button-has-type": 0,
-    "react/rules-of-hooks": 2,
-    "typescript/explicit-function-return-type": 0,
-    "typescript/no-non-null-assertion": 0,
-    "unicorn/filename-case": [2, { "case": "kebabCase" }],
-    "unicorn/no-nested-ternary": 0,
-    // "jsx-a11y/label-has-associated-control": ["warn", { "depth": 0}]
+    "jsx-a11y/label-has-associated-control": "warn"
   }
 }

--- a/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11644_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11644
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 167 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------


### PR DESCRIPTION
We could alternatiely fix this by censoring the # of rules emitted, but I don't know if that's really worthwhile. I believe this should be sufficient in that the rule will use its default values and thus still reproduces the issue correctly.

See #11644 for reference