### PR TITLE
chore(linter): port additional tests from unicorn/prefer-at rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
@@ -653,6 +653,15 @@ fn test() {
         ("array.slice(-9, 0)[0]", None),
         ("array.slice(-5, 0).pop()", None),
         ("array.slice(-3, 0).shift()", None),
+        ("++array[1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        (
+            "const offset = 5;const extraArgument = 6;string.charAt(offset + 9, extraArgument)",
+            Some(serde_json::json!([{ "checkAllIndexAccess": true }])),
+        ),
+        ("array[unknown]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        ("array[-1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        ("array[1.5]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        ("array[1n]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
     ];
 
     let fail = vec![
@@ -719,17 +728,17 @@ fn test() {
         ("_.last(new Array)", None),
         (
             "const foo = []
-			_.last([bar])",
+            _.last([bar])",
             None,
         ),
         (
             "const foo = []
-			_.last( new Array )",
+            _.last( new Array )",
             None,
         ),
         (
             "const foo = []
-			_.last( (( new Array )) )",
+            _.last( (( new Array )) )",
             None,
         ),
         ("if (foo) _.last([bar])", None),
@@ -740,6 +749,33 @@ fn test() {
             ),
         ),
         ("function foo() {return _.last(arguments)}", None),
+        // checkAllIndexAccess: true, generated dynamically so not picked up by rulegen.
+        // TODO: Fix these.
+        // ("array[0]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        ("array[1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // ("array[5 + 9]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // (
+        //     "const offset = 5;array[offset + 9]",
+        //     Some(serde_json::json!([{ "checkAllIndexAccess": true }])),
+        // ),
+        ("array[array.length - 1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // `charAt` doesn't care about value
+        // TODO: Implement charAt behavior with checkAllIndexAccess enabled.
+        // ("string.charAt(9)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // ("string.charAt(5 + 9)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // (
+        //     "const offset = 5;string.charAt(offset + 9)",
+        //     Some(serde_json::json!([{ "checkAllIndexAccess": true }])),
+        // ),
+        // ("string.charAt(unknown)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // ("string.charAt(-1)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // ("string.charAt(1.5)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // ("string.charAt(1n)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
+        // (
+        //     "string.charAt(string.length - 1)",
+        //     Some(serde_json::json!([{ "checkAllIndexAccess": true }])),
+        // ),
+        // ("foo.charAt(bar.length - 1)", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_at.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_at.snap
@@ -520,7 +520,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `.at()` for index access
 
   ⚠ eslint-plugin-unicorn(prefer-at): Prefer `.at()` over `_.last()`
-   ╭─[prefer_at.tsx:2:4]
+   ╭─[prefer_at.tsx:2:13]
  1 │ const foo = []
  2 │             _.last([bar])
    ·             ─────────────
@@ -528,7 +528,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `.at()` for index access
 
   ⚠ eslint-plugin-unicorn(prefer-at): Prefer `.at()` over `_.last()`
-   ╭─[prefer_at.tsx:2:4]
+   ╭─[prefer_at.tsx:2:13]
  1 │ const foo = []
  2 │             _.last( new Array )
    ·             ───────────────────
@@ -536,7 +536,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `.at()` for index access
 
   ⚠ eslint-plugin-unicorn(prefer-at): Prefer `.at()` over `_.last()`
-   ╭─[prefer_at.tsx:2:4]
+   ╭─[prefer_at.tsx:2:13]
  1 │ const foo = []
  2 │             _.last( (( new Array )) )
    ·             ─────────────────────────
@@ -561,5 +561,19 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_at.tsx:1:24]
  1 │ function foo() {return _.last(arguments)}
    ·                        ─────────────────
+   ╰────
+  help: Use `.at()` for index access
+
+  ⚠ eslint-plugin-unicorn(prefer-at): Prefer `.at()` over `[index]`
+   ╭─[prefer_at.tsx:1:1]
+ 1 │ array[1]
+   · ────────
+   ╰────
+  help: Use `.at()` for index access
+
+  ⚠ eslint-plugin-unicorn(prefer-at): Prefer `.at()` over `[index]`
+   ╭─[prefer_at.tsx:1:1]
+ 1 │ array[array.length - 1]
+   · ───────────────────────
    ╰────
   help: Use `.at()` for index access


### PR DESCRIPTION
We were missing various tests that are generated dynamically in the upstream tests, unfortunately most of them fail currently. I am unsure if we excluded these test cases intentionally when adding this rule, but I assume not? They don't get picked up by the rulegen logic due to being dynamically generated.

See https://github.com/sindresorhus/eslint-plugin-unicorn/blob/8fcae1aa5a3f1f2c6014bf33aeda2f016c0a8d9a/test/prefer-at.js for further context.

I copy-pasted these tests over, and then commented out the new ones that failed.