### PR TITLE
refactor(linter/prefer-node-protocol): Standardize detection of Node.js built-in modules.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -1,3 +1,4 @@
+use nodejs_built_in_modules::is_nodejs_builtin_module;
 use oxc_ast::{
     AstKind,
     ast::{Expression, TSModuleReference},
@@ -74,9 +75,7 @@ impl Rule for PreferNodeProtocol {
         } else {
             string_lit_value.as_str()
         };
-        if module_name.starts_with("node:")
-            || nodejs_built_in_modules::BUILTINS.binary_search(&module_name).is_err()
-        {
+        if module_name.starts_with("node:") || !is_nodejs_builtin_module(module_name) {
             return;
         }
 


### PR DESCRIPTION
The `unicorn/prefer-no-protocol` rule was using a binary search on the built-in modules list, which is not guaranteed to be sorted as far as I can tell.

It looks like Boshen did some benchmarking to determine what was faster as well, so let's just defer the perf decision to the dedicated crate: https://github.com/oxc-project/nodejs-built-in-modules/commit/683fb559f10e239f5e04e1fe6d38423c7dc9e029