### PR TITLE
docs(linter): add eslint/camelcase rule to unsupported list in favor of another rule.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -24,6 +24,7 @@
     "jsx-a11y/accessible-emoji": "Deprecated.",
     "jsx-a11y/label-has-for": "Deprecated, replaced by `jsx-a11y/label-has-associated-control`.",
     "jsx-a11y/no-onchange": "Deprecated, based on behavior of very old browsers, and so no longer necessary.",
+    "eslint/camelcase": "Preference is to implement this rule via `@typescript-eslint/naming-convention` instead to accomplish the same behavior with more flexibility.",
 
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",


### PR DESCRIPTION
Preference is to implement this via [`@typescript-eslint/naming-convention`](https://typescript-eslint.io/rules/naming-convention/) instead.

See this comment for further context: https://github.com/oxc-project/oxc/pull/16908#issuecomment-3703651581