### PR TITLE
docs(linter): Update the tsconfig flag mention for the import plugin.

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -277,7 +277,8 @@ pub struct EnablePlugins {
     pub typescript_plugin: OverrideToggle,
 
     /// Enable import plugin and detect ESM problems.
-    /// It is recommended to use alongside the `--tsconfig` option.
+    /// It should be used with the `--tsconfig` flag if your project has a
+    /// tsconfig with a name other than `tsconfig.json`.
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub import_plugin: OverrideToggle,
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -59,7 +59,7 @@ Arguments:
 - **`    --disable-typescript-plugin`** &mdash; 
   Disable TypeScript plugin, which is turned on by default
 - **`    --import-plugin`** &mdash; 
-  Enable import plugin and detect ESM problems. It is recommended to use alongside the `--tsconfig` option.
+  Enable import plugin and detect ESM problems. It should be used with the `--tsconfig` flag if your project has a tsconfig with a name other than `tsconfig.json`.
 - **`    --react-plugin`** &mdash; 
   Enable react plugin, which is turned off by default
 - **`    --jsdoc-plugin`** &mdash; 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -35,8 +35,9 @@ Enable/Disable Plugins
         --disable-unicorn-plugin  Disable unicorn plugin, which is turned on by default
         --disable-oxc-plugin  Disable oxc unique rules, which is turned on by default
         --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
-        --import-plugin       Enable import plugin and detect ESM problems. It is recommended to use
-                              alongside the `--tsconfig` option.
+        --import-plugin       Enable import plugin and detect ESM problems. It should be used with
+                              the `--tsconfig` flag if your project has a tsconfig with a name other
+                              than `tsconfig.json`.
         --react-plugin        Enable react plugin, which is turned off by default
         --jsdoc-plugin        Enable jsdoc plugin and detect JSDoc problems
         --jest-plugin         Enable the Jest plugin and detect test problems


### PR DESCRIPTION
There's no reason to set the tsconfig flag in most projects anymore now that the tsconfig files are found automatically.