### PR TITLE
feat(linter/only-throw-error rule): add `allowRethrowing` option for 

### DIFF
--- a/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/.oxlintrc.json
@@ -43,6 +43,14 @@
       {
         "allowOptionalChaining": true
       }
+    ],
+    "typescript/only-throw-error": [
+      "error",
+      {
+        "allowRethrowing": false,
+        "allowThrowingAny": false,
+        "allowThrowingUnknown": true
+      }
     ]
   }
 }

--- a/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
+++ b/apps/oxlint/fixtures/tsgolint_rule_options/test.ts
@@ -62,4 +62,12 @@ declare const unknownValue: unknown;
 // This SHOULD error because checkUnknown is true
 const unknownStr = unknownValue.toString();
 
+// Test only-throw-error with allowRethrowing option
+// When allowRethrowing is false, rethrowing a caught error SHOULD error
+try {
+  throw new Error('test');
+} catch (e) {
+  throw e; // This SHOULD error because allowRethrowing is false
+}
+
 export { result, customStr, allowedSpread, notAllowedSpread, literalConst, optionalAccess, unsafeAccess, unknownStr };

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
@@ -39,7 +39,7 @@ working directory: fixtures/tsgolint_rule_options
     `----
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 1 file with 6 rules using 1 threads.
+Finished in <variable>ms on 1 file with 7 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -16,6 +16,8 @@ pub struct OnlyThrowErrorConfig {
     /// An array of type or value specifiers for additional types that are allowed to be thrown.
     /// Use this to allow throwing custom error types.
     pub allow: Vec<TypeOrValueSpecifier>,
+    /// Whether to allow rethrowing caught values that are not Error objects.
+    pub allow_rethrowing: bool,
     /// Whether to allow throwing values typed as `any`.
     pub allow_throwing_any: bool,
     /// Whether to allow throwing values typed as `unknown`.
@@ -24,7 +26,12 @@ pub struct OnlyThrowErrorConfig {
 
 impl Default for OnlyThrowErrorConfig {
     fn default() -> Self {
-        Self { allow: Vec::new(), allow_throwing_any: true, allow_throwing_unknown: true }
+        Self {
+            allow: Vec::new(),
+            allow_rethrowing: true,
+            allow_throwing_any: true,
+            allow_throwing_unknown: true,
+        }
     }
 }
 


### PR DESCRIPTION
I've implemented this on the tsgolint side in https://github.com/oxc-project/tsgolint/pull/552.

This PR adds the options to the rust impl