### PR TITLE
test(vscode): fix `oxc.showOutputChannel` command test after new vscode version

### DIFF
--- a/editors/vscode/tests/integration/commands.spec.ts
+++ b/editors/vscode/tests/integration/commands.spec.ts
@@ -60,7 +60,7 @@ suite('commands', () => {
 
     notEqual(window.activeTextEditor, undefined);
     const { uri } = window.activeTextEditor!.document;
-    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Lint%29');
+    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Lint%29.log');
 
     await commands.executeCommand('workbench.action.closeActiveEditor');
   });
@@ -71,7 +71,7 @@ suite('commands', () => {
 
     notEqual(window.activeTextEditor, undefined);
     const { uri } = window.activeTextEditor!.document;
-    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Fmt%29');
+    strictEqual(uri.toString(), 'output:oxc.oxc-vscode.Oxc%20%28Fmt%29.log');
 
     await commands.executeCommand('workbench.action.closeActiveEditor');
   });


### PR DESCRIPTION
looks like the newest vscode version has changed the name of the window.

```log
- Resolving version...
✔ Validated version: 1.108.0
- Found at https://update.code.visualstudio.com/1.108.0/linux-x64/stable?released=true
✔ Found at https://update.code.visualstudio.com/1.108.0/linux-x64/stable?released=true
- Downloading (155.64 MB)
✔ Downloaded VS Code into /home/runner/work/oxc/oxc/editors/vscode/.vscode-test/vscode-linux-x64-1.108.0
```