### PR TITLE
feat(linter/no-unused-vars): add fixer to remove unused catch bindings

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -148,6 +148,18 @@ impl<'a> LintContext<'a> {
             .map(|(a, _)| a as u32)
     }
 
+    /// Finds the previous occurrence of the given token in the source code,
+    /// starting from the specified position, skipping over comments.
+    #[expect(clippy::cast_possible_truncation)]
+    pub fn find_prev_token_from(&self, start: u32, token: &str) -> Option<u32> {
+        let source = self.source_range(Span::from(0..start));
+
+        source
+            .rmatch_indices(token)
+            .find(|(a, _)| !self.is_inside_comment(*a as u32))
+            .map(|(a, _)| a as u32)
+    }
+
     /// Finds the next occurrence of the given token within a bounded span,
     /// starting from the specified position, skipping over comments.
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -3,7 +3,7 @@ use oxc_ast::{
     ast::{Expression, ForInStatement, ForOfStatement, VariableDeclarator},
 };
 use oxc_semantic::NodeId;
-use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan};
 
 use super::{BindingInfo, NoUnusedVars, Symbol, count_whitespace_or_commas};
 use crate::{
@@ -144,38 +144,6 @@ impl NoUnusedVars {
         }
 
         Some(new_name.into())
-    }
-    pub(in super::super) fn find_prev_token_pos<'a>(
-        &self,
-        source_text: &'a str,
-        span: Span,
-        expected: char,
-    ) -> Option<u32> {
-        let source = source_text[0..span.start as usize].chars().rev();
-        let mut pos: u32 = 0;
-        for c in source {
-            pos += c.len_utf8() as u32;
-            if c.is_whitespace() {
-                continue;
-            }
-            return (c == expected).then_some(span.start - pos);
-        }
-        None
-    }
-
-    pub(in super::super) fn find_next_token_pos<'a>(
-        &self,
-        source_text: &'a str,
-        span: Span,
-        expected: u8,
-    ) -> Option<u32> {
-        if span.end >= source_text.len() as u32 {
-            return None;
-        }
-        memchr::memchr(expected, source_text[span.end as usize..].as_bytes()).and_then(|idx| {
-            let source_idx = span.end + idx as u32;
-            (source_idx < source_text.len() as u32).then_some(source_idx)
-        })
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -521,12 +521,36 @@ fn test_vars_catch() {
     // these suggestion fixes are safe
     let fix = vec![
         ("try {} catch (error) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        (
+            "try { const x = (1 + 1); } catch (error) { }",
+            "try { const x = (1 + 1); } catch  { }",
+            None,
+            FixKind::Suggestion,
+        ),
         ("try {} catch ({ msg }) { }", "try {} catch  { }", None, FixKind::Suggestion),
         // spacing
         ("try {} catch (e) { }", "try {} catch  { }", None, FixKind::Suggestion),
         ("try {} catch(e){ }", "try {} catch{ }", None, FixKind::Suggestion),
         ("try {} catch (      e) { }", "try {} catch  { }", None, FixKind::Suggestion),
         ("try {} catch (      e \t\n ) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        // comments
+        ("try {} catch (/* comment() */ e) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        ("try {} catch (e /* comment() */) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        (
+            "try {} catch /* comment */ (e) { }",
+            "try {} catch /* comment */  { }",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"try {} catch (
+            // comment
+            // ()
+            e) { }",
+            "try {} catch  { }",
+            None,
+            FixKind::Suggestion,
+        ),
         // typescript
         ("try {} catch (error: Error) { }", "try {} catch  { }", None, FixKind::Suggestion),
         (

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -518,8 +518,22 @@ fn test_vars_catch() {
         ),
     ];
 
+    // these suggestion fixes are safe
+    let fix = vec![
+        ("try {} catch (error) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        ("try {} catch ({ msg }) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        // spacing
+        ("try {} catch (e) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        ("try {} catch(e){ }", "try {} catch{ }", None, FixKind::Suggestion),
+        ("try {} catch (      e) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        ("try {} catch (      e \t\n ) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        // typescript
+        ("try {} catch (error: Error) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        ("try {} catch (error: (typeof thing)[number]) { }", "try {} catch  { }", None, FixKind::Suggestion),
+    ];
+
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
-        .intentionally_allow_no_fix_tests()
+        .expect_fix(fix)
         .with_snapshot_suffix("oxc-vars-catch")
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -529,7 +529,12 @@ fn test_vars_catch() {
         ("try {} catch (      e \t\n ) { }", "try {} catch  { }", None, FixKind::Suggestion),
         // typescript
         ("try {} catch (error: Error) { }", "try {} catch  { }", None, FixKind::Suggestion),
-        ("try {} catch (error: (typeof thing)[number]) { }", "try {} catch  { }", None, FixKind::Suggestion),
+        (
+            "try {} catch (error: (typeof thing)[number]) { }",
+            "try {} catch  { }",
+            None,
+            FixKind::Suggestion,
+        ),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)


### PR DESCRIPTION
# What This PR Does

Adds an safe-suggestion autofix to `no-unused-vars` for deleting unused catch bindings.

```ts
try {
  // ...
} catch (e) {
  console.error('oops')
}

// fixes into
try {
  // ...
} catch {
  console.error('oops')
}
```

## TODO
- [x] check for comments
- ~~[ ] use `memchr` for SIMD~~ OOS, thinking of making another PR to do this