### PR TITLE
fix(linter): skip looking for ignore files in parent directories

### DIFF
--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -102,6 +102,7 @@ impl Walk {
             .git_global(false)
             .git_ignore(true)
             .follow_links(true)
+            .parents(false)
             .hidden(false)
             .require_git(false)
             .build_parallel();


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/17805
closes #17513
fixes https://github.com/oxc-project/oxc/issues/17510
