### PR TITLE
fix(vscode): search for `oxlint` and `oxfmt` in every workspace directory

### DIFF
--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -30,6 +30,10 @@ const allTestSuites = new Map([
     {
       ...baseTest,
       files: "out_test/unit/**/*.spec.js",
+      workspaceFolder: multiRootWorkspaceFile,
+      env: {
+        MULTI_FOLDER_WORKSPACE: "true",
+      },
     },
   ],
   [


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-vscode/issues/93

Looks like people are using multiple workspaces more often, then I thought. Using now all workspaces to search for the binaries. Using `oxc.path.*` still will look only up the first workspace for relative paths.

We have a cancel-token of 10 seconds, maybe we should increase it to a respectable time for multi workspace?