### PR TITLE
fix(parser/trivia): correctly mark whether a block comment is on a newline

### DIFF
--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -33,6 +33,17 @@ fn unit() {
     test_same("export { parseAst as /** @deprecated */ b };\n");
 }
 
+pub mod misc_comments {
+    use crate::snapshot;
+
+    #[test]
+    fn comment() {
+        let cases = vec!["/** block1 */ /** block2 */\nfunction foo() {}\n"];
+
+        snapshot("misc_comments", &cases);
+    }
+}
+
 pub mod jsdoc {
     use crate::snapshot;
 

--- a/crates/oxc_codegen/tests/integration/snapshots/misc_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/misc_comments.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_codegen/tests/integration/tester.rs
+---
+########## 0
+/** block1 */ /** block2 */
+function foo() {}
+
+----------
+/** block1 *//** block2 */
+function foo() {}

--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -2,8 +2,4 @@ commit: 761c2509
 
 codegen_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2233/2235 (99.91%)
-Normal: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
-
-Normal: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
-
+Positive Passed: 2235/2235 (100.00%)

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -2,8 +2,4 @@ commit: 761c2509
 
 minifier_babel Summary:
 AST Parsed     : 1795/1795 (100.00%)
-Positive Passed: 1793/1795 (99.89%)
-Compress: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
-
-Compress: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
-
+Positive Passed: 1795/1795 (100.00%)

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -2,10 +2,6 @@ commit: 761c2509
 
 transformer_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2232/2235 (99.87%)
+Positive Passed: 2234/2235 (99.96%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowYieldOutsideFunction-true-2/input.js
-
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/47/input.js
-
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/48/input.js
 


### PR DESCRIPTION
CI is green(er) https://github.com/oxc-project/monitor-oxc/actions/runs/20788815777/job/59705840652