### PR TITLE
fix(oxfmt/tailwindcss): Bundle `prettier/plugins/*`

### DIFF
--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
   noExternal: [
     // Bundle it to control version
     "prettier",
+
+    // We are using patched version, so we must bundle it
+    // Also, it internally loads plugins dynamically, so they also must be bundled
     "prettier-plugin-tailwindcss",
+    /^prettier\/plugins\//,
+
     // Cannot bundle: worker.js runs in separate thread and can't resolve bundled chunks
     // Be sure to add it to "dependencies" in `npm/oxfmt/package.json`!
     // "tinypool",


### PR DESCRIPTION
Fixes #17762

---

TL;DR: `experimentalTailwindcss` wasn't working in environments where `prettier` wasn't installed separately.

We had agreed in the review that it wasn't necessary, but it seems it actually was needed.