### PR TITLE
perf(semantic): remove hash when checking identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,6 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxc_syntax",
- "phf",
  "rustc-hash",
  "self_cell",
  "serde_json",

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -33,14 +33,12 @@ oxc_syntax = { workspace = true }
 
 itertools = { workspace = true }
 memchr = { workspace = true }
-phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }
 oxc_parser = { workspace = true }
-phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1,7 +1,6 @@
 use std::ptr;
 
 use memchr::memchr_iter;
-use phf::{Set, phf_set};
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::GetAddress;
@@ -79,18 +78,6 @@ pub fn check_duplicate_class_elements(ctx: &SemanticBuilder<'_>) {
     });
 }
 
-pub const STRICT_MODE_NAMES: Set<&'static str> = phf_set! {
-    "implements",
-    "interface",
-    "let",
-    "package",
-    "private",
-    "protected",
-    "public",
-    "static",
-    "yield",
-};
-
 pub fn check_identifier(
     name: &str,
     span: Span,
@@ -102,20 +89,28 @@ pub fn check_identifier(
     {
         return;
     }
-    if name == "await" {
-        // It is a Syntax Error if the goal symbol of the syntactic grammar is Module and the StringValue of IdentifierName is "await".
-        if ctx.source_type.is_module() {
-            return ctx.error(diagnostics::reserved_keyword(name, span));
-        }
-        // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-        if ctx.scoping.scope_flags(ctx.current_scope_id).is_class_static_block() {
-            return ctx.error(diagnostics::class_static_block_await(span));
-        }
-    }
 
-    // It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName is: "implements", "interface", "let", "package", "private", "protected", "public", "static", or "yield".
-    if ctx.strict_mode() && STRICT_MODE_NAMES.contains(name) {
-        ctx.error(diagnostics::reserved_keyword(name, span));
+    match name {
+        "await" => {
+            // It is a Syntax Error if the goal symbol of the syntactic grammar is Module and the StringValue of IdentifierName is "await".
+            if ctx.source_type.is_module() {
+                ctx.error(diagnostics::reserved_keyword(name, span));
+            }
+            // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
+            else if ctx.scoping.scope_flags(ctx.current_scope_id).is_class_static_block() {
+                ctx.error(diagnostics::class_static_block_await(span));
+            }
+        }
+        // TODO: Revisit this match arm when we add `Ident` and pre-hash the identifier names and see if a HashSet
+        // becomes better for performance again.
+        "implements" | "interface" | "let" | "package" | "private" | "protected" | "public"
+        | "static" | "yield"
+            if ctx.strict_mode() =>
+        {
+            // It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName is: "implements", "interface", "let", "package", "private", "protected", "public", "static", or "yield".
+            ctx.error(diagnostics::reserved_keyword(name, span));
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
`phf_set!` is good for large lists of strings, but in cases of small lists, it is often faster to just do a `.contains` or a `matches!`. It also slightly improves compile times since no work needs to be done to hash at compile time.

It's possible the math on this might flip once we implement `Ident` (i.e., https://github.com/oxc-project/oxc/pull/16416), since the hashes will be pre-computed at parse-time.