### PR TITLE
feat(linter): implement eslint-plugin-vitest/prefer-import-in-mock

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4231,6 +4231,11 @@ impl RuleRunner for crate::rules::vitest::prefer_expect_type_of::PreferExpectTyp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_import_in_mock::PreferImportInMock {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -675,6 +675,7 @@ pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPref
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
 pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle as VitestPreferDescribeFunctionTitle;
 pub use crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf as VitestPreferExpectTypeOf;
+pub use crate::rules::vitest::prefer_import_in_mock::PreferImportInMock as VitestPreferImportInMock;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1370,6 +1371,7 @@ pub enum RuleEnum {
     VitestPreferCalledTimes(VitestPreferCalledTimes),
     VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle),
     VitestPreferExpectTypeOf(VitestPreferExpectTypeOf),
+    VitestPreferImportInMock(VitestPreferImportInMock),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -2144,7 +2146,8 @@ const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_NO_IMPORT_NODE_TEST_ID + 1usi
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
 const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_EXPECT_TYPE_OF_ID: usize = VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID + 1usize;
-const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_EXPECT_TYPE_OF_ID + 1usize;
+const VITEST_PREFER_IMPORT_IN_MOCK_ID: usize = VITEST_PREFER_EXPECT_TYPE_OF_ID + 1usize;
+const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_IMPORT_IN_MOCK_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
@@ -2942,6 +2945,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
             Self::VitestPreferDescribeFunctionTitle(_) => VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID,
             Self::VitestPreferExpectTypeOf(_) => VITEST_PREFER_EXPECT_TYPE_OF_ID,
+            Self::VitestPreferImportInMock(_) => VITEST_PREFER_IMPORT_IN_MOCK_ID,
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
@@ -3729,6 +3733,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::NAME,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::NAME,
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -4560,6 +4565,7 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::CATEGORY
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::CATEGORY,
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::CATEGORY,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -5350,6 +5356,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::FIX,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::FIX,
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -6330,6 +6337,7 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::documentation()
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::documentation(),
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::documentation(),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -8247,6 +8255,8 @@ impl RuleEnum {
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::config_schema(generator)
                 .or_else(|| VitestPreferExpectTypeOf::schema(generator)),
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::config_schema(generator)
+                .or_else(|| VitestPreferImportInMock::schema(generator)),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -8988,6 +8998,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => "vitest",
             Self::VitestPreferDescribeFunctionTitle(_) => "vitest",
             Self::VitestPreferExpectTypeOf(_) => "vitest",
+            Self::VitestPreferImportInMock(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -11148,6 +11159,9 @@ impl RuleEnum {
             Self::VitestPreferExpectTypeOf(_) => Ok(Self::VitestPreferExpectTypeOf(
                 VitestPreferExpectTypeOf::from_configuration(value)?,
             )),
+            Self::VitestPreferImportInMock(_) => Ok(Self::VitestPreferImportInMock(
+                VitestPreferImportInMock::from_configuration(value)?,
+            )),
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -11899,6 +11913,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.to_configuration(),
             Self::VitestPreferExpectTypeOf(rule) => rule.to_configuration(),
+            Self::VitestPreferImportInMock(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -12594,6 +12609,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run(node, ctx),
+            Self::VitestPreferImportInMock(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -13287,6 +13303,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_once(ctx),
+            Self::VitestPreferImportInMock(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -14076,6 +14093,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferImportInMock(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14771,6 +14789,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.should_run(ctx),
+            Self::VitestPreferImportInMock(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -15748,6 +15767,7 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::IS_TSGOLINT_RULE
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::IS_TSGOLINT_RULE,
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -16608,6 +16628,7 @@ impl RuleEnum {
                 VitestPreferDescribeFunctionTitle::HAS_CONFIG
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::HAS_CONFIG,
+            Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::HAS_CONFIG,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -17305,6 +17326,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.types_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.types_info(),
+            Self::VitestPreferImportInMock(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -17998,6 +18020,7 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_info(),
+            Self::VitestPreferImportInMock(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -18805,6 +18828,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),
         RuleEnum::VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle::default()),
         RuleEnum::VitestPreferExpectTypeOf(VitestPreferExpectTypeOf::default()),
+        RuleEnum::VitestPreferImportInMock(VitestPreferImportInMock::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -704,6 +704,7 @@ pub(crate) mod vitest {
     pub mod prefer_called_times;
     pub mod prefer_describe_function_title;
     pub mod prefer_expect_type_of;
+    pub mod prefer_import_in_mock;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
@@ -1,0 +1,192 @@
+use oxc_ast::{AstKind, ast::Argument};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{PossibleJestNode, parse_general_jest_fn_call},
+};
+
+fn prefer_import_in_mock_diagnostic(span: Span, path: &str) -> OxcDiagnostic {
+    let help = format!(
+        "Dynamic import improves the type information and IntelliSense. Substitute `{path}` with `import('{path}')`"
+    );
+
+    OxcDiagnostic::warn("Mocked modules must be dynamic imported.").with_help(help).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferImportInMock(Box<PreferImportInMockConfig>);
+
+impl std::ops::Deref for PreferImportInMock {
+    type Target = PreferImportInMockConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+pub struct PreferImportInMockConfig {
+    fixable: bool,
+}
+
+impl Default for PreferImportInMockConfig {
+    fn default() -> Self {
+        Self { fixable: true }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule enforces using a dynamic import() in `vi.mock()`, which improves type information and IntelliSense for the mocked module.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A lack of type information and IntelliSense increase the risk of mismatches between the real module and it's mock.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// vi.mock('./path/to/module')
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// vi.mock(import('./path/to/module'))
+    /// ```
+    PreferImportInMock,
+    vitest,
+    style,
+    fix,
+    config = PreferImportInMockConfig
+);
+
+impl Rule for PreferImportInMock {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        Ok(Self(Box::new(
+            serde_json::from_value::<DefaultRuleConfig<PreferImportInMockConfig>>(value)
+                .unwrap_or_default()
+                .into_inner(),
+        )))
+    }
+
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        self.run(jest_node, ctx);
+    }
+}
+
+impl PreferImportInMock {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if call_expr.callee_name().is_some_and(|callee| callee != "mock") {
+            return;
+        }
+
+        if parse_general_jest_fn_call(call_expr, possible_jest_node, ctx).is_none() {
+            return;
+        }
+
+        let Some(Argument::StringLiteral(import_value)) = call_expr.arguments.first() else {
+            return;
+        };
+
+        ctx.diagnostic_with_fix(
+            prefer_import_in_mock_diagnostic(
+                call_expr.arguments_span().unwrap(),
+                import_value.value.as_ref(),
+            ),
+            |fixer| {
+                if !self.fixable {
+                    return fixer.noop();
+                }
+
+                fixer.replace(
+                    import_value.span,
+                    format!("import('{}')", import_value.value.as_ref()),
+                )
+            },
+        );
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"vi.mock(import("foo"))"#, None),
+        (r#"vi.mock(import("node:fs/promises"))"#, None),
+        (r#"vi.mock(import("./foo.js"), () => ({ Foo: vi.fn() }))"#, None),
+        (r#"vi.mock(import("./foo.js"), { spy: true });"#, None),
+        (r#"vi.mock(import("foo"))"#, None),
+        (r#"vi.mock(import("node:fs/promises"))"#, None),
+        (r#"vi.mock(import("./foo.js"), () => ({ Foo: vi.fn() }))"#, None),
+        (r#"vi.mock(import("./foo.js"), { spy: true });"#, None),
+    ];
+
+    let fail = vec![
+        ("vi.mock('foo', () => {})", Some(serde_json::json!([ { "fixable": false, }, ]))),
+        (r#"vi.mock("node:fs/promises")"#, Some(serde_json::json!([ { "fixable": false, }, ]))),
+        (
+            r#"vi.mock("./foo.js", () => ({ Foo: vi.fn() }))"#,
+            Some(serde_json::json!([ { "fixable": false, }, ])),
+        ),
+        (
+            "
+                    import { vi as renamedVi } from 'vitest';
+                    renamedVi.mock('./foo.js', () => ({ Foo: vi.fn() }))
+                  ",
+            Some(serde_json::json!([ { "fixable": false, }, ])),
+        ),
+        ("vi.mock('foo', () => {})", None),
+        (r#"vi.mock("node:fs/promises")"#, None),
+        (r#"vi.mock("./foo.js", () => ({ Foo: vi.fn() }))"#, None),
+        (
+            "
+                    import { vi as renamedVi } from 'vitest';
+                    renamedVi.mock('./foo.js', () => ({ Foo: vi.fn() }))
+                  ",
+            None,
+        ),
+    ];
+
+    let fix = vec![
+        ("vi.mock('foo', () => {})", "vi.mock(import('foo'), () => {})"),
+        (r#"vi.mock("node:fs/promises")"#, "vi.mock(import('node:fs/promises'))"),
+        (
+            r#"vi.mock("./foo.js", () => ({ Foo: vi.fn() }))"#,
+            "vi.mock(import('./foo.js'), () => ({ Foo: vi.fn() }))",
+        ),
+        (
+            "
+                    import { vi as renamedVi } from 'vitest';
+                    renamedVi.mock('./foo.js', () => ({ Foo: vi.fn() }))
+                  ",
+            "
+                    import { vi as renamedVi } from 'vitest';
+                    renamedVi.mock(import('./foo.js'), () => ({ Foo: vi.fn() }))
+                  ",
+        ),
+    ];
+
+    Tester::new(PreferImportInMock::NAME, PreferImportInMock::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_import_in_mock.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_import_in_mock.snap
@@ -1,0 +1,63 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock('foo', () => {})
+   ·         ───────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `foo` with `import('foo')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock("node:fs/promises")
+   ·         ──────────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `node:fs/promises` with `import('node:fs/promises')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock("./foo.js", () => ({ Foo: vi.fn() }))
+   ·         ────────────────────────────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `./foo.js` with `import('./foo.js')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:3:36]
+ 2 │                     import { vi as renamedVi } from 'vitest';
+ 3 │                     renamedVi.mock('./foo.js', () => ({ Foo: vi.fn() }))
+   ·                                    ────────────────────────────────────
+ 4 │                   
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `./foo.js` with `import('./foo.js')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock('foo', () => {})
+   ·         ───────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `foo` with `import('foo')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock("node:fs/promises")
+   ·         ──────────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `node:fs/promises` with `import('node:fs/promises')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:1:9]
+ 1 │ vi.mock("./foo.js", () => ({ Foo: vi.fn() }))
+   ·         ────────────────────────────────────
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `./foo.js` with `import('./foo.js')`
+
+  ⚠ eslint-plugin-vitest(prefer-import-in-mock): Mocked modules must be dynamic imported.
+   ╭─[prefer_import_in_mock.tsx:3:36]
+ 2 │                     import { vi as renamedVi } from 'vitest';
+ 3 │                     renamedVi.mock('./foo.js', () => ({ Foo: vi.fn() }))
+   ·                                    ────────────────────────────────────
+ 4 │                   
+   ╰────
+  help: Dynamic import improves the type information and IntelliSense. Substitute `./foo.js` with `import('./foo.js')`


### PR DESCRIPTION
Related https://github.com/oxc-project/oxc/issues/4656

- [Docs](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-import-in-mock.md)
- [Source Code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/prefer-import-in-mock.ts)
- [Test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/prefer-import-in-mock.test.ts)