### PR TITLE
fix(oxfmt,oxlint): Use correct logging facade so logs are actually output to stdout when enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,7 +2550,6 @@ dependencies = [
  "ignore",
  "insta",
  "json-strip-comments",
- "log",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2586,7 +2585,6 @@ dependencies = [
  "ignore",
  "insta",
  "lazy-regex",
- "log",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2610,6 +2608,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp-server",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -41,7 +41,6 @@ cow-utils = { workspace = true }
 editorconfig-parser = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 json-strip-comments = { workspace = true }
-log = { workspace = true }
 miette = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::lsp::{FORMAT_CONFIG_FILES, options::FormatOptions as LSPFormatOptions};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use log::{debug, warn};
 use oxc_allocator::Allocator;
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_formatter::{
@@ -10,8 +10,7 @@ use oxc_formatter::{
 };
 use oxc_parser::Parser;
 use tower_lsp_server::ls_types::{Pattern, Position, Range, ServerCapabilities, TextEdit, Uri};
-
-use crate::lsp::{FORMAT_CONFIG_FILES, options::FormatOptions as LSPFormatOptions};
+use tracing::{debug, warn};
 
 use oxc_language_server::{
     Capabilities,
@@ -82,9 +81,10 @@ impl ServerFormatterBuilder {
                 Oxfmtrc::default()
             }
         } else {
+            let config_names = &FORMAT_CONFIG_FILES.join(", ");
             warn!(
                 "Config file not found: {}, fallback to default config",
-                config_path.unwrap_or(&FORMAT_CONFIG_FILES.join(", "))
+                config_path.unwrap_or(config_names)
             );
             Oxfmtrc::default()
         }

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -42,7 +42,6 @@ bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"]
 cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 miette = { workspace = true }
-log = { workspace = true }
 napi = { workspace = true, features = ["async"], optional = true }
 napi-derive = { workspace = true, optional = true }
 rayon = { workspace = true }
@@ -52,6 +51,7 @@ serde_json = { workspace = true }
 simdutf8 = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 tower-lsp-server = { workspace = true, features = ["proposed"] }
 

--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use tower_lsp_server::ls_types::{CodeAction, CodeActionKind, TextEdit, Uri, WorkspaceEdit};
+use tracing::debug;
 
 use crate::lsp::error_with_position::{FixedContent, LinterCodeAction};
 

--- a/apps/oxlint/src/lsp/isolated_lint_handler.rs
+++ b/apps/oxlint/src/lsp/isolated_lint_handler.rs
@@ -3,10 +3,10 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use log::{debug, warn};
 use oxc_data_structures::rope::Rope;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::Uri;
+use tracing::{debug, warn};
 
 use oxc_allocator::Allocator;
 use oxc_linter::{

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ignore::gitignore::Gitignore;
-use log::{debug, warn};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::{DiagnosticOptions, DiagnosticServerCapabilities};
 use tower_lsp_server::{
@@ -13,6 +12,7 @@ use tower_lsp_server::{
         WorkDoneProgressOptions, WorkspaceEdit,
     },
 };
+use tracing::{debug, warn};
 
 use oxc_linter::{
     AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, ExternalPluginStore, FixKind,


### PR DESCRIPTION
The `log` crate alone doesn't output anything, so these existing logs aren't actually being output. This changes the logs to use the `tracing` crate which is configured to output logs to stdout.

Haven't been able to test this yet, but I think it's the right fix.

Ref: https://github.com/oxc-project/oxc/issues/17702