### PR TITLE
chore(rulegen): Fix the vue rule/test paths.

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -87,9 +87,9 @@ const VITEST_RULES_PATH: &str =
     "https://raw.githubusercontent.com/vitest-dev/eslint-plugin-vitest/main/src/rules";
 
 const VUE_TEST_PATH: &str =
-    "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules/";
+    "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules";
 const VUE_RULES_PATH: &str =
-    "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/lib/rules/";
+    "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/lib/rules";
 
 struct TestCase {
     source_text: String,


### PR DESCRIPTION
These technically still worked, but it's basically a fluke that they did. The trailing `/` results in pulling a URL with two slashes lol

Noticed this from the logs while running the command:

```
Reading rule source file from https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/lib/rules//require-direct-export.js
```