### PR TITLE
fix(formatter/sort-imports): hard line inside multiline import leads to incorrect results

### DIFF
--- a/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports.rs
@@ -2050,6 +2050,32 @@ import "node:os";
     );
 }
 
+#[test]
+fn should_sort_multiline_import_containing_comment() {
+    // "a" -> "b" -> "c"
+    assert_format(
+        r#"
+import c from "c";
+import b from "b";
+import {
+  type Data,
+  // this comment makes the source of this import become "Data"
+  xyz,
+} from "a";
+"#,
+        r#"{ "experimentalSortImports": {} }"#,
+        r#"
+import {
+  type Data,
+  // this comment makes the source of this import become "Data"
+  xyz,
+} from "a";
+import b from "b";
+import c from "c";
+"#,
+    );
+}
+
 // ---
 
 #[test]


### PR DESCRIPTION
This PR fixes a minor issue mentioned in #17576.

<img width="4064" height="2152" alt="image" src="https://github.com/user-attachments/assets/c9c0c1ca-2a77-440d-8e84-c74efa4e9bd0" />