### PR TITLE
fix(formatter): don't move comments into optional call parentheses

### DIFF
--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -84,7 +84,7 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                 );
 
                 // `A.b /* comment */ (c)` -> `A.b(/* comment */ c)`
-                if !matches!(member.parent, AstNodes::CallExpression(call) if call.type_arguments.is_none())
+                if !matches!(member.parent, AstNodes::CallExpression(call) if call.type_arguments.is_none() && !call.optional)
                 {
                     member.format_trailing_comments(f);
                 }

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-17570.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-17570.ts
@@ -1,0 +1,13 @@
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+this
+  .getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+foo
+  .getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-17570.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-17570.ts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+this
+  .getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+foo
+  .getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+  ?.();
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+foo.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+this.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+foo.getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+getParameters /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */?.();
+
+===================== End =====================


### PR DESCRIPTION
- Closes: #17570 

## Known Limitations
This PR only fixes the comment placement issue. 

Line breaking behavior when comments are present is not addressed and may be handled in a follow-up PR.
