### PR TITLE
docs(linter/no-unsafe-finally): Improve rule docs.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -26,8 +26,12 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// JavaScript suspends the control flow statements of try and catch blocks until the execution of finally block finishes.
-    /// So, when return, throw, break, or continue is used in finally, control flow statements inside try and catch are overwritten, which is considered as unexpected behavior.
+    /// JavaScript suspends the control flow statements of `try` and `catch`
+    /// blocks until the execution of a `finally` block finishes.
+    ///
+    /// So, when `return`, `throw`, `break`, or `continue` is used in `finally`,
+    /// control flow statements inside `try` and `catch` are overwritten.
+    /// This is possibly unexpected behavior for the developer.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
Add backticks for JS keywords to make the docs a bit clearer, and rephrase the docs slightly.