### PR TITLE
refactor(linter/plugins): add napi function `createWorkspace` and `destroyWorkspace`

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -34,6 +34,14 @@ export declare const enum Severity {
  */
 export declare function getBufferOffset(buffer: Uint8Array): number
 
+/** JS callback to create a workspace. */
+export type JsCreateWorkspaceCb =
+  ((arg0: string) => Promise<undefined>)
+
+/** JS callback to destroy a workspace. */
+export type JsDestroyWorkspaceCb =
+  ((arg0: string) => void)
+
 /** JS callback to lint a file. */
 export type JsLintFileCb =
   ((arg0: string, arg1: number, arg2: Uint8Array | undefined | null, arg3: Array<number>, arg4: Array<number>, arg5: string, arg6: string) => string | null)
@@ -57,7 +65,7 @@ export type JsSetupRuleConfigsCb =
  *
  * Returns `true` if linting succeeded without errors, `false` otherwise.
  */
-export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb): Promise<boolean>
+export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb, createWorkspace: JsCreateWorkspaceCb, destroyWorkspace: JsDestroyWorkspaceCb): Promise<boolean>
 
 /**
  * Parse AST into provided `Uint8Array` buffer, synchronously.

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -7,6 +7,8 @@ import { debugAssertIsNonNull } from "./utils/asserts.ts";
 let loadPlugin: typeof import("./plugins/index.ts").loadPlugin | null = null;
 let setupRuleConfigs: typeof import("./plugins/index.ts").setupRuleConfigs | null = null;
 let lintFile: typeof import("./plugins/index.ts").lintFile | null = null;
+let createWorkspace: typeof import("./workspace/index.ts").createWorkspace | null = null;
+let destroyWorkspace: typeof import("./workspace/index.ts").destroyWorkspace | null = null;
 
 /**
  * Load a plugin.
@@ -77,11 +79,55 @@ function lintFileWrapper(
   return lintFile(filePath, bufferId, buffer, ruleIds, optionsIds, settingsJSON, globalsJSON);
 }
 
+/**
+ * Create a new workspace.
+ *
+ * Lazy-loads workspace code on first call, so that overhead is skipped if user doesn't use JS plugins.
+ *
+ * @param workspace - Workspace URI
+ * @returns Promise which resolves when workspace is created
+ */
+function createWorkspaceWrapper(workspace: string): Promise<undefined> {
+  if (createWorkspace === null) {
+    // Use promises here instead of making `createWorkspaceWrapper` an async function,
+    // to avoid a micro-tick and extra wrapper `Promise` in all later calls to `createWorkspaceWrapper`
+    return import("./workspace/index.ts").then((mod) => {
+      ({ createWorkspace, destroyWorkspace } = mod);
+      return createWorkspace(workspace);
+    });
+  }
+  debugAssertIsNonNull(createWorkspace);
+  return Promise.resolve(createWorkspace(workspace));
+}
+
+/**
+ * Destroy a workspace.
+ *
+ * Delegates to `destroyWorkspace`, which was lazy-loaded by `createWorkspaceWrapper`.
+ *
+ * @param workspace - Workspace URI
+ * @returns `undefined`
+ */
+function destroyWorkspaceWrapper(workspace: string): undefined {
+  // `destroyWorkspaceWrapper` is never called without `createWorkspaceWrapper` being called first,
+  // so `destroyWorkspace` must be defined here
+  debugAssertIsNonNull(destroyWorkspace);
+  destroyWorkspace(workspace);
+}
+
 // Get command line arguments, skipping first 2 (node binary and script path)
 const args = process.argv.slice(2);
 
-// Call Rust, passing `loadPlugin`, `setupRuleConfigs`, and `lintFile` as callbacks, and CLI arguments
-const success = await lint(args, loadPluginWrapper, setupRuleConfigsWrapper, lintFileWrapper);
+// Call Rust, passing `loadPlugin`, `setupRuleConfigs`, `lintFile`, `createWorkspace`, and `destroyWorkspace`
+// as callbacks, and CLI arguments
+const success = await lint(
+  args,
+  loadPluginWrapper,
+  setupRuleConfigsWrapper,
+  lintFileWrapper,
+  createWorkspaceWrapper,
+  destroyWorkspaceWrapper,
+);
 
 // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -12,12 +12,13 @@ import { join as pathJoin, isAbsolute as isAbsolutePath, dirname } from "node:pa
 import util from "node:util";
 import stableJsonStringify from "json-stable-stringify-without-jsonify";
 import { ecmaFeaturesOverride, setEcmaVersion, ECMA_VERSION } from "../plugins/context.ts";
-import { registerPlugin, registeredRules } from "../plugins/load.ts";
+import { registerPlugin } from "../plugins/load.ts";
 import { lintFileImpl, resetStateAfterError } from "../plugins/lint.ts";
 import { getLineColumnFromOffset, getNodeByRangeIndex } from "../plugins/location.ts";
-import { allOptions, setOptions, DEFAULT_OPTIONS_ID } from "../plugins/options.ts";
+import { setOptions, DEFAULT_OPTIONS_ID } from "../plugins/options.ts";
 import { diagnostics, replacePlaceholders, PLACEHOLDER_REGEX } from "../plugins/report.ts";
 import { parse } from "./parse.ts";
+import { createWorkspace, destroyWorkspace } from "../workspace/index.ts";
 
 import type { RequireAtLeastOne } from "type-fest";
 import type { Plugin, Rule } from "../plugins/load.ts";
@@ -975,9 +976,10 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
   // Get parse options
   const parseOptions = getParseOptions(test);
 
-  // Determine path.
-  // If not provided, use default filename based on `parseOptions.lang`.
-  let path: string;
+  // Determine path and CWD.
+  // If not provided, use default filename based on `parseOptions.lang`,
+  // and the directory of this file as CWD.
+  let path: string, cwd: string;
 
   const { filename } = test;
   if (filename == null) {
@@ -987,21 +989,24 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
     } else if (ext === "dts") {
       ext = "d.ts";
     }
-    const cwd = dirname(import.meta.dirname); // Root of `oxlint` package once bundled into `dist`
+    cwd = dirname(import.meta.dirname); // Root of `oxlint` package once bundled into `dist`
     path = pathJoin(cwd, `${DEFAULT_FILENAME_BASE}.${ext}`);
   } else if (isAbsolutePath(filename)) {
+    cwd = dirname(filename);
     path = filename;
   } else {
-    const cwd = dirname(import.meta.dirname); // Root of `oxlint` package once bundled into `dist`
+    cwd = dirname(import.meta.dirname); // Root of `oxlint` package once bundled into `dist`
     path = pathJoin(cwd, filename);
   }
 
+  createWorkspace(cwd);
+
   try {
     // Register plugin. This adds rule to `registeredRules` array.
-    registerPlugin(plugin, null, false);
+    registerPlugin(path, plugin, null, false);
 
     // Set up options
-    const optionsId = setupOptions(test);
+    const optionsId = setupOptions(test, cwd);
 
     // Parse file into buffer
     parse(path, test.code, parseOptions);
@@ -1056,8 +1061,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
     });
   } finally {
     // Reset state
-    registeredRules.length = 0;
-    if (allOptions !== null) allOptions.length = 1;
+    destroyWorkspace(cwd);
 
     // Even if there hasn't been an error, do a full reset of state just to be sure.
     // This includes emptying `diagnostics`.
@@ -1208,9 +1212,10 @@ function getGlobalsJson(test: TestCase): string {
  * Returns the options ID to pass to `lintFileImpl` (either 0 for default options, or 1 for user-provided options).
  *
  * @param test - Test case
+ * @param cwd - Current working directory for test case
  * @returns Options ID to pass to `lintFileImpl`
  */
-function setupOptions(test: TestCase): number {
+function setupOptions(test: TestCase, cwd: string): number {
   // Initial entries for default options
   const allOptions: Options[] = [[]],
     allRuleIds: number[] = [0];
@@ -1228,7 +1233,11 @@ function setupOptions(test: TestCase): number {
   // Serialize to JSON and pass to `setOptions`
   let allOptionsJson: string;
   try {
-    allOptionsJson = JSON.stringify({ options: allOptions, ruleIds: allRuleIds });
+    allOptionsJson = JSON.stringify({
+      options: allOptions,
+      ruleIds: allRuleIds,
+      cwd,
+    });
   } catch (err) {
     throw new Error(`Failed to serialize options: ${err}`);
   }

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -8,7 +8,8 @@ import ajvPackageJson from "ajv/package.json" with { type: "json" };
 import metaSchema from "ajv/lib/refs/json-schema-draft-04.json" with { type: "json" };
 import { registeredRules } from "./load.ts";
 import { deepCloneJsonValue, deepFreezeJsonArray } from "./json.ts";
-import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
+import { debugAssert } from "../utils/asserts.ts";
+import { getWorkspace, WorkspaceIdentifier } from "../workspace/index.ts";
 
 import type { JSONSchema4 } from "json-schema";
 import type { Writable } from "type-fest";
@@ -49,7 +50,7 @@ export const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 // All rule options.
 // `lintFile` is called with an array of options IDs, which are indices into this array.
 // First element is irrelevant - never accessed - because 0 index is a sentinel meaning default options.
-export let allOptions: Readonly<Options>[] | null = null;
+export const allOptions: Map<WorkspaceIdentifier, Readonly<Options>[]> = new Map();
 
 // Index into `allOptions` for default options
 export const DEFAULT_OPTIONS_ID = 0;
@@ -180,23 +181,25 @@ function wrapSchemaValidator(validate: Ajv.ValidateFunction): SchemaValidator {
  */
 export function setOptions(optionsJson: string): void {
   const details = JSON.parse(optionsJson);
-  allOptions = details.options;
-  debugAssertIsNonNull(allOptions);
 
-  const { ruleIds } = details;
+  const { ruleIds, cwd, options } = details;
+  allOptions.set(cwd, options);
 
   // Validate
   if (DEBUG) {
-    assert(Array.isArray(allOptions), `options must be an array, got ${typeof allOptions}`);
-    assert(Array.isArray(ruleIds), `ruleIds must be an array, got ${typeof allOptions}`);
+    assert(typeof cwd === "string", `cwd must be a string, got ${typeof cwd}`);
+    assert(getWorkspace(cwd) !== null, `cwd "${cwd}" is not a workspace`);
+    assert(registeredRules.has(cwd), `No registered rules for workspace cwd "${cwd}"`);
+    assert(Array.isArray(options), `options must be an array, got ${typeof options}`);
+    assert(Array.isArray(ruleIds), `ruleIds must be an array, got ${typeof ruleIds}`);
     assert.strictEqual(
-      allOptions.length,
+      options.length,
       ruleIds.length,
       "ruleIds and options arrays must be the same length",
     );
 
-    for (const options of allOptions) {
-      assert(Array.isArray(options), `Elements of options must be arrays, got ${typeof options}`);
+    for (const option of options) {
+      assert(Array.isArray(option), `Elements of options must be arrays, got ${typeof option}`);
     }
 
     for (const ruleId of ruleIds) {
@@ -211,11 +214,12 @@ export function setOptions(optionsJson: string): void {
   // For each options array, merge with default options and apply schema defaults for the corresponding rule.
   // Skip the first, as index 0 is a sentinel value meaning default options. First element is never accessed.
   // `processOptions` also deep-freezes the options.
-  for (let i = 1, len = allOptions.length; i < len; i++) {
-    allOptions[i] = processOptions(
+  const registeredWorkspaceRules = registeredRules.get(cwd)!;
+  for (let i = 1, len = options.length; i < len; i++) {
+    options[i] = processOptions(
       // `allOptions`' type is `Readonly`, but the array is mutable at present
-      allOptions[i] as Writable<(typeof allOptions)[number]>,
-      registeredRules[ruleIds[i]],
+      options[i] as Writable<(typeof options)[number]>,
+      registeredWorkspaceRules[ruleIds[i]],
     );
   }
 }
@@ -367,4 +371,24 @@ function mergeValues(configValue: JsonValue, defaultValue: JsonValue): JsonValue
   }
 
   return configValue;
+}
+
+/**
+ * Setups all needed data structures to hold options for a workspace.
+ *
+ * @param workspace the workspace identifier
+ */
+export function setupOptionsForWorkspace(workspace: WorkspaceIdentifier) {
+  debugAssert(
+    !allOptions.has(workspace),
+    "Workspace must not already have registered options array",
+  );
+  allOptions.set(workspace, []);
+}
+
+/**
+ * Remove all options associated with a workspace.
+ */
+export function removeOptionsInWorkspace(workspace: WorkspaceIdentifier) {
+  allOptions.delete(workspace);
 }

--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -1,0 +1,82 @@
+/*
+ * Isolated Workspaces.
+ *
+ * Every Workspace starts with a "workspace root" directory. This directory is
+ * used to isolate the plugin's dependencies from other plugins and the main
+ * application.
+ *
+ * Each workspace can be created, used, and then cleared to free up resources.
+ */
+
+import { removePluginsInWorkspace, setupPluginSystemForWorkspace } from "../plugins/load";
+import { removeOptionsInWorkspace, setupOptionsForWorkspace } from "../plugins/options";
+import { debugAssert } from "../utils/asserts";
+
+/**
+ * Type representing a workspace identifier.
+ * Currently, this is just a string representing the workspace root directory.
+ */
+export type WorkspaceIdentifier = string;
+
+/**
+ * Type representing a workspace.
+ * Currently it only contains the identifier.
+ */
+export type Workspace = WorkspaceIdentifier;
+
+/**
+ * Set of workspace root directories.
+ */
+const workspaces = new Set<Workspace>();
+
+/**
+ * Create a new workspace.
+ */
+export function createWorkspace(workspace: WorkspaceIdentifier): undefined {
+  debugAssert(!workspaces.has(workspace), `Workspace "${workspace.toString()}" already exists`);
+  workspaces.add(workspace);
+  setupPluginSystemForWorkspace(workspace);
+  setupOptionsForWorkspace(workspace);
+}
+
+/**
+ * Destroy a workspace.
+ * Unloads all plugin data associated with this workspace.
+ */
+export function destroyWorkspace(workspace: WorkspaceIdentifier): undefined {
+  debugAssert(workspaces.has(workspace), `Workspace "${workspace.toString()}" does not exist`);
+
+  workspaces.delete(workspace);
+  removePluginsInWorkspace(workspace);
+  removeOptionsInWorkspace(workspace);
+}
+
+/**
+ * Get a workspace by its identifier.
+ */
+export function getWorkspace(workspace: WorkspaceIdentifier): Workspace | null {
+  return workspaces.has(workspace) ? workspace : null;
+}
+
+/**
+ * Checks if a filePath is responsible for a workspace.
+ */
+export const isWorkspaceResponsible = (workspace: WorkspaceIdentifier, url: string): boolean => {
+  return getResponsibleWorkspace(url) === workspace;
+};
+
+/**
+ * Gets the workspace responsible for a given filePath.
+ * Returns `null` if no workspace is responsible.
+ *
+ * This function is kept in sync with Rust's `WorkspaceWorker::is_responsible_for_file` (`oxc_language_server` crate).
+ * Changing this function requires a corresponding change in Rust implementation.
+ */
+export const getResponsibleWorkspace = (filePath: string): Workspace | null => {
+  return (
+    [...workspaces.keys()]
+      .filter((ws) => filePath.startsWith(ws))
+      // Get the longest matching workspace path
+      .sort((a, b) => b.length - a.length)[0] ?? null
+  );
+};

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -13,7 +13,7 @@ use tower_lsp_server::{
         WorkDoneProgressOptions, WorkspaceEdit,
     },
 };
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use oxc_linter::{
     AllowWarnDeny, Config, ConfigStore, ConfigStoreBuilder, ExternalLinter, ExternalPluginStore,
@@ -66,6 +66,15 @@ impl ServerLinterBuilder {
         };
         let root_path = root_uri.to_file_path().unwrap();
         let mut external_plugin_store = ExternalPluginStore::new(self.external_linter.is_some());
+
+        // Setup JS workspace. This must be done before loading any configs
+        if let Some(external_linter) = &self.external_linter {
+            let res = (external_linter.create_workspace)(root_path.to_string_lossy().into_owned());
+
+            if let Err(err) = res {
+                error!("Failed to setup JS workspace:\n{err}\n");
+            }
+        }
 
         let mut nested_ignore_patterns = Vec::new();
         let mut extended_paths = FxHashSet::default();
@@ -263,6 +272,14 @@ impl ToolBuilder for ServerLinterBuilder {
 
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool> {
         Box::new(self.build(root_uri, options))
+    }
+
+    fn shutdown(&self, root_uri: &Uri) {
+        // Destroy JS workspace
+        if let Some(external_linter) = &self.external_linter {
+            let root_path = root_uri.to_file_path().unwrap();
+            (external_linter.destroy_workspace)(root_path.to_string_lossy().into_owned());
+        }
     }
 }
 

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -3,6 +3,7 @@ use std::process::{ExitCode, Termination};
 #[derive(Debug)]
 pub enum CliRunResult {
     None,
+    JsPluginWorkspaceSetupFailed,
     InvalidOptionConfig,
     InvalidOptionTsConfig,
     InvalidOptionSeverityWithoutFilter,
@@ -29,6 +30,7 @@ impl Termination for CliRunResult {
             // ToDo: when oxc_linter (config) validates the configuration, we can use exit_code = 1 to fail
             | Self::LintNoFilesFound => ExitCode::SUCCESS,
             Self::ConfigFileInitFailed
+            | Self::JsPluginWorkspaceSetupFailed
             | Self::LintFoundErrors
             | Self::LintNoWarningsAllowed
             | Self::LintMaxWarningsExceeded

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -9,6 +9,10 @@ use crate::{
     context::ContextHost,
 };
 
+pub type ExternalLinterCreateWorkspaceCb = Box<dyn Fn(String) -> Result<(), String> + Send + Sync>;
+
+pub type ExternalLinterDestroyWorkspaceCb = Box<dyn Fn(String) + Send + Sync>;
+
 pub type ExternalLinterLoadPluginCb = Box<
     dyn Fn(
             // File URL to load plugin from
@@ -67,6 +71,8 @@ pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,
+    pub create_workspace: ExternalLinterCreateWorkspaceCb,
+    pub destroy_workspace: ExternalLinterDestroyWorkspaceCb,
 }
 
 impl ExternalLinter {
@@ -74,8 +80,10 @@ impl ExternalLinter {
         load_plugin: ExternalLinterLoadPluginCb,
         setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
         lint_file: ExternalLinterLintFileCb,
+        create_workspace: ExternalLinterCreateWorkspaceCb,
+        destroy_workspace: ExternalLinterDestroyWorkspaceCb,
     ) -> Self {
-        Self { load_plugin, setup_rule_configs, lint_file }
+        Self { load_plugin, setup_rule_configs, lint_file, create_workspace, destroy_workspace }
     }
 }
 

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -163,8 +163,12 @@ impl ExternalPluginStore {
     ///
     /// # Errors
     /// Returns an error if serialization of rule options fails.
-    pub fn setup_rule_configs(&self, external_linter: &ExternalLinter) -> Result<(), String> {
-        let json = serde_json::to_string(&ConfigSer::new(self));
+    pub fn setup_rule_configs(
+        &self,
+        cwd: String,
+        external_linter: &ExternalLinter,
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(&ConfigSer::new(cwd, self));
         match json {
             Ok(options_json) => (external_linter.setup_rule_configs)(options_json),
             Err(err) => Err(format!("Failed to serialize external plugin options: {err}")),
@@ -198,13 +202,15 @@ impl ExternalPluginStore {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigSer<'s> {
+    cwd: String,
     rule_ids: ConfigSerRuleIds<'s>,
     options: ConfigSerOptions<'s>,
 }
 
 impl<'s> ConfigSer<'s> {
-    fn new(external_plugin_store: &'s ExternalPluginStore) -> Self {
+    fn new(cwd: String, external_plugin_store: &'s ExternalPluginStore) -> Self {
         Self {
+            cwd,
             rule_ids: ConfigSerRuleIds(external_plugin_store),
             options: ConfigSerOptions(external_plugin_store),
         }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -67,8 +67,9 @@ pub use crate::{
     },
     context::{ContextSubHost, LintContext},
     external_linter::{
-        ExternalLinter, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
-        ExternalLinterSetupRuleConfigsCb, JsFix, LintFileResult, LoadPluginResult,
+        ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
+        ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,
+        JsFix, LintFileResult, LoadPluginResult,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
     fixer::{Fix, FixKind, Message, PossibleFixes},


### PR DESCRIPTION
This PR introduces workspace isolation for the oxlint NAPI plugin system, adding `createWorkspace` and `destroyWorkspace` functions to manage multi workspace support for the language server.

This does not fully solve the integration, but should be a good start for all future work. One example is the buffer for multiple calls at the same time (?).

Added a new workspace isolation layer that uses the current working directory (cwd) as the workspace identifier:

- `createWorkspace(cwd:  string)`: Initializes a new isolated workspace for plugins and configurations
- `destroyWorkspace(cwd: string)`: Cleans up workspace resources, unloading all associated plugins and options
- `getResponsibleWorkspace(filePath: string)`: Determines which workspace is responsible for a given file path, reflecting the changes in https://github.com/oxc-project/oxc/pull/17853

