### PR TITLE
perf(parser): do not re-allocate TS interface heritage

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -11,8 +11,7 @@ use crate::{
 
 use super::FunctionKind;
 
-type Extends<'a> =
-    Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>;
+type ImplementsWithKeywordSpan<'a> = (Span, Vec<'a, TSClassImplements<'a>>);
 
 /// Section 15.7 Class Definitions
 impl<'a> ParserImpl<'a> {
@@ -88,10 +87,10 @@ impl<'a> ParserImpl<'a> {
             && !extends.is_empty()
         {
             let first_extends = extends.remove(0);
-            super_class = Some(first_extends.0);
-            super_type_parameters = first_extends.1;
-            for (_, _, span) in extends {
-                self.error(diagnostics::classes_can_only_extend_single_class(span));
+            super_class = Some(first_extends.expression);
+            super_type_parameters = first_extends.type_arguments;
+            for extend in extends {
+                self.error(diagnostics::classes_can_only_extend_single_class(extend.span));
             }
         }
         let body = self.parse_class_body();
@@ -120,7 +119,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_heritage_clause(
         &mut self,
-    ) -> (Option<Extends<'a>>, Option<(Span, Vec<'a, TSClassImplements<'a>>)>) {
+    ) -> (Option<Vec<'a, TSInterfaceHeritage<'a>>>, Option<ImplementsWithKeywordSpan<'a>>) {
         let mut extends = None;
         let mut implements: Option<(Span, Vec<'a, TSClassImplements<'a>>)> = None;
 
@@ -165,7 +164,7 @@ impl<'a> ParserImpl<'a> {
 
     /// `ClassHeritage`
     /// extends `LeftHandSideExpression`[?Yield, ?Await]
-    fn parse_extends_clause(&mut self) -> Extends<'a> {
+    fn parse_extends_clause(&mut self) -> Vec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
         let mut extends = self.ast.vec();
@@ -181,7 +180,11 @@ impl<'a> ParserImpl<'a> {
                 type_argument = self.try_parse_type_arguments();
             }
 
-            extends.push((extend, type_argument, self.end_span(span)));
+            extends.push(self.ast.ts_interface_heritage(
+                self.end_span(span),
+                extend,
+                type_argument,
+            ));
 
             if !self.eat(Kind::Comma) {
                 break;

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -182,14 +182,7 @@ impl<'a> ParserImpl<'a> {
         let type_parameters = self.parse_ts_type_parameters();
         let (extends, implements) = self.parse_heritage_clause();
         let body = self.parse_ts_interface_body();
-        let extends = extends.map_or_else(
-            || self.ast.vec(),
-            |e| {
-                self.ast.vec_from_iter(e.into_iter().map(|(expression, type_parameters, span)| {
-                    TSInterfaceHeritage { span, expression, type_arguments: type_parameters }
-                }))
-            },
-        );
+        let extends = extends.unwrap_or_else(|| self.ast.vec());
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE,

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,8 +1,8 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267681 |          22847
+checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267680 |          22847
 
-cal.com.tsx                | 1.06 MB        ||           1091 |             49 ||         138162 |          13699
+cal.com.tsx                | 1.06 MB        ||           1091 |             49 ||         138159 |          13699
 
 RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            365 |             66
 


### PR DESCRIPTION
- related to https://github.com/oxc-project/backlog/issues/74

this was a small refactor that came out of removing the extra pass for counting nodes in semantic. this is the only place (as far as I can tell) that we don't use the `AstBuilder` functions in the parser.

- updated parsing code to use `AstBuilder` instead of `TSInterfaceHeritage { ... }` directly
- reduced allocations by returning `TSInterfaceHeritage` directly from parsing functions, instead of its constituent data