### PR TITLE
refactor(oxfmt/lsp): pass errors to client

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -240,17 +240,19 @@ impl Tool for ServerFormatter {
         }
     }
 
-    fn run_format(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<TextEdit>> {
-        // Formatter is disabled
-
-        let path = uri.to_file_path()?;
+    fn run_format(&self, uri: &Uri, content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+        let Some(path) = uri.to_file_path() else { return Err("Invalid file URI".to_string()) };
 
         if self.is_ignored(&path) {
             debug!("File is ignored: {}", path.display());
-            return None;
+            return Ok(Vec::new());
         }
 
-        let source_type = get_supported_source_type(&path).map(enable_jsx_source_type)?;
+        let Some(source_type) = get_supported_source_type(&path).map(enable_jsx_source_type) else {
+            debug!("Unsupported source type for formatting: {}", path.display());
+            return Ok(Vec::new());
+        };
+
         // Declaring Variable to satisfy borrow checker
         let file_content;
         let source_text = if let Some(content) = content {
@@ -258,13 +260,16 @@ impl Tool for ServerFormatter {
         } else {
             #[cfg(not(all(test, windows)))]
             {
-                file_content = std::fs::read_to_string(&path).ok()?;
+                file_content = std::fs::read_to_string(&path)
+                    .map_err(|e| format!("Failed to read file: {e}"))?;
             }
             #[cfg(all(test, windows))]
             #[expect(clippy::disallowed_methods)] // no `cow_replace` in tests are fine
             // On Windows, convert CRLF to LF for consistent formatting results
             {
-                file_content = std::fs::read_to_string(&path).ok()?.replace("\r\n", "\n");
+                file_content = std::fs::read_to_string(&path)
+                    .map_err(|e| format!("Failed to read file: {e}"))?
+                    .replace("\r\n", "\n");
             }
             &file_content
         };
@@ -275,14 +280,16 @@ impl Tool for ServerFormatter {
             .parse();
 
         if !ret.errors.is_empty() {
-            return None;
+            // Parser errors should not be returned to the user.
+            // The user probably wanted to format while typing incomplete code.
+            return Ok(Vec::new());
         }
 
         let code = Formatter::new(&allocator, self.options.clone()).build(&ret.program);
 
         // nothing has changed
         if code == *source_text {
-            return Some(vec![]);
+            return Ok(vec![]);
         }
 
         let (start, end, replacement) = compute_minimal_text_edit(source_text, &code);
@@ -290,7 +297,7 @@ impl Tool for ServerFormatter {
         let (start_line, start_character) = get_line_column(&rope, start, source_text);
         let (end_line, end_character) = get_line_column(&rope, end, source_text);
 
-        Some(vec![TextEdit::new(
+        Ok(vec![TextEdit::new(
             Range::new(
                 Position::new(start_line, start_character),
                 Position::new(end_line, end_character),

--- a/apps/oxfmt/src/lsp/snapshots/test_fixtures_lsp_ignore-file@ignored.ts_not-ignored.js.snap
+++ b/apps/oxfmt/src/lsp/snapshots/test_fixtures_lsp_ignore-file@ignored.ts_not-ignored.js.snap
@@ -4,7 +4,7 @@ source: apps/oxfmt/src/lsp/tester.rs
 ========================================
 File: test/fixtures/lsp/ignore-file/ignored.ts
 ========================================
-File is ignored
+No changes
 ========================================
 File: test/fixtures/lsp/ignore-file/not-ignored.js
 ========================================

--- a/apps/oxfmt/src/lsp/snapshots/test_fixtures_lsp_ignore-pattern@ignored.ts_not-ignored.js.snap
+++ b/apps/oxfmt/src/lsp/snapshots/test_fixtures_lsp_ignore-pattern@ignored.ts_not-ignored.js.snap
@@ -4,7 +4,7 @@ source: apps/oxfmt/src/lsp/tester.rs
 ========================================
 File: test/fixtures/lsp/ignore-pattern/ignored.ts
 ========================================
-File is ignored
+No changes
 ========================================
 File: test/fixtures/lsp/ignore-pattern/not-ignored.js
 ========================================

--- a/apps/oxfmt/src/lsp/tester.rs
+++ b/apps/oxfmt/src/lsp/tester.rs
@@ -17,6 +17,9 @@ pub fn get_file_uri(relative_file_path: &str) -> Uri {
 }
 
 fn get_snapshot_from_text_edits(edits: &[TextEdit]) -> String {
+    if edits.is_empty() {
+        return "No changes".to_string();
+    }
     if edits.len() == 1 {
         // Single edit - show range and the actual formatted content with proper indentation
         let edit = &edits[0];
@@ -76,10 +79,9 @@ impl Tester<'_> {
             let uri = get_file_uri(&format!("{}/{}", self.relative_root_dir, relative_file_path));
             let formatted = self.create_formatter().run_format(&uri, None);
 
-            let snapshot = if let Some(formatted) = formatted {
-                get_snapshot_from_text_edits(&formatted)
-            } else {
-                "File is ignored".to_string()
+            let snapshot = match formatted {
+                Ok(edits) => get_snapshot_from_text_edits(&edits),
+                Err(e) => format!("Error: {e}"),
             };
 
             let _ = write!(

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -93,9 +93,12 @@ pub trait Tool: Send + Sync {
     /// If `content` is `None`, the tool should read the content from the file system.
     /// Returns a vector of `TextEdit` representing the formatting changes.
     ///
-    /// Not all tools will implement formatting, so the default implementation returns `None`.
-    fn run_format(&self, _uri: &Uri, _content: Option<&str>) -> Option<Vec<TextEdit>> {
-        None
+    /// Not all tools will implement formatting, so the default implementation returns empty vector.
+    ///
+    /// # Errors
+    /// Return [`Err`] when an error occurs, ignoring formatting should return [`Ok`] with an empty vector.
+    fn run_format(&self, _uri: &Uri, _content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+        Ok(Vec::new())
     }
 
     /// Run diagnostics on the content of the given URI.

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -205,15 +205,23 @@ impl WorkspaceWorker {
     }
 
     /// Format a file with the current formatter
-    /// - If no file is not formattable or ignored, [`None`] is returned
+    /// - If the file is not formattable or is ignored, an empty vector is returned
     /// - If the file is formattable, but no changes are made, an empty vector is returned
-    pub async fn format_file(&self, uri: &Uri, content: Option<&str>) -> Option<Vec<TextEdit>> {
+    /// - If a tool error occurs, an Err is returned
+    pub async fn format_file(
+        &self,
+        uri: &Uri,
+        content: Option<&str>,
+    ) -> Result<Vec<TextEdit>, String> {
         for tool in self.tools.read().await.iter() {
-            if let Some(edits) = tool.run_format(uri, content) {
-                return Some(edits);
+            let edits = tool.run_format(uri, content)?;
+            // If no edits are made, continue to the next tool
+            if edits.is_empty() {
+                continue;
             }
+            return Ok(edits);
         }
-        None
+        Ok(Vec::new())
     }
 
     /// Shutdown the worker and return any necessary changes to be made after shutdown.


### PR DESCRIPTION
> This PR refactors the formatting error handling in the LSP implementation to properly propagate errors to the client instead of silently ignoring them. Previously, formatting errors were hidden by returning None, but now they are returned as Result<Vec<TextEdit>, String> allowing clients to receive meaningful error messages.