### PR TITLE
fix(linter): Move jsx-a11y/no-static-element-interactions rule to nursery.

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -78,7 +78,7 @@ declare_oxc_lint!(
     /// ```
     NoStaticElementInteractions,
     jsx_a11y,
-    correctness,
+    nursery,
     config = NoStaticElementInteractionsConfig,
 );
 


### PR DESCRIPTION
This is necessary until we can fix the implementation, there are too many tests missing from the original rule. See #17817.

Example of a failure from oxc-ecosystem-ci: https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/20838332588/job/59867835388

I can confirm I have a codebase where this rule also shows differing behavior from the original rule.