### PR TITLE
test(linter): Clean up tests for no-class-assign and no-obj-calls rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -117,36 +117,36 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("class A { } foo(A);", None),
-        ("let A = class A { }; foo(A);", None),
-        ("class A { b(A) { A = 0; } }", None),
-        ("class A { b() { let A; A = 0; } }", None),
-        ("let A = class { b() { A = 0; } }", None),
-        ("let A = class B { foo() { A = 0; } }", None),
-        ("let A = class A {}; A = 1", None),
-        ("var x = 0; x = 1;", None),
-        ("let x = 0; x = 1;", None),
-        ("const x = 0; x = 1;", None),
-        ("function x() {} x = 1;", None),
-        ("function foo(x) { x = 1; }", None),
-        ("try {} catch (x) { x = 1; }", None),
-        ("if (foo) { class A {} } else { class A {} } A = 1;", None),
+        "class A { } foo(A);",
+        "let A = class A { }; foo(A);",
+        "class A { b(A) { A = 0; } }",
+        "class A { b() { let A; A = 0; } }",
+        "let A = class { b() { A = 0; } }",
+        "let A = class B { foo() { A = 0; } }",
+        "let A = class A {}; A = 1",
+        "var x = 0; x = 1;",
+        "let x = 0; x = 1;",
+        "const x = 0; x = 1;",
+        "function x() {} x = 1;",
+        "function foo(x) { x = 1; }",
+        "try {} catch (x) { x = 1; }",
+        "if (foo) { class A {} } else { class A {} } A = 1;",
         // Sequence expression
-        ("(class A {}, A = 1)", None),
+        "(class A {}, A = 1)",
         // Class expressions
-        ("let A = class { }; A = 1;", None),
-        ("let A = class B { }; A = 1;", None),
+        "let A = class { }; A = 1;",
+        "let A = class B { }; A = 1;",
     ];
 
     let fail = vec![
-        ("class A { } A = 0;", None),
-        ("class A { } ({A} = 0);", None),
-        ("class A { } ({b: A = 0} = {});", None),
-        ("A = 0; class A { }", None),
-        ("class A { b() { A = 0; } }", None),
-        ("let A = class A { b() { A = 0; } }", None),
-        ("class A { } A = 0; A = 1;", None),
-        ("if (foo) { class A {} A = 1; }", None),
+        "class A { } A = 0;",
+        "class A { } ({A} = 0);",
+        "class A { } ({b: A = 0} = {});",
+        "A = 0; class A { }",
+        "class A { b() { A = 0; } }",
+        "let A = class A { b() { A = 0; } }",
+        "class A { } A = 0; A = 1;",
+        "if (foo) { class A {} A = 1; }",
     ];
 
     Tester::new(NoClassAssign::NAME, NoClassAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -160,53 +160,46 @@ fn test() {
     // see: https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/no-obj-calls.js
 
     let pass = vec![
-        ("const m = Math;", None),
-        ("let m = foo.Math();", None),
-        ("JSON.parse(\"{}\")", None),
-        ("Math.PI * 2 * (r * r)", None),
-        ("bar.Atomics(foo)", None),
+        "const m = Math;",
+        "let m = foo.Math();",
+        "JSON.parse(\"{}\")",
+        "Math.PI * 2 * (r * r)",
+        "bar.Atomics(foo)",
         // reference test cases
-        (
-            "let j = JSON;
-            function foo() {
-                let j = x => x;
-                return x();
-            }",
-            None,
-        ),
+        "let j = JSON;
+        function foo() {
+            let j = x => x;
+            return x();
+        }",
         // https://github.com/oxc-project/oxc/pull/508#issuecomment-1618850742
-        ("{const Math = () => {}; {let obj = new Math();}}", None),
-        ("{const {parse} = JSON;parse('{}')}", None),
+        "{const Math = () => {}; {let obj = new Math();}}",
+        "{const {parse} = JSON;parse('{}')}",
         // https://github.com/oxc-project/oxc/issues/4389
-        (
-            r"
-        export const getConfig = getConfig;
+        r"export const getConfig = getConfig;
         getConfig();",
-            None,
-        ),
     ];
 
     let fail = vec![
-        ("let newObj = new JSON();", None),
-        ("let obj = JSON();", None),
-        ("let obj = globalThis.JSON()", None),
-        ("new JSON", None),
-        ("const foo = x => new JSON()", None),
-        ("let newObj = new Math();", None),
-        ("let obj = Math();", None),
-        ("let obj = new Math().foo;", None),
-        ("let obj = new globalThis.Math()", None),
-        ("let newObj = new Atomics();", None),
-        ("let obj = Atomics();", None),
-        ("let newObj = new Intl();", None),
-        ("let obj = Intl();", None),
-        ("let newObj = new Reflect();", None),
-        ("let obj = Reflect();", None),
-        ("function d() { JSON.parse(Atomics()) }", None),
+        "let newObj = new JSON();",
+        "let obj = JSON();",
+        "let obj = globalThis.JSON()",
+        "new JSON",
+        "const foo = x => new JSON()",
+        "let newObj = new Math();",
+        "let obj = Math();",
+        "let obj = new Math().foo;",
+        "let obj = new globalThis.Math()",
+        "let newObj = new Atomics();",
+        "let obj = Atomics();",
+        "let newObj = new Intl();",
+        "let obj = Intl();",
+        "let newObj = new Reflect();",
+        "let obj = Reflect();",
+        "function d() { JSON.parse(Atomics()) }",
         // reference test cases
-        ("let j = JSON; j();", None),
-        ("let a = JSON; let b = a; let c = b; b();", None),
-        ("let m = globalThis.Math; new m();", None),
+        "let j = JSON; j();",
+        "let a = JSON; let b = a; let c = b; b();",
+        "let m = globalThis.Math; new m();",
     ];
 
     Tester::new(NoObjCalls::NAME, NoObjCalls::PLUGIN, pass, fail).test_and_snapshot();


### PR DESCRIPTION
Just removing the extra tuple values since this rule takes no options. Also makes it easier to compare the rule's tests against the rulegen version.