### PR TITLE
perf(vscode): optimize binary search for pnpm monorepos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ tasks/prettier_conformance/prettier/
 
 .claude
 
+# Investigation notes
+vscode-binary-discovery-issues.md
+
 # NOTE: For non-project files such as `.vscode` or `.idea`, please add them to your `.gitignore_global`.
 # In `.gitconfig`, add `[core] excludesfile = ~/.gitignore_global`
 # See also

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ tasks/prettier_conformance/prettier/
 
 .claude
 
-# Investigation notes
-vscode-binary-discovery-issues.md
-
 # NOTE: For non-project files such as `.vscode` or `.idea`, please add them to your `.gitignore_global`.
 # In `.gitconfig`, add `[core] excludesfile = ~/.gitignore_global`
 # See also

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -160,7 +160,8 @@ export class ConfigService implements IDisposable {
       const directPath = path.join(workspacePath, "node_modules", ".bin", defaultPattern);
       try {
         await fs.access(directPath);
-        return directPath;
+        // Convert to proper file system path format (handles Windows path normalization)
+        return Uri.file(directPath).fsPath;
       } catch {
         // File doesn't exist, continue to next workspace
       }

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { promises as fs } from "node:fs";
 import { ConfigurationChangeEvent, RelativePattern, Uri, workspace, WorkspaceFolder } from "vscode";
 import { DiagnosticPullMode } from "vscode-languageclient";
 import { validateSafeBinaryPath } from "./PathValidator";
@@ -113,20 +114,8 @@ export class ConfigService implements IDisposable {
     settingsBinary: string | undefined,
     defaultPattern: string,
   ): Promise<string | undefined> {
-    const cwd = this.workspaceConfigs.keys().next().value;
-    if (!cwd) {
-      return undefined;
-    }
-
     if (!settingsBinary) {
-      // try to find the binary in node_modules/.bin, resolve to the first workspace folder
-      const files = await workspace.findFiles(
-        new RelativePattern(cwd, `**/node_modules/.bin/${defaultPattern}`),
-        null,
-        1,
-      );
-
-      return files.length > 0 ? files[0].fsPath : undefined;
+      return this.searchBinaryInWorkspaces(defaultPattern);
     }
 
     if (!workspace.isTrusted) {
@@ -140,6 +129,10 @@ export class ConfigService implements IDisposable {
 
     if (!path.isAbsolute(settingsBinary)) {
       // if the path is not absolute, resolve it to the first workspace folder
+      const cwd = this.workspaceConfigs.keys().next().value;
+      if (!cwd) {
+        return undefined;
+      }
       settingsBinary = path.normalize(path.join(cwd, settingsBinary));
       // strip the leading slash on Windows
       if (process.platform === "win32" && settingsBinary.startsWith("\\")) {
@@ -148,6 +141,50 @@ export class ConfigService implements IDisposable {
     }
 
     return settingsBinary;
+  }
+
+  /**
+   * Search for binary in all workspace folders, using optimized strategy:
+   * 1. Check direct paths in all workspace node_modules/.bin/ first
+   * 2. Fall back to recursive glob search only if needed
+   */
+  private async searchBinaryInWorkspaces(defaultPattern: string): Promise<string | undefined> {
+    const workspacePaths = Array.from(this.workspaceConfigs.keys());
+
+    if (workspacePaths.length === 0) {
+      return undefined;
+    }
+
+    // First, try direct path checks in all workspace folders
+    for (const workspacePath of workspacePaths) {
+      const directPath = path.join(workspacePath, "node_modules", ".bin", defaultPattern);
+      try {
+        await fs.access(directPath);
+        return directPath;
+      } catch {
+        // File doesn't exist, continue to next workspace
+      }
+    }
+
+    // If direct path checks fail, fall back to recursive glob search
+    // Try each workspace folder in order
+    for (const workspacePath of workspacePaths) {
+      try {
+        const files = await workspace.findFiles(
+          new RelativePattern(workspacePath, `**/node_modules/.bin/${defaultPattern}`),
+          null,
+          1,
+        );
+
+        if (files.length > 0) {
+          return files[0].fsPath;
+        }
+      } catch {
+        // Glob search failed (timeout, permission issues, etc.), try next workspace
+      }
+    }
+
+    return undefined;
   }
 
   private async onVscodeConfigChange(event: ConfigurationChangeEvent): Promise<void> {


### PR DESCRIPTION
## Summary

Improves binary discovery performance in large pnpm monorepos by implementing two critical optimizations:

### Changes

1. **Search all workspace folders instead of only the first one**
   - Fixes issue where binary exists in a different workspace folder
   - Particularly important for multi-root workspaces in pnpm monorepos

2. **Check direct paths before recursive glob search**
   - Try `{workspace}/node_modules/.bin/{binary}` directly first using `fs.access()`
   - Avoids expensive recursive search through hundreds/thousands of directories
   - In large monorepos with 800+ `.bin` directories, this provides significant performance improvement

### New Search Strategy

The optimized strategy is:
1. **Fast path**: Direct file access check in all workspace folders
2. **Fallback**: Recursive glob search only if direct check fails  
3. **Error handling**: Gracefully handles timeouts and permission issues

### Problem Solved

Fixes binary discovery failures in large pnpm monorepos (like orthlyweb) where:
- oxlint is installed at the root `node_modules/.bin/`
- The old logic only checked the first workspace folder
- The recursive glob pattern `**/node_modules/.bin/oxlint` would timeout due to searching through 800+ `.bin` directories

### Test Plan

- ✅ All existing unit tests pass
- ✅ Maintains backward compatibility with existing configurations
- ✅ Tested compilation with TypeScript

## Related Issues

This is the first PR in a series to improve VS Code extension performance in pnpm monorepos. See investigation notes in `vscode-binary-discovery-issues.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)