### PR TITLE
test(oxfmt): Set `--threads=1` for tests

### DIFF
--- a/apps/oxfmt/test/utils.ts
+++ b/apps/oxfmt/test/utils.ts
@@ -14,7 +14,7 @@ declare global {
 
 export function runCli(cwd: string, args: string[]) {
   const cliPath = join(import.meta.dirname, "..", "dist", "cli.js");
-  return execa("node", [cliPath, ...args], {
+  return execa("node", [cliPath, ...args, "--threads=1"], {
     cwd,
     reject: false,
     timeout: 5000,


### PR DESCRIPTION
Experiment to see if test execution speeds up.

With this change alone, test time on my end was cut roughly 1/2, so I hope it will yield similar results in CI...