### PR TITLE
fix(linter):  fix false positive detection in `react-perf/jsx-no-new-object-as-prop`

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
@@ -2,6 +2,48 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:3:25]
+ 2 │             const a = ({ value }) => {
+ 3 │                 const { min = {} } = value;
+   ·                         ─┬─   ─┬
+   ·                          │     ╰── And assigned a new value here
+   ·                          ╰── The prop was declared here
+ 4 │                 return <InputNumber value={min} />
+   ·                                            ─┬─
+   ·                                             ╰── And used here
+ 5 │             }
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:3:25]
+ 2 │             const a = ({ value }) => {
+ 3 │                 const { min = Object() } = value;
+   ·                         ─┬─   ────┬───
+   ·                          │        ╰── And assigned a new value here
+   ·                          ╰── The prop was declared here
+ 4 │                 return <InputNumber value={min} />
+   ·                                            ─┬─
+   ·                                             ╰── And used here
+ 5 │             }
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:3:25]
+ 2 │             const a = ({ value }) => {
+ 3 │                 const { min = new Object() } = value;
+   ·                         ─┬─   ──────┬─────
+   ·                          │          ╰── And assigned a new value here
+   ·                          ╰── The prop was declared here
+ 4 │                 return <InputNumber value={min} />
+   ·                                            ─┬─
+   ·                                             ╰── And used here
+ 5 │             }
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
    ╭─[jsx_no_new_object_as_prop.tsx:1:33]
  1 │ const Foo = () => <Item config={{}} />
    ·                                 ──


### PR DESCRIPTION
Fixes #17743 