### PR TITLE
fix(codegen): remove spaces around `=` in minified type parameter defaults

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3346,7 +3346,9 @@ impl Gen for TSTypeParameter<'_> {
             constraint.print(p, ctx);
         }
         if let Some(default) = &self.default {
-            p.print_str(" = ");
+            p.print_soft_space();
+            p.print_ascii_byte(b'=');
+            p.print_soft_space();
             default.print(p, ctx);
         }
     }
@@ -3833,7 +3835,9 @@ impl Gen for TSImportEqualsDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("import ");
         self.id.print(p, ctx);
-        p.print_str(" = ");
+        p.print_soft_space();
+        p.print_ascii_byte(b'=');
+        p.print_soft_space();
         self.module_reference.print(p, ctx);
     }
 }

--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -150,7 +150,7 @@ div<T>``;
 ########## 35
 export type Component<Props = any> = Foo;
 ----------
-export type Component<Props = any>=Foo;
+export type Component<Props=any>=Foo;
 ########## 36
 
 export type Component<
@@ -166,7 +166,7 @@ export type Component<
   | ComponentPublicInstanceConstructor<Props>
 
 ----------
-export type Component<Props = any,RawBindings = any,D = any,C extends ComputedOptions = ComputedOptions,M extends MethodOptions = MethodOptions,E extends EmitsOptions|Record<string,any[]> = {},S extends Record<string,any> = any>=ConcreteComponent<Props,RawBindings,D,C,M,E,S>|ComponentPublicInstanceConstructor<Props>;
+export type Component<Props=any,RawBindings=any,D=any,C extends ComputedOptions=ComputedOptions,M extends MethodOptions=MethodOptions,E extends EmitsOptions|Record<string,any[]>={},S extends Record<string,any>=any>=ConcreteComponent<Props,RawBindings,D,C,M,E,S>|ComponentPublicInstanceConstructor<Props>;
 ########## 37
 (a || b) as any
 ----------
@@ -222,7 +222,7 @@ import a = require("a");
 export import b = require("b");
 
 ----------
-import a = require("a");export import b = require("b");
+import a=require("a");export import b=require("b");
 ########## 42
 class C {
   static


### PR DESCRIPTION
## Summary
- Remove unnecessary spaces around `=` in type parameter defaults
- Remove unnecessary spaces around `=` in import equals declarations

## Changes
- `<Props = any>` → `<Props=any>`
- `import a = require("a")` → `import a=require("a")`

Both syntaxes parse correctly without spaces (verified).

## Test plan
- [x] All codegen tests pass
- [x] All coverage tests pass (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)