### PR TITLE
perf(semantic): use smallvec for storing reference IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,7 @@ dependencies = [
  "rustc-hash",
  "self_cell",
  "serde_json",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -35,6 +35,7 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -525,7 +525,8 @@ impl<'a> SemanticBuilder<'a> {
             let bindings = self.scoping.get_bindings(self.current_scope_id);
             if let Some(symbol_id) = bindings.get(name.as_str()).copied() {
                 let symbol_flags = self.scoping.symbol_flags(symbol_id);
-                references.retain(|&reference_id| {
+                references.retain(|reference_id| {
+                    let reference_id = *reference_id;
                     let reference = &mut self.scoping.references[reference_id];
 
                     let flags = reference.flags_mut();

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -250,6 +250,8 @@ mod scoping_cell {
 }
 use scoping_cell::ScopingCell;
 
+use crate::unresolved_stack::ReferenceIds;
+
 pub struct ScopingInner<'cell> {
     /* Symbol Table Fields */
     symbol_names: ArenaVec<'cell, Atom<'cell>>,
@@ -627,7 +629,7 @@ impl Scoping {
 
     pub(crate) fn set_root_unresolved_references<'a>(
         &mut self,
-        entries: impl Iterator<Item = (&'a str, Vec<ReferenceId>)>,
+        entries: impl Iterator<Item = (&'a str, ReferenceIds)>,
     ) {
         self.cell.with_dependent_mut(|allocator, cell| {
             for (k, v) in entries {

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,12 +1,18 @@
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use oxc_data_structures::assert_unchecked;
 use oxc_span::Atom;
 use oxc_syntax::reference::ReferenceId;
 
+/// Stores reference IDs for a single identifier name within a scope.
+/// Uses `SmallVec` to avoid heap allocations for the common case where an identifier
+/// is referenced only a few times within a given scope.
+pub type ReferenceIds = SmallVec<[ReferenceId; 8]>;
+
 /// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Atom` as the key,
 /// and uses a heap-allocated hashmap (not arena-allocated)
-type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<ReferenceId>>;
+type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, ReferenceIds>;
 
 // Stack used to accumulate unresolved refs while traversing scopes.
 // Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal


### PR DESCRIPTION
We process a lot of identifiers. Some of the most commonly allocating operations are declaring identifier references and resolving them. However, most identifiers are not referenced hundreds of times. Instead, identifiers are typically referenced just a few times. So, we can optimize for the common case by inlining the list of reference IDs onto the stack through `smallvec`. As long as there are 8 IDs or fewer, then all of the references can be stored on the stack instead of in a heap allocated `Vec`. If there are more references than that, then it will heap allocate a larger array.

Based on some [benchmarking of different inline lengths](https://github.com/oxc-project/oxc/pull/17731#issuecomment-3717190681), I think inlining 8 IDs is close to maximizing the performance here and makes for a nice round number: 8 u32 = 32 bytes. This yields good performance on the benchmarks and shouldn't pessimize the performance too much when there are more than 8 IDs, since it will just fall back to acting like a normal `Vec`.