### PR TITLE
fix(codegen): clear `print_next_indent_as_space` after newlines

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -420,12 +420,14 @@ impl<'a> Codegen<'a> {
     fn print_soft_newline(&mut self) {
         if !self.options.minify {
             self.print_ascii_byte(b'\n');
+            self.print_next_indent_as_space = false;
         }
     }
 
     #[inline]
     fn print_hard_newline(&mut self) {
         self.print_ascii_byte(b'\n');
+        self.print_next_indent_as_space = false;
     }
 
     #[inline]
@@ -527,7 +529,8 @@ impl<'a> Codegen<'a> {
         if self.options.minify {
             self.needs_semicolon = true;
         } else {
-            self.print_str(";\n");
+            self.print_str(";");
+            self.print_hard_newline();
         }
     }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -111,7 +111,7 @@ function foo() {
 * @preserve
 */
 /**
- * @preserve
+* @preserve
 */
 
 ########## 8

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -318,14 +318,14 @@ export function* generatorFunctionName() {/* … */}
 export const { name5, name2: bar } = o;
 export const [name6, name7] = array;
 export { name8, /* …, */ name81 };
- export { variable1 as name9, variable2 as name10, /* …, */ name82 };
- export { variable1 as 'string name' };
+export { variable1 as name9, variable2 as name10, /* …, */ name82 };
+export { variable1 as 'string name' };
 export { name1 as default1 };
 export * from 'module-name';
 export * as name11 from 'module-name';
 export { name12, /* …, */ nameN } from 'module-name';
- export { import1 as name13, import2 as name14, /* …, */ name15 } from 'module-name';
- export { default } from 'module-name';
+export { import1 as name13, import2 as name14, /* …, */ name15 } from 'module-name';
+export { default } from 'module-name';
 export { default as name16 } from 'module-name';
 
 ########## 41


### PR DESCRIPTION
`print_comments()` can set `print_next_indent_as_space` after inline comments to request a single space before the next token. If a newline is emitted before the flag is consumed, the flag may leak across line boundaries and get consumed at the start of the next statement, producing stray leading spaces.

This PR clears `print_next_indent_as_space` whenever a newline is emitted (`print_soft_newline` / `print_hard_newline`) and routes `print_semicolon_after_statement()` through `print_hard_newline()` so newline handling consistently resets the flag.