### PR TITLE
test(formatter): make tests run faster

### DIFF
--- a/apps/oxfmt/vitest.config.ts
+++ b/apps/oxfmt/vitest.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
     testTimeout: 10_000,
     // Limit workers to avoid resource contention
     // - each test spawns CLI subprocesses with their own worker pools
-    maxWorkers: Math.floor(os.cpus().length / 2),
+    maxWorkers: Math.max(1, Math.floor(os.cpus().length / 2)),
   },
 });

--- a/apps/oxfmt/vitest.config.ts
+++ b/apps/oxfmt/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       printBasicPrototype: false,
     },
     snapshotSerializers: [],
+    testTimeout: 10_000,
     // Limit workers to avoid resource contention
     // - each test spawns CLI subprocesses with their own worker pools
     maxWorkers: Math.floor(os.cpus().length / 2),

--- a/apps/oxfmt/vitest.config.ts
+++ b/apps/oxfmt/vitest.config.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -8,6 +9,8 @@ export default defineConfig({
       printBasicPrototype: false,
     },
     snapshotSerializers: [],
-    testTimeout: 10000,
+    // Limit workers to avoid resource contention
+    // - each test spawns CLI subprocesses with their own worker pools
+    maxWorkers: Math.floor(os.cpus().length / 2),
   },
 });


### PR DESCRIPTION
## Summary

Optimizes oxfmt test suite performance by:

- **Parallelize test utilities**: Replace sequential `await` loops with `Promise.all` for running CLI calls and reading files
- **Batch CLI invocations**: Run CLI once with all files instead of per-file in write mode tests
- **Limit Vitest workers**: Use `os.cpus().length / 2` to avoid resource contention, since each test spawns CLI subprocesses that create their own Tinypool worker pools (for Prettier/Tailwind formatting)

## Test plan

- [x] `pnpm test` passes in `apps/oxfmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)