### PR TITLE
test(linter): Regenerate test cases for a few more rules

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -110,15 +110,15 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("new Promise((resolve, reject) => {})", None),
-        ("new Promise((resolve, reject) => {}, async function unrelated() {})", None),
-        ("new Foo(async (resolve, reject) => {})", None),
+        "new Promise((resolve, reject) => {})",
+        "new Promise((resolve, reject) => {}, async function unrelated() {})",
+        "new Foo(async (resolve, reject) => {})",
     ];
 
     let fail = vec![
-        ("new Promise(async function foo(resolve, reject) {})", None),
-        ("new Promise(async (resolve, reject) => {})", None),
-        ("new Promise(((((async () => {})))))", None),
+        "new Promise(async function foo(resolve, reject) {})",
+        "new Promise(async (resolve, reject) => {})",
+        "new Promise(((((async () => {})))))",
     ];
 
     Tester::new(NoAsyncPromiseExecutor::NAME, NoAsyncPromiseExecutor::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -82,17 +82,17 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("try { } catch (e) { three = 2 + 1; }", None),
-        ("try { } catch ({e}) { this.something = 2; }", None),
-        ("function foo() { try { } catch (e) { return false; } }", None),
+        "try { } catch (e) { three = 2 + 1; }",
+        "try { } catch ({e}) { this.something = 2; }", // { "ecmaVersion": 6 },
+        "function foo() { try { } catch (e) { return false; } }",
     ];
 
     let fail = vec![
-        ("try { } catch (e) { e = 10; }", None),
-        ("try { } catch (ex) { ex = 10; }", None),
-        ("try { } catch (ex) { [ex] = []; }", None),
-        ("try { } catch (ex) { ({x: ex = 0} = {}); }", None),
-        ("try { } catch ({message}) { message = 10; }", None),
+        "try { } catch (e) { e = 10; }",
+        "try { } catch (ex) { ex = 10; }",
+        "try { } catch (ex) { [ex] = []; }", // { "ecmaVersion": 6 },
+        "try { } catch (ex) { ({x: ex = 0} = {}); }", // { "ecmaVersion": 6 },
+        "try { } catch ({message}) { message = 10; }", // { "ecmaVersion": 6 }
     ];
 
     Tester::new(NoExAssign::NAME, NoExAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -94,25 +94,25 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("function foo() { var foo = bar; }", None),
-        ("function foo(foo) { foo = bar; }", None),
-        ("function foo() { var foo; foo = bar; }", None),
-        ("var foo = () => {}; foo = bar;", None),
-        ("var foo = function() {}; foo = bar;", None),
-        ("var foo = function() { foo = bar; };", None),
-        ("import bar from 'bar'; function foo() { var foo = bar; }", None),
+        "function foo() { var foo = bar; }",
+        "function foo(foo) { foo = bar; }",
+        "function foo() { var foo; foo = bar; }",
+        "var foo = () => {}; foo = bar;", // { "ecmaVersion": 6 },
+        "var foo = function() {}; foo = bar;",
+        "var foo = function() { foo = bar; };",
+        "import bar from 'bar'; function foo() { var foo = bar; }", // { "ecmaVersion": 6, "sourceType": "module" }
     ];
 
     let fail = vec![
-        ("function foo() {}; foo = bar;", None),
-        ("function foo() { foo = bar; }", None),
-        ("foo = bar; function foo() { };", None),
-        ("[foo] = bar; function foo() { };", None),
-        ("({x: foo = 0} = bar); function foo() { };", None),
-        ("function foo() { [foo] = bar; }", None),
-        ("(function() { ({x: foo = 0} = bar); function foo() { }; })();", None),
-        ("var a = function foo() { foo = 123; };", None),
-        ("let a = function hello() { hello = 123;};", None),
+        "function foo() {}; foo = bar;",
+        "function foo() { foo = bar; }",
+        "foo = bar; function foo() { };",
+        "[foo] = bar; function foo() { };", // { "ecmaVersion": 6 },
+        "({x: foo = 0} = bar); function foo() { };", // { "ecmaVersion": 6 },
+        "function foo() { [foo] = bar; }",  // { "ecmaVersion": 6 },
+        "(function() { ({x: foo = 0} = bar); function foo() { }; })();", // { "ecmaVersion": 6 },
+        "var a = function foo() { foo = 123; };",
+        "let a = function hello() { hello = 123;};",
     ];
 
     Tester::new(NoFuncAssign::NAME, NoFuncAssign::PLUGIN, pass, fail).test_and_snapshot();


### PR DESCRIPTION
Get them matching the rulegen output, no real change to content.

The only difference from what is created by the rulegen tool is that the `no-func-assign` tests had a different case from the upstream, and I didn't know whether it was a custom case we added or just a change by the upstream. So that case is kept for now.