### PR TITLE
fix(oxlint): do not panic on invalid `no-unused-vars` configuration

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -203,7 +203,7 @@ impl Deref for NoUnusedVars {
 
 impl Rule for NoUnusedVars {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(Self(Box::new(NoUnusedVarsOptions::try_from(value).unwrap())))
+        Ok(Self(Box::new(NoUnusedVarsOptions::try_from(value).unwrap_or_default())))
     }
 
     fn run_once(&self, ctx: &LintContext) {


### PR DESCRIPTION
I tried to return `serde_json::Error::Error`, but `NoUnusedVarsOptions::try_from` is returning diagnostics / strings, which can not easily be converted to `serde_json::Error::Error` (I could not achieve this :( ). So falling back to the default configuration, instead of panicking.

closes https://github.com/oxc-project/oxc/issues/17715