### PR TITLE
feat(vscode): activate extension on more languages

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -284,12 +284,20 @@
   },
   "activationEvents": [
     "onLanguage:astro",
+    "onLanguage:css",
+    "onLanguage:handlebars",
+    "onLanguage:html",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
+    "onLanguage:json",
+    "onLanguage:jsonc",
+    "onLanguage:markdown",
     "onLanguage:svelte",
+    "onLanguage:toml",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
-    "onLanguage:vue"
+    "onLanguage:vue",
+    "onLanguage:yaml"
   ],
   "icon": "icon.png",
   "engines": {


### PR DESCRIPTION
Follow up from https://github.com/oxc-project/oxc/pull/17615

Activates the extension on the languages which are supported now by `oxfmt`