### PR TITLE
refactor(linter/no-useless-constructor): move help to notes for diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -34,7 +34,8 @@ fn no_redundant_super_call(constructor_span: Span, super_span: Span) -> OxcDiagn
             constructor_span.primary_label("This constructor is unnecessary,"),
             super_span.label("because it only passes arguments through to the superclass"),
         ])
-        .with_help("Subclasses automatically use the constructor of their superclass, making this redundant.\nRemove this constructor or add code to it.")
+        .with_note("Subclasses automatically use the constructor of their superclass, making this redundant.")
+        .with_help("Remove this constructor or add code to it.")
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_constructor.snap
@@ -22,8 +22,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │             ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:2:5]
@@ -36,8 +36,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── because it only passes arguments through to the superclass
  4 │     }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:21]
@@ -46,8 +46,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │                 ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:21]
@@ -56,8 +56,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │                        ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:21]
@@ -66,8 +66,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │                       ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:23]
@@ -76,8 +76,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                            │                   ╰── because it only passes arguments through to the superclass
    ·                            ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:21]
@@ -86,8 +86,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │                             ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:1:21]
@@ -96,8 +96,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │                            ╰── because it only passes arguments through to the superclass
    ·                          ╰── This constructor is unnecessary,
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Empty constructors are unnecessary
    ╭─[no_useless_constructor.tsx:1:11]
@@ -126,8 +126,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -140,8 +140,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -154,8 +154,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -168,8 +168,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -182,8 +182,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -196,8 +196,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Redundant super call in constructor
    ╭─[no_useless_constructor.tsx:3:6]
@@ -210,8 +210,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ╰── because it only passes arguments through to the superclass
  5 │               }
    ╰────
-  help: Subclasses automatically use the constructor of their superclass, making this redundant.
-        Remove this constructor or add code to it.
+  help: Remove this constructor or add code to it.
+  note: Subclasses automatically use the constructor of their superclass, making this redundant.
 
   ⚠ eslint(no-useless-constructor): Empty constructors are unnecessary
    ╭─[no_useless_constructor.tsx:3:6]


### PR DESCRIPTION
This rule effectively had a note already init, so just splitting that out into a separate field.