### PR TITLE
refactor(oxlint/lsp): pass tsgolint error to client

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -4,7 +4,11 @@ source: apps/oxlint/src/lsp/tester.rs
 ########## 
 Linted file: fixtures/lsp/ignore_patterns/ignored-file.ts
 ----------
-No diagnostics / Files are ignored
+########## Diagnostic Reports
+File URI: file://<variable>/fixtures/lsp/ignore_patterns/ignored-file.ts
+
+########### Code Actions/Commands
+
 ########## 
 Linted file: fixtures/lsp/ignore_patterns/another_config/not-ignored-file.ts
 ----------


### PR DESCRIPTION
## Pull Mode

<img width="448" height="98" alt="grafik" src="https://github.com/user-attachments/assets/f7011a8e-bd1e-4a90-b79f-b353a2ea8f0d" />

Output channel:
```
[2026-01-04T12:28:30Z ERROR oxc_language_server::backend] running diagnostics for file:///home/sysix/dev/oxc/editors/vscode/fixtures/type_aware/index.ts failed: Error running tsgolint: "tsgolint process exited with status: exit status: 2, "

2026-01-04 13:28:30.124 [info] [Trace - 1:28:30 PM] Received response 'textDocument/diagnostic - (1)' in 96ms. Request failed: Error running tsgolint: "tsgolint process exited with status: exit status: 2, " (1).
2026-01-04 13:28:30.125 [info] [Error - 1:28:30 PM] Request textDocument/diagnostic failed.
2026-01-04 13:28:30.125 [info]   Message: Error running tsgolint: "tsgolint process exited with status: exit status: 2, "
  Code: 1 
2026-01-04 13:28:30.125 [info] [Error - 1:28:30 PM] Document pull failed for text document file:///home/sysix/dev/oxc/editors/vscode/fixtures/type_aware/index.ts
2026-01-04 13:28:30.125 [info]   Message: Error running tsgolint: "tsgolint process exited with status: exit status: 2, "
  Code: 1 
```

## Push Mode

(simulated for other editors, which does not support pull mode)

<img width="453" height="130" alt="grafik" src="https://github.com/user-attachments/assets/10fe94a3-1b0c-4c89-8f83-77400c0061b6" />

```

2026-01-05 21:18:14.198 [info] [Trace - 9:18:14 PM] Received notification 'window/showMessage'.
2026-01-05 21:18:14.198 [info] Params: {
    "type": 1,
    "message": "Error running tsgolint: \"tsgolint process exited with status: exit status: 2, \""
}

```
