### PR TITLE
fix(formatter): should not treat multi-type arguments of TSTypeReference as a complex type

### DIFF
--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -1027,7 +1027,7 @@ fn is_complex_type_arguments(type_arguments: &TSTypeParameterInstantiation) -> b
         if let TSType::TSTypeReference(type_ref) = first_argument
             && let Some(type_args) = &type_ref.type_arguments
         {
-            return is_complex_type_arguments(type_args);
+            return type_args.params.iter().any(is_complex_ts_type);
         }
 
         false

--- a/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts
@@ -18,3 +18,8 @@ export class Test {
 		  }>
 	  >();
 }
+
+// Non-complex type arguments, as none of the type arguments of Record is a complex type.
+const result = configurationService.getValue<Record<string, boolean>>(
+  enalementSetting
+);

--- a/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/assignments/complex-type-arguments.ts.snap
@@ -23,6 +23,11 @@ export class Test {
 	  >();
 }
 
+// Non-complex type arguments, as none of the type arguments of Record is a complex type.
+const result = configurationService.getValue<Record<string, boolean>>(
+  enalementSetting
+);
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -48,6 +53,10 @@ export class Test {
   >();
 }
 
+// Non-complex type arguments, as none of the type arguments of Record is a complex type.
+const result =
+  configurationService.getValue<Record<string, boolean>>(enalementSetting);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -71,5 +80,8 @@ export class Test {
     }>
   >();
 }
+
+// Non-complex type arguments, as none of the type arguments of Record is a complex type.
+const result = configurationService.getValue<Record<string, boolean>>(enalementSetting);
 
 ===================== End =====================


### PR DESCRIPTION

**Input:**
<!-- prettier-ignore -->
```tsx

// Non-complex type arguments, as none of the type arguments of Record is a complex type.
const result = configurationService.getValue<Record<string, boolean>>(
  enalementSetting
);
```

**Before output:**
<!-- prettier-ignore -->
```tsx
// Non-complex type arguments, as none of the type arguments of Record is a complex type.
const result = configurationService.getValue<
  Record<string, boolean>
>(enalementSetting);

```


[Prettier Playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAdKB6DACActAWkgFsAHAGzgA9sYBPUubAQwCcBzAV2IRgGcANCz7Yo0JhABmtABZN6jFh268RU7ACU4kVgBNsASxHNsJCtVoM4AOnSQofGNlZw+nck4C8p6JINdWZhgDaABlOFYANwMwG3Y4GAA1ZnJOOAAeLR1ddMdWAyh2IQAjCAhKZigAPiqACnRsbAQUuB5YcJhgwvQASgBuEAEQCFJg6D5kUDZWCAB3AAU2BAmUFNnmOgmh4sCwAGsE0OYeABkCuGRJFL44IYhigCttGAB1QNJkEFIXG6iL7d2BxgoVIzDABXYyBgrDSQxuxAMUJhtxA1EY+TaMBSAHl0UEIKx5hA+AYxlBPghdINUVR0QZMSkACoRKBsAyuS7XFEkwqUACKnAg8E55BuQwefCooQh-MFwqQV1FKIAjnK4PMZqQViBmHwCFA4HBdEbqdDmAZyBCAMIQYjEZifFLkak89iUACCnXyxU48HmETOBpFYpAMhgxHILxkpNcoNi4QcpIM0XonzAfC2IEiaQAklBje0wPlRu786F6JRgyjvsS4G9mB8UN9XBFIv9UfnsZJAxcUORJNSCr8YBrmOx7VWhqDWL9PsVmMU4OQCPxqd8Cq8DLoYDJkAAOAAMQxcqoMLlH44dCq5QyxxReW53yAATENODdGQuVoqQ61F7pjV0E5Ki4Mc4AAMQJe1OghR1fQgEAAF9EKAA)
**After output:**
<!-- prettier-ignore -->
```tsx
// Non-complex type arguments, as none of the type arguments of Record is a complex type.
const result =
  configurationService.getValue<Record<string, boolean>>(enalementSetting);

```
