### PR TITLE
docs(linter): Tweak docs for no-useless-constructor and hoisted-apis-on-top

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -53,8 +53,10 @@ declare_oxc_lint!(
     /// simply delegates into its parent class.
     ///
     /// ::: warning
-    /// Caveat: This lint rule will report on constructors whose sole purpose is to change visibility of a parent constructor.
-    /// This is because the rule does not have type information to determine if the parent constructor is public, protected, or private.
+    /// Caveat: This lint rule will report on constructors whose sole purpose
+    /// is to change visibility of a parent constructor. This is because the rule
+    /// does not have type information to determine if the parent constructor is
+    /// `public`, `protected`, or `private`.
     /// :::
     ///
     /// ### Examples
@@ -62,14 +64,13 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// class A {
-    ///     constructor () {
-    ///     }
+    ///   constructor() {}
     /// }
     ///
     /// class B extends A {
-    ///     constructor (...args) {
-    ///       super(...args);
-    ///     }
+    ///   constructor(...args) {
+    ///     super(...args);
+    ///   }
     /// }
     /// ```
     ///
@@ -78,22 +79,22 @@ declare_oxc_lint!(
     /// class A { }
     ///
     /// class B {
-    ///     constructor () {
-    ///         doSomething();
-    ///     }
+    ///   constructor() {
+    ///     doSomething();
+    ///   }
     /// }
     ///
     /// class C extends A {
-    ///     constructor() {
-    ///         super('foo');
-    ///     }
+    ///   constructor() {
+    ///     super('foo');
+    ///   }
     /// }
     ///
     /// class D extends A {
-    ///     constructor() {
-    ///         super();
-    ///         doSomething();
-    ///     }
+    ///   constructor() {
+    ///     super();
+    ///     doSomething();
+    ///   }
     /// }
     /// ```
     NoUselessConstructor,

--- a/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
+++ b/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 fn hoisted_apis_on_top_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Hoisted API can not be used in a runtime location in this file.")
-        .with_help("Move this hoisted API to the top of the file to better reflect its behavior.\nIf it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.")
+    OxcDiagnostic::warn("Hoisted API cannot be used in a runtime location in this file.")
+        .with_help("Move this hoisted API to the top of the file to better reflect its behavior.\nIf possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.")
         .with_label(span)
 }
 
@@ -39,36 +39,38 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```js
     /// if (condition) {
-    ///  vi.mock('some-module', () => {})
+    ///   vi.mock('some-module', () => {})
     /// }
     /// ```
     ///
     /// ```js
     /// if (condition) {
-    ///  vi.unmock('some-module', () => {})
+    ///   vi.unmock('some-module', () => {})
     /// }
     /// ```
     ///
     /// ```js
     /// if (condition) {
-    ///  vi.hoisted(() => {})
+    ///   vi.hoisted(() => {})
     /// }
     /// ```
     ///
     /// ```js
     /// describe('suite', () => {
-    ///     it('test', async () => {
-    ///         vi.mock('some-module', () => {})
+    ///   it('test', async () => {
+    ///     vi.mock('some-module', () => {})
     ///
-    ///         const sm = await import('some-module')
+    ///     const sm = await import('some-module')
     ///
     ///   })
     /// })
     /// ```
     ///
     /// Examples of **correct** code for this rule:
+    ///
+    /// ```js
     /// if (condition) {
-    ///  vi.doMock('some-module', () => {})
+    ///   vi.doMock('some-module', () => {})
     /// }
     /// ```
     ///
@@ -76,6 +78,7 @@ declare_oxc_lint!(
     /// vi.mock('some-module', () => {})
     /// if (condition) {}
     /// ```
+    ///
     /// ```js
     /// vi.unmock('some-module', () => {})
     /// if (condition) {}
@@ -89,14 +92,12 @@ declare_oxc_lint!(
     /// ```js
     /// vi.mock('some-module', () => {})
     ///
-    ///
     /// describe('suite', () => {
     ///   it('test', async () => {
     ///     const sm = await import('some-module')
     ///   })
     /// })
     /// ```
-    ///
     HoistedApisOnTop,
     vitest,
     correctness,

--- a/crates/oxc_linter/src/snapshots/vitest_hoisted_apis_on_top.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_hoisted_apis_on_top.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API can not be used in a runtime location in this file.
+  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.tsx:3:6]
  2 │             if (foo) {
  3 │               vi.mock('foo', () => {});
@@ -9,9 +9,9 @@ source: crates/oxc_linter/src/tester.rs
  4 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
-  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API can not be used in a runtime location in this file.
+  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.tsx:5:6]
  4 │             if (foo) {
  5 │               vi.hoisted();
@@ -19,9 +19,9 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
-  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API can not be used in a runtime location in this file.
+  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.tsx:5:6]
  4 │             if (foo) {
  5 │               vi.unmock();
@@ -29,9 +29,9 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
-  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API can not be used in a runtime location in this file.
+  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.tsx:5:6]
  4 │             if (foo) {
  5 │               vi.mock();
@@ -39,9 +39,9 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
-  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API can not be used in a runtime location in this file.
+  ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.tsx:3:6]
  2 │             if (shouldMock) {
  3 │               vi.mock(import('something'), () => bar);
@@ -49,4 +49,4 @@ source: crates/oxc_linter/src/tester.rs
  4 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If it's possible replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.


### PR DESCRIPTION
Just some docs/diagnostics tweaks to improve things. Fixes invalid markdown for hoisted-apis-on-top rule.