### PR TITLE
docs(linter): Add a note to the `typescript/no-var-requires` rule about the missing `allow` option

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -22,7 +22,11 @@ pub struct NoVarRequires;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `require` statements except in import statements
+    /// Disallow `require` statements except in import statements.
+    ///
+    /// **NOTE**: This rule is intentionally missing the `allow` option from the original typescript-eslint rule.
+    /// This rule is deprecated in the upstream plugin and the `typescript/no-require-imports` rule should be
+    /// used instead.
     ///
     /// ### Why is this bad?
     ///


### PR DESCRIPTION
The rule should probably be deprecated in oxlint in favor of the `typescript/no-require-imports` rule, but we don't really have a deprecation process currently.

See the docs for the upstream rule here: https://typescript-eslint.io/rules/no-var-requires/