### PR TITLE
refactor(oxlint/lsp): add plugin prefix to disable quick action

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
@@ -20,7 +20,7 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Disable no-cycle for this line
+Title: Disable import/no-cycle for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -33,12 +33,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-cycle\n",
+    new_text: "// oxlint-disable-next-line import/no-cycle\n",
 }
 
 
 CodeAction: 
-Title: Disable no-cycle for this whole file
+Title: Disable import/no-cycle for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -51,5 +51,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-cycle\n",
+    new_text: "// oxlint-disable import/no-cycle\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
@@ -20,7 +20,7 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Disable no-cycle for this line
+Title: Disable import/no-cycle for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -33,12 +33,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-cycle\n",
+    new_text: "// oxlint-disable-next-line import/no-cycle\n",
 }
 
 
 CodeAction: 
-Title: Disable no-cycle for this whole file
+Title: Disable import/no-cycle for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -51,5 +51,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-cycle\n",
+    new_text: "// oxlint-disable import/no-cycle\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -28,7 +28,7 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Disable no-cycle for this line
+Title: Disable import/no-cycle for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -41,12 +41,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-cycle\n",
+    new_text: "// oxlint-disable-next-line import/no-cycle\n",
 }
 
 
 CodeAction: 
-Title: Disable no-cycle for this whole file
+Title: Disable import/no-cycle for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -59,5 +59,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-cycle\n",
+    new_text: "// oxlint-disable import/no-cycle\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
@@ -81,7 +81,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-non-null-asserted-optional-chain for this line
+Title: Disable typescript/no-non-null-asserted-optional-chain for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -94,12 +94,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "  // oxlint-disable-next-line no-non-null-asserted-optional-chain\n",
+    new_text: "  // oxlint-disable-next-line typescript/no-non-null-asserted-optional-chain\n",
 }
 
 
 CodeAction: 
-Title: Disable no-non-null-asserted-optional-chain for this whole file
+Title: Disable typescript/no-non-null-asserted-optional-chain for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -112,5 +112,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-non-null-asserted-optional-chain\n",
+    new_text: "// oxlint-disable typescript/no-non-null-asserted-optional-chain\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
@@ -56,7 +56,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable forward-ref-uses-ref for this line
+Title: Disable react/forward-ref-uses-ref for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -69,12 +69,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line forward-ref-uses-ref\n",
+    new_text: "// oxlint-disable-next-line react/forward-ref-uses-ref\n",
 }
 
 
 CodeAction: 
-Title: Disable forward-ref-uses-ref for this whole file
+Title: Disable react/forward-ref-uses-ref for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -87,5 +87,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable forward-ref-uses-ref\n",
+    new_text: "// oxlint-disable react/forward-ref-uses-ref\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
@@ -20,7 +20,7 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Disable no-cycle for this line
+Title: Disable import/no-cycle for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -33,12 +33,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-cycle\n",
+    new_text: "// oxlint-disable-next-line import/no-cycle\n",
 }
 
 
 CodeAction: 
-Title: Disable no-cycle for this whole file
+Title: Disable import/no-cycle for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -51,5 +51,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-cycle\n",
+    new_text: "// oxlint-disable import/no-cycle\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
@@ -147,7 +147,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -160,12 +160,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -178,7 +178,7 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
 
 
@@ -219,7 +219,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -232,12 +232,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -250,7 +250,7 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
 
 
@@ -291,7 +291,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -304,12 +304,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -322,7 +322,7 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
 
 
@@ -363,7 +363,7 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -376,12 +376,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -394,12 +394,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -412,12 +412,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -430,5 +430,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
@@ -31,7 +31,7 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -44,12 +44,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -62,12 +62,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this line
+Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -80,12 +80,12 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable-next-line no-floating-promises\n",
+    new_text: "// oxlint-disable-next-line typescript/no-floating-promises\n",
 }
 
 
 CodeAction: 
-Title: Disable no-floating-promises for this whole file
+Title: Disable typescript/no-floating-promises for this whole file
 Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
@@ -98,5 +98,5 @@ TextEdit: TextEdit {
             character: 0,
         },
     },
-    new_text: "// oxlint-disable no-floating-promises\n",
+    new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }


### PR DESCRIPTION
Adding the plugin name for the "disable this line/file" code action.
This change is needed for the future of `jsPlugins`, where the disable directive store and co. always expects a plugin prefix for js rules.