### PR TITLE
test(linter/no-promise-executor-return): Regenerate tests for rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
@@ -227,61 +227,183 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        // Empty return is allowed
-        ("new Promise((resolve, reject) => { return; })", None),
-        ("new Promise(function (resolve, reject) { return; })", None),
-        // No return at all
-        ("new Promise((resolve, reject) => { resolve(1); })", None),
-        ("new Promise(function (resolve, reject) { resolve(1); })", None),
-        // Arrow with block body, no return
-        ("new Promise(r => { r(1) })", None),
-        // Not a Promise
-        ("new Foo((resolve, reject) => { return 1; })", None),
-        ("new Foo(r => r(1))", None),
-        // Nested function with return is ok
-        ("new Promise((resolve) => { function inner() { return 1; } inner(); resolve(); })", None),
-        ("new Promise((resolve) => { const inner = () => 1; resolve(inner()); })", None),
-        // void is allowed with allowVoid option (explicit return)
+        ("function foo(resolve, reject) { return 1; }", None),
+        ("function Promise(resolve, reject) { return 1; }", None),
+        ("(function (resolve, reject) { return 1; })", None),
+        ("(function foo(resolve, reject) { return 1; })", None),
+        ("(function Promise(resolve, reject) { return 1; })", None),
+        ("var foo = function (resolve, reject) { return 1; }", None),
+        ("var foo = function Promise(resolve, reject) { return 1; }", None),
+        ("var Promise = function (resolve, reject) { return 1; }", None),
+        ("(resolve, reject) => { return 1; }", None),
+        ("(resolve, reject) => 1", None),
+        ("var foo = (resolve, reject) => { return 1; }", None),
+        ("var Promise = (resolve, reject) => { return 1; }", None),
+        ("var foo = (resolve, reject) => 1", None),
+        ("var Promise = (resolve, reject) => 1", None),
+        ("var foo = { bar(resolve, reject) { return 1; } }", None),
+        ("var foo = { Promise(resolve, reject) { return 1; } }", None),
+        ("new foo(function (resolve, reject) { return 1; });", None),
+        ("new foo(function bar(resolve, reject) { return 1; });", None),
+        ("new foo(function Promise(resolve, reject) { return 1; });", None),
+        ("new foo((resolve, reject) => { return 1; });", None),
+        ("new foo((resolve, reject) => 1);", None),
+        ("new promise(function foo(resolve, reject) { return 1; });", None),
+        ("new Promise.foo(function foo(resolve, reject) { return 1; });", None),
+        ("new foo.Promise(function foo(resolve, reject) { return 1; });", None),
+        ("new Promise.Promise(function foo(resolve, reject) { return 1; });", None),
+        ("new Promise()(function foo(resolve, reject) { return 1; });", None),
+        ("Promise(function (resolve, reject) { return 1; });", None),
+        ("Promise((resolve, reject) => { return 1; });", None),
+        ("Promise((resolve, reject) => 1);", None),
+        ("new Promise(foo, function (resolve, reject) { return 1; });", None),
+        ("new Promise(foo, (resolve, reject) => { return 1; });", None),
+        ("new Promise(foo, (resolve, reject) => 1);", None),
+        // globals are not supported in tests.
+        // ("/* globals Promise:off */ new Promise(function (resolve, reject) { return 1; });", None)
+        // ("new Promise((resolve, reject) => { return 1; });", None), // { "globals": { "Promise": "off" } }
+        // TODO: Fix these tests.
+        // ("let Promise; new Promise(function (resolve, reject) { return 1; });", None),
+        // ("function f() { new Promise((resolve, reject) => { return 1; }); var Promise; }", None),
+        // ("function f(Promise) { new Promise((resolve, reject) => 1); }", None),
+        // (
+        //     "if (x) { const Promise = foo(); new Promise(function (resolve, reject) { return 1; }); }",
+        //     None,
+        // ),
+        // ("x = function Promise() { new Promise((resolve, reject) => { return 1; }); }", None),
+        ("new Promise(function (resolve, reject) { return; });", None),
+        ("new Promise(function (resolve, reject) { reject(new Error()); return; });", None),
+        ("new Promise(function (resolve, reject) { if (foo) { return; } });", None),
+        ("new Promise((resolve, reject) => { return; });", None),
         (
-            "new Promise((resolve) => { return void resolve(1); })",
-            Some(serde_json::json!([{ "allowVoid": true }])),
+            "new Promise((resolve, reject) => { if (foo) { resolve(1); return; } reject(new Error()); });",
+            None,
+        ),
+        ("new Promise(function (resolve, reject) { throw new Error(); });", None),
+        ("new Promise((resolve, reject) => { throw new Error(); });", None),
+        ("new Promise(function (resolve, reject) { function foo() { return 1; } });", None),
+        ("new Promise((resolve, reject) => { (function foo() { return 1; })(); });", None),
+        ("new Promise(function (resolve, reject) { () => { return 1; } });", None),
+        ("new Promise((resolve, reject) => { () => 1 });", None),
+        (
+            "function foo() { return new Promise(function (resolve, reject) { resolve(bar); }) };",
+            None,
         ),
         (
-            "new Promise((resolve) => { return void 0; })",
-            Some(serde_json::json!([{ "allowVoid": true }])),
+            "foo => new Promise((resolve, reject) => { bar(foo, (err, data) => { if (err) { reject(err); return; } resolve(data); })});",
+            None,
         ),
-        // void is allowed with allowVoid option (implicit return in arrow expression body)
-        ("new Promise(r => void r(1))", Some(serde_json::json!([{ "allowVoid": true }]))),
+        ("new Promise(function (resolve, reject) {}); function foo() { return 1; }", None),
+        ("new Promise((resolve, reject) => {}); (function () { return 1; });", None),
+        ("new Promise(function (resolve, reject) {}); () => { return 1; };", None),
+        ("new Promise((resolve, reject) => {}); () => 1;", None),
+        ("return 1;", None), // { "sourceType": "commonjs" }
+        ("return 1;", None), // { "sourceType": "script", "parserOptions": { "ecmaFeatures": { "globalReturn": true } } }
+        ("return 1; function foo(){ return 1; } return 1;", None), // { "sourceType": "commonjs" }
+        (
+            "function foo(){} return 1; var bar = function*(){ return 1; }; return 1; var baz = () => {}; return 1;",
+            None,
+        ), // { "sourceType": "commonjs" }
+        ("new Promise(function (resolve, reject) {}); return 1;", None), // { "sourceType": "commonjs" }
+        ("new Promise((r) => void cbf(r));", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => void 0)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        (
+            "new Promise(r => { return void 0 })",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        (
+            "new Promise(r => { if (foo) { return void 0 } return void 0 })",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        ("new Promise(r => {0})", None),
     ];
 
     let fail = vec![
-        // Arrow with expression body (implicit return)
-        ("new Promise(r => r(1))", None),
-        ("new Promise((resolve, reject) => resolve(1))", None),
-        // Explicit return with value
-        ("new Promise((resolve, reject) => { return 1; })", None),
         ("new Promise(function (resolve, reject) { return 1; })", None),
-        // Return in control flow
-        ("new Promise((resolve, reject) => { if (true) { return 1; } })", None),
-        ("new Promise((resolve, reject) => { if (true) return 1; })", None),
-        // Return variable
-        ("new Promise((resolve, reject) => { return resolve; })", None),
-        // Return function call result (not resolve/reject call itself)
-        ("new Promise((resolve, reject) => { return foo(); })", None),
-        // Return resolve/reject call result - these should NOT be special-cased as valid
-        ("new Promise((resolve, reject) => { return resolve(1); })", None),
-        ("new Promise((resolve, reject) => { return reject(new Error('fail')); })", None),
-        // Nested blocks
-        ("new Promise((resolve, reject) => { { { return 1; } } })", None),
-        // In try-catch
+        (
+            "new Promise((resolve, reject) => resolve(1))",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        (
+            "new Promise((resolve, reject) => { return 1 })",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        ("new Promise(r => 1)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => 1 ? 2 : 3)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => (1 ? 2 : 3))", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => (1))", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => () => {})", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => null)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => null)", Some(serde_json::json!([ { "allowVoid": false, }, ]))),
+        ("new Promise(r => /*hi*/ ~0)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => /*hi*/ ~0)", Some(serde_json::json!([ { "allowVoid": false, }, ]))),
+        ("new Promise(r => { return 0 })", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => { return 0 })", Some(serde_json::json!([ { "allowVoid": false, }, ]))),
+        (
+            "new Promise(r => { if (foo) { return void 0 } return 0 })",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        (
+            "new Promise(resolve => { return (foo = resolve(1)); })",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        (
+            "new Promise(resolve => r = resolve)",
+            Some(serde_json::json!([ { "allowVoid": true, }, ])),
+        ),
+        ("new Promise(r => { return(1) })", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r =>1)", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(r => ((1)))", Some(serde_json::json!([ { "allowVoid": true, }, ]))),
+        ("new Promise(function foo(resolve, reject) { return 1; })", None),
+        ("new Promise((resolve, reject) => { return 1; })", None),
+        ("new Promise(function (resolve, reject) { return undefined; })", None),
+        ("new Promise((resolve, reject) => { return null; })", None),
+        ("new Promise(function (resolve, reject) { return false; })", None),
+        ("new Promise((resolve, reject) => resolve)", None),
+        ("new Promise((resolve, reject) => null)", None),
+        ("new Promise(function (resolve, reject) { return resolve(foo); })", None),
+        ("new Promise((resolve, reject) => { return reject(foo); })", None),
+        ("new Promise((resolve, reject) => x + y)", None),
+        ("new Promise((resolve, reject) => { return Promise.resolve(42); })", None),
+        ("new Promise(function (resolve, reject) { if (foo) { return 1; } })", None),
         ("new Promise((resolve, reject) => { try { return 1; } catch(e) {} })", None),
-        // void is not allowed by default
-        ("new Promise((resolve) => { return void resolve(1); })", None),
-        // In switch
-        ("new Promise((resolve) => { switch(x) { case 1: return 1; } })", None),
-        // In loops
-        ("new Promise((resolve) => { while(true) { return 1; } })", None),
-        ("new Promise((resolve) => { for(;;) { return 1; } })", None),
+        (
+            "new Promise(function (resolve, reject) { while (foo){ if (bar) break; else return 1; } })",
+            None,
+        ),
+        ("new Promise(() => { return void 1; })", None),
+        ("new Promise(() => (1))", None),
+        ("() => new Promise(() => ({}));", None),
+        ("new Promise(function () { return 1; })", None),
+        ("new Promise(() => { return 1; })", None),
+        ("new Promise(() => 1)", None),
+        ("function foo() {} new Promise(function () { return 1; });", None),
+        ("function foo() { return; } new Promise(() => { return 1; });", None),
+        ("function foo() { return 1; } new Promise(() => { return 2; });", None),
+        ("function foo () { return new Promise(function () { return 1; }); }", None),
+        (
+            "function foo() { return new Promise(() => { bar(() => { return 1; }); return false; }); }",
+            None,
+        ),
+        (
+            "() => new Promise(() => { if (foo) { return 0; } else bar(() => { return 1; }); })",
+            None,
+        ),
+        (
+            "function foo () { return 1; return new Promise(function () { return 2; }); return 3;}",
+            None,
+        ),
+        ("() => 1; new Promise(() => { return 1; })", None),
+        ("new Promise(function () { return 1; }); function foo() { return 1; } ", None),
+        ("() => new Promise(() => { return 1; });", None),
+        ("() => new Promise(() => 1);", None),
+        ("() => new Promise(() => () => 1);", None),
+        ("() => new Promise(() => async () => 1);", None), // { "ecmaVersion": 2017 }
+        ("() => new Promise(() => function () {});", None),
+        ("() => new Promise(() => function foo() {});", None),
+        ("() => new Promise(() => []);", None),
+        ("new Promise((Promise) => { return 1; })", None),
+        ("new Promise(function Promise(resolve, reject) { return 1; })", None),
     ];
 
     Tester::new(NoPromiseExecutorReturn::NAME, NoPromiseExecutorReturn::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_promise_executor_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_promise_executor_return.snap
@@ -2,9 +2,9 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:18]
- 1 │ new Promise(r => r(1))
-   ·                  ────
+   ╭─[no_promise_executor_return.tsx:1:42]
+ 1 │ new Promise(function (resolve, reject) { return 1; })
+   ·                                          ─────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
@@ -17,6 +17,139 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:36]
+ 1 │ new Promise((resolve, reject) => { return 1 })
+   ·                                    ────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => 1)
+   ·                  ─
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => 1 ? 2 : 3)
+   ·                  ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => (1 ? 2 : 3))
+   ·                  ───────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => (1))
+   ·                  ───
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => () => {})
+   ·                  ────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => null)
+   ·                  ────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => null)
+   ·                  ────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ new Promise(r => /*hi*/ ~0)
+   ·                         ──
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ new Promise(r => /*hi*/ ~0)
+   ·                         ──
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:20]
+ 1 │ new Promise(r => { return 0 })
+   ·                    ────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:20]
+ 1 │ new Promise(r => { return 0 })
+   ·                    ────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:47]
+ 1 │ new Promise(r => { if (foo) { return void 0 } return 0 })
+   ·                                               ────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:26]
+ 1 │ new Promise(resolve => { return (foo = resolve(1)); })
+   ·                          ──────────────────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:24]
+ 1 │ new Promise(resolve => r = resolve)
+   ·                        ───────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:20]
+ 1 │ new Promise(r => { return(1) })
+   ·                    ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:17]
+ 1 │ new Promise(r =>1)
+   ·                 ─
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:18]
+ 1 │ new Promise(r => ((1)))
+   ·                  ─────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:45]
+ 1 │ new Promise(function foo(resolve, reject) { return 1; })
+   ·                                             ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:36]
  1 │ new Promise((resolve, reject) => { return 1; })
    ·                                    ─────────
    ╰────
@@ -24,57 +157,71 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:42]
- 1 │ new Promise(function (resolve, reject) { return 1; })
-   ·                                          ─────────
-   ╰────
-  help: Use `resolve()` or `reject()` instead of returning a value.
-
-  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:48]
- 1 │ new Promise((resolve, reject) => { if (true) { return 1; } })
-   ·                                                ─────────
-   ╰────
-  help: Use `resolve()` or `reject()` instead of returning a value.
-
-  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:46]
- 1 │ new Promise((resolve, reject) => { if (true) return 1; })
-   ·                                              ─────────
+ 1 │ new Promise(function (resolve, reject) { return undefined; })
+   ·                                          ─────────────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:36]
- 1 │ new Promise((resolve, reject) => { return resolve; })
-   ·                                    ───────────────
+ 1 │ new Promise((resolve, reject) => { return null; })
+   ·                                    ────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:42]
+ 1 │ new Promise(function (resolve, reject) { return false; })
+   ·                                          ─────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:34]
+ 1 │ new Promise((resolve, reject) => resolve)
+   ·                                  ───────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:34]
+ 1 │ new Promise((resolve, reject) => null)
+   ·                                  ────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:42]
+ 1 │ new Promise(function (resolve, reject) { return resolve(foo); })
+   ·                                          ────────────────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:36]
- 1 │ new Promise((resolve, reject) => { return foo(); })
-   ·                                    ─────────────
+ 1 │ new Promise((resolve, reject) => { return reject(foo); })
+   ·                                    ───────────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:34]
+ 1 │ new Promise((resolve, reject) => x + y)
+   ·                                  ─────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:36]
- 1 │ new Promise((resolve, reject) => { return resolve(1); })
-   ·                                    ──────────────────
+ 1 │ new Promise((resolve, reject) => { return Promise.resolve(42); })
+   ·                                    ───────────────────────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:36]
- 1 │ new Promise((resolve, reject) => { return reject(new Error('fail')); })
-   ·                                    ─────────────────────────────────
-   ╰────
-  help: Use `resolve()` or `reject()` instead of returning a value.
-
-  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:40]
- 1 │ new Promise((resolve, reject) => { { { return 1; } } })
-   ·                                        ─────────
+   ╭─[no_promise_executor_return.tsx:1:53]
+ 1 │ new Promise(function (resolve, reject) { if (foo) { return 1; } })
+   ·                                                     ─────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
@@ -86,29 +233,176 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:28]
- 1 │ new Promise((resolve) => { return void resolve(1); })
-   ·                            ───────────────────────
+   ╭─[no_promise_executor_return.tsx:1:76]
+ 1 │ new Promise(function (resolve, reject) { while (foo){ if (bar) break; else return 1; } })
+   ·                                                                            ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:21]
+ 1 │ new Promise(() => { return void 1; })
+   ·                     ──────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:19]
+ 1 │ new Promise(() => (1))
+   ·                   ───
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => ({}));
+   ·                         ────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:27]
+ 1 │ new Promise(function () { return 1; })
+   ·                           ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:21]
+ 1 │ new Promise(() => { return 1; })
+   ·                     ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:19]
+ 1 │ new Promise(() => 1)
+   ·                   ─
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:45]
+ 1 │ function foo() {} new Promise(function () { return 1; });
+   ·                                             ─────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:48]
- 1 │ new Promise((resolve) => { switch(x) { case 1: return 1; } })
+ 1 │ function foo() { return; } new Promise(() => { return 1; });
    ·                                                ─────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
-   ╭─[no_promise_executor_return.tsx:1:42]
- 1 │ new Promise((resolve) => { while(true) { return 1; } })
-   ·                                          ─────────
+   ╭─[no_promise_executor_return.tsx:1:50]
+ 1 │ function foo() { return 1; } new Promise(() => { return 2; });
+   ·                                                  ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:52]
+ 1 │ function foo () { return new Promise(function () { return 1; }); }
+   ·                                                    ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:71]
+ 1 │ function foo() { return new Promise(() => { bar(() => { return 1; }); return false; }); }
+   ·                                                                       ─────────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.
 
   ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
    ╭─[no_promise_executor_return.tsx:1:38]
- 1 │ new Promise((resolve) => { for(;;) { return 1; } })
+ 1 │ () => new Promise(() => { if (foo) { return 0; } else bar(() => { return 1; }); })
    ·                                      ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:62]
+ 1 │ function foo () { return 1; return new Promise(function () { return 2; }); return 3;}
+   ·                                                              ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:30]
+ 1 │ () => 1; new Promise(() => { return 1; })
+   ·                              ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:27]
+ 1 │ new Promise(function () { return 1; }); function foo() { return 1; } 
+   ·                           ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:27]
+ 1 │ () => new Promise(() => { return 1; });
+   ·                           ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => 1);
+   ·                         ─
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => () => 1);
+   ·                         ───────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => async () => 1);
+   ·                         ─────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => function () {});
+   ·                         ──────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => function foo() {});
+   ·                         ─────────────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:25]
+ 1 │ () => new Promise(() => []);
+   ·                         ──
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:28]
+ 1 │ new Promise((Promise) => { return 1; })
+   ·                            ─────────
+   ╰────
+  help: Use `resolve()` or `reject()` instead of returning a value.
+
+  ⚠ eslint(no-promise-executor-return): Return statement should not be used in Promise executor.
+   ╭─[no_promise_executor_return.tsx:1:49]
+ 1 │ new Promise(function Promise(resolve, reject) { return 1; })
+   ·                                                 ─────────
    ╰────
   help: Use `resolve()` or `reject()` instead of returning a value.


### PR DESCRIPTION
The original implementation of the rule did not port most of the tests. I'm not sure that it's worth retaining the previous tests, so I just replaced them entirely for now.

Almost all the tests pass, thankfully, but a few fail and needed to be commented out. We should probably fix them.

Rule was added in #16779.