### PR TITLE
chore(ci): run `track_memory_allocations` when `oxc_semantic` changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
               - 'crates/oxc_minifier/**'
               - 'crates/oxc_mangler/**'
               - 'crates/oxc_allocator/**'
+              - 'crates/oxc_semantic/**'
               - 'tasks/track_memory_allocations/**'
 
       - uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12


### PR DESCRIPTION
cause of https://github.com/oxc-project/oxc/pull/17731 making `main` CI fail