### PR TITLE
docs(website): Add a rules count value to the website to keep it updated automatically.

### DIFF
--- a/justfile
+++ b/justfile
@@ -252,7 +252,7 @@ watch-playground:
 # When testing changes to the website documentation, you may also want to run `pnpm run fmt`
 # in the website directory.
 website path:
-  cargo run -p website_linter rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules --git-ref $(git rev-parse HEAD)
+  cargo run -p website_linter rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules --git-ref $(git rev-parse HEAD) --rule-count {{path}}/src/docs/guide/usage
   cargo run -p website_linter cli > {{path}}/src/docs/guide/usage/linter/generated-cli.md
   cargo run -p website_linter schema-markdown > {{path}}/src/docs/guide/usage/linter/generated-config.md
   cargo run -p website_formatter cli > {{path}}/src/docs/guide/usage/formatter/generated-cli.md


### PR DESCRIPTION
Just like `version.data.js`. Maybe we should unify these cli flags for the website generator and just assume the structure of the website repo? Feels silly to specify all the paths like this.

See https://github.com/oxc-project/oxc-project.github.io/pull/758 for the companion PR in the actual website repo.

This will allow us to update the rule count automatically using JS, and pull it into the website docs like this:

```html
<script setup>
import { data } from './rule-count.data.js';
const ruleCount = data;
// or we can do some basic math to round the ruleCount to the nearest multiple of 5 and then show `645+ rules`
// const ruleCount = Math.ceil(data / 5) * 5;
</script>

# Oxlint

## A large and growing rule set

Oxlint includes [{{ ruleCount }} rules](/docs/guide/usage/linter/rules.md), with coverage across the plugins most teams already use, including:
```