### PR TITLE
refactor(linter): Remove extra None in fixer tuple for 7 rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -84,16 +84,16 @@ impl Rule for NoDebugger {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![("var test = { debugger: 1 }; test.debugger;", None)];
+    let pass = vec!["var test = { debugger: 1 }; test.debugger;"];
 
-    let fail = vec![("if (foo) debugger", None)];
+    let fail = vec!["if (foo) debugger"];
     let fix = vec![
-        ("let x; debugger; let y;", "let x;  let y;", None),
-        ("if (foo) debugger", "if (foo) {}", None),
-        ("for (;;) debugger", "for (;;) {}", None),
-        ("while (i > 0) debugger", "while (i > 0) {}", None),
-        ("if (foo) { debugger; }", "if (foo) {  }", None),
-        ("if (foo) { debugger }", "if (foo) {  }", None),
+        ("let x; debugger; let y;", "let x;  let y;"),
+        ("if (foo) debugger", "if (foo) {}"),
+        ("for (;;) debugger", "for (;;) {}"),
+        ("while (i > 0) debugger", "while (i > 0) {}"),
+        ("if (foo) { debugger; }", "if (foo) {  }"),
+        ("if (foo) { debugger }", "if (foo) {  }"),
     ];
 
     Tester::new(NoDebugger::NAME, NoDebugger::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -182,18 +182,18 @@ fn test() {
     ];
 
     let fix = vec![
-        ("let value: BigInt;", "let value: bigint;", None),
-        ("let value: Boolean;", "let value: boolean;", None),
-        ("let value: Number;", "let value: number;", None),
-        ("let value: Object;", "let value: object;", None),
-        ("let value: String;", "let value: string;", None),
-        ("let value: Symbol;", "let value: symbol;", None),
-        ("let value: Number | Symbol;", "let value: number | symbol;", None),
-        ("let value: { property: Number };", "let value: { property: number };", None),
-        ("0 as Number;", "0 as number;", None),
-        ("type MyType = Number;", "type MyType = number;", None),
-        ("type MyType = [Number];", "type MyType = [number];", None),
-        ("type MyType = Number & String;", "type MyType = number & string;", None),
+        ("let value: BigInt;", "let value: bigint;"),
+        ("let value: Boolean;", "let value: boolean;"),
+        ("let value: Number;", "let value: number;"),
+        ("let value: Object;", "let value: object;"),
+        ("let value: String;", "let value: string;"),
+        ("let value: Symbol;", "let value: symbol;"),
+        ("let value: Number | Symbol;", "let value: number | symbol;"),
+        ("let value: { property: Number };", "let value: { property: number };"),
+        ("0 as Number;", "0 as number;"),
+        ("type MyType = Number;", "type MyType = number;"),
+        ("type MyType = [Number];", "type MyType = [number];"),
+        ("type MyType = Number & String;", "type MyType = number & string;"),
     ];
 
     Tester::new(NoWrapperObjectTypes::NAME, NoWrapperObjectTypes::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -321,25 +321,21 @@ fn test() {
     ];
 
     let fix = vec![
-        ("const a = {\n};", "const a = {};", None),
-        ("return {\n\n};", "return {};", None),
-        ("const x = () => {\n\n};", "const x = () => {};", None),
-        ("class A {\n}", "class A {}", None),
-        ("function a(){ }", "function a(){}", None),
-        ("do { }while(true)", "do {}while(true)", None),
-        ("class A {\nstatic { }\n}", "class A {\nstatic {}\n}", None),
-        ("class A {\nstatic{ }\n}", "class A {\nstatic {}\n}", None),
-        ("with (foo) {   }", "with (foo) {}", None),
-        ("\nif (true) {\n}", "\nif (true) {}", None),
-        ("\nif (true) {   }", "\nif (true) {}", None),
-        ("try{  }catch{  }", "try{}catch{}", None),
-        ("for(let i = 0; i <3; i += 1) {\n  }", "for(let i = 0; i <3; i += 1) {}", None),
-        ("try{console.log('Hello');}finally{ \n}", "try{console.log('Hello');}finally{}", None),
-        (
-            "try{\nconsole.log(\'test\');\n}catch{ }\n",
-            "try{\nconsole.log(\'test\');\n}catch{}\n",
-            None,
-        ),
+        ("const a = {\n};", "const a = {};"),
+        ("return {\n\n};", "return {};"),
+        ("const x = () => {\n\n};", "const x = () => {};"),
+        ("class A {\n}", "class A {}"),
+        ("function a(){ }", "function a(){}"),
+        ("do { }while(true)", "do {}while(true)"),
+        ("class A {\nstatic { }\n}", "class A {\nstatic {}\n}"),
+        ("class A {\nstatic{ }\n}", "class A {\nstatic {}\n}"),
+        ("with (foo) {   }", "with (foo) {}"),
+        ("\nif (true) {\n}", "\nif (true) {}"),
+        ("\nif (true) {   }", "\nif (true) {}"),
+        ("try{  }catch{  }", "try{}catch{}"),
+        ("for(let i = 0; i <3; i += 1) {\n  }", "for(let i = 0; i <3; i += 1) {}"),
+        ("try{console.log('Hello');}finally{ \n}", "try{console.log('Hello');}finally{}"),
+        ("try{\nconsole.log(\'test\');\n}catch{ }\n", "try{\nconsole.log(\'test\');\n}catch{}\n"),
     ];
 
     Tester::new(EmptyBraceSpaces::NAME, EmptyBraceSpaces::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -160,14 +160,14 @@ fn test() {
     ];
 
     let fix = vec![
-        ("await []", "[]", None),
-        ("await (a == b)", "(a == b)", None),
-        ("+await -1", "+-1", None),
-        ("-await +1", "-+1", None),
-        ("await function() {}", "await function() {}", None), // no autofix
-        ("await class {}", "await class {}", None),           // no autofix
-        ("+await +1", "+await +1", None),                     // no autofix
-        ("-await -1", "-await -1", None),                     // no autofix
+        ("await []", "[]"),
+        ("await (a == b)", "(a == b)"),
+        ("+await -1", "+-1"),
+        ("-await +1", "-+1"),
+        ("await function() {}", "await function() {}"), // no autofix
+        ("await class {}", "await class {}"),           // no autofix
+        ("+await +1", "+await +1"),                     // no autofix
+        ("-await -1", "-await -1"),                     // no autofix
     ];
 
     Tester::new(NoUnnecessaryAwait::NAME, NoUnnecessaryAwait::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -142,13 +142,13 @@ fn test() {
     ];
 
     let fix = vec![
-        (r#"import fs from "fs";"#, r#"import fs from "node:fs";"#, None),
-        (r#"import * as fs from "fs";"#, r#"import * as fs from "node:fs";"#, None),
-        (r"import fs from 'fs';", r"import fs from 'node:fs';", None),
-        (r"const fs = require('fs');", r"const fs = require('node:fs');", None),
-        (r"import fs = require('fs');", r"import fs = require('node:fs');", None),
-        (r#"import "child_process";"#, r#"import "node:child_process";"#, None),
-        (r#"import fs from "fs/promises";"#, r#"import fs from "node:fs/promises";"#, None),
+        (r#"import fs from "fs";"#, r#"import fs from "node:fs";"#),
+        (r#"import * as fs from "fs";"#, r#"import * as fs from "node:fs";"#),
+        (r"import fs from 'fs';", r"import fs from 'node:fs';"),
+        (r"const fs = require('fs');", r"const fs = require('node:fs');"),
+        (r"import fs = require('fs');", r"import fs = require('node:fs');"),
+        (r#"import "child_process";"#, r#"import "node:child_process";"#),
+        (r#"import fs from "fs/promises";"#, r#"import fs from "node:fs/promises";"#),
     ];
 
     Tester::new(PreferNodeProtocol::NAME, PreferNodeProtocol::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -284,30 +284,29 @@ fn test() {
     ];
 
     let fix = vec![
-        ("/^foo/.test(x)", r"x.startsWith('foo')", None),
-        ("/foo$/.test(x)", r"x.endsWith('foo')", None),
-        ("/^foo/.test(x.y)", r"x.y.startsWith('foo')", None),
-        ("/foo$/.test(x.y)", r"x.y.endsWith('foo')", None),
-        ("/^foo/.test('x')", r"'x'.startsWith('foo')", None),
-        ("/foo$/.test('x')", r"'x'.endsWith('foo')", None),
-        ("/^foo/.test(`x${y}`)", r"`x${y}`.startsWith('foo')", None),
-        ("/foo$/.test(`x${y}`)", r"`x${y}`.endsWith('foo')", None),
-        ("/^foo/.test(String(x))", r"String(x).startsWith('foo')", None),
-        ("/foo$/.test(String(x))", r"String(x).endsWith('foo')", None),
+        ("/^foo/.test(x)", r"x.startsWith('foo')"),
+        ("/foo$/.test(x)", r"x.endsWith('foo')"),
+        ("/^foo/.test(x.y)", r"x.y.startsWith('foo')"),
+        ("/foo$/.test(x.y)", r"x.y.endsWith('foo')"),
+        ("/^foo/.test('x')", r"'x'.startsWith('foo')"),
+        ("/foo$/.test('x')", r"'x'.endsWith('foo')"),
+        ("/^foo/.test(`x${y}`)", r"`x${y}`.startsWith('foo')"),
+        ("/foo$/.test(`x${y}`)", r"`x${y}`.endsWith('foo')"),
+        ("/^foo/.test(String(x))", r"String(x).startsWith('foo')"),
+        ("/foo$/.test(String(x))", r"String(x).endsWith('foo')"),
         // https://github.com/oxc-project/oxc/issues/10523
         (
             r"const makePosix = str => /^\\\\\?\\/.test(str)",
             r"const makePosix = str => str.startsWith('\\\\?\\')",
-            None,
         ),
-        ("/^'/.test('foo')", r"'foo'.startsWith('\'')", None),
-        (r#"/^"/.test('foo')"#, r#"'foo'.startsWith('"')"#, None),
+        ("/^'/.test('foo')", r"'foo'.startsWith('\'')"),
+        (r#"/^"/.test('foo')"#, r#"'foo'.startsWith('"')"#),
         // should not get fixed
-        ("/^foo/.test(new String('bar'))", "/^foo/.test(new String('bar'))", None),
-        ("/^foo/.test(x as string)", "/^foo/.test(x as string)", None),
-        ("/^foo/.test(5)", "/^foo/.test(5)", None),
-        ("/^foo/.test(x?.y)", "/^foo/.test(x?.y)", None),
-        ("/^foo/.test(x + y)", "/^foo/.test(x + y)", None),
+        ("/^foo/.test(new String('bar'))", "/^foo/.test(new String('bar'))"),
+        ("/^foo/.test(x as string)", "/^foo/.test(x as string)"),
+        ("/^foo/.test(5)", "/^foo/.test(5)"),
+        ("/^foo/.test(x?.y)", "/^foo/.test(x?.y)"),
+        ("/^foo/.test(x + y)", "/^foo/.test(x + y)"),
     ];
 
     Tester::new(PreferStringStartsEndsWith::NAME, PreferStringStartsEndsWith::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
@@ -236,56 +236,48 @@ fn test() {
     ];
 
     let fix = vec![
-        (r#"import "foo" with {}"#, r#"import "foo""#, None),
-        (r#"import foo from "foo" with {}"#, r#"import foo from "foo""#, None),
-        (r#"export {foo} from "foo" with {}"#, r#"export {foo} from "foo""#, None),
-        (r#"export * from "foo" with {}"#, r#"export * from "foo""#, None),
-        (r#"export * from "foo"with{}"#, r#"export * from "foo""#, None),
+        (r#"import "foo" with {}"#, r#"import "foo""#),
+        (r#"import foo from "foo" with {}"#, r#"import foo from "foo""#),
+        (r#"export {foo} from "foo" with {}"#, r#"export {foo} from "foo""#),
+        (r#"export * from "foo" with {}"#, r#"export * from "foo""#),
+        (r#"export * from "foo"with{}"#, r#"export * from "foo""#),
         (
             r#"export * from "foo"/* comment 1 */with/* comment 2 */{/* comment 3 */}/* comment 4 */"#,
             r#"export * from "foo"/* comment 4 */"#,
-            None,
         ),
-        (r#"import("foo", {})"#, r#"import("foo")"#, None),
-        (r#"import("foo", (( {} )))"#, r#"import("foo")"#, None),
-        (r#"import("foo", {},)"#, r#"import("foo",)"#, None),
-        (r#"import("foo", {with:{},},)"#, r#"import("foo",)"#, None),
+        (r#"import("foo", {})"#, r#"import("foo")"#),
+        (r#"import("foo", (( {} )))"#, r#"import("foo")"#),
+        (r#"import("foo", {},)"#, r#"import("foo",)"#),
+        (r#"import("foo", {with:{},},)"#, r#"import("foo",)"#),
         (
             r#"import("foo", {with:{}, unknown:"unknown"},)"#,
             r#"import("foo", {unknown:"unknown"},)"#,
-            None,
         ),
         (
             r#"import("foo", {"with":{}, unknown:"unknown"},)"#,
             r#"import("foo", {unknown:"unknown"},)"#,
-            None,
         ),
         (
             r#"import("foo", {unknown:"unknown", with:{}, },)"#,
             r#"import("foo", {unknown:"unknown", },)"#,
-            None,
         ),
         (
             r#"import("foo", {unknown:"unknown", with:{} },)"#,
             r#"import("foo", {unknown:"unknown" },)"#,
-            None,
         ),
         (
             r#"import("foo", {unknown:"unknown", with:{}, unknown2:"unknown2", },)"#,
             r#"import("foo", {unknown:"unknown", unknown2:"unknown2", },)"#,
-            None,
         ),
         (
             r#"import("foo"/* comment 1 */, /* comment 2 */{/* comment 3 */}/* comment 4 */,/* comment 5 */)"#,
             r#"import("foo"/* comment 4 */,/* comment 5 */)"#,
-            None,
         ),
         (
             r#"import("foo", {/* comment 1 */"with"/* comment 2 */:/* comment 3 */{/* comment 4 */}, }/* comment 5 */,)"#,
             r#"import("foo"/* comment 5 */,)"#,
-            None,
         ),
-        (r#"import("foo", {with: (({}))})"#, r#"import("foo")"#, None),
+        (r#"import("foo", {with: (({}))})"#, r#"import("foo")"#),
     ];
 
     Tester::new(RequireModuleAttributes::NAME, RequireModuleAttributes::PLUGIN, pass, fail)


### PR DESCRIPTION
No reason to have these when the rules accept no config options anyway.