### PR TITLE
perf(formatter): speed up get_lines_before reverse traversal

### DIFF
--- a/crates/oxc_formatter/src/formatter/source_text.rs
+++ b/crates/oxc_formatter/src/formatter/source_text.rs
@@ -348,14 +348,8 @@ const z = 3;
         let bar_start = source.find("bar").unwrap() as u32;
 
         // The node wrapped inside parentheses should not inherit the blank lines from within.
-        assert_eq!(
-            source_text.get_lines_before(Span::new(foo_start, foo_start + 3), &comments),
-            0
-        );
+        assert_eq!(source_text.get_lines_before(Span::new(foo_start, foo_start + 3), &comments), 0);
         // The node outside the parentheses should still see the two preceding blank lines.
-        assert_eq!(
-            source_text.get_lines_before(Span::new(bar_start, bar_start + 3), &comments),
-            2
-        );
+        assert_eq!(source_text.get_lines_before(Span::new(bar_start, bar_start + 3), &comments), 2);
     }
 }

--- a/crates/oxc_formatter/src/formatter/source_text.rs
+++ b/crates/oxc_formatter/src/formatter/source_text.rs
@@ -325,8 +325,8 @@ const z = 3;
         let source_text = SourceText::new(source);
         let comments = empty_comments(source_text);
 
-        let beta_start = source.find("const β").unwrap() as u32;
-        let gamma_start = source.find("const γ").unwrap() as u32;
+        let beta_start = u32::try_from(source.find("const β").unwrap()).unwrap();
+        let gamma_start = u32::try_from(source.find("const γ").unwrap()).unwrap();
 
         assert_eq!(
             source_text.get_lines_before(Span::new(beta_start, beta_start + 6), &comments),
@@ -344,18 +344,12 @@ const z = 3;
         let source_text = SourceText::new(source);
         let comments = empty_comments(source_text);
 
-        let foo_start = source.find("foo").unwrap() as u32;
-        let bar_start = source.find("bar").unwrap() as u32;
+        let foo_start = u32::try_from(source.find("foo").unwrap()).unwrap();
+        let bar_start = u32::try_from(source.find("bar").unwrap()).unwrap();
 
         // The node wrapped inside parentheses should not inherit the blank lines from within.
-        assert_eq!(
-            source_text.get_lines_before(Span::new(foo_start, foo_start + 3), &comments),
-            0
-        );
+        assert_eq!(source_text.get_lines_before(Span::new(foo_start, foo_start + 3), &comments), 0);
         // The node outside the parentheses should still see the two preceding blank lines.
-        assert_eq!(
-            source_text.get_lines_before(Span::new(bar_start, bar_start + 3), &comments),
-            2
-        );
+        assert_eq!(source_text.get_lines_before(Span::new(bar_start, bar_start + 3), &comments), 2);
     }
 }


### PR DESCRIPTION
 - `SourceText::get_lines_before` recreated a `chars().rev()` iterator for every node, giving O(n²) behavior on long lists. Replace it with a lightweight UTF‑8 backward scanner that keeps the comment/semicolon/parenthesis logic intact while
    reusing the existing bytes_from(span.end) iterator.
  - Add small helper routines (char_before, skip_wrapping_parenthesis) so the new traversal logic stays isolated and the rest of the formatter doesn’t need to change.

```sh
cargo bench -p oxc_benchmark --bench formatter
   Compiling oxc_formatter v0.21.0 (/home/vvacla/repo/oss/oxc/crates/oxc_formatter)
   Compiling oxc_benchmark v0.0.0 (/home/vvacla/repo/oss/oxc/tasks/benchmark)
    Finished `bench` profile [optimized] target(s) in 34.65s
     Running benches/formatter.rs (target/release/deps/formatter-a3c4cc8c8f13edda)
Benchmarking formatter/RadixUIAdoptionSection.jsx: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, enable flat sampling, or reduce sample count to 60.
formatter/RadixUIAdoptionSection.jsx
                        time:   [796.83 µs 813.75 µs 834.49 µs]
                        change: [−6.9351% −4.5236% −1.8561%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
Benchmarking formatter/errors.ts: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.8s, enable flat sampling, or reduce sample count to 50.
formatter/errors.ts     time:   [1.5158 ms 1.5388 ms 1.5653 ms]
                        change: [−7.9572% −6.2700% −4.6514%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
formatter/Search.tsx    time:   [2.5541 ms 2.5849 ms 2.6199 ms]
                        change: [−9.7090% −7.9194% −6.1674%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
formatter/core.js       time:   [2.2968 ms 2.3232 ms 2.3538 ms]
                        change: [−11.441% −9.2004% −7.1027%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
formatter/next.ts       time:   [3.4596 ms 3.5156 ms 3.5796 ms]
                        change: [−12.277% −9.9368% −7.6815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
formatter/index.tsx     time:   [3.7524 ms 3.8099 ms 3.8822 ms]
                        change: [−12.521% −10.354% −8.0870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
formatter/handle-comments.js
                        time:   [3.2383 ms 3.2844 ms 3.3384 ms]
                        change: [−13.920% −11.183% −8.4461%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
formatter/types.ts      time:   [3.9375 ms 4.0018 ms 4.0750 ms]
                        change: [−9.0463% −6.9891% −4.7820%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
formatter/App.tsx       time:   [4.6822 ms 4.7467 ms 4.8164 ms]
                        change: [−10.019% −8.1301% −6.2538%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe
```