### PR TITLE
feat(rulegen): Improve rulegen output and add tests

### DIFF
--- a/tasks/rulegen/src/json.rs
+++ b/tasks/rulegen/src/json.rs
@@ -5,18 +5,26 @@ use lazy_regex::{Captures, regex};
 /// Convert a javascript object literal to JSON by wrapping the property keys in double quotes,
 /// converting single quotes to double quotes, and replacing tabs with spaces.
 pub fn convert_config_to_json_literal(object: &str) -> String {
-    let ident_matcher = regex!(r"(?P<ident>[[:alpha:]]\w*\s*):");
+    // Only rewrite identifiers that appear to be object keys (start of string or
+    // immediately after `{`, `[` or `,`). This avoids touching colons that are
+    // part of string contents such as "Note:".
+    let ident_matcher = regex!(r"(^\s*|[\{\[,]\s*)(?P<ident>[[:alpha:]]\w*)\s*:");
 
     let after_ident = ident_matcher.replace_all(object, |capture: &Captures| {
+        let prefix = capture.get(1).map_or("", |m| m.as_str());
         let ident = &capture["ident"];
-        Cow::Owned(format!(r#""{ident}":"#))
+        Cow::Owned(format!(r#"{prefix}"{ident}":"#))
     });
     let comment_matcher = regex!("//.*?\n");
-    let whitespace_matcher = regex!(r"(\t| )+");
+    let whitespace_matcher = regex!(r"(\s)+");
     whitespace_matcher
         .replace_all(&comment_matcher.replace_all(&after_ident, ""), " ")
         .replace('\'', "\"")
         .replace('\n', " ")
+        .replace('\t', "  ")
+        .trim()
+        .trim_end_matches(',')
+        .to_string()
 }
 
 #[cfg(test)]
@@ -56,5 +64,69 @@ mod tests {
         let input = "{   foo:   'bar'   }";
         let out = convert_config_to_json_literal(input);
         assert_eq!(out, "{ \"foo\": \"bar\" }");
+    }
+
+    #[test]
+    fn test_leading_following_spaces() {
+        let input = " {   foo:   'bar'   } ";
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "{ \"foo\": \"bar\" }");
+    }
+
+    #[test]
+    fn test_multiple_attributes() {
+        let input = r#" { foo: "bar", baz: "qux" } "#;
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "{ \"foo\": \"bar\", \"baz\": \"qux\" }");
+    }
+
+    #[test]
+    fn test_trailing_commas() {
+        let input = r"{
+            foo: true
+        },";
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "{ \"foo\": true }");
+    }
+
+    #[test]
+    fn test_newlines_for_json() {
+        let input = r#"[
+            {
+                foo: true,
+                bar: "baz"
+            }
+        ]"#;
+        let out = convert_config_to_json_literal(input);
+        // TODO: We want to remove the extra spaces in here.
+        assert_eq!(out, "[ { \"foo\": true, \"bar\": \"baz\" } ]");
+    }
+
+    #[test]
+    fn test_newlines_for_json_with_trailers() {
+        let input = r#"[
+            {
+                foo: true,
+                bar: "baz",
+            },
+        ],"#;
+        let out = convert_config_to_json_literal(input);
+        // TODO: We want to remove the extra spaces and commas in here.
+        assert_eq!(out, "[ { \"foo\": true, \"bar\": \"baz\", }, ]");
+    }
+
+    #[test]
+    fn test_parsing_with_extra_colon() {
+        let input = r#"[{ foo: "Note:" }]"#;
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "[{ \"foo\": \"Note:\" }]");
+
+        let input = r#"[{ foo: "Note:Bar" }]"#;
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "[{ \"foo\": \"Note:Bar\" }]");
+
+        let input = r#"[{ foo: ":foo:" }]"#;
+        let out = convert_config_to_json_literal(input);
+        assert_eq!(out, "[{ \"foo\": \":foo:\" }]");
     }
 }


### PR DESCRIPTION
Simple changes cut out of #17620, to fix some minor issues with the rulegen code.

Basically, just improves consistency in the code output by the rulegen tool:

- Replaces tabs in the test cases with spaces, previously we inserted tabs for indentation and that lead to weird differences in the code.
- Reduce unnecessary usage of `r#"` escaping that resulted in clippy warnings about unnecessary escaping when generating some rules (this doesn't fix _all_ problems here, but it fixes a lot of them).
- Adds tests

I've used a script I wrote to regenerate every ESLint rule in the repo and gone through them to make sure this doesn't break anything, and I believe this is a safe change.