### PR TITLE
fix(codegen): remove unnecessary double parentheses from satisfies expressions

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2269,20 +2269,13 @@ impl GenExpr for TSAsExpression<'_> {
 
 impl GenExpr for TSSatisfiesExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        p.print_ascii_byte(b'(');
-        let should_wrap =
-            if let Expression::FunctionExpression(func) = &self.expression.without_parentheses() {
-                // pife is handled on Function side
-                !func.pife
-            } else {
-                true
-            };
-        p.wrap(should_wrap, |p| {
-            self.expression.print_expr(p, precedence, Context::default());
+        let wrap = precedence >= Precedence::Compare;
+
+        p.wrap(wrap, |p| {
+            self.expression.print_expr(p, Precedence::Exponentiation, ctx);
+            p.print_str(" satisfies ");
+            self.type_annotation.print(p, ctx);
         });
-        p.print_str(" satisfies ");
-        self.type_annotation.print(p, ctx);
-        p.print_ascii_byte(b')');
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -138,7 +138,7 @@ new Map<string,number>;
 ########## 32
 d = x satisfies y;
 ----------
-d=((x) satisfies y);
+d=x satisfies y;
 ########## 33
 export @x declare abstract class C {}
 ----------

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -451,7 +451,7 @@ const Foo = (/* @__PURE__ */ (() => {})() as unknown) as {
 ########## 27
 const Foo = /* @__PURE__ */ (() => {})() satisfies X
 ----------
-const Foo = ((/* @__PURE__ */ (() => {})()) satisfies X);
+const Foo = /* @__PURE__ */ (() => {})() satisfies X;
 
 ########## 28
 const Foo = /* @__PURE__ */ (() => {})()<X>
@@ -466,7 +466,7 @@ const Foo = (<Foo>(/* @__PURE__ */ (() => {})())!);
 ########## 30
 const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y
 ----------
-const Foo = (((<Foo>(/* @__PURE__ */ (() => {})())!) as X) satisfies Y);
+const Foo = ((<Foo>(/* @__PURE__ */ (() => {})())!) as X) satisfies Y;
 
 ########## 31
 /* @__NO_SIDE_EFFECTS__ */ ((options, extraOptions) => {

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -205,7 +205,7 @@ new Map<string, number>();
 ########## 32
 d = x satisfies y;
 ----------
-d = ((x) satisfies y);
+d = x satisfies y;
 
 ########## 33
 export @x declare abstract class C {}

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -154,3 +154,16 @@ fn ts_as_expression_in_binary_expr() {
         "!(typeof that === 'object' && 'keys' in that && typeof (that as object & { keys: unknown }).keys === 'function')",
     );
 }
+
+#[test]
+fn ts_satisfies_expression() {
+    test_idempotency("d = x satisfies y");
+    test_idempotency("const Foo = (() => {})() satisfies X");
+    test_idempotency("const Bar = (x as Y) satisfies Z");
+    test_idempotency("(x satisfies Y).foo");
+    test_idempotency("(x satisfies Y)[0]");
+    test_idempotency("(x satisfies Y)()");
+    test_idempotency("x satisfies Y || z");
+    test_idempotency("x satisfies Y && z");
+    test_idempotency("x satisfies Y === z");
+}


### PR DESCRIPTION
## Summary
- Fixed `TSSatisfiesExpression` to only add parentheses when precedence requires it
- Before: `((x) satisfies y)`, After: `x satisfies y`
- Aligned implementation with `TSAsExpression` pattern
- Added idempotency tests to ensure semantic correctness

## Test plan
- [x] Added `ts_satisfies_expression` test with 9 idempotency test cases
- [x] All codegen tests pass
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)