### PR TITLE
fix(linter): panic in `sort-keys` rule with Unicode numeric characters

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -360,7 +360,9 @@ fn natural_sort(arr: &mut [String]) {
         loop {
             match (a_chars.next(), b_chars.next()) {
                 (Some(a_char), Some(b_char)) if a_char == b_char => {}
-                (Some(a_char), Some(b_char)) if a_char.is_numeric() && b_char.is_numeric() => {
+                (Some(a_char), Some(b_char))
+                    if a_char.is_ascii_digit() && b_char.is_ascii_digit() =>
+                {
                     let n1 = take_numeric(&mut a_chars, a_char);
                     let n2 = take_numeric(&mut b_chars, b_char);
                     match n1.cmp(&n2) {
@@ -506,6 +508,7 @@ fn test() {
             "var obj = {'#':1, 'Z':2, À:3, è:4}",
             Some(serde_json::json!(["asc", { "natural": true }])),
         ),
+        ("var obj = {'a²': 1, 'b³': 2}", Some(serde_json::json!(["asc", { "natural": true }]))),
         (
             "var obj = {b_:1, a:2, b:3}",
             Some(serde_json::json!(["asc", { "natural": true, "minKeys": 4 }])),


### PR DESCRIPTION
Disclosure: I used Claude Opus 4.5 to make this fix.

Fixes a panic in the `eslint/sort-keys` rule when using `natural: true` option with property keys containing Unicode numeric characters (e.g., superscripts like `²`, `³`).

The issue was that `char::is_numeric()` returns `true` for all Unicode numeric characters, but `char::to_digit(10)` only works for ASCII digits `0-9`. This caused an `unwrap()` on `None` when processing non-ASCII numeric characters.

Changed `is_numeric()` to `is_ascii_digit()` to match ESLint's `natural-compare` library behavior, which only treats ASCII digits as numeric for natural sorting.

---

I checked the original rule implementation which uses https://github.com/litejs/natural-compare-lite/blob/main/index.js and that seems to handle superscripts as regular characters, so this fix would match the original implementation.