### PR TITLE
refactor(oxfmt): Use `Box<FormatOptions>` for `ResolvedOptions`

### DIFF
--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -51,7 +51,7 @@ pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
 pub enum ResolvedOptions {
     /// For JS/TS files formatted by oxc_formatter.
     OxcFormatter {
-        format_options: FormatOptions,
+        format_options: Box<FormatOptions>,
         /// For embedded language formatting (e.g., CSS in template literals)
         external_options: Value,
         insert_final_newline: bool,
@@ -199,7 +199,7 @@ impl ConfigResolver {
 
         match strategy {
             FormatFileStrategy::OxcFormatter { .. } => ResolvedOptions::OxcFormatter {
-                format_options,
+                format_options: Box::new(format_options),
                 external_options,
                 insert_final_newline,
             },

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -61,7 +61,7 @@ impl SourceFormatter {
                     source_text,
                     path,
                     *source_type,
-                    format_options,
+                    *format_options,
                     external_options,
                 ),
                 insert_final_newline,


### PR DESCRIPTION
Preparation for #17576

```
error: large size difference between variants
  --> apps/oxfmt/src/core/config.rs:51:1
   |
51 | /   pub enum ResolvedOptions {
52 | |       /// For JS/TS files formatted by oxc_formatter.
53 | | /     OxcFormatter {
54 | | |         format_options: FormatOptions,
55 | | |         /// For embedded language formatting (e.g., CSS in template literals)
56 | | |         external_options: Value,
57 | | |         insert_final_newline: bool,
58 | | |     },
   | | |_____- the largest variant contains at least 281 bytes
...  |
66 | | /     ExternalFormatterPackageJson {
67 | | |         external_options: Value,
68 | | |         sort_package_json: Option<sort_package_json::SortOptions>,
69 | | |         insert_final_newline: bool,
70 | | |     },
   | | |_____- the second-largest variant contains at least 75 bytes
71 | |   }
   | |___^ the entire enum is at least 288 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#large_enum_variant
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   |
54 -         format_options: FormatOptions,
54 +         format_options: Box<FormatOptions>,
   |

```