### PR TITLE
docs(linter): Add `import/enforce-node-protocol-usage` and `import/no-deprecated` to unsupported rule list.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -28,6 +28,8 @@
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",
     "n/file-extension-in-import": "No need to implement, already implemented by `import/extensions`.",
+    "import/enforce-node-protocol-usage": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
+    "import/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
 
     "jest/no-unnecessary-assertion": "Requires type information. Not currently possible to implement in oxlint.",
     "jest/unbound-method": "Requires type information. Not currently possible to implement in oxlint.",


### PR DESCRIPTION
`import/enforce-node-protocol-usage` is already implemented as you can get the same behavior via `unicorn/prefer-node-protocol`. Only difference is that the import rule allows configuration to enforce _not_ using the `node:` protocol. If someone requests that behavior later, we can just add a config option to `unicorn/prefer-node-protocol`.

[`import/no-deprecated`](https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-deprecated.md) does not need to be implemented, as we support the same behavior via `typescript/no-deprecated` in tsgolint. This rule would also be incredibly difficult to implement in a performant way without TypeScript, so it'd be a lot of work to reimplement this for no great reason.