### PR TITLE
refactor(lsp): move `shutdown` method to `ToolBuilder`

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -198,6 +198,7 @@ impl Tool for ServerFormatter {
             return ToolRestartChanges { tool: None, watch_patterns: None };
         }
 
+        builder.shutdown(root_uri);
         let new_formatter = builder.build_boxed(root_uri, new_options_json.clone());
         let watch_patterns = new_formatter.get_watcher_patterns(new_options_json);
         ToolRestartChanges { tool: Some(new_formatter), watch_patterns: Some(watch_patterns) }
@@ -229,7 +230,7 @@ impl Tool for ServerFormatter {
         options: serde_json::Value,
     ) -> ToolRestartChanges {
         // TODO: Check if the changed file is actually a config file
-
+        builder.shutdown(root_uri);
         let new_formatter = builder.build_boxed(root_uri, options);
 
         ToolRestartChanges {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -356,6 +356,7 @@ impl Tool for ServerLinter {
         }
 
         // get the cached files before refreshing the linter, and revalidate them after
+        builder.shutdown(root_uri);
         let new_linter = builder.build_boxed(root_uri, new_options_json.clone());
 
         let patterns = {
@@ -414,6 +415,7 @@ impl Tool for ServerLinter {
         options: serde_json::Value,
     ) -> ToolRestartChanges {
         // TODO: Check if the changed file is actually a config file (including extended paths)
+        builder.shutdown(root_uri);
         let new_linter = builder.build_boxed(root_uri, options);
 
         ToolRestartChanges {

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -19,6 +19,11 @@ pub trait ToolBuilder: Send + Sync {
 
     /// Build a boxed instance of the tool for the given root URI and options.
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;
+
+    /// Shutdown hook for the tool. Implementors may perform any necessary cleanup here.
+    fn shutdown(&self, _root_uri: &Uri) {
+        // Default implementation does nothing.
+    }
 }
 
 pub type DiagnosticResult = Result<Vec<(Uri, Vec<Diagnostic>)>, String>;
@@ -127,11 +132,6 @@ pub trait Tool: Send + Sync {
 
     /// Remove internal cache for the given URI, if any.
     fn remove_uri_cache(&self, _uri: &Uri) {
-        // Default implementation does nothing.
-    }
-
-    /// Shutdown hook for the tool. Implementors may perform any necessary cleanup here.
-    fn shutdown(&self) {
         // Default implementation does nothing.
     }
 }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -229,8 +229,9 @@ impl WorkspaceWorker {
         let uris_to_clear_diagnostics =
             self.published_diagnostics.lock().await.drain().collect::<Vec<Uri>>();
         let mut watchers_to_unregister = Vec::new();
-        for tool in self.tools.read().await.iter() {
-            tool.shutdown();
+        for (tool, builder) in self.tools.read().await.iter().zip(self.builders.iter()) {
+            builder.shutdown(&self.root_uri);
+
             watchers_to_unregister
                 .push(unregistration_tool_watcher_id(tool.name(), &self.root_uri));
         }


### PR DESCRIPTION
> This PR refactors the LSP shutdown mechanism by moving the shutdown method from the Tool trait to the ToolBuilder trait. This design change allows cleanup operations to be performed at the builder level (which is stateless and shared) rather than at the tool instance level. The method signature also changes to accept a root_uri parameter.

Because `ServerXBuilder` will hold a ExternalXBuilder in the future, the `ServerXBuilder` should shut down the instance. 
It created it in the first place, :) 