### PR TITLE
feat(linter/no-ex-assign): improve diagnostic with more detail

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -7,7 +7,10 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_ex_assign_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span)
+    OxcDiagnostic::warn("Do not assign to the exception parameter.")
+        .with_help("Remove the assignment to the exception parameter, or refactor the code to use a different variable.")
+        .with_note("If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.")
+        .with_label(span.label("this assignment destroys access to the caught exception"))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_ex_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_ex_assign.snap
@@ -4,34 +4,44 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-ex-assign): Do not assign to the exception parameter.
    ╭─[no_ex_assign.tsx:1:21]
  1 │ try { } catch (e) { e = 10; }
-   ·                     ─
+   ·                     ┬
+   ·                     ╰── this assignment destroys access to the caught exception
    ╰────
-  help: If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+  help: Remove the assignment to the exception parameter, or refactor the code to use a different variable.
+  note: If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.
 
   ⚠ eslint(no-ex-assign): Do not assign to the exception parameter.
    ╭─[no_ex_assign.tsx:1:22]
  1 │ try { } catch (ex) { ex = 10; }
-   ·                      ──
+   ·                      ─┬
+   ·                       ╰── this assignment destroys access to the caught exception
    ╰────
-  help: If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+  help: Remove the assignment to the exception parameter, or refactor the code to use a different variable.
+  note: If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.
 
   ⚠ eslint(no-ex-assign): Do not assign to the exception parameter.
    ╭─[no_ex_assign.tsx:1:23]
  1 │ try { } catch (ex) { [ex] = []; }
-   ·                       ──
+   ·                       ─┬
+   ·                        ╰── this assignment destroys access to the caught exception
    ╰────
-  help: If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+  help: Remove the assignment to the exception parameter, or refactor the code to use a different variable.
+  note: If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.
 
   ⚠ eslint(no-ex-assign): Do not assign to the exception parameter.
    ╭─[no_ex_assign.tsx:1:27]
  1 │ try { } catch (ex) { ({x: ex = 0} = {}); }
-   ·                           ──
+   ·                           ─┬
+   ·                            ╰── this assignment destroys access to the caught exception
    ╰────
-  help: If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+  help: Remove the assignment to the exception parameter, or refactor the code to use a different variable.
+  note: If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.
 
   ⚠ eslint(no-ex-assign): Do not assign to the exception parameter.
    ╭─[no_ex_assign.tsx:1:29]
  1 │ try { } catch ({message}) { message = 10; }
-   ·                             ───────
+   ·                             ───┬───
+   ·                                ╰── this assignment destroys access to the caught exception
    ╰────
-  help: If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+  help: Remove the assignment to the exception parameter, or refactor the code to use a different variable.
+  note: If code in a catch block assigns a value to the exception parameter, it becomes impossible to refer to the error. Since there is no alternative way to access to this data, assignment of the parameter is absolutely destructive.


### PR DESCRIPTION
All of the information was in the help text. Now it's split across the help text, notes, and the span label. Also rewrote the help text to be a bit more succinct.