### PR TITLE
feat(traverse): add into_state and into_state_and_scoping methods to ReusableTraverseCtx

### DIFF
--- a/crates/oxc_traverse/src/context/reusable.rs
+++ b/crates/oxc_traverse/src/context/reusable.rs
@@ -29,6 +29,16 @@ impl<'a, State> ReusableTraverseCtx<'a, State> {
         self.0.scoping.into_scoping()
     }
 
+    /// Consume [`ReusableTraverseCtx`] and return the user state.
+    pub fn into_state(self) -> State {
+        self.0.state
+    }
+
+    /// Consume [`ReusableTraverseCtx`] and return both user state and [`Scoping`].
+    pub fn into_state_and_scoping(self) -> (State, Scoping) {
+        (self.0.state, self.0.scoping.into_scoping())
+    }
+
     /// Unwrap [`TraverseCtx`] in a [`ReusableTraverseCtx`].
     ///
     /// Only for use in tests. Allows circumventing the safety invariants of [`TraverseAncestry`].


### PR DESCRIPTION
## Summary

Add methods to extract user state from `ReusableTraverseCtx` after traversal:

- `into_state()` - consumes ctx and returns just the user state
- `into_state_and_scoping()` - consumes ctx and returns both state and `Scoping`

## Motivation

When implementing multi-pass AST transformations, passes often need to:
1. Accumulate state during traversal (e.g., detect patterns)
2. Extract that state after traversal
3. Pass accumulated state to subsequent passes

Currently, the only way to extract state is via `unsafe fn unwrap()`. These new methods provide a safe API for this common pattern.

## Example Use Case

```rust
// Pass 1: Detect string arrays
let mut ctx = ReusableTraverseCtx::new(MyState::new(), scoping, &allocator);
traverse_mut_with_ctx(&mut pass1, &mut program, &mut ctx);

// Extract state for next pass
let mut state = ctx.into_state();
pass1.finalize(&mut state);

// Pass 2: Use accumulated state
let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
let mut ctx = ReusableTraverseCtx::new(state, scoping, &allocator);
traverse_mut_with_ctx(&mut pass2, &mut program, &mut ctx);
```

## Changes

- Added `pub fn into_state(self) -> State`
- Added `pub fn into_state_and_scoping(self) -> (State, Scoping)`