### PR TITLE
feat(linter/eslint-plugin-vitest): Implements `prefer-describe-function-title`

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4033,6 +4033,13 @@ impl RuleRunner for crate::rules::vitest::prefer_called_times::PreferCalledTimes
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -672,6 +672,7 @@ pub(crate) mod vitest {
     pub mod no_conditional_tests;
     pub mod no_import_node_test;
     pub mod prefer_called_times;
+    pub mod prefer_describe_function_title;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;
@@ -1337,6 +1338,7 @@ oxc_macros::declare_all_lint_rules! {
     vitest::no_conditional_tests,
     vitest::no_import_node_test,
     vitest::prefer_called_times,
+    vitest::prefer_describe_function_title,
     vitest::prefer_to_be_falsy,
     vitest::prefer_to_be_object,
     vitest::prefer_to_be_truthy,

--- a/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
@@ -1,0 +1,366 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use rustc_hash::FxHashSet;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, parse_general_jest_fn_call},
+};
+
+fn prefer_describe_function_title_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Title description can not have the same content as a imported function name.")
+        .with_help("Pass the function as a description title argument or modify the description title to not match any imported function name.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferDescribeFunctionTitle;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// When testing a specific function, this rule aims to enforce passing a named function to describe()
+    /// instead of an equivalent hardcoded string.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Tests that are related to a specific function, if the function being tested is renamed,
+    /// the describe title will be not match anymore and can make confusion in the future. Using the function
+    /// ensure a consistency even if the function is renamed.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // myFunction.test.js
+    /// import { myFunction } from './myFunction'
+    ///
+    /// describe('myFunction', () => {
+    ///   // ...
+    /// })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // myFunction.test.js
+    /// import { myFunction } from './myFunction'
+    ///
+    /// describe(myFunction, () => {
+    ///   // ...
+    /// })
+    /// ```
+    PreferDescribeFunctionTitle,
+    vitest,
+    style,
+    fix,
+);
+
+impl Rule for PreferDescribeFunctionTitle {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &crate::utils::PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        Self::run(jest_node, ctx);
+    }
+}
+
+impl PreferDescribeFunctionTitle {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if call_expr.arguments.len() < 2 {
+            return;
+        }
+
+        let imported_entries_iter =
+            ctx.module_record().import_entries.iter().map(|entry| entry.local_name.name.as_ref());
+
+        let imported_entries = FxHashSet::from_iter(imported_entries_iter);
+
+        let Some(title_arg) = call_expr.arguments.first() else {
+            return;
+        };
+
+        match title_arg {
+            Argument::StaticMemberExpression(title_expression) => {
+                let Expression::Identifier(identifier) = &title_expression.object else {
+                    return;
+                };
+
+                if title_expression.property.name == "name"
+                    && !imported_entries.contains(identifier.name.as_ref())
+                {
+                    return;
+                }
+
+                ctx.diagnostic_with_fix(
+                    prefer_describe_function_title_diagnostic(title_expression.span),
+                    |fixer| {
+                        let variable = format!("{}", identifier.name.as_ref());
+
+                        fixer.replace(title_expression.span, variable)
+                    },
+                );
+            }
+            Argument::StringLiteral(string_title) => {
+                let Some(test_vitest_fn) =
+                    parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)
+                else {
+                    return;
+                };
+
+                if test_vitest_fn.kind != JestFnKind::General(JestGeneralFnKind::Describe) {
+                    return;
+                }
+
+                if !imported_entries.contains(string_title.value.as_ref()) {
+                    return;
+                }
+
+                if ctx.settings().vitest.typecheck {
+                    // TODO https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/prefer-describe-function-title.ts#L85C9-L92C10
+                    return;
+                }
+
+                ctx.diagnostic_with_fix(
+                    prefer_describe_function_title_diagnostic(string_title.span),
+                    |fixer| {
+                        let span_without_quotes =
+                            Span::new(string_title.span.start + 1, string_title.span.end - 1);
+
+                        let variable = format!("{}", ctx.source_range(span_without_quotes));
+
+                        fixer.replace(string_title.span, variable)
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe()
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("myFunction")
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe.todo("myFunction")
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe.each("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(() => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("other", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        it("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        test("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { other } from "./other.js"
+			        describe("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction.js"
+			        describe(otherFunction.name, () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        declare const myFunction: () => unknown
+			        describe("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        const myFunction = ""
+			        describe("myFunction", () => {})
+			      "#,
+            None,
+            Some(serde_json::json!({ "settings": {  "vitest": {  "typecheck": true,  },  } })),
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("myFunction", () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(myFunction.name, () => {})
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        if (someProcessEnvCheck) {
+			          describe("myFunction", () => {})
+			        }
+			      "#,
+            None,
+            None,
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        /*
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("myFunction", () => {})
+			      "#,
+            None,
+            Some(serde_json::json!({ "settings": {  "vitest": {  "typecheck": true,  },  } })),
+            Some(PathBuf::from("myFunction.test.ts")),
+        ),
+        */
+    ];
+
+    let fix = vec![
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("myFunction", () => {})
+			      "#,
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(myFunction, () => {})
+			      "#,
+            None,
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(myFunction.name, () => {})
+			      "#,
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(myFunction, () => {})
+			      "#,
+            None,
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        if (someProcessEnvCheck) {
+			          describe("myFunction", () => {})
+			        }
+			      "#,
+            r#"
+			        import { myFunction } from "./myFunction"
+			        if (someProcessEnvCheck) {
+			          describe(myFunction, () => {})
+			        }
+			      "#,
+            None,
+        ),
+        (
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe("myFunction", () => {})
+			      "#,
+            r#"
+			        import { myFunction } from "./myFunction"
+			        describe(myFunction, () => {})
+			      "#,
+            None,
+        ),
+    ];
+    Tester::new(PreferDescribeFunctionTitle::NAME, PreferDescribeFunctionTitle::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression},
@@ -5,7 +7,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use rustc_hash::FxHashSet;
 
 use crate::{
     context::LintContext,
@@ -83,12 +84,8 @@ impl PreferDescribeFunctionTitle {
             return;
         }
 
-        let imported_entries = ctx
-            .module_record()
-            .import_entries
-            .iter()
-            .map(|entry| entry.local_name.name.as_ref())
-            .collect::<FxHashSet<_>>();
+        let mut imported_entries =
+            ctx.module_record().import_entries.iter().map(|entry| entry.local_name.name.as_ref());
 
         let Some(title_arg) = call_expr.arguments.first() else {
             return;

--- a/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
@@ -83,10 +83,12 @@ impl PreferDescribeFunctionTitle {
             return;
         }
 
-        let imported_entries_iter =
-            ctx.module_record().import_entries.iter().map(|entry| entry.local_name.name.as_ref());
-
-        let imported_entries = FxHashSet::from_iter(imported_entries_iter);
+        let imported_entries = ctx
+            .module_record()
+            .import_entries
+            .iter()
+            .map(|entry| entry.local_name.name.as_ref())
+            .collect::<FxHashSet<_>>();
 
         let Some(title_arg) = call_expr.arguments.first() else {
             return;
@@ -107,7 +109,7 @@ impl PreferDescribeFunctionTitle {
                 ctx.diagnostic_with_fix(
                     prefer_describe_function_title_diagnostic(title_expression.span),
                     |fixer| {
-                        let variable = format!("{}", identifier.name.as_ref());
+                        let variable = identifier.name.to_string();
 
                         fixer.replace(title_expression.span, variable)
                     },
@@ -139,7 +141,7 @@ impl PreferDescribeFunctionTitle {
                         let span_without_quotes =
                             Span::new(string_title.span.start + 1, string_title.span.end - 1);
 
-                        let variable = format!("{}", ctx.source_range(span_without_quotes));
+                        let variable = ctx.source_range(span_without_quotes).to_string();
 
                         fixer.replace(string_title.span, variable)
                     },

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_describe_function_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_describe_function_title.snap
@@ -1,0 +1,29 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(prefer-describe-function-title): Title description can not have the same content as a imported function name.
+   ╭─[prefer_describe_function_title.tsx:3:21]
+ 2 │                     import { myFunction } from "./myFunction"
+ 3 │                     describe("myFunction", () => {})
+   ·                              ────────────
+ 4 │                   
+   ╰────
+  help: Pass the function as a description title argument or modify the description title to not match any imported function name.
+
+  ⚠ eslint-plugin-vitest(prefer-describe-function-title): Title description can not have the same content as a imported function name.
+   ╭─[prefer_describe_function_title.tsx:3:21]
+ 2 │                     import { myFunction } from "./myFunction"
+ 3 │                     describe(myFunction.name, () => {})
+   ·                              ───────────────
+ 4 │                   
+   ╰────
+  help: Pass the function as a description title argument or modify the description title to not match any imported function name.
+
+  ⚠ eslint-plugin-vitest(prefer-describe-function-title): Title description can not have the same content as a imported function name.
+   ╭─[prefer_describe_function_title.tsx:4:23]
+ 3 │                     if (someProcessEnvCheck) {
+ 4 │                       describe("myFunction", () => {})
+   ·                                ────────────
+ 5 │                     }
+   ╰────
+  help: Pass the function as a description title argument or modify the description title to not match any imported function name.


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

Implements `prefer-describe-function-title` rule, the `typecheck` is added as a TODO, as far as I know we can't infer types from oxlint. The check of filename is omitted, as the eslint rule code for this check is commented.

- [Docs](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-describe-function-title.md)
- [Source Code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/prefer-describe-function-title.ts)
- [Test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/prefer-describe-function-title.test.ts)