### PR TITLE
fix(oxfmt): Do not wrap with `block_indent()` if `format_embedded` fails

### DIFF
--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -72,10 +72,12 @@ export async function formatEmbeddedCode({
 
   // SAFETY: `options` is created in Rust side, so it's safe to mutate here
   options.parser = parserName;
-  return prettier
-    .format(code, options)
-    .then((formatted) => formatted.trimEnd())
-    .catch(() => code);
+
+  // NOTE: This will throw if:
+  // - Specified parser is not available
+  // - Or, code has syntax errors
+  // In such cases, Rust side will fallback to original code
+  return prettier.format(code, options);
 }
 
 // ---

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -230,7 +230,12 @@ fn wrap_format_embedded(cb: JsFormatEmbeddedCb) -> FormatEmbeddedWithConfigCallb
                 .await;
             match status {
                 Ok(promise) => match promise.await {
-                    Ok(formatted_code) => Ok(formatted_code),
+                    Ok(mut formatted_code) => {
+                        // Trim trailing newline added by Prettier without allocation
+                        let trimmed_len = formatted_code.trim_end().len();
+                        formatted_code.truncate(trimmed_len);
+                        Ok(formatted_code)
+                    }
                     Err(err) => {
                         Err(format!("JS formatter promise rejected for tag '{tag_name}': {err}"))
                     }

--- a/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
@@ -86,7 +86,7 @@ const ignoredGql = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 const normalGql = gql\`query GetPosts{posts{title author}}\`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -116,6 +116,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --- AFTER ----------
@@ -269,7 +285,7 @@ const normalGql = gql\`
 \`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -299,6 +315,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --------------------"
@@ -390,7 +422,7 @@ const ignoredGql = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 const normalGql = gql\`query GetPosts{posts{title author}}\`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -420,6 +452,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --- AFTER ----------
@@ -573,7 +621,7 @@ const normalGql = gql\`
 \`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -603,6 +651,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --------------------"
@@ -694,7 +758,7 @@ const ignoredGql = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 const normalGql = gql\`query GetPosts{posts{title author}}\`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -724,6 +788,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --- AFTER ----------
@@ -809,7 +889,7 @@ const ignoredGql = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 const normalGql = gql\`query GetPosts{posts{title author}}\`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag\`
@@ -839,6 +919,22 @@ const sql = sql\`
           
           
                       SELECT * FROM users WHERE id = 1
+\`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css\`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 \`;
 
 --------------------"

--- a/apps/oxfmt/test/cli/embedded_languages/fixtures/embedded_languages.js
+++ b/apps/oxfmt/test/cli/embedded_languages/fixtures/embedded_languages.js
@@ -80,7 +80,7 @@ const ignoredGql = gql`query GetUser($id:ID!){user(id:$id){name email}}`;
 const normalGql = gql`query GetPosts{posts{title author}}`;
 
 // ============================================================================
-// Unsupported Tags - Tags not recognized by the formatter
+// Unsupported Tags - Tags not recognized by the formatter, to be left unformatted
 // ============================================================================
 
 const unknown = customTag`
@@ -110,4 +110,20 @@ const sql = sql`
           
           
                       SELECT * FROM users WHERE id = 1
+`;
+
+// ============================================================================
+// Supported Tags contains invalid syntax - To be left unformatted too
+// ============================================================================
+
+// Value only, key missing
+const invalidCss = css`
+  repeating-linear-gradient(
+    0deg,
+var(--schemas-lines-color),
+var(--schemas-lines-color) 3px,
+    transparent 3px,
+    transparent 5px,
+    var(--schemas-lines-color) 5px
+  );
 `;


### PR DESCRIPTION
Fixes #17948 and may fix `next.js` repo diffs. => Confirmed all xxx-in-js diffs are resolved ✨ 

---

When Prettier fails to format embedded code (e.g., valid `css` tag but with invalid content), the previous implementation returned the original code as a successful result.

This caused issues because `block_indent` is always added (assuming Prettier has normalized root indentation).

As a result, indentation/newlines grow infinitely on each format run.
