### PR TITLE
fix(formatter/tailwindcss): class name is broken after sorting when its contains single quotes with `singleQuote: true`

### DIFF
--- a/apps/oxfmt/test/tailwindcss.test.ts
+++ b/apps/oxfmt/test/tailwindcss.test.ts
@@ -1049,3 +1049,62 @@ describe("Tailwind CSS Sorting with `experimentalSortImports` enabled", () => {
     expect(resultWithOption.errors).toStrictEqual([]);
   });
 });
+
+describe("Tailwind CSS Sorting works with other options", () => {
+  test("should keep quotes with `singleQuote: false`", async () => {
+    const input = `
+      <div className={clsx('text-md before:content-["hello"]')}>Hello</div>;
+      <div className={clsx("text-md before:content-['hello']")}>Hello</div>;
+    `;
+
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {
+        functions: ["clsx"],
+      },
+      singleQuote: false,
+    });
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "<div className={clsx('text-md before:content-["hello"]')}>Hello</div>;
+      <div className={clsx("text-md before:content-['hello']")}>Hello</div>;
+      "
+    `);
+  });
+
+  test("should keep quotes with default `singleQuote`", async () => {
+    const input = `
+      <div className={clsx('text-md before:content-["hello"]')}>Hello</div>;
+      <div className={clsx("text-md before:content-['hello']")}>Hello</div>;
+    `;
+
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {
+        functions: ["clsx"],
+      },
+    });
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "<div className={clsx('text-md before:content-["hello"]')}>Hello</div>;
+      <div className={clsx("text-md before:content-['hello']")}>Hello</div>;
+      "
+    `);
+  });
+
+  test("should handle quotes with `jsxSingleQuote: true` correctly", async () => {
+    const input = `
+        <div className="text-md before:content-['hello']">Hello</div>;
+        <div className='text-md before:content-["hello"]'>Hello</div>;
+    `;
+
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {},
+      jsxSingleQuote: true,
+    });
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "<div className="text-md before:content-['hello']">Hello</div>;
+      <div className='text-md before:content-["hello"]'>Hello</div>;
+      "
+    `);
+  });
+});

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::Deref};
 
 use oxc_span::SourceType;
 use oxc_syntax::identifier::{is_identifier_part, is_identifier_start};
@@ -63,6 +63,14 @@ impl<'a> FormatLiteralStringToken<'a> {
 
 pub struct CleanedStringLiteralText<'a> {
     text: Cow<'a, str>,
+}
+
+impl Deref for CleanedStringLiteralText<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.text
+    }
 }
 
 impl CleanedStringLiteralText<'_> {


### PR DESCRIPTION
close: #17761