### PR TITLE
fix(formatter): classes will be stripped out when both `experimentalTailwindcss` and `experimentalSortImports` are enabled

### DIFF
--- a/apps/oxfmt/test/tailwindcss.test.ts
+++ b/apps/oxfmt/test/tailwindcss.test.ts
@@ -1010,3 +1010,42 @@ describe("Tailwind CSS Sorting (Non-JS Files)", () => {
     expect(result.errors).toStrictEqual([]);
   });
 });
+
+describe("Tailwind CSS Sorting with `experimentalSortImports` enabled", () => {
+  test("should sort Tailwind classes in default options", async () => {
+    const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
+
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {},
+    });
+
+    // After sorting, flex should come before p-4 (display before spacing)
+    // The exact order of bg-red-500 and text-white may vary by Tailwind version
+    expect(result.code).toContain('className="flex');
+    expect(result.code).not.toContain('className="p-4 flex'); // p-4 should not be before flex
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  test("should preserve whitespace when preserveWhitespace is true", async () => {
+    // Input with leading/trailing whitespace in class string
+    const input = `const A = <div className="  p-4 flex  ">Hello</div>;`;
+
+    // Without preserveWhitespace, whitespace should be trimmed
+    const resultWithoutOption = await format("test.tsx", input, {
+      experimentalTailwindcss: {},
+      experimentalSortImports: {},
+    });
+    expect(resultWithoutOption.code).toContain('className="flex p-4"');
+
+    // With preserveWhitespace: true, whitespace should be preserved
+    const resultWithOption = await format("test.tsx", input, {
+      experimentalTailwindcss: {
+        preserveWhitespace: true,
+      },
+      experimentalSortImports: {},
+    });
+    // Whitespace should be preserved around the sorted classes
+    expect(resultWithOption.code).toContain('className="  flex p-4  "');
+    expect(resultWithOption.errors).toStrictEqual([]);
+  });
+});

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -32,6 +32,14 @@ impl<'a> Document<'a> {
     pub fn into_elements_and_tailwind_classes(self) -> (&'a [FormatElement<'a>], Vec<String>) {
         (self.elements, self.sorted_tailwind_classes)
     }
+
+    /// Replaces the document's format elements with new ones.
+    ///
+    /// If you have modified the elements and want to update the document,
+    /// use this method to set the new elements.
+    pub fn replace_elements(&mut self, elements: ArenaVec<'a, FormatElement<'a>>) {
+        self.elements = elements.into_bump_slice();
+    }
 }
 
 impl Document<'_> {
@@ -147,12 +155,6 @@ impl Document<'_> {
         let mut enclosing: Vec<Enclosing> = Vec::new();
         let mut interned = FxHashMap::default();
         propagate_expands(self, &mut enclosing, &mut interned);
-    }
-}
-
-impl<'a> From<ArenaVec<'a, FormatElement<'a>>> for Document<'a> {
-    fn from(elements: ArenaVec<'a, FormatElement<'a>>) -> Self {
-        Self { elements: elements.into_bump_slice(), sorted_tailwind_classes: Vec::default() }
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -1611,7 +1611,7 @@ two lines`,
             )
             .finish();
 
-        let document = Document::from(buffer.into_vec());
+        let document = Document::new(buffer.into_vec(), Vec::default());
 
         let printed = Printer::new(
             PrinterOptions::default()

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -36,7 +36,7 @@ impl SortImportsTransform {
         document: &Document<'a>,
         options: &SortImportsOptions,
         allocator: &'a Allocator,
-    ) -> Option<Document<'a>> {
+    ) -> Option<ArenaVec<'a, FormatElement<'a>>> {
         // Early return for empty files
         if document.len() == 1 && matches!(document[0], FormatElement::Line(LineMode::Hard)) {
             return None;
@@ -305,6 +305,6 @@ impl SortImportsTransform {
             }
         }
 
-        Some(Document::from(next_elements))
+        Some(next_elements)
     }
 }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -79,13 +79,13 @@ impl<'a> Formatter<'a> {
         // Basic formatting and `document.propagate_expand()` are already done here.
         // Now apply additional transforms if enabled.
         if let Some(sort_imports_options) = &formatted.context().options().experimental_sort_imports
-            && let Some(transformed_document) = SortImportsTransform::transform(
+            && let Some(transformed_elements) = SortImportsTransform::transform(
                 formatted.document(),
                 sort_imports_options,
                 self.allocator,
             )
         {
-            *formatted.document_mut() = transformed_document;
+            formatted.document_mut().replace_elements(transformed_elements);
         }
 
         formatted

--- a/crates/oxc_formatter/src/write/template.rs
+++ b/crates/oxc_formatter/src/write/template.rs
@@ -662,7 +662,7 @@ impl<'a> EachTemplateTable<'a> {
 
             recording.stop();
 
-            let root = Document::from(vec_buffer.into_vec());
+            let root = Document::new(vec_buffer.into_vec(), Vec::default());
 
             // let range = element.range();
             let print_options = f.options().as_print_options();


### PR DESCRIPTION
close: #17725

This is caused by our use of `Document::from` for sorted elements when `experimentalSortImports` is enabled. This method will use `Vec::default()` for `sorted_tailwind_classes`, which causes classes to be stripped.

In this PR,

I removed `Document::from` and used `Document::new` everywhere that needs to pass `sorted_tailwind_classes` explicitly, so that we can ensure it is passed correctly. 

And for the `experimentalSortImports`, it will replace sorted elements directly instead of constructing a new `Document`, so that the `sorted_tailwind_classes` remains as is.