### PR TITLE
fix(formatter/sort_imports): Handle alignable comment with JsLabels

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -69,42 +69,44 @@ impl SortImportsTransform {
         //   - If this is the case, we should check `Tag::StartLabelled(JsLabels::ImportDeclaration)`
         let mut lines = vec![];
         let mut current_line_start = 0;
-        // Track if we're inside a multiline block comment (started with `/*` but not yet closed with `*/`)
-        let mut in_multiline_comment = false;
-        // Track if current line is a standalone multiline comment (no import on same line)
-        let mut is_standalone_multiline_comment = false;
+        // Track if we're inside an alignable block comment (identified by `JsLabels::AlignableBlockComment`)
+        let mut in_alignable_block_comment = false;
+        // Track if current line is a standalone alignable comment (no import on same line)
+        let mut is_standalone_alignable_comment = false;
 
         for (idx, el) in prev_elements.iter().enumerate() {
-            // Check for multiline comment boundaries
-            if let FormatElement::Text { text, .. } = el {
-                if !in_multiline_comment && text.starts_with("/*") && !text.ends_with("*/") {
-                    in_multiline_comment = true;
-                    is_standalone_multiline_comment = true;
-                } else if in_multiline_comment && text.ends_with("*/") {
-                    in_multiline_comment = false;
+            // Check for alignable block comment boundaries.
+            // These comments are split across multiple lines with hard_line_break() between them,
+            // so we need to track when we're inside one to avoid flushing lines prematurely.
+            if let FormatElement::Tag(Tag::StartLabelled(id)) = el {
+                if *id == LabelId::of(JsLabels::AlignableBlockComment) {
+                    in_alignable_block_comment = true;
+                    is_standalone_alignable_comment = true;
+                } else if *id == LabelId::of(JsLabels::ImportDeclaration) {
+                    // An import on the same line means the comment is attached to it, not standalone
+                    is_standalone_alignable_comment = false;
                 }
-            }
-
-            // An import on the same line means the comment is attached to it, not standalone
-            if let FormatElement::Tag(Tag::StartLabelled(id)) = el
-                && *id == LabelId::of(JsLabels::ImportDeclaration)
-            {
-                is_standalone_multiline_comment = false;
+            } else if matches!(el, FormatElement::Tag(Tag::EndLabelled)) {
+                // EndLabelled doesn't carry the label ID, but since AlignableBlockComment
+                // doesn't nest with other labels in practice, we can safely reset here.
+                if in_alignable_block_comment {
+                    in_alignable_block_comment = false;
+                }
             }
 
             if let FormatElement::Line(mode) = el
                 && matches!(mode, LineMode::Empty | LineMode::Hard)
             {
-                // If we're inside a multiline comment, don't flush the line yet.
+                // If we're inside an alignable block comment, don't flush the line yet.
                 // Wait until the comment is closed so the entire comment is treated as one line.
-                if in_multiline_comment {
+                if in_alignable_block_comment {
                     continue;
                 }
 
                 // Flush current line
                 if current_line_start < idx {
-                    let line = if is_standalone_multiline_comment {
-                        // Standalone multiline comment: directly create CommentOnly
+                    let line = if is_standalone_alignable_comment {
+                        // Standalone alignable comment: directly create CommentOnly
                         SourceLine::CommentOnly(current_line_start..idx, *mode)
                     } else {
                         SourceLine::from_element_range(
@@ -116,7 +118,7 @@ impl SortImportsTransform {
                     lines.push(line);
                 }
                 current_line_start = idx + 1;
-                is_standalone_multiline_comment = false;
+                is_standalone_alignable_comment = false;
 
                 // We need this explicitly to detect boundaries later.
                 if matches!(mode, LineMode::Empty) {

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -97,6 +97,10 @@ pub(crate) enum JsLabels {
     MemberChain,
     /// For `ir_transform/sort_imports`
     ImportDeclaration,
+    /// For `ir_transform/sort_imports`
+    /// Marks `alignable_comment` (Block comment where each line starts with `*`)
+    /// to distinguish from other text content like template literals that may contain `/*`.
+    AlignableBlockComment,
 }
 
 impl Label for JsLabels {
@@ -108,6 +112,7 @@ impl Label for JsLabels {
         match self {
             Self::MemberChain => "MemberChain",
             Self::ImportDeclaration => "ImportDeclaration",
+            Self::AlignableBlockComment => "AlignableBlockComment",
         }
     }
 }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -2049,3 +2049,35 @@ import "node:os";
 "#,
     );
 }
+
+// ---
+
+#[test]
+fn issue_17788() {
+    // Should not panic
+    assert_format(
+        r"
+`/*`
+",
+        r#"{ "experimentalSortImports": {} }"#,
+        r"
+`/*`;
+",
+    );
+    // Should not panic
+    assert_format(
+        r"
+acc[path] = `src/${path
+.split('/')
+.map((s) => s[0].toUpperCase() + s.slice(1))
+.join('/')}/*`;
+",
+        r#"{ "experimentalSortImports": {} }"#,
+        r#"
+acc[path] = `src/${path
+  .split("/")
+  .map((s) => s[0].toUpperCase() + s.slice(1))
+  .join("/")}/*`;
+"#,
+    );
+}


### PR DESCRIPTION
Fixes #17788

---

This bug occurred because there was no way to distinguish `Text` element between

- `/*` within TemplateLiteral
- and `/*` representing part of an alignable_comment

in IR elements.

Now made it detectable by wrapping it in a new label.
