### PR TITLE
fix(parser): improve diagnostics for double `export`

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -517,9 +517,18 @@ impl<'a> ParserImpl<'a> {
                     ),
                 }
             }
-            _ => ModuleDeclaration::ExportNamedDeclaration(
-                self.parse_export_named_declaration(span, decorators, stmt_ctx),
-            ),
+            _ => {
+                if self.at(Kind::Export) {
+                    self.error(diagnostics::modifier_already_seen(&Modifier::new(
+                        self.cur_token().span(),
+                        ModifierKind::Export,
+                    )));
+                    self.bump_any();
+                }
+                ModuleDeclaration::ExportNamedDeclaration(
+                    self.parse_export_named_declaration(span, decorators, stmt_ctx),
+                )
+            }
         };
         Statement::from(decl)
     }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6065,175 +6065,95 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·        ────────────────
    ╰────
 
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:2:12]
  1 │ namespace M {
  2 │     export export var x = 1;
    ·            ──────
  3 │     export export function f() { }
    ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:2:12]
- 1 │ namespace M {
- 2 │     export export var x = 1;
-   ·            ──────
- 3 │     export export function f() { }
-   ╰────
-  help: Only 'declare' modifier is allowed here.
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:3:12]
  2 │     export export var x = 1;
  3 │     export export function f() { }
    ·            ──────
  4 │ 
    ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:3:12]
- 2 │     export export var x = 1;
- 3 │     export export function f() { }
-   ·            ──────
- 4 │ 
-   ╰────
-  help: Allowed modifiers are: declare, async
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:5:12]
  4 │ 
  5 │     export export namespace N {
    ·            ──────
  6 │         export export class C { }
    ╰────
+  help: Remove the duplicate modifier.
 
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:6:16]
  5 │     export export namespace N {
  6 │         export export class C { }
    ·                ──────
  7 │         export export interface I { }
    ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:6:16]
- 5 │     export export namespace N {
- 6 │         export export class C { }
-   ·                ──────
- 7 │         export export interface I { }
-   ╰────
-  help: Allowed modifiers are: declare, abstract
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:7:16]
  6 │         export export class C { }
  7 │         export export interface I { }
    ·                ──────
  8 │     }  
    ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:7:16]
- 6 │         export export class C { }
- 7 │         export export interface I { }
-   ·                ──────
- 8 │     }  
-   ╰────
-  help: Only 'declare' modifier is allowed here.
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:5:12]
- 4 │ 
- 5 │     export export namespace N {
-   ·            ──────
- 6 │         export export class C { }
-   ╰────
-  help: Only 'declare' modifier is allowed here.
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:12:12]
  11 │ declare namespace A {
  12 │     export export var x;
     ·            ──────
  13 │     export export function f()
     ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:12:12]
- 11 │ declare namespace A {
- 12 │     export export var x;
-    ·            ──────
- 13 │     export export function f()
-    ╰────
-  help: Only 'declare' modifier is allowed here.
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:13:12]
  12 │     export export var x;
  13 │     export export function f()
     ·            ──────
  14 │ 
     ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:13:12]
- 12 │     export export var x;
- 13 │     export export function f()
-    ·            ──────
- 14 │ 
-    ╰────
-  help: Allowed modifiers are: declare, async
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:15:12]
  14 │ 
  15 │     export export namespace N {
     ·            ──────
  16 │         export export class C { }
     ╰────
+  help: Remove the duplicate modifier.
 
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:16:16]
  15 │     export export namespace N {
  16 │         export export class C { }
     ·                ──────
  17 │         export export interface I { }
     ╰────
+  help: Remove the duplicate modifier.
 
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:16:16]
- 15 │     export export namespace N {
- 16 │         export export class C { }
-    ·                ──────
- 17 │         export export interface I { }
-    ╰────
-  help: Allowed modifiers are: declare, abstract
-
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
     ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:17:16]
  16 │         export export class C { }
  17 │         export export interface I { }
     ·                ──────
  18 │     }
     ╰────
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:17:16]
- 16 │         export export class C { }
- 17 │         export export interface I { }
-    ·                ──────
- 18 │     }
-    ╰────
-  help: Only 'declare' modifier is allowed here.
-
-  × 'export' modifier cannot be used here.
-    ╭─[typescript/tests/cases/compiler/exportAlreadySeen.ts:15:12]
- 14 │ 
- 15 │     export export namespace N {
-    ·            ──────
- 16 │         export export class C { }
-    ╰────
-  help: Only 'declare' modifier is allowed here.
+  help: Remove the duplicate modifier.
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts:2:16]
@@ -6249,11 +6169,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·         ──────
    ╰────
 
-  × Unexpected token
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/compiler/exportAssignmentWithExportModifier.ts:2:8]
  1 │ var x;
  2 │ export export = x;
    ·        ──────
+   ╰────
+  help: Remove the duplicate modifier.
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/exportAssignmentWithExportModifier.ts:2:15]
+ 1 │ var x;
+ 2 │ export export = x;
+   ·               ─
    ╰────
 
   × TS(2309): An export assignment cannot be used in a module with other exported elements
@@ -22837,20 +22765,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Only 'declare' modifier is allowed here.
 
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration6.ts:1:8]
  1 │ export export interface I {
    ·        ──────
  2 │ }
    ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration6.ts:1:8]
- 1 │ export export interface I {
-   ·        ──────
- 2 │ }
-   ╰────
-  help: Only 'declare' modifier is allowed here.
+  help: Remove the duplicate modifier.
 
   × TS(2414): Interface name cannot be 'string'
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration8.ts:1:11]
@@ -23361,20 +23282,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
 
-  × TS(1029): 'export' modifier must precede 'declare' modifier.
+  × TS(1030): 'export' modifier already seen.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts:1:8]
  1 │ export export class Foo {
    ·        ──────
  2 │   public Bar() {
    ╰────
-
-  × 'export' modifier cannot be used here.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts:1:8]
- 1 │ export export class Foo {
-   ·        ──────
- 2 │   public Bar() {
-   ╰────
-  help: Allowed modifiers are: declare, abstract
+  help: Remove the duplicate modifier.
 
   × The keyword 'static' is reserved
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331.ts:2:18]


### PR DESCRIPTION
fixes #15870