### PR TITLE
perf(formatter): don't call `sort_tailwind_classes` if no classes need to be sorted

### DIFF
--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -70,6 +70,10 @@ impl ExternalCallbacks {
     /// # Returns
     /// The sorted classes, or the original classes unsorted if no Tailwind callback is set.
     pub fn sort_tailwind_classes(&self, classes: Vec<String>) -> Vec<String> {
+        if classes.is_empty() {
+            return classes;
+        }
+
         match self.tailwind.as_ref() {
             Some(cb) => cb(classes),
             None => classes,


### PR DESCRIPTION
If the classes are empty, that means no classes need to be sorted. Then return the original one to avoid calling the JS side, which is quite a costly function.

After this, the formatting time went from `8s` to `2s` in the `outline` repo locally.