### PR TITLE
chore(all): Enable formatOnSave for oxc repo.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,11 @@
   // "oxc.path.oxfmt": "apps/oxfmt/dist/cli.js", // debug with local oxfmt build
   "oxc.fmt.configPath": "oxfmtrc.jsonc",
   "[javascript]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
   },
   "[typescript]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
   }
 }


### PR DESCRIPTION
This will ensure that oxfmt is applied automatically on all JS/TS files that are edited by the developer when working on the oxc repo. The hope is that this avoids some unnecessary extra `just fmt` runs and autofix.ci commits.