### PR TITLE
refactor(linter): Improve the `jsx-a11y/no-autofocus` rule, add more tests

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -3,22 +3,23 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::LintContext,
     globals::HTML_TAG,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_type, has_jsx_prop},
 };
 
 fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users")
-        .with_help("Remove `autofocus` attribute")
+    OxcDiagnostic::warn("The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.")
+        .with_help("Remove the `autoFocus` attribute.")
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema)]
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(default)]
 pub struct NoAutofocus {
     /// Determines if developer-created components are checked.
@@ -59,30 +60,11 @@ declare_oxc_lint!(
     config = NoAutofocus,
 );
 
-impl NoAutofocus {
-    pub fn set_option(&mut self, value: bool) {
-        self.ignore_non_dom = value;
-    }
-}
-
 impl Rule for NoAutofocus {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut no_focus = Self::default();
-
-        if let Some(arr) = value.as_array()
-            && arr.iter().any(|v| {
-                if let serde_json::Value::Object(obj) = v
-                    && let Some(serde_json::Value::Bool(val)) = obj.get("ignoreNonDOM")
-                {
-                    return *val;
-                }
-                false
-            })
-        {
-            no_focus.set_option(true);
-        }
-
-        Ok(no_focus)
+        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+            .unwrap_or_default()
+            .into_inner())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -117,11 +99,6 @@ impl Rule for NoAutofocus {
 #[test]
 fn test() {
     use crate::tester::Tester;
-    fn config() -> serde_json::Value {
-        serde_json::json!([2,{
-            "ignoreNonDOM": true
-        }])
-    }
 
     fn settings() -> serde_json::Value {
         serde_json::json!({
@@ -139,15 +116,21 @@ fn test() {
         ("<input autofocus='true' />;", None, None),
         ("<Foo bar />", None, None),
         ("<Button />", None, None),
-        ("<Foo autoFocus />", Some(config()), None),
-        ("<div><div autofocus /></div>", Some(config()), None),
+        ("<Foo />", Some(serde_json::json!([{ "ignoreNonDOM": true }])), None),
+        ("<Foo />", Some(serde_json::json!([{ "ignoreNonDOM": false }])), None),
+        ("<Foo autoFocus />", Some(serde_json::json!([{ "ignoreNonDOM": true }])), None),
+        ("<Foo autoFocus='true' />", Some(serde_json::json!([{ "ignoreNonDOM": true }])), None),
+        ("<div><div autofocus /></div>", Some(serde_json::json!([{ "ignoreNonDOM": true }])), None),
         ("<Button />", None, Some(settings())),
-        ("<Button />", Some(config()), Some(settings())),
+        ("<Button />", Some(serde_json::json!([{ "ignoreNonDOM": true }])), Some(settings())),
     ];
 
     let fail = vec![
         ("<div autoFocus />", None, None),
         ("<div autoFocus={true} />", None, None),
+        // the value of ignoreNonDOM should not impact these failing, as div is a dom element.
+        ("<div autoFocus={true} />", Some(serde_json::json!([{ "ignoreNonDOM": true }])), None),
+        ("<div autoFocus={true} />", Some(serde_json::json!([{ "ignoreNonDOM": false }])), None),
         ("<div autoFocus={false} />", None, None),
         ("<div autoFocus={undefined} />", None, None),
         ("<div autoFocus='true' />", None, None),
@@ -155,7 +138,11 @@ fn test() {
         ("<input autoFocus />", None, None),
         ("<Foo autoFocus />", None, None),
         ("<Button autoFocus />", None, None),
-        ("<Button autoFocus />", Some(config()), Some(settings())),
+        (
+            "<Button autoFocus />",
+            Some(serde_json::json!([{ "ignoreNonDOM": true }])),
+            Some(settings()),
+        ),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_autofocus.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_autofocus.snap
@@ -1,72 +1,86 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus />
    ·      ─────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus={true} />
    ·      ────────────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:6]
+ 1 │ <div autoFocus={true} />
+   ·      ────────────────
+   ╰────
+  help: Remove the `autoFocus` attribute.
+
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:6]
+ 1 │ <div autoFocus={true} />
+   ·      ────────────────
+   ╰────
+  help: Remove the `autoFocus` attribute.
+
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus={false} />
    ·      ─────────────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus={undefined} />
    ·      ─────────────────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus='true' />
    ·      ────────────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <div autoFocus='false' />
    ·      ─────────────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:8]
  1 │ <input autoFocus />
    ·        ─────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:6]
  1 │ <Foo autoFocus />
    ·      ─────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:9]
  1 │ <Button autoFocus />
    ·         ─────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.
 
-  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
    ╭─[no_autofocus.tsx:1:9]
  1 │ <Button autoFocus />
    ·         ─────────
    ╰────
-  help: Remove `autofocus` attribute
+  help: Remove the `autoFocus` attribute.


### PR DESCRIPTION
Add a few more test cases to the rule. These are not from the upstream, but I wanted to add more tests to make sure it works as-expected for a few more cases.

Also improve the diagnostic, and update the rule to use DefaultRuleConfig.