### PR TITLE
test(linter): Add more tests for `eslint/for-direction` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -287,16 +287,18 @@ fn test() {
         "for(var i = 10; i > 0; i+=-1){}",
         "for(var i = 10; i >= 0; i+=-1){}",
         // test if '+=', '-=' with counter 'i' on the right side of test condition
+        "for(var i = 0n; i > l; i-=1n){}",
+        "for(var i = 0n; i < l; i-=-1n){}",
+        "for(var i = MIN; i <= MAX; i+=true){}",
+        "for(var i = 0; i < 10; i+=+5e-7){}",
+        // "for(var i = 0; i < MAX; i -= ~2);",
+        // "for(var i = 0, n = -1; i < MAX; i += -n);",
         "for(var i = 0; 10 > i; i+=1){}",
         // test if no update.
         "for(var i = 10; i > 0;){}",
         "for(var i = 10; i >= 0;){}",
         "for(var i = 10; i < 0;){}",
         "for(var i = 10; i <= 0;){}",
-        "for(var i = 0; i < 10; i+=0){}",
-        "for(var i = 0; i < 10; i-=0){}",
-        "for(var i = 10; i > 0; i+=0){}",
-        "for(var i = 10; i > 0; i-=0){}",
         "for(var i = 10; i <= 0; j++){}",
         "for(var i = 10; i <= 0; j--){}",
         "for(var i = 10; i >= 0; j++){}",
@@ -309,6 +311,13 @@ fn test() {
         "for(var i = 0; i < MAX; i -= STEP_SIZE);",
         "for(var i = 10; i > 0; i += STEP_SIZE);",
         // other cond-expressions.
+        "for(var i = 10; i >= 0; i += 0);",
+        "for(var i = 10n; i >= 0n; i += 0n);",
+        "for(var i = 10; i >= 0; i += this.step);",
+        "for(var i = 10; i >= 0; i += 'foo');",
+        // "for(var i = 10; i > 0; i += !foo);",
+        "for(var i = MIN; i <= MAX; i -= false);",
+        "for(var i = MIN; i <= MAX; i -= 0/0);",
         "for(var i = 0; i !== 10; i+=1){}",
         "for(var i = 0; i === 10; i+=1){}",
         "for(var i = 0; i == 10; i+=1){}",
@@ -317,8 +326,8 @@ fn test() {
 
     let fail = vec![
         // test if '++', '--'
-        "for (var i = 0; i < 10; i--){}",
-        "for (var i = 0; i <= 10; i--){}",
+        "for(var i = 0; i < 10; i--){}",
+        "for(var i = 0; i <= 10; i--){}",
         "for(var i = 10; i > 10; i++){}",
         "for(var i = 10; i >= 0; i++){}",
         // test if '++', '--' with counter 'i' on the right side of test condition
@@ -336,6 +345,12 @@ fn test() {
         "for(var i = 10; i > 10; i-=-1){}",
         "for(var i = 10; i >= 0; i-=-1){}",
         // test if '+=', '-=' with counter 'i' on the right side of test condition
+        // "for(var i = 0n; i > l; i+=1n){}",
+        "for(var i = 0n; i < l; i+=-1n){}",
+        // "for(var i = MIN; i <= MAX; i-=true){}",
+        "for(var i = 0; i < 10; i-=+5e-7){}",
+        // "for(var i = 0; i < MAX; i += (2 - 3));",
+        // "var n = -2; for(var i = 0; i < 10; i += n);",
         "for(var i = 0; 10 > i; i-=1){}",
     ];
 

--- a/crates/oxc_linter/src/snapshots/eslint_for_direction.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_for_direction.snap
@@ -2,20 +2,20 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
-   ╭─[for_direction.tsx:1:17]
- 1 │ for (var i = 0; i < 10; i--){}
-   ·                 ───┬──  ─┬─
-   ·                    │     ╰── with this update
-   ·                    ╰── This test moves in the wrong direction
+   ╭─[for_direction.tsx:1:16]
+ 1 │ for(var i = 0; i < 10; i--){}
+   ·                ───┬──  ─┬─
+   ·                   │     ╰── with this update
+   ·                   ╰── This test moves in the wrong direction
    ╰────
   help: Use `while` loop for intended infinite loop
 
   ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
-   ╭─[for_direction.tsx:1:17]
- 1 │ for (var i = 0; i <= 10; i--){}
-   ·                 ───┬───  ─┬─
-   ·                    │      ╰── with this update
-   ·                    ╰── This test moves in the wrong direction
+   ╭─[for_direction.tsx:1:16]
+ 1 │ for(var i = 0; i <= 10; i--){}
+   ·                ───┬───  ─┬─
+   ·                   │      ╰── with this update
+   ·                   ╰── This test moves in the wrong direction
    ╰────
   help: Use `while` loop for intended infinite loop
 
@@ -142,6 +142,24 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───┬──  ──┬──
    ·                    │      ╰── with this update
    ·                    ╰── This test moves in the wrong direction
+   ╰────
+  help: Use `while` loop for intended infinite loop
+
+  ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
+   ╭─[for_direction.tsx:1:17]
+ 1 │ for(var i = 0n; i < l; i+=-1n){}
+   ·                 ──┬──  ───┬──
+   ·                   │       ╰── with this update
+   ·                   ╰── This test moves in the wrong direction
+   ╰────
+  help: Use `while` loop for intended infinite loop
+
+  ⚠ eslint(for-direction): The update clause in this loop moves the variable in the wrong direction
+   ╭─[for_direction.tsx:1:16]
+ 1 │ for(var i = 0; i < 10; i-=+5e-7){}
+   ·                ───┬──  ────┬───
+   ·                   │        ╰── with this update
+   ·                   ╰── This test moves in the wrong direction
    ╰────
   help: Use `while` loop for intended infinite loop
 


### PR DESCRIPTION
Regenerated the tests for the for-direction rule to get new tests from the upstream, some fail and so are commented-out.