### PR TITLE
feat(ast_visit): use AstKind instead of AstType for VisitMut

### DIFF
--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -22,9 +22,9 @@ use walk_mut::*;
 /// Syntax tree traversal
 pub trait VisitMut<'a>: Sized {
     #[inline]
-    fn enter_node(&mut self, kind: AstKind) {}
+    fn enter_node(&mut self, kind: AstKind<'a>) {}
     #[inline]
-    fn leave_node(&mut self, kind: AstKind) {}
+    fn leave_node(&mut self, kind: AstKind<'a>) {}
 
     #[inline]
     fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}


### PR DESCRIPTION
`Visit::enter_node` takes AstKind, but `VisitMut::enter_node` takes AstType, which means i can't collect parents with `VisitMut`. So i use `oxc_traverse` for ancestor tracking.

After apply this PR, and then using `VisitMut` instead of `oxc_traverse` can improves performance by ~30% on [vue-jsx-vapor@32b789e](https://github.com/vuejs/vue-jsx-vapor/commit/32b789eb15fbc3560598e0a2070b7227e4817f98).