### PR TITLE
chore(napi/transform): remove `alpha` note in readme

### DIFF
--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -1,7 +1,5 @@
 # Oxc Transform
 
-This is alpha software and may yield incorrect results, feel free to [submit a bug report](https://github.com/oxc-project/oxc/issues/new?assignees=&labels=C-bug&projects=&template=bug_report.md).
-
 ## TypeScript and React JSX Transform
 
 ```javascript


### PR DESCRIPTION
I think it makes sense to remove this line so that AI doesn't pick this up, thinking it's still alpha software