### PR TITLE
fix(oxlint/lsp): don't send `workspace/diagnostic/refresh` notification on watched file changes

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -82,7 +82,7 @@ impl ToolBuilder for ServerFormatterBuilder {
     fn server_capabilities(
         &self,
         capabilities: &mut ServerCapabilities,
-        _backend_capabilities: &Capabilities,
+        _backend_capabilities: &mut Capabilities,
     ) {
         capabilities.document_formatting_provider =
             Some(tower_lsp_server::ls_types::OneOf::Left(true));
@@ -390,7 +390,7 @@ mod tests_builder {
         let builder = ServerFormatterBuilder::dummy();
         let mut capabilities = ServerCapabilities::default();
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         assert_eq!(capabilities.document_formatting_provider, Some(OneOf::Left(true)));
     }

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -20,7 +20,8 @@ use oxc_linter::{
 };
 
 use oxc_language_server::{
-    Capabilities, ConcurrentHashMap, DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges,
+    Capabilities, ConcurrentHashMap, DiagnosticMode, DiagnosticResult, Tool, ToolBuilder,
+    ToolRestartChanges,
 };
 
 use crate::lsp::{
@@ -162,7 +163,7 @@ impl ToolBuilder for ServerLinterBuilder {
     fn server_capabilities(
         &self,
         capabilities: &mut ServerCapabilities,
-        backend_capabilities: &Capabilities,
+        backend_capabilities: &mut Capabilities,
     ) {
         let mut code_action_kinds = capabilities
             .code_action_provider
@@ -221,11 +222,22 @@ impl ToolBuilder for ServerLinterBuilder {
             },
         });
 
-        capabilities.diagnostic_provider = if backend_capabilities.use_push_diagnostics() {
-            None
+        // The server supports pull and push diagnostics.
+        // Only use push diagnostics if the client does not support pull diagnostics,
+        // or we cannot ask the client to refresh diagnostics.
+        if !backend_capabilities.pull_diagnostics || !backend_capabilities.refresh_diagnostics {
+            backend_capabilities.diagnostic_mode = DiagnosticMode::Push;
         } else {
-            Some(DiagnosticServerCapabilities::Options(DiagnosticOptions::default()))
-        };
+            backend_capabilities.diagnostic_mode = DiagnosticMode::Pull;
+        }
+
+        // tell the client we support pull diagnostics
+        capabilities.diagnostic_provider =
+            if backend_capabilities.diagnostic_mode == DiagnosticMode::Pull {
+                Some(DiagnosticServerCapabilities::Options(DiagnosticOptions::default()))
+            } else {
+                None
+            };
     }
 
     fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool> {
@@ -665,7 +677,7 @@ mod tests_builder {
         ServerCapabilities, WorkDoneProgressOptions,
     };
 
-    use oxc_language_server::{Capabilities, ToolBuilder};
+    use oxc_language_server::{Capabilities, DiagnosticMode, ToolBuilder};
 
     use crate::lsp::{
         code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, commands::FIX_ALL_COMMAND_ID,
@@ -677,7 +689,7 @@ mod tests_builder {
         let builder = ServerLinterBuilder::default();
         let mut capabilities = ServerCapabilities::default();
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         // Should set code action provider with quickfix and source fix all kinds
         match &capabilities.code_action_provider {
@@ -708,7 +720,7 @@ mod tests_builder {
             ..Default::default()
         };
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         match &capabilities.code_action_provider {
             Some(CodeActionProviderCapability::Options(options)) => {
@@ -735,7 +747,7 @@ mod tests_builder {
             ..Default::default()
         };
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         match &capabilities.code_action_provider {
             Some(CodeActionProviderCapability::Options(options)) => {
@@ -756,7 +768,7 @@ mod tests_builder {
             ..Default::default()
         };
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         // Should override with options
         match &capabilities.code_action_provider {
@@ -783,7 +795,7 @@ mod tests_builder {
             ..Default::default()
         };
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         let execute_command_provider = capabilities.execute_command_provider.as_ref().unwrap();
         assert!(execute_command_provider.commands.contains(&"existing.command".to_string()));
@@ -806,11 +818,51 @@ mod tests_builder {
             ..Default::default()
         };
 
-        builder.server_capabilities(&mut capabilities, &Capabilities::default());
+        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
 
         let execute_command_provider = capabilities.execute_command_provider.as_ref().unwrap();
         assert!(execute_command_provider.commands.contains(&FIX_ALL_COMMAND_ID.to_string()));
         assert_eq!(execute_command_provider.commands.len(), 1);
+    }
+
+    #[test]
+    fn test_server_capabilities_diagnostic_mode() {
+        let builder = ServerLinterBuilder::default();
+        let mut capabilities = Capabilities {
+            pull_diagnostics: true,
+            refresh_diagnostics: true,
+            ..Default::default()
+        };
+        let mut server_capabilities = ServerCapabilities::default();
+        builder.server_capabilities(&mut server_capabilities, &mut capabilities);
+        assert_eq!(capabilities.diagnostic_mode, DiagnosticMode::Pull);
+
+        let mut capabilities = Capabilities {
+            pull_diagnostics: false,
+            refresh_diagnostics: true,
+            ..Default::default()
+        };
+        let mut server_capabilities = ServerCapabilities::default();
+        builder.server_capabilities(&mut server_capabilities, &mut capabilities);
+        assert_eq!(capabilities.diagnostic_mode, DiagnosticMode::Push);
+
+        let mut capabilities = Capabilities {
+            pull_diagnostics: true,
+            refresh_diagnostics: false,
+            ..Default::default()
+        };
+        let mut server_capabilities = ServerCapabilities::default();
+        builder.server_capabilities(&mut server_capabilities, &mut capabilities);
+        assert_eq!(capabilities.diagnostic_mode, DiagnosticMode::Push);
+
+        let mut capabilities = Capabilities {
+            pull_diagnostics: false,
+            refresh_diagnostics: false,
+            ..Default::default()
+        };
+        let mut server_capabilities = ServerCapabilities::default();
+        builder.server_capabilities(&mut server_capabilities, &mut capabilities);
+        assert_eq!(capabilities.diagnostic_mode, DiagnosticMode::Push);
     }
 }
 

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -10,7 +10,7 @@ mod tests;
 mod tool;
 mod worker;
 
-pub use crate::capabilities::Capabilities;
+pub use crate::capabilities::{Capabilities, DiagnosticMode};
 pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
 
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -13,7 +13,7 @@ pub trait ToolBuilder: Send + Sync {
     fn server_capabilities(
         &self,
         _capabilities: &mut ServerCapabilities,
-        _backend_capabilities: &Capabilities,
+        _backend_capabilities: &mut Capabilities,
     ) {
     }
 


### PR DESCRIPTION
> This PR refactors the diagnostic mode handling in the language server to prevent oxfmt from sending unnecessary workspace/diagnostic/refresh notifications on watched file changes. 

The key change introduces a Diagnostic Mode enum (Pull, Push, None) to replace the previous boolean-based approach, allowing tools to opt into diagnostic mode. Without this mode, the Backend will not try to ask the workspace workers for doing their diagnostics