### PR TITLE
fix(tasks/coverage): Update `Expand` format option usage

### DIFF
--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -2,7 +2,7 @@ commit: 761c2509
 
 formatter_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
-Positive Passed: 2228/2235 (99.69%)
+Positive Passed: 2229/2235 (99.73%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/async-arrow-function/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-method/input.js
@@ -15,5 +15,3 @@ Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basi
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/sequence-expression/input.js
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-false-positive/input.ts
-Unexpected token

--- a/tasks/coverage/src/tools/formatter.rs
+++ b/tasks/coverage/src/tools/formatter.rs
@@ -38,7 +38,7 @@ fn get_formatter_options_list() -> [FormatOptions; 3] {
             bracket_spacing: BracketSpacing::from(false),
             bracket_same_line: BracketSameLine::from(false),
             attribute_position: AttributePosition::Multiline,
-            expand: Expand::Always,
+            expand: Expand::Never,
             ..Default::default()
         },
         // Different from above two options
@@ -48,7 +48,6 @@ fn get_formatter_options_list() -> [FormatOptions; 3] {
             line_ending: LineEnding::Lf,
             quote_properties: QuoteProperties::Preserve,
             trailing_commas: TrailingCommas::None,
-            expand: Expand::Never,
             ..Default::default()
         },
     ]


### PR DESCRIPTION
Part of #17330

Do not use `Expand::Always`.