### PR TITLE
feat(formatter): support migration of `prettier-plugin-tailwindcss` in `--migrate:prettier`

### DIFF
--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -3,6 +3,8 @@
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { hasOxfmtrcFile, createBlankOxfmtrcFile, saveOxfmtrcFile, exitWithError } from "./shared";
+import { TAILWIND_OPTION_MAPPING } from "../../libs/prettier";
+import { Options } from "prettier";
 
 /**
  * Run the `--migrate prettier` command to migrate various Prettier's config to `.oxfmtrc.json` file.
@@ -64,9 +66,18 @@ export async function runMigratePrettier() {
       console.error(`  - "overrides" is not supported, skipping...`);
       continue;
     }
-    // Oxfmt does not yet support plugins
-    if (key === "plugins") {
-      console.error(`  - "plugins" is not supported yet, skipping...`);
+    // Handle plugins - check for prettier-plugin-tailwindcss and warn about others
+    if (key === "plugins" && Array.isArray(value)) {
+      for (const plugin of (value as Options["plugins"])!) {
+        if (plugin === "prettier-plugin-tailwindcss") {
+          // Migrate `prettier-plugin-tailwindcss` options
+          migrateTailwindOptions(prettierConfig!, oxfmtrc);
+        } else if (typeof plugin === "string") {
+          console.error(`  - plugins: "${plugin}" is not supported, skipping...`);
+        } else {
+          console.error(`  - plugins: custom plugin module is not supported, skipping...`);
+        }
+      }
       continue;
     }
     // Oxfmt does not support this, fallback to default
@@ -77,6 +88,11 @@ export async function runMigratePrettier() {
     // Oxfmt does not support these experimental options yet
     if (key === "experimentalTernaries" || key === "experimentalOperatorPosition") {
       console.error(`  - "${key}" is not supported in JS/TS files yet`);
+      continue;
+    }
+
+    // Skip Tailwind options - handled separately by migrateTailwindOptions
+    if (key.startsWith("tailwind")) {
       continue;
     }
 
@@ -138,4 +154,59 @@ async function resolvePrettierIgnore(cwd: string) {
   } catch {}
 
   return ignores;
+}
+
+// ---
+
+/**
+ * Migrate prettier-plugin-tailwindcss options to Oxfmt's experimentalTailwindcss format.
+ *
+ * Prettier format:
+ * ```json
+ * {
+ *   "plugins": ["prettier-plugin-tailwindcss"],
+ *   "tailwindConfig": "./tailwind.config.js",
+ *   "tailwindFunctions": ["clsx", "cn"]
+ * }
+ * ```
+ *
+ * Oxfmt format:
+ * ```json
+ * {
+ *   "experimentalTailwindcss": {
+ *     "config": "./tailwind.config.js",
+ *     "functions": ["clsx", "cn"]
+ *   }
+ * }
+ * ```
+ */
+function migrateTailwindOptions(
+  prettierConfig: Record<string, unknown>,
+  oxfmtrc: Record<string, unknown>,
+): void {
+  // Collect Tailwind options from Prettier config
+  const tailwindOptions: Record<string, unknown> = {};
+  for (const [oxfmtKey, prettierKey] of Object.entries(TAILWIND_OPTION_MAPPING)) {
+    const value = prettierConfig[prettierKey];
+    if (value !== undefined) {
+      if (
+        (prettierKey == "tailwindFunctions" || prettierKey == "tailwindAttributes") &&
+        Array.isArray(value)
+      ) {
+        for (const item of value as string[]) {
+          if (typeof item === "string" && item.startsWith("/") && item.endsWith("/")) {
+            console.warn(
+              `  - Do not support regex in "${prettierKey}" option yet, skipping: ${item}`,
+            );
+            continue;
+          }
+        }
+      }
+      tailwindOptions[oxfmtKey] = value;
+    }
+  }
+
+  // Only add experimentalTailwindcss if plugin is used or options are present
+  oxfmtrc.experimentalTailwindcss = tailwindOptions;
+  console.log("Migrated prettier-plugin-tailwindcss options to experimentalTailwindcss");
 }

--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -117,7 +117,7 @@ import type { TailwindcssOptions } from "../index";
 let tailwindPlugin: typeof import("prettier-plugin-tailwindcss") | null = null;
 
 // Oxfmt to Prettier option name mapping (adds `tailwind` prefix)
-const TAILWIND_OPTION_MAPPING: Record<string, string> = {
+export const TAILWIND_OPTION_MAPPING: Record<string, string> = {
   config: "tailwindConfig",
   stylesheet: "tailwindStylesheet",
   functions: "tailwindFunctions",


### PR DESCRIPTION
 This PR adds support for migrating `prettier-plugin-tailwindcss` configuration when running `oxfmt --migrate prettier`.

### Example

Prettier config (input):
```json
  {
    "plugins": ["prettier-plugin-tailwindcss"],
    "tailwindConfig": "./tailwind.config.js",
    "tailwindFunctions": ["clsx", "cn"],
    "tailwindAttributes": ["myClass"],
    "tailwindPreserveWhitespace": true
  }
```
 Oxfmt config (output):
```json
  {
    "printWidth": 80,
    "experimentalTailwindcss": {
      "config": "./tailwind.config.js",
      "functions": ["clsx", "cn"],
      "attributes": ["myClass"],
      "preserveWhitespace": true
    },
    "ignorePatterns": []
  }
```

### Notes
  - If the plugin is listed but no Tailwind options are specified, `experimentalTailwindcss` will be set to an empty object `{}` to enable the feature
  - Tailwind options without the plugin in the plugins array will NOT be migrated (they are skipped)