### PR TITLE
fix(formatter): incorrect type annotation check for short argument

### DIFF
--- a/crates/oxc_formatter/src/write/call_arguments.rs
+++ b/crates/oxc_formatter/src/write/call_arguments.rs
@@ -462,10 +462,10 @@ fn is_simple_ts_type(ty: &TSType<'_>) -> bool {
     //     string[][][] => string[]
     let extracted_array_type = match ty {
         TSType::TSArrayType(array) => match &array.element_type {
-            TSType::TSArrayType(inner_array) => Some(&inner_array.element_type),
-            element_type => Some(element_type),
+            TSType::TSArrayType(inner_array) => &inner_array.element_type,
+            element_type => element_type,
         },
-        _ => None,
+        _ => ty,
     };
 
     // Then, extract the first type parameter of a Generic as long as it's the
@@ -473,10 +473,10 @@ fn is_simple_ts_type(ty: &TSType<'_>) -> bool {
     //     Foo<number> => number
     //     Foo<number, string> => Foo<number, string>
     let extracted_generic_type = match &extracted_array_type {
-        Some(TSType::TSTypeReference(generic)) => {
+        TSType::TSTypeReference(generic) => {
             if let Some(type_arguments) = &generic.type_arguments {
                 let argument_list = &type_arguments.params;
-                if argument_list.len() == 1 { argument_list.first() } else { extracted_array_type }
+                if argument_list.len() == 1 { &argument_list[0] } else { extracted_array_type }
             } else {
                 extracted_array_type
             }
@@ -484,8 +484,7 @@ fn is_simple_ts_type(ty: &TSType<'_>) -> bool {
         _ => extracted_array_type,
     };
 
-    let resolved_type = extracted_generic_type.unwrap_or(ty);
-    match resolved_type {
+    match extracted_generic_type {
         // Any keyword or literal types
         TSType::TSLiteralType(_)
         | TSType::TSTemplateLiteralType(_)

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-17871.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-17871.ts
@@ -1,0 +1,4 @@
+
+const x = [].reduce(() => {
+  return "y";
+}, {} as SomeType<OtherType>);

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-17871.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-17871.ts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+
+const x = [].reduce(() => {
+  return "y";
+}, {} as SomeType<OtherType>);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const x = [].reduce(() => {
+  return "y";
+}, {} as SomeType<OtherType>);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const x = [].reduce(() => {
+  return "y";
+}, {} as SomeType<OtherType>);
+
+===================== End =====================


### PR DESCRIPTION
Fixes: #17871

Correct code to align with [Prettier](https://github.com/prettier/prettier/blob/093745f0ec429d3db47c1edd823357e0ef24e226/src/language-js/print/call-arguments.js#L284-L306)