### PR TITLE
docs(linter/no-caller): Improve docs and diagnostic for rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_caller_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use `arguments.{method_name}`"))
-        .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.")
+    OxcDiagnostic::warn(format!("Do not use `arguments.{method_name}`."))
+        .with_help("`caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them.")
         .with_label(span)
 }
 
@@ -22,13 +22,12 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// The use of `arguments.caller` and `arguments.callee` make several code
-    /// optimizations impossible.  They have been deprecated in future versions
-    /// of JavaScript and their use is forbidden in ECMAScript 5 while in strict
-    /// mode.
+    /// optimizations impossible. They have been deprecated in JavaScript, and
+    /// their use is forbidden while in strict mode.
     ///
     /// ```js
     /// function foo() {
-    /// var callee = arguments.callee;
+    ///   var callee = arguments.callee;
     /// }
     /// ```
     ///
@@ -36,35 +35,38 @@ declare_oxc_lint!(
     /// code by disallowing the use of `arguments.caller` and `arguments.callee`. As
     /// such, it will warn when `arguments.caller` and `arguments.callee` are used.
     ///
+    /// See [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
+    /// for more information.
+    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
     /// function foo(n) {
-    ///     if (n <= 0) {
-    ///         return;
-    ///     }
+    ///   if (n <= 0) {
+    ///     return;
+    ///   }
     ///
-    ///     arguments.callee(n - 1);
+    ///   arguments.callee(n - 1);
     /// }
     ///
     /// [1,2,3,4,5].map(function(n) {
-    ///    return !(n > 1) ? 1 : arguments.callee(n - 1) * n;
+    ///   return !(n > 1) ? 1 : arguments.callee(n - 1) * n;
     /// });
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
     /// function foo(n) {
-    ///     if (n <= 0) {
-    ///         return;
-    ///     }
+    ///   if (n <= 0) {
+    ///     return;
+    ///   }
     ///
-    ///     foo(n - 1);
+    ///   foo(n - 1);
     /// }
     ///
     /// [1,2,3,4,5].map(function factorial(n) {
-    ///     return !(n > 1) ? 1 : factorial(n - 1) * n;
+    ///   return !(n > 1) ? 1 : factorial(n - 1) * n;
     /// });
     /// ```
     NoCaller,
@@ -88,13 +90,13 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("var x = arguments.length", None),
-        ("var x = arguments", None),
-        ("var x = arguments[0]", None),
-        ("var x = arguments[caller]", None),
+        "var x = arguments.length",
+        "var x = arguments",
+        "var x = arguments[0]",
+        "var x = arguments[caller]",
     ];
 
-    let fail = vec![("var x = arguments.callee", None), ("var x = arguments.caller", None)];
+    let fail = vec!["var x = arguments.callee", "var x = arguments.caller"];
 
     Tester::new(NoCaller::NAME, NoCaller::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_caller.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_caller.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-caller): Do not use `arguments.callee`
+  ⚠ eslint(no-caller): Do not use `arguments.callee`.
    ╭─[no_caller.tsx:1:19]
  1 │ var x = arguments.callee
    ·                   ──────
    ╰────
-  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.
+  help: `caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them.
 
-  ⚠ eslint(no-caller): Do not use `arguments.caller`
+  ⚠ eslint(no-caller): Do not use `arguments.caller`.
    ╭─[no_caller.tsx:1:19]
  1 │ var x = arguments.caller
    ·                   ──────
    ╰────
-  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.
+  help: `caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them.


### PR DESCRIPTION
Simple improvement. Also improved the tests slightly to remove unnecessary tuple usage, as the rule takes no config options.