### PR TITLE
docs(linter): add `no-octal-escape` to unsupported rules

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -2,6 +2,7 @@
   "unsupportedRules": {
     "eslint/no-dupe-args": "Superseded by strict mode.",
     "eslint/no-octal": "Superseded by strict mode.",
+    "eslint/no-octal-escape": "Superseded by strict mode.",
     "eslint/no-new-symbol": "Deprecated as of ESLint v9, but for a while disable manually.",
     "eslint/no-undef-init": "#6456, `unicorn/no-useless-undefined` covers this case.",
     "import/no-unresolved": "Will always contain false positives due to module resolution complexity.",


### PR DESCRIPTION
Hello! I'm pretty new to contributing to `oxc`, so feel free to give me some feedback.

From what I have researched on the docs, strict mode will automatically catch this anyway, like the `no-octal` rule, so I figured that, like `no-octal`, this rule should not be supported as well.

Reference: 
- https://eslint.org/docs/latest/rules/no-octal-escape
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal_escape_sequence
- https://github.com/oxc-project/oxc/pull/8151