### PR TITLE
fix(codegen): remove trailing space before semicolon in minified TypeScript

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -59,10 +59,16 @@ fn print_binary_operator(op: BinaryOperator, p: &mut Codegen) {
         p.print_space_before_identifier();
         p.print_str(operator);
     } else {
-        let op: Operator = op.into();
-        p.print_space_before_operator(op);
+        let o: Operator = op.into();
+        p.print_space_before_operator(o);
+        // Avoid `!` + `=` or `==` or `===` forming `!=` or `!==`
+        if matches!(op, BinaryOperator::Equality | BinaryOperator::StrictEquality)
+            && p.last_char() == Some('!')
+        {
+            p.print_hard_space();
+        }
         p.print_str(operator);
-        p.prev_op = Some(op);
+        p.prev_op = Some(o);
         p.prev_op_end = p.code().len();
     }
 }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1904,7 +1904,12 @@ impl GenExpr for AssignmentExpression<'_> {
         p.wrap(wrap || precedence >= self.precedence(), |p| {
             p.add_source_mapping(self.span);
             self.left.print(p, ctx);
-            p.print_soft_space();
+            // Avoid `!` + `=` forming `!=`
+            if self.operator == AssignmentOperator::Assign && p.last_char() == Some('!') {
+                p.print_hard_space();
+            } else {
+                p.print_soft_space();
+            }
             p.print_str(self.operator.as_str());
             p.print_soft_space();
             self.right.print_expr(p, Precedence::Comma, ctx);
@@ -2292,9 +2297,6 @@ impl GenExpr for TSNonNullExpression<'_> {
             self.expression.print_expr(p, precedence, ctx);
         });
         p.print_ascii_byte(b'!');
-        if p.options.minify {
-            p.print_hard_space();
-        }
     }
 }
 
@@ -2302,9 +2304,6 @@ impl GenExpr for TSInstantiationExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         self.expression.print_expr(p, precedence, ctx);
         self.type_arguments.print(p, ctx);
-        if p.options.minify {
-            p.print_hard_space();
-        }
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -122,7 +122,7 @@ declare module "a";
 ########## 28
 a = x!;
 ----------
-a=x! ;
+a=x!;
 ########## 29
 b = (x as y);
 ----------
@@ -130,7 +130,7 @@ b=x as y;
 ########## 30
 c = foo<string>;
 ----------
-c=foo<string> ;
+c=foo<string>;
 ########## 31
 new Map<string, number>();
 ----------


### PR DESCRIPTION
## Summary

- Remove unnecessary `print_hard_space()` calls from `TSNonNullExpression` and `TSInstantiationExpression`

These TypeScript expression types were incorrectly adding a trailing space in minified output:

Before:
```js
a=x! ;
c=foo<string> ;
```

After:
```js
a=x!;
c=foo<string>;
```

The space is unnecessary because `!` and `>` are not identifier characters, so the parser correctly handles these without whitespace.

## Test plan

- Existing tests pass
- Snapshot updated to reflect the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)