### PR TITLE
refactor(linter): Update `jsx-a11y/mouse-events-have-key-events` rule to use DefaultRuleConfig.

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -3,12 +3,13 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::LintContext,
     globals::HTML_TAG,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_type, get_prop_value, has_jsx_prop},
 };
 
@@ -26,10 +27,10 @@ fn miss_on_blur(span: Span, attr_name: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct MouseEventsHaveKeyEvents(Box<MouseEventsHaveKeyEventsConfig>);
 
-#[derive(Debug, Clone, JsonSchema)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct MouseEventsHaveKeyEventsConfig {
     /// List of hover-in mouse event handlers that require corresponding keyboard event handlers.
@@ -50,7 +51,7 @@ impl Default for MouseEventsHaveKeyEventsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce onMouseOver/onMouseOut are accompanied by onFocus/onBlur.
+    /// Enforce `onMouseOver`/`onMouseOut` are accompanied by `onFocus`/`onBlur`.
     ///
     /// ### Why is this bad?
     ///
@@ -76,33 +77,9 @@ declare_oxc_lint!(
 
 impl Rule for MouseEventsHaveKeyEvents {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut config = MouseEventsHaveKeyEventsConfig::default();
-
-        if let Some(hover_in_handlers_config) = value
-            .get(0)
-            .and_then(|v| v.get("hoverInHandlers"))
-            .and_then(serde_json::Value::as_array)
-        {
-            config.hover_in_handlers = hover_in_handlers_config
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .map(CompactStr::from)
-                .collect();
-        }
-
-        if let Some(hover_out_handlers_config) = value
-            .get(0)
-            .and_then(|v| v.get("hoverOutHandlers"))
-            .and_then(serde_json::Value::as_array)
-        {
-            config.hover_out_handlers = hover_out_handlers_config
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .map(CompactStr::from)
-                .collect();
-        }
-
-        Ok(Self(Box::new(config)))
+        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+            .unwrap_or_default()
+            .into_inner())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
Simple enough change.