### PR TITLE
refactor(linter/no-dupe-else-if): add labels to spans and improve help text

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -10,9 +10,14 @@ use oxc_syntax::operator::LogicalOperator;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_dupe_else_if_diagnostic(first_test: Span, second_test: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("duplicate conditions in if-else-if chains")
-        .with_help("This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain")
-        .with_labels([first_test, second_test])
+    OxcDiagnostic::warn("Duplicate conditions in if-else-if chain")
+        .with_help(
+            "Remove or modify the duplicate condition, as its branch will never be executed.",
+        )
+        .with_labels([
+            first_test.label("condition first checked here"),
+            second_test.label("this branch will never be executed"),
+        ])
 }
 
 #[derive(Debug, Default, Clone)]
@@ -165,7 +170,7 @@ impl Rule for NoDupeElseIf {
                 .collect();
 
             if list_to_check.iter().any(Vec::is_empty) {
-                ctx.diagnostic(no_dupe_else_if_diagnostic(if_stmt.test.span(), stmt.test.span()));
+                ctx.diagnostic(no_dupe_else_if_diagnostic(stmt.test.span(), if_stmt.test.span()));
                 break;
             }
         }

--- a/crates/oxc_linter/src/snapshots/eslint_no_dupe_else_if.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_dupe_else_if.snap
@@ -1,415 +1,533 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a) {}
-   ·     ─              ─
+   ·     ┬              ┬
+   ·     │              ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a); else if (a);
-   ·     ─            ─
+   ·     ┬            ┬
+   ·     │            ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a) {} else {}
-   ·     ─              ─
+   ·     ┬              ┬
+   ·     │              ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (a) {} else if (c) {}
-   ·     ─                             ─
+   ·     ┬                             ┬
+   ·     │                             ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (a) {}
-   ·     ─                             ─
+   ·     ┬                             ┬
+   ·     │                             ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (c) {} else if (a) {}
-   ·     ─                                            ─
+   ·     ┬                                            ┬
+   ·     │                                            ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:20]
  1 │ if (a) {} else if (b) {} else if (b) {}
-   ·                    ─              ─
+   ·                    ┬              ┬
+   ·                    │              ╰── this branch will never be executed
+   ·                    ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:20]
  1 │ if (a) {} else if (b) {} else if (b) {} else {}
-   ·                    ─              ─
+   ·                    ┬              ┬
+   ·                    │              ╰── this branch will never be executed
+   ·                    ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:20]
  1 │ if (a) {} else if (b) {} else if (c) {} else if (b) {}
-   ·                    ─                             ─
+   ·                    ┬                             ┬
+   ·                    │                             ╰── this branch will never be executed
+   ·                    ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:18]
  1 │ if (a); else if (b); else if (c); else if (b); else if (d); else;
-   ·                  ─                         ─
+   ·                  ┬                         ┬
+   ·                  │                         ╰── this branch will never be executed
+   ·                  ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:18]
  1 │ if (a); else if (b); else if (c); else if (d); else if (b); else if (e);
-   ·                  ─                                      ─
+   ·                  ┬                                      ┬
+   ·                  │                                      ╰── this branch will never be executed
+   ·                  ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a) {} else if (a) {}
-   ·     ─              ─
+   ·     ┬              ┬
+   ·     │              ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:20]
  1 │ if (a) {} else if (a) {} else if (a) {}
-   ·                    ─              ─
+   ·                    ┬              ┬
+   ·                    │              ╰── this branch will never be executed
+   ·                    ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}
-   ·     ─                             ─
+   ·     ┬                             ┬
+   ·     │                             ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:20]
  1 │ if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}
-   ·                    ─                             ─
+   ·                    ┬                             ┬
+   ·                    │                             ╰── this branch will never be executed
+   ·                    ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:35]
  1 │ if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}
-   ·                                   ─                             ─
+   ·                                   ┬                             ┬
+   ·                                   │                             ╰── this branch will never be executed
+   ·                                   ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) { if (b) {} } else if (a) {}
-   ·     ─                         ─
+   ·     ┬                         ┬
+   ·     │                         ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a === 1) {} else if (a === 1) {}
-   ·     ───────              ───────
+   ·     ───┬───              ───┬───
+   ·        │                    ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (1 < a) {} else if (1 < a) {}
-   ·     ─────              ─────
+   ·     ──┬──              ──┬──
+   ·       │                  ╰── this branch will never be executed
+   ·       ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (true) {} else if (true) {}
-   ·     ────              ────
+   ·     ──┬─              ──┬─
+   ·       │                 ╰── this branch will never be executed
+   ·       ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && b) {} else if (a && b) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && b || c)  {} else if (a && b || c) {}
-   ·     ───────────               ───────────
+   ·     ─────┬─────               ─────┬─────
+   ·          │                         ╰── this branch will never be executed
+   ·          ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (f(a)) {} else if (f(a)) {}
-   ·     ────              ────
+   ·     ──┬─              ──┬─
+   ·       │                 ╰── this branch will never be executed
+   ·       ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a === 1) {} else if (a===1) {}
-   ·     ───────              ─────
+   ·     ───┬───              ──┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a === 1) {} else if (a === /* comment */ 1) {}
-   ·     ───────              ─────────────────────
+   ·     ───┬───              ──────────┬──────────
+   ·        │                           ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a === 1) {} else if ((a === 1)) {}
-   ·     ───────              ─────────
+   ·     ───┬───              ────┬────
+   ·        │                     ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (a) {}
-   ·     ──────              ─
+   ·     ───┬──              ┬
+   ·        │                ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (a) {} else if (b) {}
-   ·     ──────              ─
+   ·     ───┬──              ┬
+   ·        │                ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (a) {} else if (b) {}
-   ·     ──────                             ─
+   ·     ───┬──                             ┬
+   ·        │                               ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (b || a) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (a || b) {}
-   ·     ─                             ──────
+   ·     ┬                             ───┬──
+   ·     │                                ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (c || d) {} else if (a || d) {}
-   ·     ──────                                  ──────
+   ·     ───┬──                                  ───┬──
+   ·        │                                       ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}
-   ·     ───────────────────────              ────────────────
+   ·     ───────────┬───────────              ────────┬───────
+   ·                │                                 ╰── this branch will never be executed
+   ·                ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a && b) {}
-   ·     ─              ──────
+   ·     ┬              ───┬──
+   ·     │                 ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && b) {} else if (b && a) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && b) {} else if (a && b && c) {}
-   ·     ──────              ───────────
+   ·     ───┬──              ─────┬─────
+   ·        │                     ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || c) {} else if (a && b || c) {}
-   ·     ──────              ───────────
+   ·     ───┬──              ─────┬─────
+   ·        │                     ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (c && a || b) {}
-   ·     ─                             ───────────
+   ·     ┬                             ─────┬─────
+   ·     │                                  ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (c && (a || b)) {}
-   ·     ─                             ─────────────
+   ·     ┬                             ──────┬──────
+   ·     │                                   ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}
-   ·     ─                                  ───────────────────────
+   ·     ┬                                  ───────────┬───────────
+   ·     │                                             ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b && c) {} else if (b && c && d) {}
-   ·     ───────────              ───────────
+   ·     ─────┬─────              ─────┬─────
+   ·          │                        ╰── this branch will never be executed
+   ·          ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (b && c) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if ((a || b) && c) {}
-   ·     ─                             ─────────────
+   ·     ┬                             ──────┬──────
+   ·     │                                   ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}
-   ·     ────────────────────              ──────────────────
+   ·     ──────────┬─────────              ─────────┬────────
+   ·               │                                ╰── this branch will never be executed
+   ·               ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && b || b && c) {} else if (a && b && c) {}
-   ·     ────────────────              ───────────
+   ·     ────────┬───────              ─────┬─────
+   ·             │                          ╰── this branch will never be executed
+   ·             ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}
-   ·     ─                                  ───────────────────────
+   ·     ┬                                  ───────────┬───────────
+   ·     │                                             ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || (b && (c || d))) {} else if ((d || c) && b) {}
-   ·     ────────────────────              ─────────────
+   ·     ──────────┬─────────              ──────┬──────
+   ·               │                             ╰── this branch will never be executed
+   ·               ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if ((b || a) && c) {}
-   ·     ──────              ─────────────
+   ·     ───┬──              ──────┬──────
+   ·        │                      ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}
-   ·     ──────                                            ─────────────
+   ·     ───┬──                                            ──────┬──────
+   ·        │                                                    ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b || c) {} else if (a || (b && d) || (c && e)) {}
-   ·     ───────────              ─────────────────────────
+   ·     ─────┬─────              ────────────┬────────────
+   ·          │                               ╰── this branch will never be executed
+   ·          ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || (b || c)) {} else if (a || (b && c)) {}
-   ·     ─────────────              ─────────────
+   ·     ──────┬──────              ──────┬──────
+   ·           │                          ╰── this branch will never be executed
+   ·           ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}
-   ·     ──────                                            ────────────────────
+   ·     ───┬──                                            ──────────┬─────────
+   ·        │                                                        ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (b) {} else if (c && (a || d && b)) {}
-   ·     ─                             ──────────────────
+   ·     ┬                             ─────────┬────────
+   ·     │                                      ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a || a) {}
-   ·     ─              ──────
+   ·     ┬              ───┬──
+   ·     │                 ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || a) {} else if (a || a) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a || a) {} else if (a) {}
-   ·     ──────              ─
+   ·     ───┬──              ┬
+   ·        │                ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a) {} else if (a && a) {}
-   ·     ─              ──────
+   ·     ┬              ───┬──
+   ·     │                 ╰── this branch will never be executed
+   ·     ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && a) {} else if (a && a) {}
-   ·     ──────              ──────
+   ·     ───┬──              ───┬──
+   ·        │                   ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.
 
-  ⚠ eslint(no-dupe-else-if): duplicate conditions in if-else-if chains
+  ⚠ eslint(no-dupe-else-if): Duplicate conditions in if-else-if chain
    ╭─[no_dupe_else_if.tsx:1:5]
  1 │ if (a && a) {} else if (a) {}
-   ·     ──────              ─
+   ·     ───┬──              ┬
+   ·        │                ╰── this branch will never be executed
+   ·        ╰── condition first checked here
    ╰────
-  help: This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain
+  help: Remove or modify the duplicate condition, as its branch will never be executed.


### PR DESCRIPTION
Add labels to the spans to make it clear which branch is executed and which one is not.