### PR TITLE
fix(codegen): fix inconsistent multiline EOF comment formatting

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -208,6 +208,8 @@ impl Codegen<'_> {
         match legal_comments {
             LegalComment::Eof => {
                 self.print_hard_newline();
+                // Clear the flag to ensure consistent formatting for all EOF comments
+                self.print_next_indent_as_space = false;
                 for c in comments {
                     self.print_comment(&c);
                     self.print_hard_newline();

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_comments.snap
@@ -111,7 +111,7 @@ function foo() {
 * @preserve
 */
 /**
- * @preserve
+* @preserve
 */
 
 ########## 8


### PR DESCRIPTION
## Summary

- Clear the `print_next_indent_as_space` flag before printing EOF legal comments to ensure consistent formatting

When inline comments set the `print_next_indent_as_space` flag, it was leaking to EOF comment printing, causing inconsistent formatting where some multiline block comments had a leading space before `*` and others didn't.

Before:
```js
/**
* @preserve
*/
/**
 * @preserve   <-- inconsistent leading space
*/
```

After:
```js
/**
* @preserve
*/
/**
* @preserve
*/
```

## Test plan

- Existing tests pass
- Snapshot updated to reflect the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)