### PR TITLE
test(linter/no-unused-vars): add tests for generics shadowing namespaces

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -1407,6 +1407,71 @@ fn test() {
             ",
             None,
         ),
+        // https://github.com/oxc-project/oxc/issues/17927
+        // https://github.com/typescript-eslint/typescript-eslint/issues/10746
+        // Namespace should not be flagged as unused when shadowed by type parameter
+        // but used in a qualified name
+        (
+            "
+        namespace Database {
+          export type Table<T> = T;
+        }
+
+        export function test<Database, Table extends Database.Table<Database>>(
+          database: Database,
+          table: Table
+        ): { database: Database; table: Table } {
+          return { database, table };
+        }
+            ",
+            None,
+        ),
+        // Namespace used in extends clause, shadowed by type parameter
+        (
+            "
+        export namespace A1 {
+          namespace T {
+            export class C<U = 1> { prop: U }
+          }
+          export class Foo<T> extends T.C { prop2: T }
+        }
+            ",
+            None,
+        ),
+        // Namespace used in type alias, shadowed by type parameter
+        (
+            "
+        export namespace One {
+          namespace T {
+            export type Foo<U = 1> = U;
+          }
+          export type Bar<T> = T.Foo<T>;
+        }
+            ",
+            None,
+        ),
+        // Deeply nested qualified name with shadowing
+        (
+            "
+        namespace A {
+          export namespace B {
+            export type C<T> = T;
+          }
+        }
+        export type Test<A> = A.B.C<A>;
+            ",
+            None,
+        ),
+        // Import namespace used in implements clause, shadowed by type parameter
+        (
+            "
+        import type * as NS from 'foo';
+        export class Bar<NS> implements NS.Foo {
+          value: NS;
+        }
+            ",
+            None,
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/17927