### PR TITLE
fix(formatter): should not set up tailwindcss callback when no tailwindcss configuration is set

### DIFF
--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -143,15 +143,7 @@ impl SourceFormatter {
                 .as_ref()
                 .expect("`external_formatter` must exist when `napi` feature is enabled");
 
-            // Only create callbacks if at least one feature needs them
-            let needs_embedded = !format_options.embedded_language_formatting.is_off();
-            let needs_tailwind = format_options.experimental_tailwindcss.is_some();
-
-            if needs_embedded || needs_tailwind {
-                Some(external_formatter.to_external_callbacks(path, external_options))
-            } else {
-                None
-            }
+            Some(external_formatter.to_external_callbacks(path, &format_options, external_options))
         };
 
         #[cfg(not(feature = "napi"))]

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -31,15 +31,15 @@ impl ExternalCallbacks {
 
     /// Set the embedded formatter callback.
     #[must_use]
-    pub fn with_embedded_formatter(mut self, callback: EmbeddedFormatterCallback) -> Self {
-        self.embedded_formatter = Some(callback);
+    pub fn with_embedded_formatter(mut self, callback: Option<EmbeddedFormatterCallback>) -> Self {
+        self.embedded_formatter = callback;
         self
     }
 
     /// Set the Tailwind callback.
     #[must_use]
-    pub fn with_tailwind(mut self, callback: TailwindCallback) -> Self {
-        self.tailwind = Some(callback);
+    pub fn with_tailwind(mut self, callback: Option<TailwindCallback>) -> Self {
+        self.tailwind = callback;
         self
     }
 


### PR DESCRIPTION
Only set up the tailwindcss callback when the `experimentalTailwindcss` configuration is set. Previously, it would also set up when the `emebeddedLanguageFormatting` is `on`.