### PR TITLE
fix(vscode): resolve binary paths with node resolver

### DIFF
--- a/editors/vscode/client/tools/formatter.ts
+++ b/editors/vscode/client/tools/formatter.ts
@@ -34,6 +34,9 @@ export default class FormatterTool implements ToolInterface {
     outputChannel: LogOutputChannel,
     configService: ConfigService,
   ): Promise<string | undefined> {
+    if (process.env.SERVER_PATH_DEV) {
+      return process.env.SERVER_PATH_DEV;
+    }
     const bin = await configService.getOxfmtServerBinPath();
     if (bin) {
       try {
@@ -43,7 +46,6 @@ export default class FormatterTool implements ToolInterface {
         outputChannel.error(`Invalid bin path: ${bin}`, e);
       }
     }
-    return process.env.SERVER_PATH_DEV;
   }
 
   async activate(
@@ -67,7 +69,7 @@ export default class FormatterTool implements ToolInterface {
 
     outputChannel.info(`Using server binary at: ${binaryPath}`);
 
-    const run: Executable = runExecutable(binaryPath, configService.vsCodeConfig.nodePath);
+    const run: Executable = runExecutable(binaryPath, "oxfmt", configService.vsCodeConfig.nodePath);
 
     const serverOptions: ServerOptions = {
       run,

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -48,6 +48,9 @@ export default class LinterTool implements ToolInterface {
     outputChannel: LogOutputChannel,
     configService: ConfigService,
   ): Promise<string | undefined> {
+    if (process.env.SERVER_PATH_DEV) {
+      return process.env.SERVER_PATH_DEV;
+    }
     const bin = await configService.getOxlintServerBinPath();
     if (bin) {
       try {
@@ -57,7 +60,6 @@ export default class LinterTool implements ToolInterface {
         outputChannel.error(`Invalid bin path: ${bin}`, e);
       }
     }
-    return process.env.SERVER_PATH_DEV;
   }
 
   async activate(
@@ -116,6 +118,7 @@ export default class LinterTool implements ToolInterface {
 
     const run: Executable = runExecutable(
       binaryPath,
+      "oxlint",
       configService.vsCodeConfig.nodePath,
       configService.vsCodeConfig.binPathTsGoLint,
     );

--- a/editors/vscode/client/tools/lsp_helper.ts
+++ b/editors/vscode/client/tools/lsp_helper.ts
@@ -1,7 +1,13 @@
+import * as path from "node:path";
 import { LogOutputChannel, window } from "vscode";
 import { Executable, MessageType, ShowMessageParams } from "vscode-languageclient/node";
 
-export function runExecutable(path: string, nodePath?: string, tsgolintPath?: string): Executable {
+export function runExecutable(
+  binaryPath: string,
+  nodeBinName: string,
+  nodePath?: string,
+  tsgolintPath?: string,
+): Executable {
   const serverEnv: Record<string, string> = {
     ...process.env,
     RUST_LOG: process.env.RUST_LOG || "info", // Keep for backward compatibility for a while
@@ -13,20 +19,27 @@ export function runExecutable(path: string, nodePath?: string, tsgolintPath?: st
   if (tsgolintPath) {
     serverEnv.OXLINT_TSGOLINT_PATH = tsgolintPath;
   }
-  const isNode = path.endsWith(".js") || path.endsWith(".cjs") || path.endsWith(".mjs");
+  // when the binary path ends with `oxlint/bin/oxlint` or a common js extension, we should run it with `node`
+  // the path is defined in `ConfigService.searchNodeModulesBin`
+  const isNode =
+    binaryPath.endsWith(".js") ||
+    binaryPath.endsWith(".cjs") ||
+    binaryPath.endsWith(".mjs") ||
+    binaryPath.endsWith(`${nodeBinName}${path.sep}bin${path.sep}${nodeBinName}`);
+
   const isWindows = process.platform === "win32";
 
   return isNode
     ? {
         command: "node",
-        args: [path, "--lsp"],
+        args: [binaryPath, "--lsp"],
         options: {
           env: serverEnv,
         },
       }
     : {
         // On Windows with shell, quote the command path to handle spaces in usernames/paths
-        command: isWindows ? `"${path}"` : path,
+        command: isWindows ? `"${binaryPath}"` : binaryPath,
         args: ["--lsp"],
         options: {
           // On Windows we need to run the binary in a shell to be able to execute the shell npm bin script.

--- a/editors/vscode/tests/unit/lsp_helper.spec.ts
+++ b/editors/vscode/tests/unit/lsp_helper.spec.ts
@@ -4,14 +4,16 @@ import { runExecutable } from '../../client/tools/lsp_helper';
 suite('runExecutable', () => {
   const originalPlatform = process.platform;
   const originalEnv = process.env;
+  const tool = "oxlint";
 
   teardown(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
     process.env = originalEnv;
   });
 
+
   test('should create Node.js executable for .js files', () => {
-    const result = runExecutable('/path/to/server.js');
+    const result = runExecutable('/path/to/server.js', tool);
 
     strictEqual(result.command, 'node');
     strictEqual(result.args?.[0], '/path/to/server.js');
@@ -19,7 +21,7 @@ suite('runExecutable', () => {
   });
 
   test('should create Node.js executable for .cjs files', () => {
-    const result = runExecutable('/path/to/server.cjs');
+    const result = runExecutable('/path/to/server.cjs', tool);
 
     strictEqual(result.command, 'node');
     strictEqual(result.args?.[0], '/path/to/server.cjs');
@@ -27,7 +29,7 @@ suite('runExecutable', () => {
   });
 
   test('should create Node.js executable for .mjs files', () => {
-    const result = runExecutable('/path/to/server.mjs');
+    const result = runExecutable('/path/to/server.mjs', tool);
 
     strictEqual(result.command, 'node');
     strictEqual(result.args?.[0], '/path/to/server.mjs');
@@ -35,7 +37,7 @@ suite('runExecutable', () => {
   });
 
   test('should create binary executable for non-Node files', () => {
-    const result = runExecutable('/path/to/oxc-language-server');
+    const result = runExecutable('/path/to/oxc-language-server', tool);
 
     strictEqual(result.command, '/path/to/oxc-language-server');
     strictEqual(result.args?.[0], '--lsp');
@@ -45,7 +47,7 @@ suite('runExecutable', () => {
   test('should use shell on Windows for binary executables', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
-    const result = runExecutable('/path/to/oxc-language-server');
+    const result = runExecutable('/path/to/oxc-language-server', tool);
 
     strictEqual(result.options?.shell, true);
   });
@@ -54,7 +56,7 @@ suite('runExecutable', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     process.env.PATH = '/usr/bin:/bin';
 
-    const result = runExecutable('/path/to/server', '/custom/node/path');
+    const result = runExecutable('/path/to/server', tool, '/custom/node/path');
 
     strictEqual(result.options?.env?.PATH, '/custom/node/path:/usr/bin:/bin');
   });
@@ -62,7 +64,7 @@ suite('runExecutable', () => {
   test('should set path in quotes on Windows for binary executables', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
-    const result = runExecutable('C:\\Path With Spaces\\oxc-language-server');
+    const result = runExecutable('C:\\Path With Spaces\\oxc-language-server', tool);
 
     strictEqual(result.command, '"C:\\Path With Spaces\\oxc-language-server"');
   });


### PR DESCRIPTION
Refactored the search to use `path.resolve` instead of glob search with VSCode.
The VSCode snippet did some excludes in the background with `search.excludes` and/or other settings.
Now it should work without these restriction and hopefully

closes https://github.com/oxc-project/oxc/issues/17936
closes https://github.com/oxc-project/oxc/issues/17881
closes https://github.com/oxc-project/oxc/issues/17744

It will not search for globally installed oxlint/oxfmt. Created an extra issue for this: https://github.com/oxc-project/oxc/issues/18005