### PR TITLE
fix(oxfmt): unstable Vue template formatting

### DIFF
--- a/apps/oxfmt/test/api.test.ts
+++ b/apps/oxfmt/test/api.test.ts
@@ -64,10 +64,23 @@ describe("API Tests", () => {
       `
 <template><div>Vue</div></template>
 <style>
-  div{color:red;}
+  div {
+    color: red;
+  }
 </style>
 `.trimStart(),
     );
     expect(result3.errors).toStrictEqual([]);
+  });
+
+  // Regression test for https://github.com/oxc-project/oxc/issues/17604
+  test("should format Vue file with interpolations idempotently", async () => {
+    const vueCode = `<template><div>{{ msg }}</div></template>`;
+    const result1 = await format("test.vue", vueCode);
+    const result2 = await format("test.vue", result1.code);
+    const result3 = await format("test.vue", result2.code);
+    expect(result1.code).toBe(result2.code);
+    expect(result2.code).toBe(result3.code);
+    expect(result1.errors).toStrictEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #17604

## Summary

oxfmt's `embeddedLanguageFormatting` option (default `"off"`) is for oxc's JS/TS embedded language handling, not for Prettier. When passed to Prettier's Vue parser, it triggers a formatting instability bug that adds newlines inside `{{ }}` interpolations on each format run.

Fix: Remove `embeddedLanguageFormatting` from options before passing to external formatter.

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/oxfmt-17604 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set oxfmt-17604
cd oxfmt-17604 && pnpm i && node verify.mjs
```

Expected: Format is stable after first run
Actual: Each run shows `Changed=true` (adds newlines inside `{{ }}`)

## Verify Fix

```bash
git sparse-checkout add oxfmt-17604-fixed
cd ../oxfmt-17604-fixed && pnpm i && node verify.mjs
```

The `-fixed` folder uses `.oxfmtrc.json` with `"embeddedLanguageFormatting": "auto"` as workaround, which this PR makes the default behavior when calling Prettier.