### PR TITLE
fix(parser): preserve `@__NO_SIDE_EFFECTS__` annotation with parenthesized expressions

### DIFF
--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -510,6 +510,13 @@ delete /* @__PURE__ */ (() => {})();",
             "const Foo = /* @__PURE__ */ (() => {})()<X>",
             "const Foo = /* @__PURE__ */ <Foo>(() => {})()!",
             "const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y",
+            // https://github.com/oxc-project/oxc/issues/17670 - annotation before parenthesized arrow function
+            r"/* @__NO_SIDE_EFFECTS__ */ ((options, extraOptions) => {
+  return defineCustomElement(options, extraOptions, hydrate);
+})",
+            r"/* @__NO_SIDE_EFFECTS__ */ ((x) => x)",
+            r"/* @__NO_SIDE_EFFECTS__ */ (function() {})",
+            r"/* @__NO_SIDE_EFFECTS__ */ (function foo() {})",
         ];
 
         snapshot("pure_comments", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/oxc_codegen/tests/integration/main.rs
+source: crates/oxc_codegen/tests/integration/tester.rs
 ---
 ########## 0
 
@@ -467,3 +467,27 @@ const Foo = (<Foo>(/* @__PURE__ */ (() => {})())!);
 const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y
 ----------
 const Foo = (((<Foo>(/* @__PURE__ */ (() => {})())!) as X) satisfies Y);
+
+########## 31
+/* @__NO_SIDE_EFFECTS__ */ ((options, extraOptions) => {
+  return defineCustomElement(options, extraOptions, hydrate);
+})
+----------
+/* @__NO_SIDE_EFFECTS__ */ ((options, extraOptions) => {
+	return defineCustomElement(options, extraOptions, hydrate);
+});
+
+########## 32
+/* @__NO_SIDE_EFFECTS__ */ ((x) => x)
+----------
+/* @__NO_SIDE_EFFECTS__ */ ((x) => x);
+
+########## 33
+/* @__NO_SIDE_EFFECTS__ */ (function() {})
+----------
+/* @__NO_SIDE_EFFECTS__ */ (function() {});
+
+########## 34
+/* @__NO_SIDE_EFFECTS__ */ (function foo() {})
+----------
+/* @__NO_SIDE_EFFECTS__ */ (function foo() {});

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -45,6 +45,8 @@ pub struct LexerCheckpoint<'a> {
     source_position: SourcePosition<'a>,
     token: Token,
     errors_snapshot: ErrorSnapshot,
+    has_pure_comment: bool,
+    has_no_side_effects_comment: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -153,6 +155,8 @@ impl<'a> Lexer<'a> {
             source_position: self.source.position(),
             token: self.token,
             errors_snapshot,
+            has_pure_comment: self.trivia_builder.has_pure_comment,
+            has_no_side_effects_comment: self.trivia_builder.has_no_side_effects_comment,
         }
     }
 
@@ -168,6 +172,8 @@ impl<'a> Lexer<'a> {
             source_position: self.source.position(),
             token: self.token,
             errors_snapshot,
+            has_pure_comment: self.trivia_builder.has_pure_comment,
+            has_no_side_effects_comment: self.trivia_builder.has_no_side_effects_comment,
         }
     }
 
@@ -180,6 +186,8 @@ impl<'a> Lexer<'a> {
         }
         self.source.set_position(checkpoint.source_position);
         self.token = checkpoint.token;
+        self.trivia_builder.has_pure_comment = checkpoint.has_pure_comment;
+        self.trivia_builder.has_no_side_effects_comment = checkpoint.has_no_side_effects_comment;
     }
 
     pub fn peek_token(&mut self) -> Token {


### PR DESCRIPTION
Fixes #17670

Two issues caused the annotation to be lost:
1. LexerCheckpoint did not save/restore trivia flags, so lookahead operations would reset them
2. parse_parenthesized_expression did not capture the annotation before bumping `(`


monitor oxc https://github.com/oxc-project/monitor-oxc/actions/runs/20745400998/job/59561563786

CI is not yet green, but the codegen diff looks a lot better