### PR TITLE
docs(linter/react): improve docs for jsx-curly-brace-presence

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -70,8 +70,27 @@ impl Allowed {
 #[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct JsxCurlyBracePresence {
+    /// Whether to enforce or disallow curly braces for props on JSX elements.
+    ///
+    /// - `never` will disallow unnecessary curly braces, e.g. this will be preferred: `<Foo foo="bar" />`
+    /// - `always` will force the usage of curly braces like this, in all cases: `<Foo foo={'bar'} />`
+    /// - `ignore` will allow either style for prop values.
     props: Allowed,
+    /// Whether to enforce or disallow curly braces for child content of a JSX element.
+    ///
+    /// - `never` will disallow unnecessary curly braces, e.g. this will be preferred: `<Foo>I love oxlint</Foo>`
+    /// - `always` will force the usage of curly braces like this, in all cases: `<Foo>{'I love oxlint'}</Foo>`
+    /// - `ignore` will allow either style for child content.
     children: Allowed,
+    /// When set to `ignore` or `never`, this JSX code is allowed (or enforced):
+    /// `<App prop=<div /> />;`
+    ///
+    /// When set to `always`, the curly braces are required for prop values that are
+    /// JSX elements: `<App prop={<div />} />;`
+    ///
+    /// **Note**: it is _highly_ recommended that you set `propElementValues` to `always`.
+    /// The ability to omit curly braces around prop values that are JSX elements is obscure, and
+    /// intentionally undocumented, and should not be relied upon.
     prop_element_values: Allowed,
 }
 
@@ -86,19 +105,30 @@ impl Default for JsxCurlyBracePresence {
 }
 
 declare_oxc_lint!(
+    /// ### What it does
+    ///
     /// Disallow unnecessary JSX expressions when literals alone are
     /// sufficient or enforce JSX expressions on literals in JSX children or
-    /// attributes (`react/jsx-curly-brace-presence`)
+    /// attributes.
     ///
     /// This rule allows you to enforce curly braces or disallow unnecessary
     /// curly braces in JSX props and/or children.
     ///
     /// For situations where JSX expressions are unnecessary, please refer to
-    /// [the React doc](https://facebook.github.io/react/docs/jsx-in-depth.html)
+    /// [the React doc](https://react.dev/learn/writing-markup-with-jsx)
     /// and [this page about JSX
     /// gotchas](https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities).
     ///
-    /// ## Rule Details
+    /// ### Why is this bad?
+    ///
+    /// Using different styles for your JSX code can make it harder to read and
+    /// less consistent.
+    ///
+    /// Code consistency improves readability. By enforcing or disallowing
+    /// curly braces in JSX props and/or children, this rule helps maintain
+    /// consistent patterns across your application.
+    ///
+    /// ### Rule Details
     ///
     /// By default, this rule will check for and warn about unnecessary curly
     /// braces in both JSX props and children. For the sake of backwards
@@ -115,30 +145,27 @@ declare_oxc_lint!(
     /// to omit curly braces around prop values that are JSX elements is
     /// obscure, and intentionally undocumented, and should not be relied upon.
     ///
-    /// ## Rule Options
+    /// #### Example Configurations
     ///
-    /// ```js
-    /// ...
-    /// "react/jsx-curly-brace-presence": [<enabled>, { "props": <string>, "children": <string>, "propElementValues": <string> }]
-    /// ...
+    /// ```jsonc
+    /// {
+    ///   "rules": {
+    ///     "react/jsx-curly-brace-presence": ["error", { "props": <string>, "children": <string>, "propElementValues": <string> }]
+    ///   }
+    /// }
     /// ```
     ///
     /// or alternatively
     ///
-    /// ```js
-    /// ...
-    /// "react/jsx-curly-brace-presence": [<enabled>, <string>]
-    /// ...
+    /// ```jsonc
+    /// {
+    ///   "rules": {
+    ///     "react/jsx-curly-brace-presence": ["error", "always"] // or "never" or "ignore"
+    ///   }
+    /// }
     /// ```
     ///
-    /// ### Valid options for `<string>`
-    ///
-    /// They are `always`, `never` and `ignore` for checking on JSX props and
-    /// children.
-    ///
-    /// - `always`: always enforce curly braces inside JSX props, children, and/or JSX prop values that are JSX Elements
-    /// - `never`: never allow unnecessary curly braces inside JSX props, children, and/or JSX prop values that are JSX Elements
-    /// - `ignore`: ignore the rule for JSX props, children, and/or JSX prop values that are JSX Elements
+    /// ### Fix Details
     ///
     /// If passed in the option to fix, this is how a style violation will get fixed
     ///
@@ -147,7 +174,7 @@ declare_oxc_lint!(
     ///
     /// - All fixing operations use double quotes.
     ///
-    /// For examples:
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule, when configured with `{ props: "always", children: "always" }`:
     ///
@@ -201,15 +228,6 @@ declare_oxc_lint!(
     /// <App prop=<div /> />;
     /// ```
     ///
-    /// ### Alternative syntax
-    ///
-    /// The options are also `always`, `never`, and `ignore` for the same meanings.
-    ///
-    /// In this syntax, only a string is provided and the default will be set to
-    /// that option for checking on both JSX props and children.
-    ///
-    /// For examples:
-    ///
     /// Examples of **incorrect** code for this rule, when configured with `"always"`:
     ///
     /// ```jsx
@@ -236,7 +254,7 @@ declare_oxc_lint!(
     /// <App prop="foo" attr="bar">Hello world</App>;
     /// ```
     ///
-    /// ## Edge cases
+    /// ### Edge cases
     ///
     /// The fix also deals with template literals, strings with quotes, and
     /// strings with escapes characters.
@@ -294,7 +312,7 @@ declare_oxc_lint!(
     /// <App>{/* comment */ <Bpp />}</App> // the comment makes the container necessary
     /// ```
     ///
-    /// ## When Not To Use It
+    /// ### When Not To Use It
     ///
     /// You should turn this rule off if you are not concerned about maintaining
     /// consistency regarding the use of curly braces in JSX props and/or
@@ -315,10 +333,11 @@ impl Rule for JsxCurlyBracePresence {
         };
         match value {
             Value::String(s) => {
+                // TODO: Replace this with a proper DefaultRuleConfig implementation and handle errors with that.
                 let allowed = Allowed::try_from(s.as_str())
-				.map_err(|()| Error::msg(
-					r#"Invalid string config for eslint-plugin-react/jsx-curly-brace-presence: only "always", "never", or "ignored" are allowed. "#
-				)).unwrap();
+                .map_err(|()| Error::msg(
+                    r#"Invalid string config for react/jsx-curly-brace-presence: only "always", "never", or "ignore" are allowed. "#
+                )).unwrap();
                 Ok(Self { props: allowed, children: allowed, prop_element_values: allowed })
             }
             Value::Object(obj) => {
@@ -805,13 +824,13 @@ fn test() {
         ("<App>{' '}</App>", None),
         (
             "<App>{' '}
-			</App>",
+            </App>",
             None,
         ),
         ("<App>{'     '}</App>", None),
         (
             "<App>{'     '}
-			</App>",
+            </App>",
             None,
         ),
         ("<App>{' '}</App>", Some(json!([{ "children": "never" }]))),
@@ -822,20 +841,20 @@ fn test() {
         ("<App>{`Hello ${word} World`}</App>", Some(json!([{ "children": "never" }]))),
         (
             "
-			        <React.Fragment>
-			          foo{' '}
-			          <span>bar</span>
-			        </React.Fragment>
-			      ",
+                    <React.Fragment>
+                      foo{' '}
+                      <span>bar</span>
+                    </React.Fragment>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <>
-			          foo{' '}
-			          <span>bar</span>
-			        </>
-			      ",
+                    <>
+                      foo{' '}
+                      <span>bar</span>
+                    </>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         ("<App>{`Hello \n World`}</App>", Some(json!([{ "children": "never" }]))),
@@ -895,133 +914,133 @@ fn test() {
         ("<MyComponent>{` space before`}</MyComponent>", Some(json!(["never"]))),
         (
             "
-			        <App prop={`
-			          a
-			          b
-			        `} />
-			      ",
+                    <App prop={`
+                      a
+                      b
+                    `} />
+                  ",
             Some(json!(["never"])),
         ),
         (
             "
-			        <App prop={`
-			          a
-			          b
-			        `} />
-			      ",
+                    <App prop={`
+                      a
+                      b
+                    `} />
+                  ",
             Some(json!(["always"])),
         ),
         (
             "
-			        <App>
-			          {`
-			            a
-			            b
-			          `}
-			        </App>
-			      ",
+                    <App>
+                      {`
+                        a
+                        b
+                      `}
+                    </App>
+                  ",
             Some(json!(["never"])),
         ),
         (
             "
-			        <App>{`
-			          a
-			          b
-			        `}</App>
-			      ",
+                    <App>{`
+                      a
+                      b
+                    `}</App>
+                  ",
             Some(json!(["always"])),
         ),
         (
             "
-			        <MyComponent>
-			          %
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      %
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          { 'space after ' }
-			          <b>foo</b>
-			          { ' space before' }
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      { 'space after ' }
+                      <b>foo</b>
+                      { ' space before' }
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          { `space after ` }
-			          <b>foo</b>
-			          { ` space before` }
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      { `space after ` }
+                      <b>foo</b>
+                      { ` space before` }
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          foo
-			          <div>bar</div>
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      foo
+                      <div>bar</div>
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent p={<Foo>Bar</Foo>}>
-			        </MyComponent>
-			      ",
+                    <MyComponent p={<Foo>Bar</Foo>}>
+                    </MyComponent>
+                  ",
             None,
         ),
         (
             r#"
-			        <MyComponent>
-			          <div>
-			            <p>
-			              <span>
-			                {"foo"}
-			              </span>
-			            </p>
-			          </div>
-			        </MyComponent>
-			      "#,
+                    <MyComponent>
+                      <div>
+                        <p>
+                          <span>
+                            {"foo"}
+                          </span>
+                        </p>
+                      </div>
+                    </MyComponent>
+                  "#,
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-			        <App>
-			          <Component />&nbsp;
-			          &nbsp;
-			        </App>
-			      ",
+                    <App>
+                      <Component />&nbsp;
+                      &nbsp;
+                    </App>
+                  ",
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-			        const Component2 = () => {
-			          return <span>/*</span>;
-			        };
-			      ",
+                    const Component2 = () => {
+                      return <span>/*</span>;
+                    };
+                  ",
             None,
         ),
         (
             "
-			        const Component2 = () => {
-			          return <span>/*</span>;
-			        };
-			      ",
+                    const Component2 = () => {
+                      return <span>/*</span>;
+                    };
+                  ",
             Some(json!([{ "props": "never", "children": "never" }])),
         ),
         (
             r#"
-			        import React from "react";
+                    import React from "react";
 
-			        const Component = () => {
-			          return <span>{"/*"}</span>;
-			        };
-			      "#,
+                    const Component = () => {
+                      return <span>{"/*"}</span>;
+                    };
+                  "#,
             Some(json!([{ "props": "never", "children": "never" }])),
         ),
         ("<App>{/* comment */}</App>", None),
@@ -1031,16 +1050,16 @@ fn test() {
         ("<App horror={<div />} />", Some(json!([{ "propElementValues": "ignore" }]))),
         (
             r#"
-			        <script>{`window.foo = "bar"`}</script>
-			      "#,
+                    <script>{`window.foo = "bar"`}</script>
+                  "#,
             None,
         ),
         (
             r#"
-			        <CollapsibleTitle
-			          extra={<span className="activity-type">{activity.type}</span>}
-			        />
-			      "#,
+                    <CollapsibleTitle
+                      extra={<span className="activity-type">{activity.type}</span>}
+                    />
+                  "#,
             Some(json!(["never"])),
         ),
         ("<App label={`${label}`} />", Some(json!(["never"]))),
@@ -1061,35 +1080,35 @@ fn test() {
         ("<MyComponent prop={'bar'}>foo</MyComponent>", Some(json!([{ "props": "never" }]))),
         (
             "
-			        <MyComponent>
-			          {'%'}
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      {'%'}
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          {'foo'}
-			          <div>
-			            {'bar'}
-			          </div>
-			          {'baz'}
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      {'foo'}
+                      <div>
+                        {'bar'}
+                      </div>
+                      {'baz'}
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          {'foo'}
-			          <div>
-			            {'bar'}
-			          </div>
-			          {'baz'}
-			          {'some-complicated-exp'}
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      {'foo'}
+                      <div>
+                        {'bar'}
+                      </div>
+                      {'baz'}
+                      {'some-complicated-exp'}
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         ("<MyComponent prop='bar'>foo</MyComponent>", Some(json!([{ "props": "always" }]))),
@@ -1129,49 +1148,49 @@ fn test() {
         (r#"<App>{"foo 'bar'"}</App>"#, Some(json!([{ "children": "never" }]))),
         (
             r#"
-			        <App prop="" />"#,
+                    <App prop="" />"#,
             Some(json!(["always"])),
         ),
         (
             "
-			        <App prop='' />",
+                    <App prop='' />",
             Some(json!(["always"])),
         ),
         (
             "
-			        <App>
-			          foo bar
-			          <div>foo bar foo</div>
-			          <span>
-			            foo bar <i>foo bar</i>
-			            <strong>
-			              foo bar
-			            </strong>
-			          </span>
-			        </App>
-			      ",
+                    <App>
+                      foo bar
+                      <div>foo bar foo</div>
+                      <span>
+                        foo bar <i>foo bar</i>
+                        <strong>
+                          foo bar
+                        </strong>
+                      </span>
+                    </App>
+                  ",
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-        	        <App>
-        	          &lt;Component&gt;
-        	          &nbsp;<Component />&nbsp;
-        	          &nbsp;
-        	        </App>
-        	      ",
+                    <App>
+                      &lt;Component&gt;
+                      &nbsp;<Component />&nbsp;
+                      &nbsp;
+                    </App>
+                  ",
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-			        <Box mb={'1rem'} />
-			      ",
+                    <Box mb={'1rem'} />
+                  ",
             Some(json!([{ "props": "never" }])),
         ),
         (
             "
-			        <Box mb={'1rem {}'} />
-			      ",
+                    <Box mb={'1rem {}'} />
+                  ",
             Some(json!(["never"])),
         ),
         (r#"<MyComponent prop={"{ style: true }"}>bar</MyComponent>"#, Some(json!(["never"]))),
@@ -1192,8 +1211,8 @@ fn test() {
         ),
         (
             r#"
-        	        <Foo help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'} />
-        	      "#,
+                    <Foo help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'} />
+                  "#,
             Some(json!(["never"])),
         ),
     ];
@@ -1231,59 +1250,59 @@ fn test() {
         ),
         (
             "
-			        <MyComponent>
-			          {'%'}
-			        </MyComponent>
-			      ",
+            <MyComponent>
+                {'%'}
+            </MyComponent>
+            ",
             "
-			        <MyComponent>
-			          %
-			        </MyComponent>
-			      ",
+            <MyComponent>
+                %
+            </MyComponent>
+            ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          {'foo'}
-			          <div>
-			            {'bar'}
-			          </div>
-			          {'baz'}
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      {'foo'}
+                      <div>
+                        {'bar'}
+                      </div>
+                      {'baz'}
+                    </MyComponent>
+                  ",
             "
-			        <MyComponent>
-			          foo
-			          <div>
-			            bar
-			          </div>
-			          baz
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      foo
+                      <div>
+                        bar
+                      </div>
+                      baz
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
             "
-			        <MyComponent>
-			          {'foo'}
-			          <div>
-			            {'bar'}
-			          </div>
-			          {'baz'}
-			          {'some-complicated-exp'}
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      {'foo'}
+                      <div>
+                        {'bar'}
+                      </div>
+                      {'baz'}
+                      {'some-complicated-exp'}
+                    </MyComponent>
+                  ",
             "
-			        <MyComponent>
-			          foo
-			          <div>
-			            bar
-			          </div>
-			          baz
-			          some-complicated-exp
-			        </MyComponent>
-			      ",
+                    <MyComponent>
+                      foo
+                      <div>
+                        bar
+                      </div>
+                      baz
+                      some-complicated-exp
+                    </MyComponent>
+                  ",
             Some(json!([{ "children": "never" }])),
         ),
         (
@@ -1405,78 +1424,78 @@ fn test() {
         (
             // Note: this case does not exist in the eslint tests cases
             r#"
-			        <App prop="" />"#,
+                    <App prop="" />"#,
             r#"
-			        <App prop={""} />"#,
+                    <App prop={""} />"#,
             Some(json!(["always"])),
         ),
         (
             "
-			        <App prop='",
+                    <App prop='",
             "
-			        <App prop='",
+                    <App prop='",
             Some(json!(["always"])),
         ),
         (
             "
-			        <App>
-			          foo bar
-			          <div>foo bar foo</div>
-			          <span>
-			            foo bar <i>foo bar</i>
-			            <strong>
-			              foo bar
-			            </strong>
-			          </span>
-			        </App>
-			      ",
+                    <App>
+                      foo bar
+                      <div>foo bar foo</div>
+                      <span>
+                        foo bar <i>foo bar</i>
+                        <strong>
+                          foo bar
+                        </strong>
+                      </span>
+                    </App>
+                  ",
             r#"
-			        <App>
-			          {"foo bar"}
-			          <div>{"foo bar foo"}</div>
-			          <span>
-			            {"foo bar "}<i>{"foo bar"}</i>
-			            <strong>
-			              {"foo bar"}
-			            </strong>
-			          </span>
-			        </App>
-			      "#,
+                    <App>
+                      {"foo bar"}
+                      <div>{"foo bar foo"}</div>
+                      <span>
+                        {"foo bar "}<i>{"foo bar"}</i>
+                        <strong>
+                          {"foo bar"}
+                        </strong>
+                      </span>
+                    </App>
+                  "#,
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-			        <App>
-			          &lt;Component&gt;
-			          &nbsp;<Component />&nbsp;
-			          &nbsp;
-			        </App>
-			      ",
+                    <App>
+                      &lt;Component&gt;
+                      &nbsp;<Component />&nbsp;
+                      &nbsp;
+                    </App>
+                  ",
             r#"
-			        <App>
-			          &lt;{"Component"}&gt;
-			          &nbsp;<Component />&nbsp;
-			          &nbsp;
-			        </App>
-			      "#,
+                    <App>
+                      &lt;{"Component"}&gt;
+                      &nbsp;<Component />&nbsp;
+                      &nbsp;
+                    </App>
+                  "#,
             Some(json!([{ "children": "always" }])),
         ),
         (
             "
-			        <Box mb={'1rem'} />
-			      ",
+                    <Box mb={'1rem'} />
+                  ",
             r#"
-			        <Box mb="1rem" />
-			      "#,
+                    <Box mb="1rem" />
+                  "#,
             Some(json!([{ "props": "never" }])),
         ),
         (
             "
-			        <Box mb={'1rem {}'} />
-			      ",
+                    <Box mb={'1rem {}'} />
+                  ",
             r#"
-			        <Box mb="1rem {}" />
-			      "#,
+                    <Box mb="1rem {}" />
+                  "#,
             Some(json!(["never"])),
         ),
         (
@@ -1508,11 +1527,11 @@ fn test() {
         ),
         (
             r#"
-			        <Foo help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'} />
-			      "#,
+                    <Foo help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'} />
+                  "#,
             r#"
-			        <Foo help='The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)' />
-			      "#,
+                    <Foo help='The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)' />
+                  "#,
             Some(json!(["never"])),
         ),
         (
@@ -1532,6 +1551,7 @@ fn test() {
         ),
         (r#"<Foo bar={'"'} />"#, r#"<Foo bar='"' />"#, Some(json!(["never"]))),
     ];
+
     Tester::new(JsxCurlyBracePresence::NAME, JsxCurlyBracePresence::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
@@ -72,7 +72,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'bar'}` with `"bar"`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:3:15]
+   ╭─[jsx_curly_brace_presence.tsx:3:24]
  2 │                     <MyComponent>
  3 │                       {'%'}
    ·                        ───
@@ -81,7 +81,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'%'}` with `%`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:3:15]
+   ╭─[jsx_curly_brace_presence.tsx:3:24]
  2 │                     <MyComponent>
  3 │                       {'foo'}
    ·                        ─────
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'foo'}` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:7:15]
+   ╭─[jsx_curly_brace_presence.tsx:7:24]
  6 │                       </div>
  7 │                       {'baz'}
    ·                        ─────
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'baz'}` with `baz`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:5:17]
+   ╭─[jsx_curly_brace_presence.tsx:5:26]
  4 │                       <div>
  5 │                         {'bar'}
    ·                          ─────
@@ -108,7 +108,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'bar'}` with `bar`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:3:15]
+   ╭─[jsx_curly_brace_presence.tsx:3:24]
  2 │                     <MyComponent>
  3 │                       {'foo'}
    ·                        ─────
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'foo'}` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:7:15]
+   ╭─[jsx_curly_brace_presence.tsx:7:24]
  6 │                       </div>
  7 │                       {'baz'}
    ·                        ─────
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'baz'}` with `baz`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:8:15]
+   ╭─[jsx_curly_brace_presence.tsx:8:24]
  7 │                       {'baz'}
  8 │                       {'some-complicated-exp'}
    ·                        ──────────────────────
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'some-complicated-exp'}` with `some-complicated-exp`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:5:17]
+   ╭─[jsx_curly_brace_presence.tsx:5:26]
  4 │                       <div>
  5 │                         {'bar'}
    ·                          ─────
@@ -354,7 +354,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{"foo 'bar'"}` with `foo 'bar'`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:2:22]
+   ╭─[jsx_curly_brace_presence.tsx:2:31]
  1 │ 
  2 │                     <App prop="" />
    ·                               ─┬
@@ -363,7 +363,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:2:22]
+   ╭─[jsx_curly_brace_presence.tsx:2:31]
  1 │ 
  2 │                     <App prop='' />
    ·                               ─┬
@@ -372,7 +372,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:2:17]
+   ╭─[jsx_curly_brace_presence.tsx:2:26]
  1 │     
  2 │ ╭─▶                     <App>
  3 │ │                         foo bar
@@ -383,7 +383,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:4:19]
+   ╭─[jsx_curly_brace_presence.tsx:4:28]
  3 │                       foo bar
  4 │                       <div>foo bar foo</div>
    ·                            ─────┬─────
@@ -393,7 +393,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:5:20]
+   ╭─[jsx_curly_brace_presence.tsx:5:29]
  4 │                           <div>foo bar foo</div>
  5 │ ╭─▶                       <span>
  6 │ ├─▶                         foo bar <i>foo bar</i>
@@ -403,7 +403,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:6:27]
+   ╭─[jsx_curly_brace_presence.tsx:6:36]
  5 │                       <span>
  6 │                         foo bar <i>foo bar</i>
    ·                                    ───┬───
@@ -413,7 +413,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-    ╭─[jsx_curly_brace_presence.tsx:7:24]
+    ╭─[jsx_curly_brace_presence.tsx:7:33]
   6 │                             foo bar <i>foo bar</i>
   7 │ ╭─▶                         <strong>
   8 │ │                             foo bar
@@ -424,7 +424,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are required here.
-   ╭─[jsx_curly_brace_presence.tsx:2:23]
+   ╭─[jsx_curly_brace_presence.tsx:2:26]
  1 │     
  2 │ ╭─▶                     <App>
  3 │ │                         &lt;Component&gt;
@@ -435,7 +435,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap this value in curly braces
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:2:21]
+   ╭─[jsx_curly_brace_presence.tsx:2:30]
  1 │ 
  2 │                     <Box mb={'1rem'} />
    ·                              ──────
@@ -444,7 +444,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{'1rem'}` with `"1rem"`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:2:21]
+   ╭─[jsx_curly_brace_presence.tsx:2:30]
  1 │ 
  2 │                     <Box mb={'1rem {}'} />
    ·                              ─────────
@@ -489,7 +489,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `{"'"}` with `"'"`.
 
   ⚠ eslint-plugin-react(jsx-curly-brace-presence): Curly braces are unnecessary here.
-   ╭─[jsx_curly_brace_presence.tsx:2:29]
+   ╭─[jsx_curly_brace_presence.tsx:2:32]
  1 │ 
  2 │                     <Foo help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'} />
    ·                                ──────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
For some reason, this rule was never updated to use the standard documentation format. The fields on the config struct were also not updated with doc comments, and so had no explanation. Now they do.

Generated docs:

````md
### What it does

Disallow unnecessary JSX expressions when literals alone are
sufficient or enforce JSX expressions on literals in JSX children or
attributes.

This rule allows you to enforce curly braces or disallow unnecessary
curly braces in JSX props and/or children.

For situations where JSX expressions are unnecessary, please refer to
[the React doc](https://react.dev/learn/writing-markup-with-jsx)
and [this page about JSX
gotchas](https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities).

### Why is this bad?

Using different styles for your JSX code can make it harder to read and
less consistent.

Code consistency improves readability. By enforcing or disallowing
curly braces in JSX props and/or children, this rule helps maintain
consistent patterns across your application.

### Rule Details

By default, this rule will check for and warn about unnecessary curly
braces in both JSX props and children. For the sake of backwards
compatibility, prop values that are JSX elements are not considered by
default.

You can pass in options to enforce the presence of curly braces on JSX
props, children, JSX prop values that are JSX elements, or any
combination of the three. The same options are available for not
allowing unnecessary curly braces as well as ignoring the check.

**Note**: it is _highly recommended_ that you configure this rule with
an object, and that you set "propElementValues" to "always". The ability
to omit curly braces around prop values that are JSX elements is
obscure, and intentionally undocumented, and should not be relied upon.

#### Example Configurations

```jsonc
{
  "rules": {
    "react/jsx-curly-brace-presence": ["error", { "props": <string>, "children": <string>, "propElementValues": <string> }]
  }
}
```

or alternatively

```jsonc
{
  "rules": {
    "react/jsx-curly-brace-presence": ["error", "always"], // or "never" or "ignore"
  },
}
```

### Fix Details

If passed in the option to fix, this is how a style violation will get fixed

- `always`: wrap a JSX attribute in curly braces/JSX expression and/or a JSX child the same way but also with double quotes
- `never`: get rid of curly braces from a JSX attribute and/or a JSX child

- All fixing operations use double quotes.

### Examples

Examples of **incorrect** code for this rule, when configured with `{ props: "always", children: "always" }`:

```jsx
<App>Hello world</App>;
<App prop="Hello world">{"Hello world"}</App>;
```

They can be fixed to:

```jsx
<App>{"Hello world"}</App>;
<App prop={"Hello world"}>{"Hello world"}</App>;
```

Examples of **incorrect** code for this rule, when configured with `{ props: "never", children: "never" }`:

```jsx
<App>{"Hello world"}</App>;
<App prop={"Hello world"} attr={"foo"} />;
```

They can be fixed to:

```jsx
<App>Hello world</App>;
<App prop="Hello world" attr="foo" />;
```

Examples of **incorrect** code for this rule, when configured with `{ props: "always", children: "always", "propElementValues": "always" }`:

```jsx
<App prop=<div /> />
```

They can be fixed to:

```jsx
<App prop={<div />} />
```

Examples of **incorrect** code for this rule, when configured with `{ props: "never", children: "never", "propElementValues": "never" }`:

```jsx
<App prop={<div />} />
```

They can be fixed to:

```jsx
<App prop=<div /> />
```

Examples of **incorrect** code for this rule, when configured with `"always"`:

```jsx
<App>Hello world</App>;
<App prop="Hello world" attr="foo">
  Hello world
</App>;
```

They can be fixed to:

```jsx
<App>{"Hello world"}</App>;
<App prop={"Hello world"} attr={"foo"}>
  {"Hello world"}
</App>;
```

Examples of **incorrect** code for this rule, when configured with `"never"`:

```jsx
<App prop={"foo"} attr={"bar"}>
  {"Hello world"}
</App>
```

It can fixed to:

```jsx
<App prop="foo" attr="bar">
  Hello world
</App>
```

### Edge cases

The fix also deals with template literals, strings with quotes, and
strings with escapes characters.

- If the rule is set to get rid of unnecessary curly braces and the
  template literal inside a JSX expression has no expression, it will
  throw a warning and be fixed with double quotes. For example:

```jsx
<App prop={`Hello world`}>{`Hello world`}</App>
```

will be warned and fixed to:

```jsx
<App prop="Hello world">Hello world</App>
```

- If the rule is set to enforce curly braces and the strings have
  quotes, it will be fixed with double quotes for JSX children and the
  normal way for JSX attributes. Also, double quotes will be escaped in
  the fix.

For example:

```jsx
<App prop='Hello "foo" world'>Hello 'foo' "bar" world</App>
```

will warned and fixed to:

```jsx
<App prop={'Hello "foo" world'}>{"Hello 'foo' \"bar\" world"}</App>
```

- If the rule is set to get rid of unnecessary curly braces(JSX
  expression) and there are characters that need to be escaped in its JSX
  form, such as quote characters, [forbidden JSX text
  characters](https://facebook.github.io/jsx/), escaped characters and
  anything that looks like HTML entity names, the code will not be warned
  because the fix may make the code less readable.

Examples of **correct** code for this rule, even when configured with `"never"`:

```jsx
<Color text={"\u00a0"} />
<App>{"Hello \u00b7 world"}</App>;
<style type="text/css">{'.main { margin-top: 0; }'}</style>;
/**
 * there's no way to inject a whitespace into jsx without a container so this
 * will always be allowed.
 */
<App>{' '}</App>
<App>{'     '}</App>
<App>{/* comment */ <Bpp />}</App> // the comment makes the container necessary
```

### When Not To Use It

You should turn this rule off if you are not concerned about maintaining
consistency regarding the use of curly braces in JSX props and/or
children as well as the use of unnecessary JSX expressions.

## Configuration

This rule accepts a configuration object with the following properties:

### children

type: `"always" | "never" | "ignore"`

default: `"never"`

Whether to enforce or disallow curly braces for child content of a JSX element.

- `never` will disallow unnecessary curly braces, e.g. this will be preferred: `<Foo>I love oxlint</Foo>`
- `always` will force the usage of curly braces like this, in all cases: `<Foo>{'I love oxlint'}</Foo>`
- `ignore` will allow either style for child content.

### propElementValues

type: `"always" | "never" | "ignore"`

default: `"ignore"`

When set to `ignore` or `never`, this JSX code is allowed (or enforced):
`<App prop=<div /> />;`

When set to `always`, the curly braces are required for prop values that are
JSX elements: `<App prop={<div />} />;`

**Note**: it is _highly_ recommended that you set `propElementValues` to `always`.
The ability to omit curly braces around prop values that are JSX elements is obscure, and
intentionally undocumented, and should not be relied upon.

### props

type: `"always" | "never" | "ignore"`

default: `"never"`

Whether to enforce or disallow curly braces for props on JSX elements.

- `never` will disallow unnecessary curly braces, e.g. this will be preferred: `<Foo foo="bar" />`
- `always` will force the usage of curly braces like this, in all cases: `<Foo foo={'bar'} />`
- `ignore` will allow either style for prop values.
````