### PR TITLE
chore(rulegen): Add an empty line between fix and Tester.

### DIFF
--- a/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
+++ b/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
@@ -89,5 +89,6 @@ fn test() {
     let fix = vec![
         ("fixed")
     ];
+
     Tester::new(MyRule::NAME, MyRule::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -95,6 +95,7 @@ fn test() {
     let fix = vec![
         {{fix_cases}}
     ];
+
     Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
     {{else}}
     Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).test_and_snapshot();


### PR DESCRIPTION
This was bothering me, so now it's fixed.