### PR TITLE
feat(rulegen): add `--update-tests` flag to update only test block in existing rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,8 +2966,10 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxc_tasks_common",
+ "proc-macro2",
  "rustc-hash",
  "serde",
+ "syn",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -157,6 +157,11 @@ new-rule name plugin='eslint':
   cargo run -p rulegen {{name}} {{plugin}}
   just fmt
 
+# Update test cases for an existing lint rule from upstream
+update-rule-tests name plugin='eslint':
+  cargo run -p rulegen {{name}} {{plugin}} --update-tests
+  just fmt
+
 # Legacy aliases for backward compatibility
 new-jest-rule name: (new-rule name "jest")
 new-ts-rule name: (new-rule name "typescript")

--- a/tasks/rulegen/Cargo.toml
+++ b/tasks/rulegen/Cargo.toml
@@ -26,6 +26,12 @@ handlebars = { workspace = true }
 lazy-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+syn = { workspace = true, features = ["full", "parsing", "printing"] }
+proc-macro2 = { workspace = true, features = ["span-locations"] }
 
 [dev-dependencies]
 insta = { workspace = true }
+
+
+[package.metadata.cargo-shear]
+ignored = ["proc-macro2"]


### PR DESCRIPTION
This allows updating test cases from upstream without overwriting the rule implementation. Useful for PR validation workflows.
