### PR TITLE
fix(ci): improve Discord release notification format

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -453,7 +453,9 @@ jobs:
       - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_OXC_RELEASES_CHANNEL }}
-          content: ${{ steps.release.outputs.url }}
+          embed-title: oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}
+          embed-description: A new release is available! Check the changelog for details.
+          embed-url: ${{ steps.release.outputs.url }}
 
       - name: wait 3 minutes for smoke test
         run: sleep 180s


### PR DESCRIPTION
## Summary
- Use Discord embed fields (`embed-title`, `embed-description`, `embed-url`) instead of plain `content`
- Provides a proper title showing the version numbers
- Adds a description message
- Makes the release URL a clickable link in the embed

## Test plan
- [ ] Verify on next release that Discord notification shows formatted embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)