### PR TITLE
fix(linter): Display correct plugin prefix for vitest rules and support vitest-specific behavior

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -319,7 +319,7 @@ impl CliRunner {
             if self.options.output_options.format == OutputFormat::Default {
                 // Build the set of enabled builtin rule names from the resolved config.
                 let enabled: FxHashSet<&str> =
-                    config_store.rules().iter().map(|(rule, _)| rule.name()).collect();
+                    config_store.rules().iter().map(|(rule, _, _)| rule.name()).collect();
 
                 let table = RuleTable::default();
                 for section in &table.sections {

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
    `----
   help: Add assertion(s) in this Test
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-disabled-tests.html\eslint-plugin-jest(no-disabled-tests)]8;;\: Disabled test
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-disabled-tests.html\eslint-plugin-vitest(no-disabled-tests)]8;;\: Disabled test
    ,-[fixtures/eslintrc_vitest_replace/foo.test.js:1:1]
  1 | test.skip('foo', () => {
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -15,13 +15,6 @@ working directory:
    `----
   help: Consider removing this declaration.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
-   ,-[fixtures/typescript_eslint/test.ts:4:1]
- 3 | 
- 4 | 9007199254740993 // no-loss-of-precision
-   : ^^^^^^^^^^^^^^^^
-   `----
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
@@ -29,6 +22,13 @@ working directory:
    : ^^^^^^^^^^^^^^^^
    `----
   help: Consider using this expression or removing it
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-loss-of-precision.html\typescript-eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+   ,-[fixtures/typescript_eslint/test.ts:4:1]
+ 3 | 
+ 4 | 9007199254740993 // no-loss-of-precision
+   : ^^^^^^^^^^^^^^^^
+   `----
 
 Found 2 warnings and 1 error.
 Finished in <variable>ms on 1 file with 53 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -23,13 +23,6 @@ working directory:
    `----
   help: Consider removing this declaration.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
-   ,-[fixtures/typescript_eslint/test.ts:4:1]
- 3 | 
- 4 | 9007199254740993 // no-loss-of-precision
-   : ^^^^^^^^^^^^^^^^
-   `----
-
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
@@ -37,6 +30,13 @@ working directory:
    : ^^^^^^^^^^^^^^^^
    `----
   help: Consider using this expression or removing it
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-loss-of-precision.html\typescript-eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+   ,-[fixtures/typescript_eslint/test.ts:4:1]
+ 3 | 
+ 4 | 9007199254740993 // no-loss-of-precision
+   : ^^^^^^^^^^^^^^^^
+   `----
 
 Found 3 warnings and 1 error.
 Finished in <variable>ms on 1 file with 65 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-vitest.json --report-unused-disable-directives test.js
 working directory: fixtures/disable_vitest_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-jest-methods.html\eslint-plugin-jest(no-restricted-jest-methods)]8;;\: Use of `advanceTimersByTime` is not allowed
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-restricted-jest-methods.html\eslint-plugin-vitest(no-restricted-jest-methods)]8;;\: Use of `advanceTimersByTime` is not allowed
    ,-[test.js:7:6]
  6 | it('calls the callback after 1 second via advanceTimersByTime', () => {
  7 |   vi.advanceTimersByTime(1000);

--- a/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
@@ -25,7 +25,7 @@ arguments: -c oxlint-typescript.json test.js
 working directory: fixtures/eslint_and_typescript_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-magic-numbers.html\eslint(no-magic-numbers)]8;;\: No magic number: 0.19
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-magic-numbers.html\typescript-eslint(no-magic-numbers)]8;;\: No magic number: 0.19
    ,-[test.js:4:32]
  3 | const price = 200;
  4 | const price_with_tax = price * 0.19; // taxes are expensive

--- a/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
@@ -26,7 +26,7 @@ arguments: -c oxlint-vitest.json test.js
 working directory: fixtures/jest_and_vitest_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-identical-title.html\eslint-plugin-jest(no-identical-title)]8;;\: Test title is used multiple times in the same describe block.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-identical-title.html\eslint-plugin-vitest(no-identical-title)]8;;\: Test title is used multiple times in the same describe block.
    ,-[test.js:3:6]
  2 |   it("works", () => {});
  3 |   it("works", () => {});

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -20,7 +20,7 @@ pub use ignore_matcher::LintIgnoreMatcher;
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
 pub use plugins::LintPlugins;
-pub use rules::{ESLintRule, OxlintRules};
+pub use rules::{ConfiguredNamespace, ESLintRule, OxlintRules};
 pub use settings::{OxlintSettings, ReactVersion, jsdoc::JSDocPluginSettings};
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -99,10 +99,10 @@ impl OxlintRules {
                 // If the plugin name was transformed (e.g., vitest -> jest),
                 // store the original plugin name as the configured namespace
                 let configured_namespace: ConfiguredNamespace =
-                    if original_plugin_name != plugin_name {
-                        Some(to_static_str(original_plugin_name))
-                    } else {
+                    if original_plugin_name == plugin_name {
                         None
+                    } else {
+                        Some(to_static_str(original_plugin_name))
                     };
 
                 if LintPlugins::try_from(plugin_name).is_ok() {
@@ -171,7 +171,6 @@ fn to_static_str(plugin_name: &str) -> &'static str {
         "jest" => "jest",
         "unicorn" => "unicorn",
         "typescript" => "typescript",
-        "eslint" => "eslint",
         "react" => "react",
         "jsx_a11y" => "jsx_a11y",
         "nextjs" => "nextjs",
@@ -181,7 +180,8 @@ fn to_static_str(plugin_name: &str) -> &'static str {
         "promise" => "promise",
         "security" => "security",
         "oxc" => "oxc",
-        _ => "eslint", // fallback to eslint for unknown plugins
+        // eslint and unknown plugins fallback to eslint
+        _ => "eslint",
     }
 }
 

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -19,7 +19,12 @@ use crate::{
     utils::{is_eslint_rule_adapted_to_typescript, is_jest_rule_adapted_to_vitest},
 };
 
-type RuleSet = FxHashMap<RuleEnum, AllowWarnDeny>;
+/// The namespace under which a rule was configured.
+/// For example, `vitest/valid-describe-callback` would have `ConfiguredNamespace::Vitest`.
+/// This is used to preserve the original namespace when a vitest rule is implemented by a jest rule.
+pub type ConfiguredNamespace = Option<&'static str>;
+
+type RuleSet = FxHashMap<RuleEnum, (AllowWarnDeny, ConfiguredNamespace)>;
 
 // TS type is `Record<string, RuleConf>`
 //   - type SeverityConf = 0 | 1 | 2 | "off" | "warn" | "error";
@@ -84,11 +89,21 @@ impl OxlintRules {
                 .collect::<FxHashMap<_, _>>();
 
             for rule_config in rule_configs {
-                let (rule_name, plugin_name) = transform_rule_and_plugin_name(
-                    &rule_config.rule_name,
-                    &rule_config.plugin_name,
-                );
+                // Store the original plugin name before transformation
+                let original_plugin_name = rule_config.plugin_name.as_str();
+                let (rule_name, plugin_name) =
+                    transform_rule_and_plugin_name(&rule_config.rule_name, original_plugin_name);
                 let severity = rule_config.severity;
+
+                // Determine the configured namespace:
+                // If the plugin name was transformed (e.g., vitest -> jest),
+                // store the original plugin name as the configured namespace
+                let configured_namespace: ConfiguredNamespace =
+                    if original_plugin_name != plugin_name {
+                        Some(to_static_str(original_plugin_name))
+                    } else {
+                        None
+                    };
 
                 if LintPlugins::try_from(plugin_name).is_ok() {
                     let rule = rules_map.get(&plugin_name).copied().or_else(|| {
@@ -108,6 +123,7 @@ impl OxlintRules {
                             rule.from_configuration(config)
                                 .expect("failed to parse rule configuration"),
                             severity,
+                            configured_namespace,
                         ));
                     }
                 } else {
@@ -138,12 +154,34 @@ impl OxlintRules {
             }
         }
 
-        for (rule, severity) in rules_to_replace {
+        for (rule, severity, configured_namespace) in rules_to_replace {
             let _ = rules_for_override.remove(&rule);
-            rules_for_override.insert(rule, severity);
+            rules_for_override.insert(rule, (severity, configured_namespace));
         }
 
         Ok(())
+    }
+}
+
+/// Convert a plugin name string to a static str for known plugin names.
+/// This avoids allocations by returning the canonical static string.
+fn to_static_str(plugin_name: &str) -> &'static str {
+    match plugin_name {
+        "vitest" => "vitest",
+        "jest" => "jest",
+        "unicorn" => "unicorn",
+        "typescript" => "typescript",
+        "eslint" => "eslint",
+        "react" => "react",
+        "jsx_a11y" => "jsx_a11y",
+        "nextjs" => "nextjs",
+        "import" => "import",
+        "jsdoc" => "jsdoc",
+        "node" => "node",
+        "promise" => "promise",
+        "security" => "security",
+        "oxc" => "oxc",
+        _ => "eslint", // fallback to eslint for unknown plugins
     }
 }
 
@@ -466,7 +504,7 @@ mod test {
             r#override(&mut rules, &config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let (rule, severity) = rules.iter().next().unwrap();
+            let (rule, (severity, _)) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-console", "{config:?}");
             assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }
@@ -489,7 +527,7 @@ mod test {
             1,
             "eslint rules should be configurable by their typescript-eslint reimplementations: {config:?}"
         );
-        let (rule, severity) = rules.iter().next().unwrap();
+        let (rule, (severity, _)) = rules.iter().next().unwrap();
         assert_eq!(
             rule.name(),
             "no-console",
@@ -505,10 +543,10 @@ mod test {
     #[test]
     fn test_override_allow() {
         let mut rules = RuleSet::default();
-        rules.insert(RuleEnum::EslintNoConsole(Default::default()), AllowWarnDeny::Deny);
+        rules.insert(RuleEnum::EslintNoConsole(Default::default()), (AllowWarnDeny::Deny, None));
         r#override(&mut rules, &json!({ "eslint/no-console": "off" }));
 
-        assert!(!rules.iter().any(|(_, severity)| severity.is_warn_deny()));
+        assert!(!rules.iter().any(|(_, (severity, _))| severity.is_warn_deny()));
     }
 
     #[test]
@@ -524,18 +562,21 @@ mod test {
             r#override(&mut rules, config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let (rule, severity) = rules.iter().next().unwrap();
+            let (rule, (severity, _)) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
             assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }
 
         for config in &configs {
             let mut rules = RuleSet::default();
-            rules.insert(RuleEnum::EslintNoUnusedVars(Default::default()), AllowWarnDeny::Warn);
+            rules.insert(
+                RuleEnum::EslintNoUnusedVars(Default::default()),
+                (AllowWarnDeny::Warn, None),
+            );
             r#override(&mut rules, config);
 
             assert_eq!(rules.len(), 1, "{config:?}");
-            let (rule, severity) = rules.iter().next().unwrap();
+            let (rule, (severity, _)) = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
             assert_eq!(severity, &AllowWarnDeny::Deny, "{config:?}");
         }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -15,7 +15,6 @@ use crate::rule::RuleFixMeta;
 use crate::{
     AllowWarnDeny, FrameworkFlags, ModuleRecord, OxlintEnv, OxlintGlobals, OxlintSettings,
     WEBSITE_BASE_RULES_URL,
-    config::GlobalValue,
     config::{ConfiguredNamespace, GlobalValue},
     disable_directives::DisableDirectives,
     fixer::{Fix, FixKind, Message, PossibleFixes, RuleFix, RuleFixer},

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -186,7 +186,7 @@ impl Linter {
             let semantic = ctx_host.semantic();
             let rules = rules
                 .iter()
-                .filter(|(rule, _)| {
+                .filter(|(rule, _, _)| {
                     if rule.is_tsgolint_rule() {
                         return false;
                     }
@@ -202,7 +202,9 @@ impl Linter {
 
                     rule.should_run(&ctx_host)
                 })
-                .map(|(rule, severity)| (rule, Rc::clone(&ctx_host).spawn(rule, *severity)))
+                .map(|(rule, severity, configured_namespace)| {
+                    (rule, Rc::clone(&ctx_host).spawn(rule, *severity, *configured_namespace))
+                })
                 .collect::<Vec<_>>();
 
             let should_run_on_jest_node =

--- a/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@jest-async.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@jest-async.snap
@@ -1,0 +1,110 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', async () => {})
+   ·                 ──────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', async function () {})
+   ·                 ────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:18]
+ 1 │ xdescribe('foo', async function () {})
+   ·                  ────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:18]
+ 1 │ fdescribe('foo', async function () {})
+   ·                  ────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:3:30]
+ 2 │             import { fdescribe } from '@jest/globals';
+ 3 │             fdescribe('foo', async function () {})
+   ·                              ────────────────────
+ 4 │             
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:22]
+ 1 │ describe.only('foo', async function () {})
+   ·                      ────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:22]
+ 1 │ describe.skip('foo', async function () {})
+   ·                      ────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+    ╭─[valid_describe_callback.tsx:6:35]
+  5 │                     });
+  6 │ ╭─▶                 describe('async', async () => {
+  7 │ │                       await new Promise(setImmediate);
+  8 │ │                       it('breaks', () => {
+  9 │ │                           throw new Error('Fail');
+ 10 │ │                       });
+ 11 │ ╰─▶                 });
+ 12 │                 });
+    ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+    ╭─[valid_describe_callback.tsx:2:29]
+  1 │     
+  2 │ ╭─▶             describe('foo', async () => {
+  3 │ │                   await something()
+  4 │ │                   it('does something')
+  5 │ │                   describe('nested', () => {
+  6 │ │                       return Promise.resolve().then(() => {
+  7 │ │                           it('breaks', () => {
+  8 │ │                               throw new Error('Fail')
+  9 │ │                           })
+ 10 │ │                       })
+ 11 │ │                   })
+ 12 │ ╰─▶             })
+ 13 │                 
+    ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
+    ╭─[valid_describe_callback.tsx:6:21]
+  5 │                     describe('nested', () => {
+  6 │ ╭─▶                     return Promise.resolve().then(() => {
+  7 │ │                           it('breaks', () => {
+  8 │ │                               throw new Error('Fail')
+  9 │ │                           })
+ 10 │ ╰─▶                     })
+ 11 │                     })
+    ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', async function (done) {})
+   ·                 ────────────────────────
+   ╰────
+  help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', async function (done) {})
+   ·                 ────────────────────────
+   ╰────
+  help: Remove argument(s) of describe callback

--- a/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@jest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@jest.snap
@@ -1,0 +1,126 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe.each()()
+   · ─────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe['each']()()
+   · ────────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe.each(() => {})()
+   · ─────────────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:25]
+ 1 │ describe.each(() => {})('foo')
+   ·                         ─────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe.each()(() => {})
+   ·                 ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:20]
+ 1 │ describe['each']()(() => {})
+   ·                    ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:22]
+ 1 │ describe.each('foo')(() => {})
+   ·                      ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:27]
+ 1 │ describe.only.each('foo')(() => {})
+   ·                           ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:10]
+ 1 │ describe(() => {})
+   ·          ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:10]
+ 1 │ describe('foo')
+   ·          ─────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Second argument must be a function
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', 'foo2')
+   ·                 ──────
+   ╰────
+  help: Replace second argument with a function
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe()
+   · ──────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:17]
+ 2 │                 describe('foo', function () {
+ 3 │ ╭─▶                 return Promise.resolve().then(() => {
+ 4 │ │                       it('breaks', () => {
+ 5 │ │                           throw new Error('Fail')
+ 6 │ │                       })
+ 7 │ ╰─▶                 })
+ 8 │                 })
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:1:23]
+ 1 │ describe('foo', () => test('bar', () => {})) 
+   ·                       ─────────────────────
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', done => {})
+   ·                 ──────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', function (done) {})
+   ·                 ──────────────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe('foo', function (one, two, three) {})
+   ·                 ─────────────────────────────
+   ╰────
+  help: Remove argument(s) of describe callback

--- a/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@vitest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_describe_callback@vitest.snap
@@ -1,0 +1,159 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe.each()()
+   · ─────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe["each"]()()
+   · ────────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe.each(() => {})()
+   · ─────────────────────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:25]
+ 1 │ describe.each(() => {})("foo")
+   ·                         ─────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe.each()(() => {})
+   ·                 ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:20]
+ 1 │ describe["each"]()(() => {})
+   ·                    ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:22]
+ 1 │ describe.each("foo")(() => {})
+   ·                      ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:27]
+ 1 │ describe.only.each("foo")(() => {})
+   ·                           ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:10]
+ 1 │ describe(() => {})
+   ·          ────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:10]
+ 1 │ describe("foo")
+   ·          ─────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Second argument must be a function
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe("foo", "foo2")
+   ·                 ──────
+   ╰────
+  help: Replace second argument with a function
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+   ╭─[valid_describe_callback.tsx:1:1]
+ 1 │ describe()
+   · ──────────
+   ╰────
+  help: Add name as first argument and callback as second argument
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:21]
+ 2 │                     describe('foo', function () {
+ 3 │ ╭─▶                     return Promise.resolve().then(() => {
+ 4 │ │                           it('breaks', () => {
+ 5 │ │                               throw new Error('Fail')
+ 6 │ │                           })
+ 7 │ ╰─▶                     })
+ 8 │                     })
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:21]
+ 2 │                     describe('foo', () => {
+ 3 │ ╭─▶                     return Promise.resolve().then(() => {
+ 4 │ │                           it('breaks', () => {
+ 5 │ │                               throw new Error('Fail')
+ 6 │ │                           })
+ 7 │ ╰─▶                     })
+ 8 │                         describe('nested', () => {
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+    ╭─[valid_describe_callback.tsx:9:25]
+  8 │                         describe('nested', () => {
+  9 │ ╭─▶                         return Promise.resolve().then(() => {
+ 10 │ │                               it('breaks', () => {
+ 11 │ │                                   throw new Error('Fail')
+ 12 │ │                               })
+ 13 │ ╰─▶                         })
+ 14 │                         })
+    ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:21]
+ 2 │                 describe('foo', () =>
+ 3 │                     test('bar', () => {})
+   ·                     ─────────────────────
+ 4 │                 )
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe("foo", done => {})
+   ·                 ──────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe("foo", function (done) {})
+   ·                 ──────────────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe("foo", function (one, two, three) {})
+   ·                 ─────────────────────────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:17]
+ 1 │ describe("foo", async function (done) {})
+   ·                 ────────────────────────
+   ╰────
+  help: Remove argument(s) of describe callback

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -164,10 +164,10 @@ impl TsGoLintState {
                                                 resolved_config
                                                     .rules
                                                     .iter()
-                                                    .find(|(rule, _)| {
+                                                    .find(|(rule, _, _)| {
                                                         rule.name() == tsgolint_diagnostic.rule
                                                     })
-                                                    .map(|(_, status)| *status)
+                                                    .map(|(_, status, _)| *status)
                                             })
                                             .or_else(|| {
                                                 debug_assert!(false, "resolved_config should have a matching rule for every diagnostic we received {tsgolint_diagnostic:?}");
@@ -377,14 +377,15 @@ impl TsGoLintState {
                                         continue;
                                     };
 
-                                    let severity =
-                                        resolved_config.rules.iter().find_map(|(rule, status)| {
+                                    let severity = resolved_config.rules.iter().find_map(
+                                        |(rule, status, _)| {
                                             if rule.name() == tsgolint_diagnostic.rule {
                                                 Some(*status)
                                             } else {
                                                 None
                                             }
-                                        });
+                                        },
+                                    );
                                     let Some(severity) = severity else {
                                         // If the severity is not found, we should not report the diagnostic
                                         continue;
@@ -506,7 +507,7 @@ impl TsGoLintState {
                 let rules: BTreeSet<Rule> = resolved_config
                     .rules
                     .iter()
-                    .filter_map(|(rule, status)| {
+                    .filter_map(|(rule, status, _)| {
                         if status.is_warn_deny() && rule.is_tsgolint_rule() {
                             let rule_name = rule.name().to_string();
                             let options = match rule.to_configuration() {


### PR DESCRIPTION
## What This PR Does
closes #9060

- Shows `eslint-plugin-vitest(...)` instead of `eslint-plugin-jest(...)` when rules are configured under vitest namespace
- Allows async describe callbacks in vitest context (vitest supports this, jest doesn't)
- Supports vitest's 3-argument syntax: `describe('name', { timeout }, callback)`

## Approach

Added `ConfiguredNamespace = Option<&'static str>` to track the original namespace. Extended the rules tuple from `(RuleEnum, AllowWarnDeny)` to `(RuleEnum, AllowWarnDeny, ConfiguredNamespace)`.

Used a 3-tuple instead of a struct, following #11051's direction.

## Disclosure

- **AI Assisted**: Used GitHub Copilot. All code reviewed and tested.
- **External Testing**: Built oxlint and tested on personal project.
- **First Contribution**: Looking forward to feedback!

---

## Questions for Reviewers

1. **Tuple vs Struct**: With 3 fields now, should we introduce a struct instead of the 3-tuple?

2. **Auto-detection**: Currently auto-detects vitest context when vitest plugin is enabled and a jest rule runs. Is this appropriate, or require explicit `vitest/rule-name`?

~3. **Scope**: Only `valid-describe-callback` uses `is_vitest_context()`. Should other shared rules be updated in this PR or follow-up?~
