### PR TITLE
feat(linter): implement `vitest/prefer-importing-vitest-globals` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4049,6 +4049,13 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::vitest::prefer_importing_vitest_globals::PreferImportingVitestGlobals
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4052,8 +4052,9 @@ impl RuleRunner
 impl RuleRunner
     for crate::rules::vitest::prefer_importing_vitest_globals::PreferImportingVitestGlobals
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -644,6 +644,7 @@ pub use crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsync
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
 pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle as VitestPreferDescribeFunctionTitle;
+pub use crate::rules::vitest::prefer_importing_vitest_globals::PreferImportingVitestGlobals as VitestPreferImportingVitestGlobals;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1312,6 +1313,7 @@ pub enum RuleEnum {
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
     VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle),
+    VitestPreferImportingVitestGlobals(VitestPreferImportingVitestGlobals),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -1979,32 +1981,33 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => 632usize,
             Self::VitestPreferCalledTimes(_) => 633usize,
             Self::VitestPreferDescribeFunctionTitle(_) => 634usize,
-            Self::VitestPreferToBeFalsy(_) => 635usize,
-            Self::VitestPreferToBeObject(_) => 636usize,
-            Self::VitestPreferToBeTruthy(_) => 637usize,
-            Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => 638usize,
-            Self::VitestWarnTodo(_) => 639usize,
-            Self::NodeGlobalRequire(_) => 640usize,
-            Self::NodeNoExportsAssign(_) => 641usize,
-            Self::NodeNoNewRequire(_) => 642usize,
-            Self::NodeNoProcessEnv(_) => 643usize,
-            Self::VueDefineEmitsDeclaration(_) => 644usize,
-            Self::VueDefinePropsDeclaration(_) => 645usize,
-            Self::VueDefinePropsDestructuring(_) => 646usize,
-            Self::VueMaxProps(_) => 647usize,
-            Self::VueNoArrowFunctionsInWatch(_) => 648usize,
-            Self::VueNoDeprecatedDestroyedLifecycle(_) => 649usize,
-            Self::VueNoExportInScriptSetup(_) => 650usize,
-            Self::VueNoImportCompilerMacros(_) => 651usize,
-            Self::VueNoLifecycleAfterAwait(_) => 652usize,
-            Self::VueNoMultipleSlotArgs(_) => 653usize,
-            Self::VueNoRequiredPropWithDefault(_) => 654usize,
-            Self::VueNoThisInBeforeRouteEnter(_) => 655usize,
-            Self::VuePreferImportFromVue(_) => 656usize,
-            Self::VueRequireDefaultExport(_) => 657usize,
-            Self::VueRequireTypedRef(_) => 658usize,
-            Self::VueValidDefineEmits(_) => 659usize,
-            Self::VueValidDefineProps(_) => 660usize,
+            Self::VitestPreferImportingVitestGlobals(_) => 635usize,
+            Self::VitestPreferToBeFalsy(_) => 636usize,
+            Self::VitestPreferToBeObject(_) => 637usize,
+            Self::VitestPreferToBeTruthy(_) => 638usize,
+            Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => 639usize,
+            Self::VitestWarnTodo(_) => 640usize,
+            Self::NodeGlobalRequire(_) => 641usize,
+            Self::NodeNoExportsAssign(_) => 642usize,
+            Self::NodeNoNewRequire(_) => 643usize,
+            Self::NodeNoProcessEnv(_) => 644usize,
+            Self::VueDefineEmitsDeclaration(_) => 645usize,
+            Self::VueDefinePropsDeclaration(_) => 646usize,
+            Self::VueDefinePropsDestructuring(_) => 647usize,
+            Self::VueMaxProps(_) => 648usize,
+            Self::VueNoArrowFunctionsInWatch(_) => 649usize,
+            Self::VueNoDeprecatedDestroyedLifecycle(_) => 650usize,
+            Self::VueNoExportInScriptSetup(_) => 651usize,
+            Self::VueNoImportCompilerMacros(_) => 652usize,
+            Self::VueNoLifecycleAfterAwait(_) => 653usize,
+            Self::VueNoMultipleSlotArgs(_) => 654usize,
+            Self::VueNoRequiredPropWithDefault(_) => 655usize,
+            Self::VueNoThisInBeforeRouteEnter(_) => 656usize,
+            Self::VuePreferImportFromVue(_) => 657usize,
+            Self::VueRequireDefaultExport(_) => 658usize,
+            Self::VueRequireTypedRef(_) => 659usize,
+            Self::VueValidDefineEmits(_) => 660usize,
+            Self::VueValidDefineProps(_) => 661usize,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -2728,6 +2731,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::NAME,
+            Self::VitestPreferImportingVitestGlobals(_) => VitestPreferImportingVitestGlobals::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -3517,6 +3521,9 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::CATEGORY
             }
+            Self::VitestPreferImportingVitestGlobals(_) => {
+                VitestPreferImportingVitestGlobals::CATEGORY
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -4271,6 +4278,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::FIX,
+            Self::VitestPreferImportingVitestGlobals(_) => VitestPreferImportingVitestGlobals::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -5196,6 +5204,9 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::documentation(),
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::documentation()
+            }
+            Self::VitestPreferImportingVitestGlobals(_) => {
+                VitestPreferImportingVitestGlobals::documentation()
             }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
@@ -7023,6 +7034,10 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::config_schema(generator)
                     .or_else(|| VitestPreferDescribeFunctionTitle::schema(generator))
             }
+            Self::VitestPreferImportingVitestGlobals(_) => {
+                VitestPreferImportingVitestGlobals::config_schema(generator)
+                    .or_else(|| VitestPreferImportingVitestGlobals::schema(generator))
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -7735,6 +7750,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
             Self::VitestPreferDescribeFunctionTitle(_) => "vitest",
+            Self::VitestPreferImportingVitestGlobals(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -9795,6 +9811,11 @@ impl RuleEnum {
                     VitestPreferDescribeFunctionTitle::from_configuration(value)?,
                 ))
             }
+            Self::VitestPreferImportingVitestGlobals(_) => {
+                Ok(Self::VitestPreferImportingVitestGlobals(
+                    VitestPreferImportingVitestGlobals::from_configuration(value)?,
+                ))
+            }
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -10516,6 +10537,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.to_configuration(),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -11183,6 +11205,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run(node, ctx),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -11848,6 +11871,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_once(ctx),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -12601,6 +12625,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13268,6 +13293,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.should_run(ctx),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -14191,6 +14217,9 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::IS_TSGOLINT_RULE
             }
+            Self::VitestPreferImportingVitestGlobals(_) => {
+                VitestPreferImportingVitestGlobals::IS_TSGOLINT_RULE
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -14860,6 +14889,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.types_info(),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -15525,6 +15555,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_info(),
+            Self::VitestPreferImportingVitestGlobals(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -16296,6 +16327,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),
         RuleEnum::VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle::default()),
+        RuleEnum::VitestPreferImportingVitestGlobals(VitestPreferImportingVitestGlobals::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -677,6 +677,7 @@ pub(crate) mod vitest {
     pub mod prefer_called_once;
     pub mod prefer_called_times;
     pub mod prefer_describe_function_title;
+    pub mod prefer_importing_vitest_globals;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
@@ -1,19 +1,13 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Argument, BindingPattern, Expression},
-};
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
-use rustc_hash::FxHashSet;
+use oxc_span::Span;
 
-use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
+use crate::{AstNode, context::LintContext, module_record::ImportImportName, rule::Rule};
 
-fn prefer_importing_vitest_globals_diagnostic(span: Span, globals: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer importing vitest globals: {globals}"))
-        .with_help(
-            "Import these globals from 'vitest' explicitly instead of using them as globals.",
-        )
+fn prefer_importing_vitest_globals_diagnostic(span: Span, global: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer importing vitest global `{global}`"))
+        .with_help(format!("Import `{global}` from 'vitest' explicitly."))
         .with_label(span)
 }
 
@@ -82,207 +76,57 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferImportingVitestGlobals {
-    fn run_once(&self, ctx: &LintContext<'_>) {
-        let import_info = collect_vitest_import_info(ctx);
-        let mut unimported_globals: Vec<(&str, Span)> = Vec::new();
+    fn run(&self, node: &AstNode, ctx: &LintContext) {
+        let AstKind::CallExpression(call) = node.kind() else { return };
+        let Expression::Identifier(ident) = &call.callee else { return };
 
-        for (name, reference_ids) in ctx.scoping().root_unresolved_references() {
-            if VITEST_GLOBALS.contains(name)
-                && !import_info.imported_names.contains(*name)
-                && let Some(&first_ref_id) = reference_ids.first()
-            {
-                let reference = ctx.scoping().get_reference(first_ref_id);
-                let node = ctx.nodes().get_node(reference.node_id());
-                unimported_globals.push((*name, node.span()));
-            }
-        }
-
-        if unimported_globals.is_empty() {
+        if !VITEST_GLOBALS.contains(ident.name.as_str()) {
             return;
         }
 
-        unimported_globals.sort_by_key(|(name, _)| *name);
-        // Use the first occurrence in source order for the diagnostic label
-        let first_span = unimported_globals
-            .iter()
-            .min_by_key(|(_, span)| span.start)
-            .map_or(Span::empty(0), |(_, span)| *span);
-        let globals_list: Vec<&str> = unimported_globals.iter().map(|(name, _)| *name).collect();
-        let globals_str = globals_list.join(", ");
+        let reference = ctx.scoping().get_reference(ident.reference_id());
+        if reference.symbol_id().is_some() {
+            return;
+        }
 
         ctx.diagnostic_with_fix(
-            prefer_importing_vitest_globals_diagnostic(first_span, &globals_str),
+            prefer_importing_vitest_globals_diagnostic(ident.span, ident.name.as_str()),
             |fixer| {
                 let module_record = ctx.module_record();
-                // Filter out type-only imports since they don't create runtime bindings
-                let vitest_imports: Vec<_> = module_record
-                    .import_entries
-                    .iter()
-                    .filter(|entry| entry.module_request.name() == "vitest" && !entry.is_type)
-                    .collect();
 
-                let vitest_import = vitest_imports
-                    .iter()
-                    .find(|e| matches!(e.import_name, ImportImportName::Name(_)))
-                    .or_else(|| {
-                        vitest_imports
-                            .iter()
-                            .find(|e| matches!(e.import_name, ImportImportName::Default(_)))
-                    })
-                    .or_else(|| vitest_imports.first())
-                    .copied();
+                let vitest_import = module_record.import_entries.iter().find(|e| {
+                    e.module_request.name() == "vitest"
+                        && !e.is_type
+                        && matches!(e.import_name, ImportImportName::Name(_))
+                });
 
-                if let Some(import_entry) = vitest_import {
-                    match &import_entry.import_name {
-                        ImportImportName::NamespaceObject => {
-                            let new_import = format!(
-                                "import {{ {} }} from 'vitest';\n",
-                                globals_list.join(", ")
-                            );
-                            fixer.insert_text_before_range(import_entry.statement_span, new_import)
-                        }
-                        ImportImportName::Default(_) => {
-                            let source = ctx.source_range(import_entry.statement_span);
-                            if let Some(from_pos) = source.find(" from ") {
-                                #[expect(clippy::cast_possible_truncation)]
-                                let insert_pos =
-                                    import_entry.statement_span.start + from_pos as u32;
-                                let insert_text = format!(", {{ {} }}", globals_list.join(", "));
-                                fixer.insert_text_before_range(Span::empty(insert_pos), insert_text)
-                            } else {
-                                fixer.noop()
-                            }
-                        }
-                        ImportImportName::Name(_) => {
-                            let source = ctx.source_range(import_entry.statement_span);
-                            let new_items = globals_list.join(", ");
-                            if let Some((replace_span, replace_text)) = compute_brace_insert(
-                                source,
-                                import_entry.statement_span.start,
-                                &new_items,
-                            ) {
-                                fixer.replace(replace_span, replace_text)
-                            } else {
-                                fixer.noop()
-                            }
-                        }
+                if let Some(entry) = vitest_import {
+                    let source = ctx.source_range(entry.statement_span);
+                    if let Some((span, text)) = compute_brace_insert(
+                        source,
+                        entry.statement_span.start,
+                        ident.name.as_str(),
+                    ) {
+                        return fixer.replace(span, text);
                     }
-                } else if let Some(cjs_info) = &import_info.cjs_require {
-                    match cjs_info {
-                        CommonJSVitestRequire::Destructured { pattern_span } => {
-                            let source = ctx.source_range(*pattern_span);
-                            let new_items = globals_list.join(", ");
-                            if let Some((replace_span, replace_text)) =
-                                compute_brace_insert(source, pattern_span.start, &new_items)
-                            {
-                                fixer.replace(replace_span, replace_text)
-                            } else {
-                                fixer.noop()
-                            }
-                        }
-                        CommonJSVitestRequire::DefaultOrNamespace { statement_start } => {
-                            let new_import = format!(
-                                "import {{ {} }} from 'vitest';\n",
-                                globals_list.join(", ")
-                            );
-                            fixer
-                                .insert_text_before_range(Span::empty(*statement_start), new_import)
-                        }
-                    }
+                }
+
+                let is_cjs = module_record.import_entries.is_empty();
+
+                if is_cjs {
+                    fixer.insert_text_before_range(
+                        Span::empty(0),
+                        format!("const {{ {} }} = require('vitest');\n", ident.name),
+                    )
                 } else {
-                    let new_import =
-                        format!("import {{ {} }} from 'vitest';\n", globals_list.join(", "));
-                    fixer.insert_text_before_range(Span::empty(0), new_import)
+                    fixer.insert_text_before_range(
+                        Span::empty(0),
+                        format!("import {{ {} }} from 'vitest';\n", ident.name),
+                    )
                 }
             },
         );
     }
-}
-
-struct VitestImportInfo {
-    imported_names: FxHashSet<String>,
-    cjs_require: Option<CommonJSVitestRequire>,
-}
-
-enum CommonJSVitestRequire {
-    Destructured { pattern_span: Span },
-    DefaultOrNamespace { statement_start: u32 },
-}
-
-fn collect_vitest_import_info(ctx: &LintContext<'_>) -> VitestImportInfo {
-    let mut imported_names = FxHashSet::default();
-    let mut cjs_require = None;
-
-    for entry in &ctx.module_record().import_entries {
-        if entry.module_request.name() != "vitest" {
-            continue;
-        }
-
-        // Type-only imports don't create runtime bindings
-        if entry.is_type {
-            continue;
-        }
-
-        if let ImportImportName::Name(_) = &entry.import_name {
-            // `import { describe as d }` binds `d`, not `describe`
-            imported_names.insert(entry.local_name.name().to_string());
-        }
-    }
-
-    for node in ctx.nodes() {
-        let AstKind::VariableDeclaration(var_decl) = node.kind() else { continue };
-        for decl in &var_decl.declarations {
-            let Some(Expression::CallExpression(call)) = &decl.init else { continue };
-            if !is_require_call(call, "vitest") {
-                continue;
-            }
-
-            match &decl.id {
-                BindingPattern::ObjectPattern(obj_pat) => {
-                    // `const { describe: d }` binds `d`, not `describe`
-                    for prop in &obj_pat.properties {
-                        if let BindingPattern::BindingIdentifier(ident) = &prop.value {
-                            imported_names.insert(ident.name.to_string());
-                        }
-                    }
-
-                    if cjs_require.is_none() {
-                        if obj_pat.rest.is_some() {
-                            cjs_require = Some(CommonJSVitestRequire::DefaultOrNamespace {
-                                statement_start: var_decl.span.start,
-                            });
-                        } else {
-                            cjs_require = Some(CommonJSVitestRequire::Destructured {
-                                pattern_span: obj_pat.span,
-                            });
-                        }
-                    }
-                }
-                BindingPattern::BindingIdentifier(_) => {
-                    if cjs_require.is_none() {
-                        cjs_require = Some(CommonJSVitestRequire::DefaultOrNamespace {
-                            statement_start: var_decl.span.start,
-                        });
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    VitestImportInfo { imported_names, cjs_require }
-}
-
-fn is_require_call(call: &oxc_ast::ast::CallExpression<'_>, module_name: &str) -> bool {
-    if let Expression::Identifier(ident) = &call.callee
-        && ident.name == "require"
-        && call.arguments.len() == 1
-        && let Argument::StringLiteral(lit) = &call.arguments[0]
-        && lit.value == module_name
-    {
-        return true;
-    }
-    false
 }
 
 /// Computes the span to replace and the replacement text for adding imports to an existing `{ ... }` block.
@@ -310,112 +154,108 @@ fn test() {
 
     let pass = vec![
         "vitest.describe('suite', () => {});",
-        "import { describe } from 'vitest'; describe('suite', () => {});",
-        "import { describe, it } from 'vitest'; describe('suite', () => {});",
-        "import { describe, desccribe } from 'vitest'; describe('suite', () => {});",
-        "const { describe } = require('vitest'); describe('suite', () => {});",
-        "const { describe, it } = require('vitest'); describe('suite', () => {});",
-        "const { describe, describe } = require('vitest'); describe('suite', () => {});",
-        "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { let test = 5; expect(test).toBe(5); }); });",
-        "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { const test = () => true; expect(test()).toBe(true); }); });",
-        "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { function fn(test) { return test; } expect(fn(5)).toBe(5); }); });",
+        "import { describe } from 'vitest';
+describe('suite', () => {});",
+        "import { describe, it } from 'vitest';
+describe('suite', () => {});",
+        "import { it as i, describe as d } from 'vitest';
+d('suite', () => { i('test', () => {}); });",
+        "const { describe } = require('vitest');
+describe('suite', () => {});",
+        "const { describe, it } = require('vitest');
+describe('suite', () => {});",
+        "const { describe: d, it: i } = require('vitest');
+d('suite', () => { i('test', () => {}); });",
+        "import { describe, expect, it } from 'vitest';
+describe('suite', () => {
+    it('test', () => {
+        let test = 5;
+        expect(test).toBe(5);
+    });
+});",
+        "import { describe, expect, it } from 'vitest';
+describe('suite', () => {
+    it('test', () => {
+        const test = () => true;
+        expect(test()).toBe(true);
+    });
+});",
+        "import { describe, expect, it } from 'vitest';
+describe('suite', () => {
+    it('test', () => {
+        function fn(test) { return test; }
+        expect(fn(5)).toBe(5);
+    });
+});",
     ];
 
     let fail = vec![
         "describe('suite', () => {});",
         "import { it } from 'vitest';
-			describe('suite', () => {});",
-        "import { describe } from 'jest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
         "import vitest from 'vitest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
         "import * as abc from 'vitest';
-			describe('suite', () => {});",
-        r#"import { "default" as vitest } from 'vitest'; describe('suite', () => {});"#,
-        "const x = require('something', 'else'); describe('suite', () => {});",
-        "const x = require('jest'); describe('suite', () => {});",
-        "const vitest = require('vitest'); describe('suite', () => {});",
-        "const { ...rest } = require('vitest'); describe('suite', () => {});",
-        r#"const { "default": vitest } = require('vitest'); describe('suite', () => {});"#,
+describe('suite', () => {});",
+        "import type { describe } from 'vitest';
+describe('suite', () => {});",
+        "const vitest = require('vitest');
+describe('suite', () => {});",
         "const { it } = require('vitest');
-			describe('suite', () => {});",
+describe('suite', () => {});",
     ];
 
     let fix = vec![
         (
             "describe('suite', () => {});",
-            "import { describe } from 'vitest';
-			describe('suite', () => {});",
+            "const { describe } = require('vitest');\ndescribe('suite', () => {});",
             None,
         ),
         (
             "import { it } from 'vitest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
             "import { it, describe } from 'vitest';
-			describe('suite', () => {});",
-            None,
-        ),
-        (
-            "import { describe } from 'jest';
-			describe('suite', () => {});",
-            "import { describe } from 'vitest';
-			import { describe } from 'jest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
             None,
         ),
         (
             "import vitest from 'vitest';
-			describe('suite', () => {});",
-            "import vitest, { describe } from 'vitest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
+            "import { describe } from 'vitest';
+import vitest from 'vitest';
+describe('suite', () => {});",
             None,
         ),
         (
             "import * as abc from 'vitest';
-			describe('suite', () => {});",
+describe('suite', () => {});",
             "import { describe } from 'vitest';
-			import * as abc from 'vitest';
-			describe('suite', () => {});",
+import * as abc from 'vitest';
+describe('suite', () => {});",
             None,
         ),
         (
-            r#"import { "default" as vitest } from 'vitest'; describe('suite', () => {});"#,
-            r#"import { "default" as vitest, describe } from 'vitest'; describe('suite', () => {});"#,
-            None,
-        ),
-        (
-            "const x = require('something', 'else'); describe('suite', () => {});",
+            "import type { describe } from 'vitest';
+describe('suite', () => {});",
             "import { describe } from 'vitest';
-			const x = require('something', 'else'); describe('suite', () => {});",
+import type { describe } from 'vitest';
+describe('suite', () => {});",
             None,
         ),
         (
-            "const x = require('jest'); describe('suite', () => {});",
-            "import { describe } from 'vitest';
-			const x = require('jest'); describe('suite', () => {});",
-            None,
-        ),
-        (
-            "const vitest = require('vitest'); describe('suite', () => {});",
-            "import { describe } from 'vitest';
-			const vitest = require('vitest'); describe('suite', () => {});",
-            None,
-        ),
-        (
-            "const { ...rest } = require('vitest'); describe('suite', () => {});",
-            "const { ...rest, describe } = require('vitest'); describe('suite', () => {});",
-            None,
-        ),
-        (
-            r#"const { "default": vitest } = require('vitest'); describe('suite', () => {});"#,
-            r#"const { "default": vitest, describe } = require('vitest'); describe('suite', () => {});"#,
+            "const vitest = require('vitest');
+describe('suite', () => {});",
+            "const { describe } = require('vitest');
+const vitest = require('vitest');
+describe('suite', () => {});",
             None,
         ),
         (
             "const { it } = require('vitest');
-			describe('suite', () => {});",
-            "const { it, describe } = require('vitest');
-			describe('suite', () => {});",
+describe('suite', () => {});",
+            "const { describe } = require('vitest');
+const { it } = require('vitest');
+describe('suite', () => {});",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
@@ -1,0 +1,356 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, BindingPattern, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashSet;
+
+use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
+
+fn prefer_importing_vitest_globals_diagnostic(span: Span, globals: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer importing vitest globals: {globals}"))
+        .with_help(
+            "Import these globals from 'vitest' explicitly instead of using them as globals.",
+        )
+        .with_label(span)
+}
+
+/// List of vitest globals that should be imported
+const VITEST_GLOBALS: [&str; 18] = [
+    "afterAll",
+    "afterEach",
+    "beforeAll",
+    "beforeEach",
+    "bench",
+    "describe",
+    "expect",
+    "expectTypeOf",
+    "fdescribe",
+    "fit",
+    "it",
+    "jest",
+    "pending",
+    "test",
+    "vi",
+    "xdescribe",
+    "xit",
+    "xtest",
+];
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferImportingVitestGlobals;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces explicit imports from 'vitest' instead of using vitest globals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using vitest globals without importing them relies on implicit global configuration
+    /// (`globals: true` in vitest config). Explicit imports make dependencies clear,
+    /// improve IDE support, and ensure compatibility across different setups.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// describe('suite', () => {
+    ///   it('test', () => {
+    ///     expect(true).toBe(true)
+    ///   })
+    /// })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import { describe, it, expect } from 'vitest'
+    ///
+    /// describe('suite', () => {
+    ///   it('test', () => {
+    ///     expect(true).toBe(true)
+    ///   })
+    /// })
+    /// ```
+    PreferImportingVitestGlobals,
+    vitest,
+    style,
+    fix
+);
+
+impl Rule for PreferImportingVitestGlobals {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let import_info = collect_vitest_import_info(ctx);
+        let mut unimported_globals: Vec<(&str, Span)> = Vec::new();
+
+        for (name, reference_ids) in ctx.scoping().root_unresolved_references() {
+            if VITEST_GLOBALS.contains(name)
+                && !import_info.imported_names.contains(*name)
+                && let Some(&first_ref_id) = reference_ids.first()
+            {
+                let reference = ctx.scoping().get_reference(first_ref_id);
+                let node = ctx.nodes().get_node(reference.node_id());
+                unimported_globals.push((*name, node.span()));
+            }
+        }
+
+        if unimported_globals.is_empty() {
+            return;
+        }
+
+        unimported_globals.sort_by_key(|(name, _)| *name);
+        let first_span = unimported_globals.first().map_or(Span::empty(0), |(_, span)| *span);
+        let globals_list: Vec<&str> = unimported_globals.iter().map(|(name, _)| *name).collect();
+        let globals_str = globals_list.join(", ");
+
+        ctx.diagnostic_with_fix(
+            prefer_importing_vitest_globals_diagnostic(first_span, &globals_str),
+            |fixer| {
+                let module_record = ctx.module_record();
+                let vitest_imports: Vec<_> = module_record
+                    .import_entries
+                    .iter()
+                    .filter(|entry| entry.module_request.name() == "vitest")
+                    .collect();
+
+                let vitest_import = vitest_imports
+                    .iter()
+                    .find(|e| matches!(e.import_name, ImportImportName::Name(_)))
+                    .or_else(|| {
+                        vitest_imports
+                            .iter()
+                            .find(|e| matches!(e.import_name, ImportImportName::Default(_)))
+                    })
+                    .or_else(|| vitest_imports.first())
+                    .copied();
+
+                if let Some(import_entry) = vitest_import {
+                    match &import_entry.import_name {
+                        ImportImportName::NamespaceObject => {
+                            let new_import = format!(
+                                "import {{ {} }} from 'vitest';\n",
+                                globals_list.join(", ")
+                            );
+                            fixer.insert_text_before_range(import_entry.statement_span, new_import)
+                        }
+                        ImportImportName::Default(_) => {
+                            let source = ctx.source_range(import_entry.statement_span);
+                            if let Some(from_pos) = source.find(" from ") {
+                                #[expect(clippy::cast_possible_truncation)]
+                                let insert_pos =
+                                    import_entry.statement_span.start + from_pos as u32;
+                                let insert_text = format!(", {{ {} }}", globals_list.join(", "));
+                                fixer.insert_text_before_range(Span::empty(insert_pos), insert_text)
+                            } else {
+                                fixer.noop()
+                            }
+                        }
+                        ImportImportName::Name(_) => {
+                            let source = ctx.source_range(import_entry.statement_span);
+                            if let Some(close_brace_pos) = source.rfind('}') {
+                                let before_brace = &source[..close_brace_pos];
+                                let trimmed_len = before_brace.trim_end().len();
+
+                                #[expect(clippy::cast_possible_truncation)]
+                                let insert_pos =
+                                    import_entry.statement_span.start + trimmed_len as u32;
+                                let insert_text = format!(", {}", globals_list.join(", "));
+                                fixer.insert_text_before_range(Span::empty(insert_pos), insert_text)
+                            } else {
+                                fixer.noop()
+                            }
+                        }
+                    }
+                } else if let Some(cjs_info) = &import_info.cjs_require {
+                    match cjs_info {
+                        CommonJSVitestRequire::Destructured { pattern_span } => {
+                            let source = ctx.source_range(*pattern_span);
+                            if let Some(close_brace_pos) = source.rfind('}') {
+                                let before_brace = &source[..close_brace_pos];
+                                let trimmed_len = before_brace.trim_end().len();
+
+                                #[expect(clippy::cast_possible_truncation)]
+                                let insert_pos = pattern_span.start + trimmed_len as u32;
+                                let insert_text = format!(", {}", globals_list.join(", "));
+                                fixer.insert_text_before_range(Span::empty(insert_pos), insert_text)
+                            } else {
+                                fixer.noop()
+                            }
+                        }
+                        CommonJSVitestRequire::DefaultOrNamespace { statement_start } => {
+                            let new_import = format!(
+                                "import {{ {} }} from 'vitest';\n",
+                                globals_list.join(", ")
+                            );
+                            fixer
+                                .insert_text_before_range(Span::empty(*statement_start), new_import)
+                        }
+                    }
+                } else {
+                    let new_import =
+                        format!("import {{ {} }} from 'vitest';\n", globals_list.join(", "));
+                    fixer.insert_text_before_range(Span::empty(0), new_import)
+                }
+            },
+        );
+    }
+}
+
+struct VitestImportInfo {
+    imported_names: FxHashSet<String>,
+    cjs_require: Option<CommonJSVitestRequire>,
+}
+
+enum CommonJSVitestRequire {
+    Destructured { pattern_span: Span },
+    DefaultOrNamespace { statement_start: u32 },
+}
+
+fn collect_vitest_import_info(ctx: &LintContext<'_>) -> VitestImportInfo {
+    let mut imported_names = FxHashSet::default();
+    let mut cjs_require = None;
+
+    for entry in &ctx.module_record().import_entries {
+        if entry.module_request.name() != "vitest" {
+            continue;
+        }
+
+        // Type-only imports don't create runtime bindings
+        if entry.is_type {
+            continue;
+        }
+
+        if let ImportImportName::Name(_) = &entry.import_name {
+            // `import { describe as d }` binds `d`, not `describe`
+            imported_names.insert(entry.local_name.name().to_string());
+        }
+    }
+
+    for node in ctx.nodes() {
+        let AstKind::VariableDeclaration(var_decl) = node.kind() else { continue };
+        for decl in &var_decl.declarations {
+            let Some(Expression::CallExpression(call)) = &decl.init else { continue };
+            if !is_require_call(call, "vitest") {
+                continue;
+            }
+
+            match &decl.id {
+                BindingPattern::ObjectPattern(obj_pat) => {
+                    // `const { describe: d }` binds `d`, not `describe`
+                    for prop in &obj_pat.properties {
+                        if let BindingPattern::BindingIdentifier(ident) = &prop.value {
+                            imported_names.insert(ident.name.to_string());
+                        }
+                    }
+
+                    if cjs_require.is_none() {
+                        if obj_pat.rest.is_some() {
+                            cjs_require = Some(CommonJSVitestRequire::DefaultOrNamespace {
+                                statement_start: var_decl.span.start,
+                            });
+                        } else {
+                            cjs_require = Some(CommonJSVitestRequire::Destructured {
+                                pattern_span: obj_pat.span,
+                            });
+                        }
+                    }
+                }
+                BindingPattern::BindingIdentifier(_) => {
+                    if cjs_require.is_none() {
+                        cjs_require = Some(CommonJSVitestRequire::DefaultOrNamespace {
+                            statement_start: var_decl.span.start,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    VitestImportInfo { imported_names, cjs_require }
+}
+
+fn is_require_call(call: &oxc_ast::ast::CallExpression<'_>, module_name: &str) -> bool {
+    let Expression::Identifier(ident) = &call.callee else { return false };
+    if ident.name != "require" || call.arguments.len() != 1 {
+        return false;
+    }
+    let Argument::StringLiteral(lit) = &call.arguments[0] else { return false };
+    lit.value == module_name
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "import { describe } from 'vitest'; describe('suite', () => {});",
+        "import { describe, it } from 'vitest'; describe('suite', () => {});",
+        "const { describe } = require('vitest'); describe('suite', () => {});",
+        "const { describe, it } = require('vitest'); describe('suite', () => {});",
+        "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { let test = 5; expect(test).toBe(5); }); });",
+        "import { it as i, describe as d } from 'vitest'; d('suite', () => { i('test', () => {}); });",
+    ];
+
+    let fail = vec![
+        "describe('suite', () => {});",
+        "import { it } from 'vitest';\ndescribe('suite', () => {});",
+        "import vitest from 'vitest';\ndescribe('suite', () => {});",
+        "import * as abc from 'vitest';\ndescribe('suite', () => {});",
+        "const vitest = require('vitest');\ndescribe('suite', () => {});",
+        "const { it } = require('vitest');\ndescribe('suite', () => {});",
+        "import { describe as d } from 'vitest';\ndescribe('suite', () => {});",
+        "const { describe: d } = require('vitest');\ndescribe('suite', () => {});",
+        "import type { describe } from 'vitest';\ndescribe('suite', () => {});",
+    ];
+
+    let fix = vec![
+        (
+            "describe('suite', () => {});",
+            "import { describe } from 'vitest';\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "import { it } from 'vitest';\ndescribe('suite', () => {});",
+            "import { it, describe } from 'vitest';\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "import vitest from 'vitest';\ndescribe('suite', () => {});",
+            "import vitest, { describe } from 'vitest';\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "import * as abc from 'vitest';\ndescribe('suite', () => {});",
+            "import { describe } from 'vitest';\nimport * as abc from 'vitest';\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "const vitest = require('vitest');\ndescribe('suite', () => {});",
+            "import { describe } from 'vitest';\nconst vitest = require('vitest');\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "const { it } = require('vitest');\ndescribe('suite', () => {});",
+            "const { it, describe } = require('vitest');\ndescribe('suite', () => {});",
+            None,
+        ),
+        (
+            "import * as vt from 'vitest';\nimport { it } from 'vitest';\ndescribe('suite', () => {});",
+            "import * as vt from 'vitest';\nimport { it, describe } from 'vitest';\ndescribe('suite', () => {});",
+            None,
+        ),
+    ];
+
+    Tester::new(
+        PreferImportingVitestGlobals::NAME,
+        PreferImportingVitestGlobals::PLUGIN,
+        pass,
+        fail,
+    )
+    .with_vitest_plugin(true)
+    .expect_fix(fix)
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals.snap
@@ -1,0 +1,73 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:1:1]
+ 1 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ import { it } from 'vitest';
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ import vitest from 'vitest';
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ import * as abc from 'vitest';
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ const vitest = require('vitest');
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ const { it } = require('vitest');
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ import { describe as d } from 'vitest';
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ const { describe: d } = require('vitest');
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ import type { describe } from 'vitest';
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import these globals from 'vitest' explicitly instead of using them as globals.

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals.snap
@@ -1,73 +1,57 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
    ╭─[prefer_importing_vitest_globals.tsx:1:1]
  1 │ describe('suite', () => {});
    · ────────
    ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+  help: Import `describe` from 'vitest' explicitly.
 
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
    ╭─[prefer_importing_vitest_globals.tsx:2:1]
  1 │ import { it } from 'vitest';
  2 │ describe('suite', () => {});
    · ────────
    ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+  help: Import `describe` from 'vitest' explicitly.
 
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
    ╭─[prefer_importing_vitest_globals.tsx:2:1]
  1 │ import vitest from 'vitest';
  2 │ describe('suite', () => {});
    · ────────
    ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+  help: Import `describe` from 'vitest' explicitly.
 
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
    ╭─[prefer_importing_vitest_globals.tsx:2:1]
  1 │ import * as abc from 'vitest';
  2 │ describe('suite', () => {});
    · ────────
    ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+  help: Import `describe` from 'vitest' explicitly.
 
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
-   ╭─[prefer_importing_vitest_globals.tsx:2:1]
- 1 │ const vitest = require('vitest');
- 2 │ describe('suite', () => {});
-   · ────────
-   ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
-
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
-   ╭─[prefer_importing_vitest_globals.tsx:2:1]
- 1 │ const { it } = require('vitest');
- 2 │ describe('suite', () => {});
-   · ────────
-   ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
-
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
-   ╭─[prefer_importing_vitest_globals.tsx:2:1]
- 1 │ import { describe as d } from 'vitest';
- 2 │ describe('suite', () => {});
-   · ────────
-   ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
-
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
-   ╭─[prefer_importing_vitest_globals.tsx:2:1]
- 1 │ const { describe: d } = require('vitest');
- 2 │ describe('suite', () => {});
-   · ────────
-   ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
-
-  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest globals: describe
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
    ╭─[prefer_importing_vitest_globals.tsx:2:1]
  1 │ import type { describe } from 'vitest';
  2 │ describe('suite', () => {});
    · ────────
    ╰────
-  help: Import these globals from 'vitest' explicitly instead of using them as globals.
+  help: Import `describe` from 'vitest' explicitly.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ const vitest = require('vitest');
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import `describe` from 'vitest' explicitly.
+
+  ⚠ eslint-plugin-vitest(prefer-importing-vitest-globals): Prefer importing vitest global `describe`
+   ╭─[prefer_importing_vitest_globals.tsx:2:1]
+ 1 │ const { it } = require('vitest');
+ 2 │ describe('suite', () => {});
+   · ────────
+   ╰────
+  help: Import `describe` from 'vitest' explicitly.


### PR DESCRIPTION
 # Summary

First-time contributor here, feedback welcome!

AI disclosure: used AI assistance for initial implementation, but I reviewed, tested, and validated everything myself. Built the binary and ran it against real test files to verify behavior.

Implement `vitest/prefer-importing-vitest-globals` rule that enforces explicit imports from 'vitest' instead of relying on global configuration.

related to https://github.com/oxc-project/oxc/issues/4656

  - Detects unimported vitest globals (`describe`, `it`, `expect`, `vi`, etc.)
  - Auto-fix adds missing imports to existing vitest import statements or creates new ones
  - Handles ESM imports, CommonJS requires, and mixed scenarios

  Edge cases handled:
  - Aliased imports (`import { describe as d }` - only `d` is bound, not `describe`)
  - Type-only imports (`import type { ... }` - doesn't create runtime bindings)
  - Multiple vitest imports (prefers adding to named imports over creating duplicates)
  - CommonJS destructuring with aliases (`const { describe: d } = require(...)`)




