### PR TITLE
fix(linter/prefer-called-once): avoid panic on trailing comma

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called.rs
@@ -170,6 +170,13 @@ fn test() {
             None,
         ),
         (
+            "expect(method).toHaveBeenCalledTimes(
+            0,
+            );",
+            "expect(method).not.toHaveBeenCalled();",
+            None,
+        ),
+        (
             "expect(method).not.toHaveBeenCalledTimes(0);",
             "expect(method).toHaveBeenCalled();",
             None,
@@ -186,6 +193,26 @@ fn test() {
         ),
         (
             "expect(method).rejects.not.toHaveBeenCalledTimes(0);",
+            "expect(method).rejects.toHaveBeenCalled();",
+            None,
+        ),
+        (
+            "expect(method).rejects.not.toHaveBeenCalledTimes(0,);",
+            "expect(method).rejects.toHaveBeenCalled();",
+            None,
+        ),
+        (
+            "expect(method).rejects.not.toHaveBeenCalledTimes(
+            0,
+            );",
+            "expect(method).rejects.toHaveBeenCalled();",
+            None,
+        ),
+        (
+            "expect(method).rejects.not.toHaveBeenCalledTimes(
+                /* call this zero times (because I said so) */
+                0,
+            );",
             "expect(method).rejects.toHaveBeenCalled();",
             None,
         ),

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called_times.rs
@@ -215,6 +215,21 @@ fn test() {
             None,
         ),
         (
+            "expect(method.mock.calls).toHaveLength(
+                1,
+            );",
+            "expect(method).toHaveBeenCalledTimes(1);",
+            None,
+        ),
+        (
+            "expect(method.mock.calls).toHaveLength(
+                /* number of calls (one) */
+                1,
+            );",
+            "expect(method).toHaveBeenCalledTimes(1);",
+            None,
+        ),
+        (
             "expect(method.mock.calls).resolves.toHaveLength(x);",
             "expect(method).resolves.toHaveBeenCalledTimes(x);",
             None,

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
@@ -137,17 +137,17 @@ fn is_close_parenthesis(source_text: &str) -> bool {
 }
 
 fn get_inside_parenthesis_span(argument_span: Span, ctx: &LintContext<'_>) -> Span {
-    let mut inside_parentehsis_span = Span::new(argument_span.start, argument_span.end);
+    let mut inside_parenthesis_span = Span::new(argument_span.start, argument_span.end);
 
-    while !is_open_parenthesis(ctx.source_range(inside_parentehsis_span.expand_left(1))) {
-        inside_parentehsis_span = inside_parentehsis_span.expand_left(1);
+    while !is_open_parenthesis(ctx.source_range(inside_parenthesis_span.expand_left(1))) {
+        inside_parenthesis_span = inside_parenthesis_span.expand_left(1);
     }
 
-    while !is_close_parenthesis(ctx.source_range(inside_parentehsis_span.expand_right(1))) {
-        inside_parentehsis_span = inside_parentehsis_span.expand_right(1);
+    while !is_close_parenthesis(ctx.source_range(inside_parenthesis_span.expand_right(1))) {
+        inside_parenthesis_span = inside_parenthesis_span.expand_right(1);
     }
 
-    inside_parentehsis_span
+    inside_parenthesis_span
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
@@ -199,6 +199,25 @@ fn test() {
             );",
             "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();",
         ),
+        (
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1,);",
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();",
+        ),
+        (
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(/* comment (because why not) */1,);",
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();",
+        ),
+        (
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1/* comment (because why not) */,);",
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();",
+        ),
+        (
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(
+                /* I only want to call this function 1 (ONE) time, please. */
+                1,
+            );",
+            "expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();",
+        ),
     ];
     Tester::new(PreferCalledOnce::NAME, PreferCalledOnce::PLUGIN, pass, fail)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_called_once.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_called_once.snap
@@ -49,3 +49,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────────────────────────
    ╰────
   help: Prefer `toHaveBeenCalledOnce()`.
+
+  ⚠ eslint-plugin-vitest(prefer-called-once): The use of `toBeCalledTimes(1)` and `toHaveBeenCalledTimes(1)` is discouraged.
+   ╭─[prefer_called_once.tsx:1:53]
+ 1 │ ╭─▶ expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(
+ 2 │ │                 1,
+ 3 │ ╰─▶             );
+   ╰────
+  help: Prefer `toHaveBeenCalledOnce()`.


### PR DESCRIPTION
Fix https://github.com/oxc-project/oxc/issues/17733