### PR TITLE
fix(codegen): remove leading whitespace from export statements after comments

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1080,6 +1080,7 @@ impl Gen for ExportSpecifier<'_> {
         if let Some(comments) = p.get_comments(self.local.span().start) {
             p.print_comments(&comments);
             p.print_soft_space();
+            p.print_next_indent_as_space = false;
         }
         self.local.print(p, ctx);
         let local_name = get_module_export_name(&self.local, p);
@@ -1089,6 +1090,7 @@ impl Gen for ExportSpecifier<'_> {
             if let Some(comments) = p.get_comments(self.exported.span().start) {
                 p.print_comments(&comments);
                 p.print_soft_space();
+                p.print_next_indent_as_space = false;
             }
             self.exported.print(p, ctx);
         }

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -318,14 +318,14 @@ export function* generatorFunctionName() {/* … */}
 export const { name5, name2: bar } = o;
 export const [name6, name7] = array;
 export { name8, /* …, */ name81 };
- export { variable1 as name9, variable2 as name10, /* …, */ name82 };
- export { variable1 as 'string name' };
+export { variable1 as name9, variable2 as name10, /* …, */ name82 };
+export { variable1 as 'string name' };
 export { name1 as default1 };
 export * from 'module-name';
 export * as name11 from 'module-name';
 export { name12, /* …, */ nameN } from 'module-name';
- export { import1 as name13, import2 as name14, /* …, */ name15 } from 'module-name';
- export { default } from 'module-name';
+export { import1 as name13, import2 as name14, /* …, */ name15 } from 'module-name';
+export { default } from 'module-name';
 export { default as name16 } from 'module-name';
 
 ########## 41


### PR DESCRIPTION
## Summary

- Clear the `print_next_indent_as_space` flag after printing comments in `ExportSpecifier` to prevent it from leaking to subsequent statements

When a block comment like `/* comment */` is printed inside an export specifier, the flag is set expecting `print_indent()` to consume it. However, `ExportSpecifier` calls `print_soft_space()` instead, leaving the flag set. This caused the next export statement to incorrectly print a leading space.

Before:
```js
export { name8, /* comment */ name81 };
 export { variable1 as name9 };  // <-- unwanted leading space
```

After:
```js
export { name8, /* comment */ name81 };
export { variable1 as name9 };
```

## Test plan

- Existing tests pass
- Snapshot updated to reflect the fix

Closes #17884

🤖 Generated with [Claude Code](https://claude.com/claude-code)