### PR TITLE
fix(vscode): Prevent timeout in binary search for large pnpm monorepos

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -151,10 +151,13 @@ export class ConfigService implements IDisposable {
 
     try {
       const nodeModulesPath = path.join(startPath, "node_modules", ".bin");
-      
+
       // Skip .pnpm directories to avoid traversing into pnpm's internal structure
       // Check if we're inside a .pnpm directory path
-      if (startPath.includes(path.sep + ".pnpm" + path.sep) || startPath.endsWith(path.sep + ".pnpm")) {
+      if (
+        startPath.includes(path.sep + ".pnpm" + path.sep) ||
+        startPath.endsWith(path.sep + ".pnpm")
+      ) {
         // Skip traversing into .pnpm directories - go directly to parent
         const parentPath = path.dirname(startPath);
         if (parentPath === startPath || parentPath === "/" || parentPath.match(/^[A-Za-z]:\\?$/i)) {
@@ -330,11 +333,13 @@ export class ConfigService implements IDisposable {
     if (event.affectsConfiguration(ConfigService.namespace)) {
       this.vsCodeConfig.refresh();
       isConfigChanged = true;
-      
+
       // Clear cache when binary path settings change, as they affect binary resolution
-      if (event.affectsConfiguration(`${ConfigService.namespace}.path.oxlint`) ||
-          event.affectsConfiguration(`${ConfigService.namespace}.path.oxfmt`) ||
-          event.affectsConfiguration(`${ConfigService.namespace}.path.server`)) {
+      if (
+        event.affectsConfiguration(`${ConfigService.namespace}.path.oxlint`) ||
+        event.affectsConfiguration(`${ConfigService.namespace}.path.oxfmt`) ||
+        event.affectsConfiguration(`${ConfigService.namespace}.path.server`)
+      ) {
         this.binaryPathCache.clear();
       }
     }

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { ConfigurationChangeEvent, RelativePattern, Uri, workspace, WorkspaceFolder } from "vscode";
 import { DiagnosticPullMode } from "vscode-languageclient";
@@ -17,6 +18,9 @@ export class ConfigService implements IDisposable {
   public vsCodeConfig: VSCodeConfig;
 
   private workspaceConfigs: Map<string, WorkspaceConfig> = new Map();
+
+  // Cache for binary path lookups to avoid repeated expensive searches
+  private binaryPathCache: Map<string, string | undefined> = new Map();
 
   public onConfigChange:
     | ((this: ConfigService, config: ConfigurationChangeEvent) => Promise<void>)
@@ -64,10 +68,14 @@ export class ConfigService implements IDisposable {
 
   public addWorkspaceConfig(workspace: WorkspaceFolder): void {
     this.workspaceConfigs.set(workspace.uri.path, new WorkspaceConfig(workspace));
+    // Invalidate cache when workspace folders change
+    this.binaryPathCache.clear();
   }
 
   public removeWorkspaceConfig(workspace: WorkspaceFolder): void {
     this.workspaceConfigs.delete(workspace.uri.path);
+    // Invalidate cache when workspace folders change
+    this.binaryPathCache.clear();
   }
 
   public getWorkspaceConfig(workspace: Uri): WorkspaceConfig | undefined {
@@ -109,6 +117,95 @@ export class ConfigService implements IDisposable {
     return false;
   }
 
+  /**
+   * Checks if a binary exists at the given path.
+   * Handles both Unix and Windows path differences.
+   */
+  private checkBinaryExists(binaryPath: string): boolean {
+    try {
+      // Check if file exists and is executable (on Unix) or accessible (on Windows)
+      fs.accessSync(binaryPath, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Searches for a binary in node_modules/.bin directories using file system operations.
+   * This is much faster than workspace.findFiles in large monorepos.
+   * Limits search depth and scope to avoid timeouts.
+   */
+  private async searchBinaryInNodeModules(
+    startPath: string,
+    binaryName: string,
+    maxDepth: number = 3,
+    currentDepth: number = 0,
+  ): Promise<string | undefined> {
+    // Limit depth to avoid deep recursion in large monorepos
+    if (currentDepth >= maxDepth) {
+      return undefined;
+    }
+
+    try {
+      const nodeModulesPath = path.join(startPath, "node_modules", ".bin");
+
+      // Check if this .bin directory exists
+      if (fs.existsSync(nodeModulesPath)) {
+        const binaryPath = path.join(nodeModulesPath, binaryName);
+        if (this.checkBinaryExists(binaryPath)) {
+          return binaryPath;
+        }
+
+        // Check with .exe extension on Windows
+        if (process.platform === "win32") {
+          const exePath = `${binaryPath}.exe`;
+          if (this.checkBinaryExists(exePath)) {
+            return exePath;
+          }
+        }
+      }
+
+      // Search in parent directories up to workspace root
+      const parentPath = path.dirname(startPath);
+
+      // Stop if we've reached the filesystem root or if parent is same as current
+      if (parentPath === startPath || parentPath === "/" || parentPath.match(/^[A-Z]:\\?$/)) {
+        return undefined;
+      }
+
+      // Recursively search parent directory
+      return this.searchBinaryInNodeModules(parentPath, binaryName, maxDepth, currentDepth + 1);
+    } catch {
+      // Ignore errors (permission denied, etc.) and continue searching
+      return undefined;
+    }
+  }
+
+  /**
+   * Wraps workspace.findFiles with a timeout to prevent indefinite hanging.
+   * Returns undefined if the search times out or fails.
+   */
+  private async findFilesWithTimeout(
+    pattern: RelativePattern,
+    exclude: string | null,
+    maxResults: number,
+    timeoutMs: number = 5000,
+  ): Promise<Uri[]> {
+    try {
+      const searchPromise = workspace.findFiles(pattern, exclude, maxResults);
+      const timeoutPromise = new Promise<Uri[]>((_, reject) => {
+        setTimeout(() => reject(new Error("Binary search timeout")), timeoutMs);
+      });
+
+      return await Promise.race([searchPromise, timeoutPromise]);
+    } catch {
+      // Timeout or other error - return empty array to indicate failure
+      // This allows graceful degradation without throwing
+      return [];
+    }
+  }
+
   private async searchBinaryPath(
     settingsBinary: string | undefined,
     defaultPattern: string,
@@ -119,14 +216,68 @@ export class ConfigService implements IDisposable {
     }
 
     if (!settingsBinary) {
-      // try to find the binary in node_modules/.bin, resolve to the first workspace folder
-      const files = await workspace.findFiles(
-        new RelativePattern(cwd, `**/node_modules/.bin/${defaultPattern}`),
-        null,
-        1,
-      );
+      // Check cache first
+      const cacheKey = `auto:${defaultPattern}`;
+      const cached = this.binaryPathCache.get(cacheKey);
+      if (cached !== undefined) {
+        return cached;
+      }
 
-      return files.length > 0 ? files[0].fsPath : undefined;
+      // Fast path: Check common locations first using file system operations
+      // This is much faster than recursive findFiles in large monorepos
+      const workspaceFolders = Array.from(this.workspaceConfigs.keys());
+
+      // Step 1: Check root node_modules/.bin in each workspace folder
+      for (const workspacePath of workspaceFolders) {
+        const rootBinPath = path.join(workspacePath, "node_modules", ".bin", defaultPattern);
+        if (this.checkBinaryExists(rootBinPath)) {
+          this.binaryPathCache.set(cacheKey, rootBinPath);
+          return rootBinPath;
+        }
+
+        // Also check with .exe extension on Windows
+        if (process.platform === "win32") {
+          const exePath = `${rootBinPath}.exe`;
+          if (this.checkBinaryExists(exePath)) {
+            this.binaryPathCache.set(cacheKey, exePath);
+            return exePath;
+          }
+        }
+      }
+
+      // Step 2: Search parent directories up to workspace root using file system operations
+      // This handles cases where binaries are in nested packages
+      // Search all workspace folders in parallel for better performance
+      const searchPromises = workspaceFolders.map((workspacePath) =>
+        this.searchBinaryInNodeModules(workspacePath, defaultPattern, 3),
+      );
+      const searchResults = await Promise.all(searchPromises);
+      const found = searchResults.find((result) => result !== undefined);
+      if (found) {
+        this.binaryPathCache.set(cacheKey, found);
+        return found;
+      }
+
+      // Step 3: Last resort - use findFiles with timeout protection
+      // Only search in workspace folders, not deep recursion
+      // Use Promise.race to add timeout protection
+      try {
+        const excludePattern = "**/{.pnpm,node_modules/.pnpm}/**";
+        const files = await this.findFilesWithTimeout(
+          new RelativePattern(cwd, `**/node_modules/.bin/${defaultPattern}`),
+          excludePattern,
+          1,
+          5000, // 5 second timeout
+        );
+
+        const result = files.length > 0 ? files[0].fsPath : undefined;
+        this.binaryPathCache.set(cacheKey, result);
+        return result;
+      } catch {
+        // Timeout or other error - cache undefined to avoid retrying
+        this.binaryPathCache.set(cacheKey, undefined);
+        return undefined;
+      }
     }
 
     if (!workspace.isTrusted) {


### PR DESCRIPTION
# AI Disclaimer:

The code changes in this PR was written entirely by Cursor.

I opened this issue:  https://github.com/oxc-project/oxc/issues/17578

Then I started debugging the extension locally, adding logs with cursor and tracking down where my plugin was failing to instantiate.

I walked through the entire process with cursor, feeding it logs and manually walking through several permutations of trial and error on my local instance of vscode.  The code and traversal patterns themselves were written by AI.

I have a **_large_** local pnpm monorepo that does NOT work with the published vscode extension. It _does_ work with this branch.


## Problem

This is a fix for https://github.com/oxc-project/oxc/issues/17578

The VS Code extension was timing out when searching for binaries in large pnpm monorepos. The `workspace.findFiles` call with a recursive pattern `**/node_modules/.bin/${defaultPattern}` was searching through potentially thousands of nested `node_modules` directories, causing indefinite hangs.

## Solution

Implemented a hybrid approach that prioritizes fast file system operations and only uses `findFiles` as a last resort with timeout protection:

1. **Caching**: Results are cached to avoid repeated searches
2. **Fast path checks**: Checks root `node_modules/.bin/` in each workspace folder first
3. **Depth-limited file system search**: Uses recursive file system operations (max depth 3) to search parent directories
4. **Timeout protection**: Wraps `findFiles` with a 5-second timeout using `Promise.race` to prevent indefinite hanging

## Changes

- Added `searchBinaryInNodeModules()` method for depth-limited file system search
- Added `findFilesWithTimeout()` helper method with timeout protection
- Refactored `searchBinaryPath()` to use progressive search strategy
- Added cache invalidation when workspace folders change

## Performance Benefits

- **No indefinite hangs**: Timeout ensures we never wait forever
- **Fast path**: File system operations are much faster than `findFiles` in large monorepos
- **Graceful degradation**: Falls back to `findFiles` only if needed, with timeout protection
- **Depth limiting**: Prevents deep recursion in very large monorepos

## Testing

- Verified behavior remains the same for existing scenarios
- Works in both npm/yarn and pnpm monorepos
- Handles binaries in root, nested, and workspace-specific locations