### PR TITLE
perf(linter): use SIMD string searching for finding next/prev tokens

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 mod host;
 mod search;
 pub use host::{ContextHost, ContextSubHost};
-pub(crate) use search::Searcher;
+pub use search::Searcher;
 
 /// Contains all of the state and context specific to this lint rule.
 ///

--- a/crates/oxc_linter/src/context/search.rs
+++ b/crates/oxc_linter/src/context/search.rs
@@ -71,10 +71,7 @@ impl Searcher<&str> for LintContext<'_> {
             };
         }
         #[expect(clippy::cast_possible_truncation)]
-        source
-            .rmatch_indices(*pattern)
-            .map(|(a, _)| a as u32)
-            .find(|a| !self.is_inside_comment(*a))
+        source.rmatch_indices(*pattern).map(|(a, _)| a as u32).find(|a| !self.is_inside_comment(*a))
     }
 }
 
@@ -155,7 +152,6 @@ impl<'a> LintContext<'a> {
     ) -> Option<u32> {
         // Note: memchr_iter gives indices from the start of the slice (0-based),
         // so we use rfind to get the last occurrence and return it directly as the absolute position
-        iter.rfind(|&index| !self.is_inside_comment(index as u32))
-            .map(|index| index as u32)
+        iter.rfind(|&index| !self.is_inside_comment(index as u32)).map(|index| index as u32)
     }
 }

--- a/crates/oxc_linter/src/context/search.rs
+++ b/crates/oxc_linter/src/context/search.rs
@@ -1,0 +1,165 @@
+use super::LintContext;
+use oxc_span::Span;
+use std::ops::Deref;
+
+pub(crate) struct Pattern<T>(pub(super) T);
+
+impl<T> Deref for Pattern<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Clone for Pattern<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Copy for Pattern<T> where T: Copy {}
+
+macro_rules! into_pattern {
+    ($type:ty) => {
+        impl From<$type> for Pattern<$type> {
+            fn from(value: $type) -> Self {
+                Self(value)
+            }
+        }
+    };
+}
+impl<'a> From<&'a str> for Pattern<&'a str> {
+    fn from(value: &'a str) -> Self {
+        Self(value)
+    }
+}
+into_pattern!(char);
+into_pattern!(u8);
+
+pub(crate) trait Searcher<P> {
+    fn find_next(&self, start: u32, pattern: Pattern<P>) -> Option<u32>;
+    fn find_prev(&self, end: u32, pattern: Pattern<P>) -> Option<u32>;
+}
+
+impl<'a> Searcher<&str> for LintContext<'a> {
+    fn find_next(&self, start: u32, pattern: Pattern<&str>) -> Option<u32> {
+        let source = self.source_after(start);
+        let bytes = pattern.as_bytes();
+        if bytes.len() < 4 {
+            return match bytes.len() {
+                1 => self.search_next(start, memchr::memchr_iter(bytes[0], source.as_bytes())),
+                2 => self.search_next(
+                    start,
+                    memchr::memchr2_iter(bytes[0], bytes[1], source.as_bytes()),
+                ),
+                3 => self.search_next(
+                    start,
+                    memchr::memchr3_iter(bytes[0], bytes[1], bytes[2], source.as_bytes()),
+                ),
+                _ => unreachable!(),
+            };
+        }
+        self.search_next(start, source.match_indices(*pattern).map(|(a, _)| a))
+    }
+
+    fn find_prev(&self, end: u32, pattern: Pattern<&str>) -> Option<u32> {
+        let source = self.source_before(end);
+        let bytes = pattern.as_bytes();
+        if bytes.len() < 4 {
+            return match bytes.len() {
+                1 => self.search_prev(end, memchr::memchr_iter(bytes[0], source.as_bytes())),
+                2 => self
+                    .search_prev(end, memchr::memchr2_iter(bytes[0], bytes[1], source.as_bytes())),
+                3 => self.search_prev(
+                    end,
+                    memchr::memchr3_iter(bytes[0], bytes[1], bytes[2], source.as_bytes()),
+                ),
+                _ => unreachable!(),
+            };
+        }
+        source
+            .rmatch_indices(*pattern)
+            .find(|(a, _)| !self.is_inside_comment(*a as u32))
+            .map(|(a, _)| a as u32)
+    }
+}
+
+impl<'a> Searcher<char> for LintContext<'a> {
+    #[inline]
+    fn find_next(&self, start: u32, pattern: Pattern<char>) -> Option<u32> {
+        let source = self.source_after(start);
+        let bytes = u32::from(pattern.0);
+        match pattern.len_utf8() {
+            1 => self.search_next(start, memchr::memchr_iter(bytes as u8, source.as_bytes())),
+            2 => {
+                let [first, second, ..] = bytes.to_be_bytes();
+                self.search_next(start, memchr::memchr2_iter(first, second, source.as_bytes()))
+            }
+            3 => {
+                let [first, second, third, _] = bytes.to_be_bytes();
+                self.search_next(
+                    start,
+                    memchr::memchr3_iter(first, second, third, source.as_bytes()),
+                )
+            }
+            _ => self.search_next(start, source.match_indices(pattern.0).map(|(a, _)| a)),
+        }
+    }
+
+    #[inline]
+    fn find_prev(&self, end: u32, pattern: Pattern<char>) -> Option<u32> {
+        let source = self.source_before(end);
+        let bytes = u32::from(pattern.0);
+        match pattern.len_utf8() {
+            1 => self.search_prev(end, memchr::memchr_iter(bytes as u8, source.as_bytes())),
+            2 => {
+                let [first, second, ..] = bytes.to_be_bytes();
+                self.search_prev(end, memchr::memchr2_iter(first, second, source.as_bytes()))
+            }
+            3 => {
+                let [first, second, third, _] = bytes.to_be_bytes();
+                self.search_prev(end, memchr::memchr3_iter(first, second, third, source.as_bytes()))
+            }
+            _ => self.search_prev(end, source.rmatch_indices(pattern.0).map(|(a, _)| a)),
+        }
+    }
+}
+
+impl<'a> Searcher<u8> for LintContext<'a> {
+    fn find_next(&self, start: u32, pattern: Pattern<u8>) -> Option<u32> {
+        self.search_next(start, memchr::memchr_iter(pattern.0, self.source_after(start).as_bytes()))
+    }
+
+    fn find_prev(&self, end: u32, pattern: Pattern<u8>) -> Option<u32> {
+        self.search_prev(end, memchr::memchr_iter(pattern.0, self.source_before(end).as_bytes()))
+    }
+}
+
+impl<'a> LintContext<'a> {
+    fn source_before(&self, end: u32) -> &'a str {
+        self.source_range(Span::from(0..end))
+    }
+
+    fn source_after(&self, start: u32) -> &'a str {
+        self.source_range(Span::new(start, self.source_text().len() as u32))
+    }
+
+    fn search_next<I: Iterator<Item = usize>>(&self, start: u32, mut iter: I) -> Option<u32> {
+        iter.find(|&index| !self.is_inside_comment(start + index as u32))
+            .map(|index| start + index as u32)
+    }
+
+    fn search_prev<I: DoubleEndedIterator<Item = usize>>(
+        &self,
+        end: u32,
+        mut iter: I,
+    ) -> Option<u32> {
+        iter.rfind(|&index| !self.is_inside_comment(end - index as u32))
+            .map(|index| end - index as u32)
+    }
+}

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -346,14 +346,13 @@ impl NoUnusedVars {
                     |fixer| {
                         let Span { start, end, .. } = catch.span();
 
-                        let (Some(paren_start), Some(paren_end_offset)) = (
-                            ctx.find_prev_token_from(start, "("),
-                            ctx.find_next_token_from(end, ")"),
+                        let (Some(paren_start), Some(paren_end)) = (
+                            ctx.find_prev_token_from(start, b'('),
+                            ctx.find_next_token_from(end, b')'),
                         ) else {
                             return fixer.noop();
                         };
 
-                        let paren_end = end + paren_end_offset;
                         let delete_span = Span::new(paren_start, paren_end + 1);
                         fixer.delete_range(delete_span)
                     },

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -67,17 +67,17 @@ impl Rule for NoVar {
             }
 
             let is_written_to = dec.declarations.iter().any(|v| is_written_to(&v.id, ctx));
-            
+
             // For declarations with `declare` keyword, skip past it to find the actual `var`
             let search_start = if dec.declare {
                 dec.span.start + 8 // "declare ".len()
             } else {
                 dec.span.start
             };
-            
+
             let var_start = ctx.find_next_token_from(search_start, "var").unwrap();
             let var_keyword_span = Span::sized(var_start, 3);
-            
+
             ctx.diagnostic_with_fix(no_var_diagnostic(var_keyword_span), |fixer| {
                 let parent_span = ctx.nodes().parent_kind(node.id()).span();
                 if dec.declarations.iter().any(|decl| {

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -159,8 +159,7 @@ impl Rule for RequireAwait {
 
 fn get_delete_span(ctx: &LintContext, start: u32) -> Span {
     // Find the position of "async" keyword from the start position
-    let async_pos = ctx.find_next_token_from(start, "async").unwrap_or(0);
-    let async_start = start + async_pos;
+    let async_start = ctx.find_next_token_from(start, "async").unwrap_or(0);
     let async_end = async_start + 5;
     let async_key_span = Span::new(async_start, async_end);
 

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -167,7 +167,9 @@ impl Rule for ConsistentTypeSpecifierStyle {
                         rule_fixes.push(fixer.insert_text_before(item, "type "));
                     }
                     // find the 'type' keyword and remove it
-                    if let Some(type_token_start) = ctx.find_next_token_from(import_decl.span.start, "type") {
+                    if let Some(type_token_start) =
+                        ctx.find_next_token_from(import_decl.span.start, "type")
+                    {
                         let type_token_span = Span::sized(type_token_start, 4);
                         let remove_fix = fixer.delete_range(type_token_span);
                         rule_fixes.push(remove_fix);

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -167,8 +167,8 @@ impl Rule for ConsistentTypeSpecifierStyle {
                         rule_fixes.push(fixer.insert_text_before(item, "type "));
                     }
                     // find the 'type' keyword and remove it
-                    if let Some(pos) = ctx.find_next_token_from(import_decl.span.start, "type") {
-                        let type_token_span = Span::sized(import_decl.span.start + pos, 4);
+                    if let Some(type_token_start) = ctx.find_next_token_from(import_decl.span.start, "type") {
+                        let type_token_span = Span::sized(type_token_start, 4);
                         let remove_fix = fixer.delete_range(type_token_span);
                         rule_fixes.push(remove_fix);
                     }

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -115,10 +115,9 @@ impl BadBitwiseOperator {
         good: &'static str,
         ctx: &LintContext<'_>,
     ) -> crate::fixer::RuleFix {
-        let Some(offset) = ctx.find_next_token_from(start, bad) else {
+        let Some(op_start) = ctx.find_next_token_from(start, bad) else {
             return fixer.noop();
         };
-        let op_start = start + offset;
         let op_span = Span::new(op_start, op_start + bad.len() as u32);
         fixer.replace(op_span, good)
     }
@@ -128,10 +127,9 @@ impl BadBitwiseOperator {
         start: u32,
         ctx: &LintContext<'_>,
     ) -> crate::fixer::RuleFix {
-        let Some(offset) = ctx.find_next_token_from(start, "|=") else {
+        let Some(op_start) = ctx.find_next_token_from(start, "|=") else {
             return fixer.noop();
         };
-        let op_start = start + offset;
         let op_span = Span::new(op_start, op_start + 2);
         fixer.replace(op_span, "||=")
     }

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -94,10 +94,10 @@ const ASYNC_LEN: u32 = 5;
 
 fn report_on_async_span(async_span: Span, ctx: &LintContext<'_>) {
     // find the `async` keyword within the span and report on it
-    let Some(async_keyword_offset) = ctx.find_next_token_from(async_span.start, "async") else {
+    let Some(async_keyword_start) = ctx.find_next_token_from(async_span.start, "async") else {
         return;
     };
-    let async_keyword_span = Span::sized(async_span.start + async_keyword_offset, ASYNC_LEN);
+    let async_keyword_span = Span::sized(async_keyword_start, ASYNC_LEN);
     ctx.diagnostic(no_async_diagnostic(async_keyword_span));
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -109,7 +109,7 @@ impl Rule for ConsistentTypeDefinitions {
                             let base_start = decl.span.start + 7;
 
                             ctx.find_next_token_from(base_start, "type")
-                                .map_or(base_start + 1, |v| v + base_start)
+                                .unwrap_or(base_start + 1)
                         } else {
                             decl.span.start
                         };
@@ -196,7 +196,7 @@ impl Rule for ConsistentTypeDefinitions {
                     let base_start = decl.span.start + 7;
 
                     ctx.find_next_token_from(base_start, "interface")
-                        .map_or(base_start + 1, |v| v + base_start)
+                        .unwrap_or(base_start + 1)
                 } else {
                     decl.span.start
                 };

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -108,8 +108,7 @@ impl Rule for ConsistentTypeDefinitions {
                         let start = if decl.declare {
                             let base_start = decl.span.start + 7;
 
-                            ctx.find_next_token_from(base_start, "type")
-                                .unwrap_or(base_start + 1)
+                            ctx.find_next_token_from(base_start, "type").unwrap_or(base_start + 1)
                         } else {
                             decl.span.start
                         };
@@ -195,8 +194,7 @@ impl Rule for ConsistentTypeDefinitions {
                 let start = if decl.declare {
                     let base_start = decl.span.start + 7;
 
-                    ctx.find_next_token_from(base_start, "interface")
-                        .unwrap_or(base_start + 1)
+                    ctx.find_next_token_from(base_start, "interface").unwrap_or(base_start + 1)
                 } else {
                     decl.span.start
                 };

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -151,8 +151,7 @@ impl Rule for NoNamespace {
         }
 
         let keyword = declaration.kind.as_str();
-        let mut span_start = declaration.span.start;
-        span_start += ctx.find_next_token_from(span_start, keyword).unwrap();
+        let span_start = ctx.find_next_token_from(declaration.span.start, keyword).unwrap();
         #[expect(clippy::cast_possible_truncation)]
         let span = Span::sized(span_start, keyword.len() as u32);
         ctx.diagnostic(no_namespace_diagnostic(span));

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -68,8 +68,7 @@ impl Rule for PreferNamespaceKeyword {
         }
 
         ctx.diagnostic_with_fix(prefer_namespace_keyword_diagnostic(module.span), |fixer| {
-            let mut span_start = module.span.start;
-            span_start += ctx.find_next_token_from(span_start, "module").unwrap();
+            let span_start = ctx.find_next_token_from(module.span.start, "module").unwrap();
             fixer.replace(Span::sized(span_start, 6), "namespace")
         });
     }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -150,8 +150,7 @@ impl Rule for SwitchCaseBraces {
 
             if *self.0 == SwitchCaseBracesConfig::Always && missing_braces {
                 let test_end = case.test.as_ref().map_or(case.span.start, |t| t.span().end);
-                let colon_offset = ctx.find_next_token_from(test_end, ":").unwrap();
-                let colon_pos = test_end + colon_offset;
+                let colon_pos = ctx.find_next_token_from(test_end, b':').unwrap();
                 let span = Span::new(case.span.start, colon_pos + 1);
 
                 ctx.diagnostic_with_fix(


### PR DESCRIPTION
## What This PR Does

Refactors `LintContext::find_next_token_from` and `LintContext::find_prev_token_from` to use [memchr](https://github.com/BurntSushi/memchr). Local benchmarks showed a ~3-5% perf improvement.

## Changes
- `find_next_token_from` now returns an absolute position instead of an offset. This lines up with its doc comments and cleans up callees, almost all of which were using that offset to get a position anyways
- `find_{next,prev}_token_from` now takes chars and `u8`s, not just strings
- `memchr`, `memchr2`, etc. are used where possible to speed up string searching