### PR TITLE
docs(linter): Improve prefer-spread docs.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
@@ -9,22 +9,20 @@ use oxc_span::{ContentEq, Span};
 use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
 
 fn eslint_prefer_spread_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Require spread operators instead of .apply()").with_label(span)
+    OxcDiagnostic::warn("Use spread operators instead of `.apply()`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferSpread;
 
 declare_oxc_lint!(
-    /// This rule is combined 2 rules from `eslint:prefer-spread` and `unicorn:prefer-spread`.
-    ///
     /// ### What it does
     ///
-    /// Require spread operators instead of .apply()
+    /// Require spread operators instead of `.apply()`
     ///
     /// ### Why is this bad?
     ///
-    /// Before ES2015, one must use Function.prototype.apply() to call variadic functions.
+    /// Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
     /// ```javascript
     /// var args = [1, 2, 3, 4];
     /// Math.max.apply(Math, args);

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
@@ -1,110 +1,110 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply(undefined, args);
    · ──────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply(void 0, args);
    · ───────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply(null, args);
    · ─────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ obj.foo.apply(obj, args);
    · ────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a.b.c.foo.apply(a.b.c, args);
    · ────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a.b(x, y).c.foo.apply(a.b(x, y).c, args);
    · ────────────────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ [].concat.apply([ ], args);
    · ──────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ ╭─▶ [].concat.apply([
  2 │ │               /*empty*/
  3 │ ╰─▶             ], args);
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply?.(undefined, args);
    · ────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo?.apply(undefined, args);
    · ───────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo?.apply?.(undefined, args);
    · ─────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (foo?.apply)(undefined, args);
    · ─────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (foo?.apply)?.(undefined, args);
    · ───────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (obj?.foo).apply(obj, args);
    · ───────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a?.b.c.foo.apply(a?.b.c, args);
    · ──────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (a?.b.c).foo.apply(a?.b.c, args);
    · ────────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (a?.b).c.foo.apply((a?.b).c, args);
    · ──────────────────────────────────
    ╰────
 
-  ⚠ eslint(prefer-spread): Require spread operators instead of .apply()
+  ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:25]
  1 │ class C { #foo; foo() { obj.#foo.apply(obj, args); } }
    ·                         ─────────────────────────


### PR DESCRIPTION
And diagnostic.

The rule previously said it was a merging of two rules, but we support the other rule as well, so that doens't really make sense.