### PR TITLE
fix(formatter): should not hug the type literal when its parent param has an initialzier

### DIFF
--- a/crates/oxc_formatter/src/write/object_like.rs
+++ b/crates/oxc_formatter/src/write/object_like.rs
@@ -35,7 +35,7 @@ impl<'a> ObjectLike<'a, '_> {
             // Check if parent is TSTypeAnnotation
             matches!(node.parent, AstNodes::TSTypeAnnotation(type_ann) if {
                 match &type_ann.parent {
-                    AstNodes::FormalParameter(param) => {
+                    AstNodes::FormalParameter(param) if param.initializer.is_none() => {
                         let AstNodes::FormalParameters(parameters) = &param.parent else {
                             unreachable!()
                         };

--- a/crates/oxc_formatter/tests/fixtures/ts/type-literal/params.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/type-literal/params.ts
@@ -1,0 +1,4 @@
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/type-literal/params.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/type-literal/params.ts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+export default function useTagsCount({ query }: { query?: Record<any, any> } = {}) {}
+
+===================== End =====================


### PR DESCRIPTION
Regression caused by #11489 