### PR TITLE
refactor(formatter): remove unnecessary clone for FormatContext and all its fields

### DIFF
--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -17,7 +17,7 @@ const SUPPORTED_TAGS: &[&str] = &["css", "styled", "gql", "graphql", "html", "md
 /// This struct holds all callbacks that delegate to external (typically JS) implementations:
 /// - Embedded language formatting (CSS, GraphQL, HTML in template literals)
 /// - Tailwind CSS class sorting
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct ExternalCallbacks {
     embedded_formatter: Option<EmbeddedFormatterCallback>,
     tailwind: Option<TailwindCallback>,

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -84,7 +84,6 @@ impl TailwindContextEntry {
 }
 
 /// Context object storing data relevant when formatting an object.
-#[derive(Clone)]
 pub struct FormatContext<'ast> {
     options: FormatOptions,
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -56,7 +56,7 @@ pub use self::{
 };
 use self::{format_element::document::Document, group_id::UniqueGroupIdBuilder, prelude::TagKind};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Formatted<'a> {
     document: Document<'a>,
     context: FormatContext<'a>,


### PR DESCRIPTION
Clone trait is unnecessary, so remove it.