### PR TITLE
chore(lint_rules): add `no-invalid-this` as unsupported

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -24,7 +24,8 @@
     "jsx-a11y/accessible-emoji": "Deprecated.",
     "jsx-a11y/label-has-for": "Deprecated, replaced by `jsx-a11y/label-has-associated-control`.",
     "jsx-a11y/no-onchange": "Deprecated, based on behavior of very old browsers, and so no longer necessary.",
-    "eslint/camelcase": "Preference is to implement this rule via `@typescript-eslint/naming-convention` instead to accomplish the same behavior with more flexibility.",
+    "eslint/camelcase": "Superseded by `@typescript-eslint/naming-convention`, which accomplishes the same behavior with more flexibility.",
+    "eslint/no-invalid-this": "Superseded by TypeScript's [`noImplicitThis`](https://www.typescriptlang.org/tsconfig/#noImplicitThis) compiler option (enabled by `strict` mode).",
 
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",


### PR DESCRIPTION
`no-invalid-this` is basically already implemented by TypeScript, so implementing this in the linter is redundant, especially if you're using `oxlint --type-check`. So I don't think we should implement this rule.

https://eslint.org/docs/latest/rules/no-invalid-this#handled_by_typescript