### PR TITLE
fix(linter/plugins): Handle `false` as a technically-allowed value for `rule.meta.fixable`.

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -173,7 +173,7 @@ export function registerPlugin(
       // ESLint technically only allows `null`, unset, or "code" / "whitespace" for `fixable`. Unfortunately,
       // it doesn't actually enforce this meaningfully, and so some plugins use `false` by accident.
       // So we have to handle `false` as well.
-      if (fixable != null && (fixable as any) != false) {
+      if (fixable != null && (fixable as any) !== false) {
         if (fixable !== "code" && fixable !== "whitespace") {
           throw new TypeError("Invalid `rule.meta.fixable`");
         }

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -138,6 +138,7 @@ export async function loadPlugin(
  * @throws {Error} If `plugin.meta.name` is `null` / `undefined` and `packageName` not provided
  * @throws {TypeError} If one of plugin's rules is malformed, or its `createOnce` method returns invalid visitor
  * @throws {TypeError} If `plugin.meta.name` is not a string
+ * @throws {TypeError} If the plugin has a rule with an invalid `meta.fixable` value.
  */
 export function registerPlugin(
   plugin: Plugin,
@@ -169,7 +170,10 @@ export function registerPlugin(
       if (typeof ruleMeta !== "object") throw new TypeError("Invalid `rule.meta`");
 
       const { fixable } = ruleMeta;
-      if (fixable != null) {
+      // ESLint technically only allows `null`, unset, or "code" / "whitespace" for `fixable`. Unfortunately,
+      // it doesn't actually enforce this meaningfully, and so some plugins use `false` by accident.
+      // So we have to handle `false` as well.
+      if (fixable != null && (fixable as any) != false) {
         if (fixable !== "code" && fixable !== "whitespace") {
           throw new TypeError("Invalid `rule.meta.fixable`");
         }

--- a/apps/oxlint/src-js/plugins/rule_meta.ts
+++ b/apps/oxlint/src-js/plugins/rule_meta.ts
@@ -28,6 +28,7 @@ export interface RuleMeta {
   /**
    * Type of fixes that the rule provides.
    * Must be `'code'` or `'whitespace'` if the rule provides fixes.
+   * Must be `null` or omitted entirely, if the rule does not provide fixes.
    */
   fixable?: "code" | "whitespace";
   /**


### PR DESCRIPTION
See #17967 for details. Basically, we need to allow `false` as equivalent to `null` here, because ESLint doesn't actually enforce the allowed values for `fixable` very well.

I have not added a test yet, as I want to make sure this is a fix we actually want to ship before spending time on that. I assume I should just add a new fixture with a dummy plugin that has bad values for some rules, probably?