### PR TITLE
feat(minifier): prune empty `case` before trailing `default`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 6.69 MB    | 2.22 MB    | 2.31 MB    | 458.44 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.36 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 853.35 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
## Summary

- Adds minification optimization to remove empty `case` clauses that precede a trailing `default` clause when those cases contain only primitive literals
- Port of https://github.com/evanw/esbuild/commit/add452ed51333953dd38a26f28a775bb220ea2e9

### Example

```javascript
// Before:
switch (x) { case 0: foo(); break; case 1: default: bar() }

// After:
switch (x) { case 0: foo(); break; default: bar() }
```

## Test plan

- [x] Added tests for basic case with empty literal before default
- [x] Added tests for multiple empty literal cases  
- [x] Added tests for non-literal identifiers (should NOT be removed)
- [x] Added tests for default not at end (preserved)
- [x] Added tests for string, null, and BigInt literals
- [x] All existing minifier tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)