### PR TITLE
refactor(formatter): improve printing of parentheses for TSTypeOperator

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -4432,11 +4432,21 @@ impl<'a> Format<'a> for AstNode<'a, TSParenthesizedType<'a>> {
 impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
         self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
         }
         self.format_trailing_comments(f);
     }

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -1221,16 +1221,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSParenthesizedType<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeOperator<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            write!(f, "(");
-        }
-
         write!(f, [self.operator().to_str(), hard_space(), self.type_annotation()]);
-
-        if needs_parentheses {
-            write!(f, ")");
-        }
     }
 }
 

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -42,6 +42,7 @@ const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSConstructorType",
     "TSTypeQuery",
     "TSFunctionType",
+    "TSTypeOperator",
 ];
 
 const NEEDS_IMPLEMENTING_FMT_WITH_OPTIONS: phf::Map<&'static str, &'static str> = phf::phf_map! {


### PR DESCRIPTION
Parenthesis printing should be generated by AST tools.