### PR TITLE
refactor(linter/no-delete-var): fix capitalization in diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_delete_var_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("variables should not be deleted").with_label(span)
+    OxcDiagnostic::warn("Variables should not be deleted").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-delete-var): variables should not be deleted
+  ⚠ eslint(no-delete-var): Variables should not be deleted
    ╭─[no_delete_var.tsx:1:1]
  1 │ delete x
    · ────────


### PR DESCRIPTION
Message was not capitalized, now it is.