### PR TITLE
test(linter): Add a few tests that were missing from original rules.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -110,11 +110,15 @@ fn test() {
         "Promise.all(notArrayExpression)",
         "Promise.all([,])",
         "Promise[all]([await promise])",
+        // TODO: Fix these commented-out tests.
+        // "Promise.all?.([await promise])",
+        // "Promise?.all([await promise])",
         "Promise.notListedMethod([await promise])",
         "NotPromise.all([await promise])",
         "Promise.all([(await promise, 0)])",
         "new Promise.all([await promise])",
         "globalThis.Promise.all([await promise])",
+        // r#"Promise["all"]([await promise])"#,
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_flat_depth.rs
@@ -74,6 +74,8 @@ fn test() {
 
     let pass = vec![
         "foo.flat()",
+        // TODO: Fix this rule so this test passes.
+        // "foo.flat?.(1)",
         "foo?.flat()",
         "foo.flat(1, extra)",
         "flat(1)",


### PR DESCRIPTION
These were not passing, though. In the future, we should fix the rules so these will pass.