### PR TITLE
fix(formatter): return original classes when there are no tailwindcss classes sort callback

### DIFF
--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -68,9 +68,11 @@ impl ExternalCallbacks {
     /// * `classes` - List of class strings to sort
     ///
     /// # Returns
-    /// * `Some(Vec<String>)` - The sorted classes
-    /// * `None` - No Tailwind callback is set
-    pub fn sort_tailwind_classes(&self, classes: Vec<String>) -> Option<Vec<String>> {
-        self.tailwind.as_ref().map(|cb| cb(classes))
+    /// The sorted classes, or the original classes unsorted if no Tailwind callback is set.
+    pub fn sort_tailwind_classes(&self, classes: Vec<String>) -> Vec<String> {
+        match self.tailwind.as_ref() {
+            Some(cb) => cb(classes),
+            None => classes,
+        }
     }
 }

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -329,7 +329,7 @@ pub fn format<'ast>(
 
     let tailwind_classes = context.take_tailwind_classes();
     let sorted_tailwind_classes =
-        context.external_callbacks().sort_tailwind_classes(tailwind_classes).unwrap_or_default();
+        context.external_callbacks().sort_tailwind_classes(tailwind_classes);
 
     let document = Document::new(elements, sorted_tailwind_classes);
 


### PR DESCRIPTION
close: #17690

Return original classes if there is no sort tailwindcss classes callback, that it is happens in VSCode, it can read `experimentalTailwindcss` configuration, but no tailwindcss callback setup, as LSP does not support it yet

I don't add a test for this, as it seems there are no places where I can write a test for it 😅. But luckily, the changes are obvious.