### PR TITLE
docs(linter/arrow-body-style): correctly document default mode option

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
+++ b/crates/oxc_linter/src/rules/eslint/arrow_body_style.rs
@@ -104,7 +104,7 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
-    /// #### `"never"` (default)
+    /// #### `"never"`
     ///
     /// Examples of **incorrect** code for this rule with the `never` option:
     /// ```js
@@ -145,7 +145,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     ///
-    /// #### `"as-needed"`
+    /// #### `"as-needed"` (default)
     ///
     /// Examples of **incorrect** code for this rule with the `as-needed` option:
     /// ```js


### PR DESCRIPTION
The option for arrow-body-style defaults to `"as-needed"`, as documented in the earlier sections, not `"never"`.