### PR TITLE
refactor(oxlint/lsp): add `ExternalLinter` to `ServerLinterBuilder`

### DIFF
--- a/apps/oxlint/src/lsp/mod.rs
+++ b/apps/oxlint/src/lsp/mod.rs
@@ -15,7 +15,7 @@ pub async fn run_lsp() {
     oxc_language_server::run_server(
         "oxlint".to_string(),
         env!("CARGO_PKG_VERSION").to_string(),
-        vec![Box::new(crate::lsp::server_linter::ServerLinterBuilder)],
+        vec![Box::new(crate::lsp::server_linter::ServerLinterBuilder::default())],
     )
     .await;
 }

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -185,10 +185,8 @@ impl Tester<'_> {
     }
 
     fn create_linter(&self) -> ServerLinter {
-        ServerLinterBuilder::build(
-            &Self::get_root_uri(self.relative_root_dir),
-            self.options.clone(),
-        )
+        ServerLinterBuilder::default()
+            .build(&Self::get_root_uri(self.relative_root_dir), self.options.clone())
     }
 
     pub fn get_root_uri(relative_root_dir: &str) -> Uri {
@@ -246,7 +244,7 @@ impl Tester<'_> {
         &self,
         new_options: serde_json::Value,
     ) -> ToolRestartChanges {
-        let builder = ServerLinterBuilder;
+        let builder = ServerLinterBuilder::default();
         self.create_linter().handle_configuration_change(
             &builder,
             &Self::get_root_uri(self.relative_root_dir),


### PR DESCRIPTION
First steps for `ExternalLinter`. Just creating the option, so someone in the future knows where to expect the `ExternalLinter` :) 
It is not used at the moment