### PR TITLE
refactor(linter/no-cycle): improve diagnostics and cycle display

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
@@ -9,7 +9,7 @@ File URI: file://<variable>/fixtures/lsp/cross_module/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
-message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/lsp/cross_module/dep-b.ts\n-> ./dep-a.ts - fixtures/lsp/cross_module/dep-a.ts"
+message: "Dependency cycle detected\nhelp: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import."
 range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 30 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/lsp/cross_module/dep-a.ts"

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
@@ -9,7 +9,7 @@ File URI: file://<variable>/fixtures/lsp/cross_module_extended_config/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
-message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/lsp/cross_module_extended_config/dep-b.ts\n-> ./dep-a.ts - fixtures/lsp/cross_module_extended_config/dep-a.ts"
+message: "Dependency cycle detected\nhelp: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import."
 range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 30 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/lsp/cross_module_extended_config/dep-a.ts"

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -17,7 +17,7 @@ File URI: file://<variable>/fixtures/lsp/cross_module_nested_config/folder/folde
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
-message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./folder-dep-b.ts - fixtures/lsp/cross_module_nested_config/folder/folder-dep-b.ts\n-> ./folder-dep-a.ts - fixtures/lsp/cross_module_nested_config/folder/folder-dep-a.ts"
+message: "Dependency cycle detected\nhelp: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import."
 range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 37 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/lsp/cross_module_nested_config/folder/folder-dep-a.ts"

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
@@ -9,7 +9,7 @@ File URI: file://<variable>/fixtures/lsp/ts_path_alias/deep/src/dep-a.ts
 
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
-message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> @/dep-b - fixtures/lsp/ts_path_alias/deep/src/dep-b.ts\n-> ./dep-a.ts - fixtures/lsp/ts_path_alias/deep/src/dep-a.ts"
+message: "Dependency cycle detected\nhelp: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import."
 range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 27 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/lsp/ts_path_alias/deep/src/dep-a.ts"

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
@@ -13,9 +13,12 @@ working directory: fixtures/cross_module_extended_config
    :                   ^^^^^^^^^^^^
  3 | 
    `----
-  help: These paths form a cycle:
-        -> ./dep-b.ts - fixtures/cross_module_extended_config/dep-b.ts
-        -> ./dep-a.ts - fixtures/cross_module_extended_config/dep-a.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./dep-b.ts (fixtures/cross_module_extended_config/dep-b.ts)
+           │         ⬇ imports
+           │    ./dep-a.ts (fixtures/cross_module_extended_config/dep-a.ts)
+           ╰─────────╯ imports the current file
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
    ,-[dep-b.ts:2:8]
@@ -24,9 +27,12 @@ working directory: fixtures/cross_module_extended_config
    :        ^^^^^^^^^^^^
  3 | 
    `----
-  help: These paths form a cycle:
-        -> ./dep-a.ts - fixtures/cross_module_extended_config/dep-a.ts
-        -> ./dep-b.ts - fixtures/cross_module_extended_config/dep-b.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./dep-a.ts (fixtures/cross_module_extended_config/dep-a.ts)
+           │         ⬇ imports
+           │    ./dep-b.ts (fixtures/cross_module_extended_config/dep-b.ts)
+           ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
 Finished in <variable>ms on 2 files with 1 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
@@ -13,9 +13,12 @@ working directory: fixtures/cross_module_nested_config
    :                   ^^^^^^^^^^^^^^^^^^^
  3 | 
    `----
-  help: These paths form a cycle:
-        -> ./folder-dep-b.ts - fixtures/cross_module_nested_config/folder/folder-dep-b.ts
-        -> ./folder-dep-a.ts - fixtures/cross_module_nested_config/folder/folder-dep-a.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./folder-dep-b.ts (fixtures/cross_module_nested_config/folder/folder-dep-b.ts)
+           │         ⬇ imports
+           │    ./folder-dep-a.ts (fixtures/cross_module_nested_config/folder/folder-dep-a.ts)
+           ╰─────────╯ imports the current file
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
    ,-[folder/folder-dep-b.ts:2:8]
@@ -24,9 +27,12 @@ working directory: fixtures/cross_module_nested_config
    :        ^^^^^^^^^^^^^^^^^^^
  3 | 
    `----
-  help: These paths form a cycle:
-        -> ./folder-dep-a.ts - fixtures/cross_module_nested_config/folder/folder-dep-a.ts
-        -> ./folder-dep-b.ts - fixtures/cross_module_nested_config/folder/folder-dep-b.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./folder-dep-a.ts (fixtures/cross_module_nested_config/folder/folder-dep-a.ts)
+           │         ⬇ imports
+           │    ./folder-dep-b.ts (fixtures/cross_module_nested_config/folder/folder-dep-b.ts)
+           ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
 Finished in <variable>ms on 4 files with 90 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -12,9 +12,12 @@ working directory: fixtures/import-cycle
    :                   ^^^^^
  2 | 
    `----
-  help: These paths form a cycle:
-        -> ./b - fixtures/import-cycle/b.ts
-        -> ./a - fixtures/import-cycle/a.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./b (fixtures/import-cycle/b.ts)
+           │         ⬇ imports
+           │    ./a (fixtures/import-cycle/a.ts)
+           ╰─────────╯ imports the current file
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
    ,-[b.ts:1:19]
@@ -22,9 +25,12 @@ working directory: fixtures/import-cycle
    :                   ^^^^^
  2 | 
    `----
-  help: These paths form a cycle:
-        -> ./a - fixtures/import-cycle/a.ts
-        -> ./b - fixtures/import-cycle/b.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./a (fixtures/import-cycle/a.ts)
+           │         ⬇ imports
+           │    ./b (fixtures/import-cycle/b.ts)
+           ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
 Finished in <variable>ms on 2 files with 93 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
@@ -12,9 +12,12 @@ working directory: fixtures
    :                   ^^^^^
  2 | 
    `----
-  help: These paths form a cycle:
-        -> ./b - fixtures/issue_10054/b.ts
-        -> ./a - fixtures/issue_10054/a.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./b (fixtures/issue_10054/b.ts)
+           │         ⬇ imports
+           │    ./a (fixtures/issue_10054/a.ts)
+           ╰─────────╯ imports the current file
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
    ,-[issue_10054/b.ts:1:8]
@@ -22,9 +25,12 @@ working directory: fixtures
    :        ^^^^^
  2 | 
    `----
-  help: These paths form a cycle:
-        -> ./a - fixtures/issue_10054/a.ts
-        -> ./b - fixtures/issue_10054/b.ts
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./a (fixtures/issue_10054/a.ts)
+           │         ⬇ imports
+           │    ./b (fixtures/issue_10054/b.ts)
+           ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
 Finished in <variable>ms on 2 files with 90 rules using 1 threads.

--- a/crates/oxc_linter/src/snapshots/import_no_cycle.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_cycle.snap
@@ -6,284 +6,403 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import { foo } from "./es6/depth-one"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-one-reexport"
    ·                     ──────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one-reexport - fixtures/import/cycles/es6/depth-one-reexport.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one-reexport (fixtures/import/cycles/es6/depth-one-reexport.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-one-reexport"
    ·                     ──────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one-reexport - fixtures/import/cycles/es6/depth-one-reexport.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one-reexport (fixtures/import/cycles/es6/depth-one-reexport.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { two } from "./es6/depth-three-star"
    ·                     ────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-star - fixtures/import/cycles/es6/depth-three-star.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-star (fixtures/import/cycles/es6/depth-three-star.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:33]
  1 │ import one, { two, three } from "./es6/depth-three-star"
    ·                                 ────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-star - fixtures/import/cycles/es6/depth-three-star.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-star (fixtures/import/cycles/es6/depth-three-star.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { bar } from "./es6/depth-three-indirect"
    ·                     ────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-indirect - fixtures/import/cycles/es6/depth-three-indirect.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-indirect (fixtures/import/cycles/es6/depth-three-indirect.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { bar } from "./es6/depth-three-indirect"
    ·                     ────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-indirect - fixtures/import/cycles/es6/depth-three-indirect.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-indirect (fixtures/import/cycles/es6/depth-three-indirect.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-one"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-one"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-one-reexport"
    ·                     ──────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-one-reexport - fixtures/import/cycles/es6/depth-one-reexport.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-one-reexport (fixtures/import/cycles/es6/depth-one-reexport.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { two } from "./es6/depth-three-star"
    ·                     ────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-star - fixtures/import/cycles/es6/depth-three-star.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-star (fixtures/import/cycles/es6/depth-three-star.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:33]
  1 │ import one, { two, three } from "./es6/depth-three-star"
    ·                                 ────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-star - fixtures/import/cycles/es6/depth-three-star.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-star (fixtures/import/cycles/es6/depth-three-star.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { bar } from "./es6/depth-three-indirect"
    ·                     ────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-indirect - fixtures/import/cycles/es6/depth-three-indirect.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-indirect (fixtures/import/cycles/es6/depth-three-indirect.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { bar } from "./es6/depth-three-indirect"
    ·                     ────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-three-indirect - fixtures/import/cycles/es6/depth-three-indirect.js
-        -> ./depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-three-indirect (fixtures/import/cycles/es6/depth-three-indirect.js)
+           │         ⬇ imports
+           │    ./depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./es6/depth-two"
    ·                     ─────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./es6/depth-two - fixtures/import/cycles/es6/depth-two.js
-        -> ./depth-one - fixtures/import/cycles/es6/depth-one.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./es6/depth-two (fixtures/import/cycles/es6/depth-two.js)
+           │         ⬇ imports
+           │    ./depth-one (fixtures/import/cycles/es6/depth-one.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./intermediate-ignore"
    ·                     ───────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./intermediate-ignore - fixtures/import/cycles/intermediate-ignore.js
-        -> ./ignore - fixtures/import/cycles/ignore/index.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./intermediate-ignore (fixtures/import/cycles/intermediate-ignore.js)
+           │         ⬇ imports
+           │    ./ignore (fixtures/import/cycles/ignore/index.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./ignore"
    ·                     ──────────
    ╰────
-  help: These paths form a cycle:
-        -> ./ignore - fixtures/import/cycles/ignore/index.js
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./ignore (fixtures/import/cycles/ignore/index.js)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./typescript/ts-types-some-type-imports";
    ·                     ─────────────────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./typescript/ts-types-some-type-imports - fixtures/import/cycles/typescript/ts-types-some-type-imports.ts
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./typescript/ts-types-some-type-imports (fixtures/import/cycles/typescript/ts-types-some-type-imports.ts)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./typescript/ts-types-re-exporting-type";
    ·                     ─────────────────────────────────────────
    ╰────
-  help: These paths form a cycle:
-        -> ./typescript/ts-types-re-exporting-type - fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./typescript/ts-types-re-exporting-type (fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts)
+           │         ⬇ imports
+           │    ../depth-zero (fixtures/import/cycles/depth-zero.js)
+           ╰─────────╯ imports the current file
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:41]
  1 │ export function Foo() {}; export * from './depth-zero'
-   ·                                         ──────────────
+   ·                                         ───────┬──────
+   ·                                                ╰── this module references itself
    ╰────
-  help: These paths form a cycle:
-        -> ./depth-zero - fixtures/import/cycles/depth-zero.js
+  help: Remove the self-referencing export and consider using a named export instead.
+
+  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
+   ╭─[cycles/depth-zero.js:1:28]
+ 1 │ import * as depthZero from './depth-zero'
+   ·                            ───────┬──────
+   ·                                   ╰── this module references itself
+   ╰────
+  help: Remove the self-referencing import.


### PR DESCRIPTION
This improves the output of the `no-cycle` rule in a few ways:

- When there is a cycle of length 1 (self-referential import), then we skip rendering the cycle paths. Instead, there is a more specific diagnostic that recommends removing the import/export completely.
- Adds a flow diagram to the cycle path. This is a bit more verbose, but I think is easier to understand, especially given the complexity of this rule.
- Adds an actual help text for refactoring the code.

I used Copilot/Claude Opus 4.5 to help generate the new cycle display rendering code.