### PR TITLE
docs(semantic): document `with` statement limitation in `is_global_reference`

### DIFF
--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -2,7 +2,28 @@ use oxc_ast::ast::{Expression, IdentifierReference};
 
 use crate::{ReferenceId, Scoping};
 
-/// Checks whether the a identifier reference is a global value or not.
+/// Checks whether an identifier reference is a global value or not.
+///
+/// # Limitation: `with` statements
+///
+/// This check does not correctly handle references inside `with` statements.
+/// Inside a `with` block, unresolved references may resolve to properties of
+/// the `with` object at runtime, but this function will incorrectly return
+/// `true` for such references.
+///
+/// ```js
+/// const foo = { Object: class { /* ... */ } }
+/// with (foo) { console.log(new Object()) }
+/// //                           ^^^^^^ This `Object` is NOT a global reference,
+/// //                                  but `is_global_reference` returns `true`.
+/// ```
+///
+/// This is acceptable because:
+/// 1. `with` statements are forbidden in strict mode
+/// 2. Bundlers like Rolldown don't support `with` statements
+/// 3. The minifier bails out when `with` statements are present
+///
+/// See: <https://github.com/oxc-project/oxc/issues/8365>
 pub trait IsGlobalReference {
     fn is_global_reference(&self, scoping: &Scoping) -> bool;
     fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool;


### PR DESCRIPTION
## Summary

Documents the limitation that `is_global_reference` does not correctly handle references inside `with` statements, as discussed in #8365.

The documentation explains:
- The limitation where `is_global_reference` incorrectly returns `true` for references inside `with` blocks
- A code example illustrating the issue
- Why this limitation is acceptable (strict mode forbids `with`, bundlers don't support it, minifier bails out)

Closes #8365

## Test plan

- Documentation only change, no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)