### PR TITLE
fix(formatter): correct JSON schema of `experimentalSortImports.groups`

### DIFF
--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -46,10 +46,15 @@
         "groups": {
           "description": "Custom groups configuration for organizing imports.\nEach array element represents a group, and multiple group names in the same array are treated as one.\nAccepts both `string` and `string[]` as group elements.",
           "items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           },
           "markdownDescription": "Custom groups configuration for organizing imports.\nEach array element represents a group, and multiple group names in the same array are treated as one.\nAccepts both `string` and `string[]` as group elements.",
           "type": [


### PR DESCRIPTION
Per its description from

 https://github.com/oxc-project/oxc/blob/f0fdf83afa08e4ed863de88a16b38ba2b11cbfb8/npm/oxfmt/configuration_schema.json#L47 

and types of `FormatOptions`