### PR TITLE
chore(linter): Remove unnecessary colon characters from category headers.

### DIFF
--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -139,7 +139,7 @@ impl RuleTableSection {
         let rows: &Vec<RuleTableRow> = &self.rows;
         let rule_width = self.rule_column_width;
         let plugin_width = self.plugin_column_width;
-        writeln!(s, "## {} ({}):", category, rows.len()).unwrap();
+        writeln!(s, "## {} ({})", category, rows.len()).unwrap();
 
         writeln!(s, "{}", category.description()).unwrap();
 


### PR DESCRIPTION
This looked a bit weird before, no need for `Correctness (123):` in the header.

Previously:

<img width="758" height="258" alt="Screenshot 2026-01-11 at 12 00 18 PM" src="https://github.com/user-attachments/assets/e0df4aa8-94f4-4087-895b-19fe6cd69945" />
