### PR TITLE
refactor(formatter)!: Remove `Expand::Always` variant

### DIFF
--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -85,9 +85,8 @@ export type FormatOptions = {
   bracketSameLine?: boolean;
   /**
    * How to wrap object literals when they could fit on one line or span multiple lines. (Default: `"preserve"`)
-   * NOTE: In addition to Prettier's `"preserve"` and `"collapse"`, we also support `"always"`.
    */
-  objectWrap?: "preserve" | "collapse" | "always";
+  objectWrap?: "preserve" | "collapse";
   /** Put each attribute on a new line in JSX. (Default: `false`) */
   singleAttributePerLine?: boolean;
   /** Control whether formats quoted code embedded in the file. (Default: `"auto"`) */

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -925,8 +925,6 @@ pub enum Expand {
     /// expanded if they are shorter than the line width.
     #[default]
     Auto,
-    /// Objects and arrays are always expanded.
-    Always,
     /// Objects and arrays are never expanded, if they are shorter than the line width.
     Never,
 }
@@ -937,7 +935,6 @@ impl FromStr for Expand {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "auto" => Ok(Self::Auto),
-            "always" => Ok(Self::Always),
             "never" => Ok(Self::Never),
             _ => Err(std::format!("unknown expand literal: {s}")),
         }
@@ -948,7 +945,6 @@ impl fmt::Display for Expand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             Expand::Auto => "Auto",
-            Expand::Always => "Always",
             Expand::Never => "Never",
         };
         f.write_str(s)

--- a/crates/oxc_formatter/src/oxfmtrc.rs
+++ b/crates/oxc_formatter/src/oxfmtrc.rs
@@ -64,7 +64,6 @@ pub struct Oxfmtrc {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_same_line: Option<bool>,
     /// How to wrap object literals when they could fit on one line or span multiple lines. (Default: `"preserve"`)
-    /// NOTE: In addition to Prettier's `"preserve"` and `"collapse"`, we also support `"always"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_wrap: Option<ObjectWrapConfig>,
     /// Put each attribute on a new line in JSX. (Default: `false`)
@@ -147,7 +146,6 @@ pub enum ArrowParensConfig {
 pub enum ObjectWrapConfig {
     Preserve,
     Collapse,
-    Always,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
@@ -486,8 +484,6 @@ impl Oxfmtrc {
             format_options.expand = match object_wrap {
                 ObjectWrapConfig::Preserve => Expand::Auto,
                 ObjectWrapConfig::Collapse => Expand::Never,
-                // NOTE: Our own extension
-                ObjectWrapConfig::Always => Expand::Always,
             };
         }
 
@@ -675,11 +671,10 @@ impl Oxfmtrc {
         );
 
         // [Prettier] objectWrap: "preserve" | "collapse"
-        // NOTE: "always" is our extension and not supported by Prettier, fallback to "preserve" for now
         obj.insert(
             "objectWrap".to_string(),
             Value::from(match options.expand {
-                Expand::Auto | Expand::Always => "preserve",
+                Expand::Auto => "preserve",
                 Expand::Never => "collapse",
             }),
         );
@@ -873,11 +868,6 @@ mod tests {
         let config: Oxfmtrc = serde_json::from_str(r#"{"objectWrap": "collapse"}"#).unwrap();
         let (format_options, _) = config.into_options().unwrap();
         assert_eq!(format_options.expand, Expand::Never);
-
-        // Test "always" remains unchanged
-        let config: Oxfmtrc = serde_json::from_str(r#"{"objectWrap": "always"}"#).unwrap();
-        let (format_options, _) = config.into_options().unwrap();
-        assert_eq!(format_options.expand, Expand::Always);
     }
 
     #[test]

--- a/crates/oxc_formatter/src/write/array_element_list.rs
+++ b/crates/oxc_formatter/src/write/array_element_list.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Expand, FormatTrailingCommas,
+    FormatTrailingCommas,
     ast_nodes::AstNode,
     formatter::{Buffer, Format, Formatter, GroupId, prelude::*, separated::FormatSeparatedIter},
     utils::array::write_array_node,
@@ -26,14 +26,12 @@ impl<'a, 'b> ArrayElementList<'a, 'b> {
 
 impl<'a> Format<'a> for ArrayElementList<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let expand_lists = f.context().options().expand == Expand::Always;
-        let layout = if expand_lists {
-            ArrayLayout::OnePerLine
-        } else if can_concisely_print_array_list(self.elements.parent.span(), self.elements, f) {
-            ArrayLayout::Fill
-        } else {
-            ArrayLayout::OnePerLine
-        };
+        let layout =
+            if can_concisely_print_array_list(self.elements.parent.span(), self.elements, f) {
+                ArrayLayout::Fill
+            } else {
+                ArrayLayout::OnePerLine
+            };
 
         match layout {
             ArrayLayout::Fill => {

--- a/crates/oxc_formatter/src/write/array_expression.rs
+++ b/crates/oxc_formatter/src/write/array_expression.rs
@@ -3,7 +3,6 @@ use oxc_ast::ast::*;
 use crate::{
     ast_nodes::AstNode,
     formatter::{Buffer, Formatter, prelude::*},
-    options::Expand,
     write,
 };
 
@@ -33,8 +32,7 @@ impl<'a> Format<'a> for FormatArrayExpression<'a, '_> {
             write!(f, format_dangling_comments(self.array.span).with_block_indent());
         } else {
             let group_id = f.group_id("array");
-            let should_expand = (!self.options.is_force_flat_mode && should_break(self.array))
-                || f.options().expand == Expand::Always;
+            let should_expand = !self.options.is_force_flat_mode && should_break(self.array);
 
             let elements = ArrayElementList::new(self.array.elements(), group_id);
 

--- a/crates/oxc_formatter/src/write/object_like.rs
+++ b/crates/oxc_formatter/src/write/object_like.rs
@@ -90,9 +90,8 @@ impl<'a> Format<'a> for ObjectLike<'a, '_> {
             write!(f, format_dangling_comments(self.span()).with_block_indent());
         } else {
             let should_insert_space_around_brackets = f.options().bracket_spacing.value();
-            let should_expand = (f.options().expand == Expand::Auto
-                && self.members_have_leading_newline(f))
-                || f.options().expand == Expand::Always;
+            let should_expand =
+                f.options().expand == Expand::Auto && self.members_have_leading_newline(f);
 
             // If the object type is the type annotation of the only parameter in a function,
             // try to hug the parameter; we don't create a group and inline the contents here.

--- a/crates/oxc_formatter/src/write/tuple_type.rs
+++ b/crates/oxc_formatter/src/write/tuple_type.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 
 use crate::{
-    Expand, Format, FormatTrailingCommas,
+    Format, FormatTrailingCommas,
     ast_nodes::AstNode,
     formatter::{Formatter, prelude::*, trivia::format_dangling_comments},
     write,
@@ -29,9 +29,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTupleType<'a>> {
         if element_types.is_empty() {
             write!(f, [format_dangling_comments(self.span).with_block_indent()]);
         } else {
-            let should_expand = f.options().expand == Expand::Always;
-
-            write!(f, [group(&soft_block_indent(&element_types)).should_expand(should_expand)]);
+            write!(f, [group(&soft_block_indent(&element_types))]);
         }
 
         write!(f, "]");

--- a/crates/oxc_formatter/tests/snapshots/schema_json.snap
+++ b/crates/oxc_formatter/tests/snapshots/schema_json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_formatter/tests/schema.rs
-assertion_line: 17
 expression: json
 ---
 {
@@ -33,8 +32,7 @@ expression: json
     "ObjectWrapConfig": {
       "enum": [
         "preserve",
-        "collapse",
-        "always"
+        "collapse"
       ],
       "type": "string"
     },
@@ -359,8 +357,8 @@ expression: json
           "type": "null"
         }
       ],
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)\nNOTE: In addition to Prettier's `\"preserve\"` and `\"collapse\"`, we also support `\"always\"`.",
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)\nNOTE: In addition to Prettier's `\"preserve\"` and `\"collapse\"`, we also support `\"always\"`."
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)",
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)"
     },
     "printWidth": {
       "description": "The line length that the printer will wrap on. (Default: `100`)",

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -28,8 +28,7 @@
     "ObjectWrapConfig": {
       "enum": [
         "preserve",
-        "collapse",
-        "always"
+        "collapse"
       ],
       "type": "string"
     },
@@ -354,8 +353,8 @@
           "type": "null"
         }
       ],
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)\nNOTE: In addition to Prettier's `\"preserve\"` and `\"collapse\"`, we also support `\"always\"`.",
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)\nNOTE: In addition to Prettier's `\"preserve\"` and `\"collapse\"`, we also support `\"always\"`."
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)",
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines. (Default: `\"preserve\"`)"
     },
     "printWidth": {
       "description": "The line length that the printer will wrap on. (Default: `100`)",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -259,11 +259,10 @@ Use single quotes instead of double quotes in JSX. (Default: `false`)
 
 ## objectWrap
 
-type: `"preserve" | "collapse" | "always" | null`
+type: `"preserve" | "collapse" | null`
 
 
 How to wrap object literals when they could fit on one line or span multiple lines. (Default: `"preserve"`)
-NOTE: In addition to Prettier's `"preserve"` and `"collapse"`, we also support `"always"`.
 
 
 ## printWidth


### PR DESCRIPTION
Fixes #17330
