### PR TITLE
refactor(linter): Fix up the jsx-max-depth rule to simplify the config option defaults and docs.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
@@ -36,21 +36,14 @@ impl std::ops::Deref for JsxMaxDepth {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(rename_all = "camelCase", default)]
 pub struct JsxMaxDepthConfig {
-    #[serde(default = "JsxMaxDepthConfig::default_max")]
     pub max: usize,
-}
-
-impl JsxMaxDepthConfig {
-    const fn default_max() -> usize {
-        2
-    }
 }
 
 impl Default for JsxMaxDepthConfig {
     fn default() -> Self {
-        Self { max: Self::default_max() }
+        Self { max: 2 }
     }
 }
 
@@ -88,12 +81,6 @@ declare_oxc_lint!(
     ///   </div>
     /// );
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// `react/jsx-max-depth: [<enabled>, { "max": <number> }]`
-    ///
-    /// The `max` option defaults to `2`.
     JsxMaxDepth,
     react,
     style,


### PR DESCRIPTION
Removes unnecessary duplication from the docs and removes extra code for setting default config values.