### PR TITLE
fix(tasks/prettier_conformance): Map `options.objectWrap` correctly

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 736/761 (96.71%)
+js compatibility: 737/761 (96.85%)
 
 # Failed
 
@@ -19,7 +19,6 @@ js compatibility: 736/761 (96.71%)
 | js/identifier/for-of/let.js | 💥 | 92.31% |
 | js/identifier/parentheses/let.js | 💥💥 | 82.27% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
-| js/object-multiline/multiline.js | 💥✨ | 22.22% |
 | js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 578/605 (95.54%)
+ts compatibility: 579/605 (95.70%)
 
 # Failed
 
@@ -26,7 +26,6 @@ ts compatibility: 578/605 (95.54%)
 | typescript/mapped-type/break-mode/break-mode.ts | 💥 | 68.75% |
 | typescript/multiparser-css/issue-6259.ts | 💥 | 57.14% |
 | typescript/non-null/optional-chain.ts | 💥 | 72.22% |
-| typescript/object-multiline/multiline.ts | 💥✨ | 23.21% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/union/union-parens.ts | 💥 | 92.59% |
 | typescript/union/comments/18106.ts | 💥 | 92.68% |

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -7,7 +7,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::VisitMut;
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, FormatOptions,
+    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, FormatOptions,
     IndentStyle, IndentWidth, LineEnding, LineWidth, OperatorPosition, QuoteProperties, QuoteStyle,
     Semicolons, TrailingCommas,
 };
@@ -195,8 +195,15 @@ impl VisitMut<'_> for SpecParser {
                                 }
                                 "objectWrap" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
-                                    options.bracket_spacing =
-                                        BracketSpacing::from_str(s).unwrap_or_default();
+                                    options.expand = Expand::from_str(
+                                        // Prettier uses "preserve"/"collapse", but we use "auto"/"never"
+                                        match s {
+                                            "preserve" => "auto",
+                                            "collapse" => "never",
+                                            _ => s,
+                                        },
+                                    )
+                                    .unwrap_or_default();
                                 }
                                 "arrowParens" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`


### PR DESCRIPTION
It was mapped to `bracketSpacing` incorrectly before. 🙈 