### PR TITLE
feat(linter/vitest): Implements `prefer-expect-type-of` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4089,6 +4089,11 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -652,6 +652,7 @@ pub use crate::rules::vitest::no_import_node_test::NoImportNodeTest as VitestNoI
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
 pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle as VitestPreferDescribeFunctionTitle;
+pub use crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf as VitestPreferExpectTypeOf;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1325,6 +1326,7 @@ pub enum RuleEnum {
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
     VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle),
+    VitestPreferExpectTypeOf(VitestPreferExpectTypeOf),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -1997,32 +1999,33 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => 637usize,
             Self::VitestPreferCalledTimes(_) => 638usize,
             Self::VitestPreferDescribeFunctionTitle(_) => 639usize,
-            Self::VitestPreferToBeFalsy(_) => 640usize,
-            Self::VitestPreferToBeObject(_) => 641usize,
-            Self::VitestPreferToBeTruthy(_) => 642usize,
-            Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => 643usize,
-            Self::VitestWarnTodo(_) => 644usize,
-            Self::NodeGlobalRequire(_) => 645usize,
-            Self::NodeNoExportsAssign(_) => 646usize,
-            Self::NodeNoNewRequire(_) => 647usize,
-            Self::NodeNoProcessEnv(_) => 648usize,
-            Self::VueDefineEmitsDeclaration(_) => 649usize,
-            Self::VueDefinePropsDeclaration(_) => 650usize,
-            Self::VueDefinePropsDestructuring(_) => 651usize,
-            Self::VueMaxProps(_) => 652usize,
-            Self::VueNoArrowFunctionsInWatch(_) => 653usize,
-            Self::VueNoDeprecatedDestroyedLifecycle(_) => 654usize,
-            Self::VueNoExportInScriptSetup(_) => 655usize,
-            Self::VueNoImportCompilerMacros(_) => 656usize,
-            Self::VueNoLifecycleAfterAwait(_) => 657usize,
-            Self::VueNoMultipleSlotArgs(_) => 658usize,
-            Self::VueNoRequiredPropWithDefault(_) => 659usize,
-            Self::VueNoThisInBeforeRouteEnter(_) => 660usize,
-            Self::VuePreferImportFromVue(_) => 661usize,
-            Self::VueRequireDefaultExport(_) => 662usize,
-            Self::VueRequireTypedRef(_) => 663usize,
-            Self::VueValidDefineEmits(_) => 664usize,
-            Self::VueValidDefineProps(_) => 665usize,
+            Self::VitestPreferExpectTypeOf(_) => 640usize,
+            Self::VitestPreferToBeFalsy(_) => 641usize,
+            Self::VitestPreferToBeObject(_) => 642usize,
+            Self::VitestPreferToBeTruthy(_) => 643usize,
+            Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => 644usize,
+            Self::VitestWarnTodo(_) => 645usize,
+            Self::NodeGlobalRequire(_) => 646usize,
+            Self::NodeNoExportsAssign(_) => 647usize,
+            Self::NodeNoNewRequire(_) => 648usize,
+            Self::NodeNoProcessEnv(_) => 649usize,
+            Self::VueDefineEmitsDeclaration(_) => 650usize,
+            Self::VueDefinePropsDeclaration(_) => 651usize,
+            Self::VueDefinePropsDestructuring(_) => 652usize,
+            Self::VueMaxProps(_) => 653usize,
+            Self::VueNoArrowFunctionsInWatch(_) => 654usize,
+            Self::VueNoDeprecatedDestroyedLifecycle(_) => 655usize,
+            Self::VueNoExportInScriptSetup(_) => 656usize,
+            Self::VueNoImportCompilerMacros(_) => 657usize,
+            Self::VueNoLifecycleAfterAwait(_) => 658usize,
+            Self::VueNoMultipleSlotArgs(_) => 659usize,
+            Self::VueNoRequiredPropWithDefault(_) => 660usize,
+            Self::VueNoThisInBeforeRouteEnter(_) => 661usize,
+            Self::VuePreferImportFromVue(_) => 662usize,
+            Self::VueRequireDefaultExport(_) => 663usize,
+            Self::VueRequireTypedRef(_) => 664usize,
+            Self::VueValidDefineEmits(_) => 665usize,
+            Self::VueValidDefineProps(_) => 666usize,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -2749,6 +2752,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::NAME,
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -3543,6 +3547,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::CATEGORY
             }
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::CATEGORY,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -4300,6 +4305,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::FIX,
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -5233,6 +5239,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::documentation()
             }
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::documentation(),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -7071,6 +7078,8 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::config_schema(generator)
                     .or_else(|| VitestPreferDescribeFunctionTitle::schema(generator))
             }
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::config_schema(generator)
+                .or_else(|| VitestPreferExpectTypeOf::schema(generator)),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -7788,6 +7797,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
             Self::VitestPreferDescribeFunctionTitle(_) => "vitest",
+            Self::VitestPreferExpectTypeOf(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -9863,6 +9873,9 @@ impl RuleEnum {
                     VitestPreferDescribeFunctionTitle::from_configuration(value)?,
                 ))
             }
+            Self::VitestPreferExpectTypeOf(_) => Ok(Self::VitestPreferExpectTypeOf(
+                VitestPreferExpectTypeOf::from_configuration(value)?,
+            )),
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -10589,6 +10602,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.to_configuration(),
+            Self::VitestPreferExpectTypeOf(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -11261,6 +11275,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run(node, ctx),
+            Self::VitestPreferExpectTypeOf(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -11931,6 +11946,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_once(ctx),
+            Self::VitestPreferExpectTypeOf(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -12687,6 +12703,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferExpectTypeOf(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13359,6 +13376,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.should_run(ctx),
+            Self::VitestPreferExpectTypeOf(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -14289,6 +14307,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::IS_TSGOLINT_RULE
             }
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -15108,6 +15127,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::HAS_CONFIG
             }
+            Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::HAS_CONFIG,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -15782,6 +15802,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.types_info(),
+            Self::VitestPreferExpectTypeOf(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -16452,6 +16473,7 @@ impl RuleEnum {
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_info(),
+            Self::VitestPreferExpectTypeOf(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -17226,6 +17248,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),
         RuleEnum::VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle::default()),
+        RuleEnum::VitestPreferExpectTypeOf(VitestPreferExpectTypeOf::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -682,6 +682,7 @@ pub(crate) mod vitest {
     pub mod prefer_called_once;
     pub mod prefer_called_times;
     pub mod prefer_describe_function_title;
+    pub mod prefer_expect_type_of;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
@@ -1,0 +1,192 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, UnaryOperator},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn prefer_expect_type_of_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
+    let help_message = format!("Substitute the assertion with `{help}`.");
+
+    OxcDiagnostic::warn("Type assertions should be done using `expectTypeOf`.")
+        .with_help(help_message)
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferExpectTypeOf;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce using `expectTypeOf` instead of `expect(typeof ...)`
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Vitest provide a more expressive type-safe way to test type than using `expect(typeof ...)`
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// test('type checking', () => {
+    ///   expect(typeof 'hello').toBe('string')
+    ///   expect(typeof 42).toBe('number')
+    ///   expect(typeof true).toBe('boolean')
+    ///   expect(typeof {}).toBe('object')
+    ///   expect(typeof () => {}).toBe('function')
+    ///   expect(typeof Symbol()).toBe('symbol')
+    ///   expect(typeof 123n).toBe('bigint')
+    ///   expect(typeof undefined).toBe('undefined')
+    /// })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// test('type checking', () => {
+    ///   expectTypeOf('hello').toBeString()
+    ///   expectTypeOf(42).toBeNumber()
+    ///   expectTypeOf(true).toBeBoolean()
+    ///   expectTypeOf({}).toBeObject()
+    ///   expectTypeOf(() => {}).toBeFunction()
+    ///   expectTypeOf(Symbol()).toBeSymbol()
+    ///   expectTypeOf(123n).toBeBigInt()
+    ///   expectTypeOf(undefined).toBeUndefined()
+    /// })
+    /// ```
+    PreferExpectTypeOf,
+    vitest,
+    style,
+    fix,
+);
+
+impl Rule for PreferExpectTypeOf {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        Self::run(jest_node, ctx);
+    }
+}
+
+impl PreferExpectTypeOf {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Some(expect_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+
+        let Some(Argument::UnaryExpression(typeof_expression)) =
+            expect_call.expect_arguments.and_then(|arguments| arguments.first())
+        else {
+            return;
+        };
+
+        if !matches!(typeof_expression.operator, UnaryOperator::Typeof) {
+            return;
+        }
+
+        if !expect_call
+            .members
+            .iter()
+            .any(|member| member.is_name_equal("toBe") || member.is_name_equal("toEqual"))
+        {
+            return;
+        }
+
+        let Some(Argument::StringLiteral(type_expected)) =
+            expect_call.matcher_arguments.and_then(|arguments| arguments.first())
+        else {
+            return;
+        };
+
+        let method = {
+            match type_expected.value.as_ref() {
+                "string" => "toBeString",
+                "number" => "toBeNumber",
+                "boolean" => "toBeBoolean",
+                "object" => "toBeObject",
+                "function" => "toBeFunction",
+                "symbol" => "toBeSymbol",
+                "bigint" => "toBeBigInt",
+                "undefined" => "toBeUndefined",
+                _ => return,
+            }
+        };
+
+        let modifier_text =
+            expect_call.modifiers().iter().fold(String::new(), |mut acc, modifier| {
+                use std::fmt::Write;
+                write!(&mut acc, ".{}", ctx.source_range(modifier.span)).unwrap();
+                acc
+            });
+
+        let param = ctx.source_range(GetSpan::span(&typeof_expression.argument));
+
+        let code = format!("expectTypeOf({param}){modifier_text}.{method}()");
+
+        ctx.diagnostic_with_fix(
+            prefer_expect_type_of_diagnostic(call_expr.span, code.as_ref()),
+            |fixer| fixer.replace(call_expr.span, code),
+        );
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"expectTypeOf("name").toBeString()"#,
+        r#"expectTypeOf("name").not.toBeString()"#,
+        "expectTypeOf(12).toBeNumber()",
+        "expectTypeOf(12).not.toBeNumber()",
+        "expectTypeOf(true).toBeBoolean()",
+        "expectTypeOf({a: 1}).toBeObject()",
+        "expectTypeOf(() => {}).toBeFunction()",
+        "expectTypeOf(sym).toBeSymbol()",
+        "expectTypeOf(BigInt(123)).toBeBigInt()",
+        "expectTypeOf(undefined).toBeUndefined()",
+        "expect(value).not.toBe(42)",
+        "expect(value).not.toEqual(42)",
+    ];
+
+    let fail = vec![
+        r#"expect(typeof 12).toBe("number")"#,
+        r#"expect(typeof "name").toBe("string")"#,
+        r#"expect(typeof true).toBe("boolean")"#,
+        r#"expect(typeof variable).toBe("object")"#,
+        r#"expect(typeof fn).toBe("function")"#,
+        r#"expect(typeof value).toEqual("string")"#,
+        r#"expect(typeof value).not.toBe("string")"#,
+    ];
+
+    let fix = vec![
+        (r#"expect(typeof 12).toBe("number")"#, "expectTypeOf(12).toBeNumber()"),
+        (r#"expect(typeof "name").toBe("string")"#, r#"expectTypeOf("name").toBeString()"#),
+        (r#"expect(typeof true).toBe("boolean")"#, "expectTypeOf(true).toBeBoolean()"),
+        (r#"expect(typeof variable).toBe("object")"#, "expectTypeOf(variable).toBeObject()"),
+        (r#"expect(typeof fn).toBe("function")"#, "expectTypeOf(fn).toBeFunction()"),
+        (r#"expect(typeof value).toEqual("string")"#, "expectTypeOf(value).toBeString()"),
+        (r#"expect(typeof value).not.toBe("string")"#, "expectTypeOf(value).not.toBeString()"),
+    ];
+
+    Tester::new(PreferExpectTypeOf::NAME, PreferExpectTypeOf::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
@@ -13,10 +13,8 @@ use crate::{
 };
 
 fn prefer_expect_type_of_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
-    let help_message = format!("Substitute the assertion with `{help}`.");
-
     OxcDiagnostic::warn("Type assertions should be done using `expectTypeOf`.")
-        .with_help(help_message)
+        .with_help(format!("Substitute the assertion with `{help}`."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof 12).toBe("number")
+   · ────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(12).toBeNumber()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof "name").toBe("string")
+   · ────────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf("name").toBeString()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof true).toBe("boolean")
+   · ───────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(true).toBeBoolean()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof variable).toBe("object")
+   · ──────────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(variable).toBeObject()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof fn).toBe("function")
+   · ──────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(fn).toBeFunction()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof value).toEqual("string")
+   · ──────────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(value).toBeString()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof value).not.toBe("string")
+   · ───────────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(value).not.toBeString()`.


### PR DESCRIPTION
Related to: https://github.com/oxc-project/oxc/issues/4656

- [Docs](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-type-of.md)
- [Source Code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/prefer-expect-type-of.ts)
- [Test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/prefer-expect-type-of.test.ts)