### PR TITLE
refactor(oxlint,oxfmt): Use `tracing` logger for LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,26 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,30 +1228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5434eb9cfce6454c4573a63f43fe6ea2e2a3e99e4da1620d41c1503a12b4223c"
 dependencies = [
  "phf",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2018,15 +1974,14 @@ dependencies = [
 name = "oxc_language_server"
 version = "1.38.0"
 dependencies = [
- "env_logger",
  "futures",
- "log",
  "papaya",
  "rustc-hash",
  "serde",
  "serde_json",
  "tokio",
  "tower-lsp-server",
+ "tracing",
 ]
 
 [[package]]
@@ -2550,7 +2505,6 @@ dependencies = [
  "ignore",
  "insta",
  "json-strip-comments",
- "log",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2586,7 +2540,6 @@ dependencies = [
  "ignore",
  "insta",
  "lazy-regex",
- "log",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2610,6 +2563,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp-server",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -2777,21 +2731,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,6 @@ criterion2 = { version = "3.0.2", default-features = false } # Benchmarking
 dragonbox_ecma = "0.0.5" # Fast float formatting
 encoding_rs = "0.8.35" # Character encoding
 encoding_rs_io = "0.1.7" # Encoding I/O
-env_logger = { version = "0.11.8", default-features = false } # Logging implementation
 fast-glob = "1.0.0" # Fast glob matching
 flate2 = "1.1.5" # Compression
 futures = "0.3.31" # Async utilities
@@ -198,7 +197,6 @@ itertools = "0.14.0" # Iterator utilities
 itoa = "1.0.15" # Integer to string
 language-tags = "0.3.2" # Language tag parsing
 lazy-regex = "3.4.2" # Lazy regex compilation
-log = "0.4.29" # Logging facade
 markdown = "1.0.0" # Markdown parsing
 memchr = "2.7.6" # Fast byte searching
 miette = { package = "oxc-miette", version = "2.7.0", features = [

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -41,7 +41,6 @@ cow-utils = { workspace = true }
 editorconfig-parser = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 json-strip-comments = { workspace = true }
-log = { workspace = true }
 miette = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }

--- a/apps/oxfmt/src/cli/init.rs
+++ b/apps/oxfmt/src/cli/init.rs
@@ -44,23 +44,3 @@ pub fn init_rayon(threads: Option<usize>) {
 
     rayon::ThreadPoolBuilder::new().num_threads(thread_count).build_global().unwrap();
 }
-
-/// To debug `oxc_formatter`:
-/// `OXC_LOG=oxc_formatter oxfmt`
-/// # Panics
-pub fn init_tracing() {
-    use tracing_subscriber::{filter::Targets, prelude::*};
-
-    // Usage without the `regex` feature.
-    // <https://github.com/tokio-rs/tracing/issues/1436#issuecomment-918528013>
-    tracing_subscriber::registry()
-        .with(std::env::var("OXC_LOG").map_or_else(
-            |_| Targets::new(),
-            |env_var| {
-                use std::str::FromStr;
-                Targets::from_str(&env_var).unwrap()
-            },
-        ))
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-}

--- a/apps/oxfmt/src/cli/mod.rs
+++ b/apps/oxfmt/src/cli/mod.rs
@@ -6,9 +6,10 @@ mod result;
 mod service;
 mod walk;
 
+pub use crate::core::utils::init_tracing;
 #[cfg(feature = "napi")]
 pub use command::MigrateSource;
 pub use command::{FormatCommand, Mode, format_command};
 pub use format::FormatRunner;
-pub use init::{init_miette, init_rayon, init_tracing};
+pub use init::{init_miette, init_rayon};
 pub use result::CliRunResult;

--- a/apps/oxfmt/src/core/utils.rs
+++ b/apps/oxfmt/src/core/utils.rs
@@ -1,5 +1,29 @@
 use std::{fs, io, io::Write, path::Path};
 
+/// To debug `oxc_formatter`:
+/// `OXC_LOG=oxc_formatter oxfmt`
+/// # Panics
+pub fn init_tracing() {
+    use tracing_subscriber::{filter::Targets, prelude::*};
+
+    // Usage without the `regex` feature.
+    // <https://github.com/tokio-rs/tracing/issues/1436#issuecomment-918528013>
+    tracing_subscriber::registry()
+        .with(std::env::var("OXC_LOG").map_or_else(
+            |_| Targets::new(),
+            |env_var| {
+                use std::str::FromStr;
+                Targets::from_str(&env_var).unwrap()
+            },
+        ))
+        .with(
+            tracing_subscriber::fmt::layer()
+                // https://github.com/tokio-rs/tracing/issues/2492
+                .with_writer(std::io::stderr),
+        )
+        .init();
+}
+
 pub fn read_to_string(path: &Path) -> io::Result<String> {
     // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
     let bytes = fs::read(path)?;

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use log::{debug, warn};
 use tower_lsp_server::ls_types::{Pattern, Position, Range, ServerCapabilities, TextEdit, Uri};
+use tracing::{debug, warn};
 
 use oxc_allocator::Allocator;
 use oxc_data_structures::rope::{Rope, get_line_column};
@@ -75,7 +75,6 @@ impl ToolBuilder for ServerFormatterBuilder {
 
 impl ServerFormatterBuilder {
     /// Build a `ConfigResolver` from config paths.
-    ///
     /// Returns the resolver and ignore patterns.
     ///
     /// # Errors

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -7,11 +7,11 @@ use oxc_napi::OxcError;
 use serde_json::Value;
 
 use crate::{
-    cli::{FormatRunner, Mode, format_command, init_miette, init_rayon, init_tracing},
+    cli::{FormatRunner, Mode, format_command, init_miette, init_rayon},
     core::{
         ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult as CoreFormatResult,
         JsFormatEmbeddedCb, JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb,
-        SourceFormatter,
+        SourceFormatter, utils,
     },
     lsp::run_lsp,
     stdin::StdinRunner,
@@ -68,11 +68,14 @@ pub async fn run_cli(
         Mode::Init => ("init".to_string(), None),
         Mode::Migrate(_) => ("migrate:prettier".to_string(), None),
         Mode::Lsp => {
+            utils::init_tracing();
+
             run_lsp().await;
+
             ("lsp".to_string(), Some(0))
         }
         Mode::Stdin(_) => {
-            init_tracing();
+            utils::init_tracing();
             init_miette();
 
             let result = StdinRunner::new(command)
@@ -88,7 +91,7 @@ pub async fn run_cli(
             ("stdin".to_string(), Some(result.exit_code()))
         }
         Mode::Cli(_) => {
-            init_tracing();
+            utils::init_tracing();
             init_miette();
             init_rayon(command.runtime_options.threads);
 

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -42,8 +42,8 @@ bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"]
 cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 miette = { workspace = true }
-log = { workspace = true }
 napi = { workspace = true, features = ["async"], optional = true }
+tracing = { workspace = true }
 napi-derive = { workspace = true, optional = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }

--- a/apps/oxlint/src/init.rs
+++ b/apps/oxlint/src/init.rs
@@ -20,6 +20,10 @@ pub fn init_tracing() {
                 Targets::from_str(&env_var).unwrap()
             },
         ))
-        .with(tracing_subscriber::fmt::layer())
+        .with(
+            tracing_subscriber::fmt::layer()
+                // https://github.com/tokio-rs/tracing/issues/2492
+                .with_writer(std::io::stderr),
+        )
         .init();
 }

--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use tower_lsp_server::ls_types::{CodeAction, CodeActionKind, TextEdit, Uri, WorkspaceEdit};
+use tracing::debug;
 
 use crate::lsp::error_with_position::{FixedContent, LinterCodeAction};
 

--- a/apps/oxlint/src/lsp/isolated_lint_handler.rs
+++ b/apps/oxlint/src/lsp/isolated_lint_handler.rs
@@ -3,10 +3,10 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use log::{debug, warn};
 use oxc_data_structures::rope::Rope;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::Uri;
+use tracing::{debug, warn};
 
 use oxc_allocator::Allocator;
 use oxc_linter::{

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ignore::gitignore::Gitignore;
-use log::{debug, warn};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::{DiagnosticOptions, DiagnosticServerCapabilities};
 use tower_lsp_server::{
@@ -13,6 +12,7 @@ use tower_lsp_server::{
         WorkDoneProgressOptions, WorkspaceEdit,
     },
 };
+use tracing::{debug, warn};
 
 use oxc_linter::{
     AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, ExternalLinter, ExternalPluginStore,

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -7,13 +7,15 @@ async fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = lint_command().run();
 
+    // Both LSP and CLI use `tracing` for logging
+    init_tracing();
+
     // If --lsp flag is set, run the language server
     if command.lsp {
         run_lsp().await;
         return CliRunResult::LintSucceeded;
     }
 
-    init_tracing();
     init_miette();
 
     command.handle_threads();

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -123,13 +123,15 @@ async fn lint_impl(
         }
     };
 
+    // Both LSP and CLI use `tracing` for logging
+    init_tracing();
+
     // If --lsp flag is set, run the language server
     if command.lsp {
         crate::lsp::run_lsp().await;
         return CliRunResult::LintSucceeded;
     }
 
-    init_tracing();
     init_miette();
 
     command.handle_threads();

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -20,10 +20,9 @@ workspace = true
 doctest = false
 
 [dependencies]
-env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }
-log = { workspace = true }
 papaya = { workspace = true }
+tracing = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
 use futures::future::join_all;
-use log::{debug, error, info, warn};
 use rustc_hash::FxBuildHasher;
 use serde_json::Value;
 use tokio::sync::{OnceCell, RwLock, SetError};
@@ -19,6 +18,7 @@ use tower_lsp_server::{
         Uri,
     },
 };
+use tracing::{debug, error, info, warn};
 
 use crate::{
     ConcurrentHashMap, ToolBuilder,

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -22,8 +22,6 @@ pub async fn run_server(
     server_version: String,
     tools: Vec<Box<dyn ToolBuilder>>,
 ) {
-    env_logger::init();
-
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::json;
 use std::sync::Arc;
@@ -11,6 +10,7 @@ use tower_lsp_server::{
         TextEdit, Unregistration, Uri, WatchKind, WorkspaceEdit,
     },
 };
+use tracing::debug;
 
 use crate::{
     ToolRestartChanges,

--- a/editors/vscode/client/tools/lsp_helper.ts
+++ b/editors/vscode/client/tools/lsp_helper.ts
@@ -4,7 +4,8 @@ import { Executable, MessageType, ShowMessageParams } from "vscode-languageclien
 export function runExecutable(path: string, nodePath?: string, tsgolintPath?: string): Executable {
   const serverEnv: Record<string, string> = {
     ...process.env,
-    RUST_LOG: process.env.RUST_LOG || "info",
+    RUST_LOG: process.env.RUST_LOG || "info", // Keep for backward compatibility for a while
+    OXC_LOG: process.env.OXC_LOG || "info",
   };
   if (nodePath) {
     serverEnv.PATH = `${nodePath}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`;


### PR DESCRIPTION
Fixes #17702 

NOTE: Environment variable has changed from `RUST_LOG` to `OXC_LOG`.