### PR TITLE
chore(linter): Fix the phrasing of the issue instructions.

### DIFF
--- a/justfile
+++ b/justfile
@@ -163,6 +163,7 @@ update-rule-tests name plugin='eslint':
   just fmt
 
 # Legacy aliases for backward compatibility
+new-eslint-rule name: (new-rule name "eslint")
 new-jest-rule name: (new-rule name "jest")
 new-ts-rule name: (new-rule name "typescript")
 new-unicorn-rule name: (new-rule name "unicorn")

--- a/tasks/lint_rules/src/markdown-renderer.mjs
+++ b/tasks/lint_rules/src/markdown-renderer.mjs
@@ -54,7 +54,7 @@ To get started, run the following command:
 just new-${pluginName}-rule <RULE_NAME>
 \`\`\`
 
-Then register the rule in \`crates/oxc_linter/src/rules.rs\` and also \`declare_all_lint_rules\` at the bottom.
+Then implement the rule and get all the tests passing.
 `;
 
 /**


### PR DESCRIPTION
And also update the justfile to have a `new-eslint-rule` alias. This is what is rendered in the relevant issue for eslint core rules, so we should support it.

Split out of #17620.