### PR TITLE
chore(oxfmt): Fix `Oxfmtrc.printWidth` typo

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -66,7 +66,6 @@ impl FormatService {
             // Resolve options for this specific file entry
             let resolved_options = self.config_resolver.resolve(&entry);
 
-            tracing::debug!("Format {}", path.strip_prefix(&self.cwd).unwrap().display());
             let (code, is_changed) =
                 match self.formatter.format(&entry, &source_text, resolved_options) {
                     FormatResult::Success { code, is_changed } => (code, is_changed),

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -6,6 +6,7 @@ use editorconfig_parser::{
 };
 use oxc_toml::Options as TomlFormatterOptions;
 use serde_json::Value;
+use tracing::instrument;
 
 use oxc_formatter::FormatOptions;
 
@@ -96,6 +97,7 @@ impl ConfigResolver {
     /// Returns error if:
     /// - Config file is specified but not found or invalid
     /// - Config file parsing fails
+    #[instrument(level = "debug", name = "oxfmt::config::from_config_paths", skip_all)]
     pub fn from_config_paths(
         cwd: &Path,
         oxfmtrc_path: Option<&Path>,
@@ -142,6 +144,7 @@ impl ConfigResolver {
     ///
     /// # Errors
     /// Returns error if config deserialization fails.
+    #[instrument(level = "debug", name = "oxfmt::config::build_and_validate", skip_all)]
     pub fn build_and_validate(&mut self) -> Result<Vec<String>, String> {
         let mut oxfmtrc: Oxfmtrc = serde_json::from_value(self.raw_config.clone())
             .map_err(|err| format!("Failed to deserialize Oxfmtrc: {err}"))?;
@@ -174,6 +177,7 @@ impl ConfigResolver {
     }
 
     /// Resolve format options for a specific file.
+    #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %strategy.path().display()))]
     pub fn resolve(&self, strategy: &FormatFileStrategy) -> ResolvedOptions {
         let (format_options, oxfmt_options, external_options) = if let Some(editorconfig) =
             &self.editorconfig
@@ -226,6 +230,7 @@ impl ConfigResolver {
 
     /// Resolve format options for a specific file with `.editorconfig` overrides.
     /// This is the slow path, for fast path, see [`ConfigResolver::build_and_validate`].
+    #[instrument(level = "debug", name = "oxfmt::config::resolve_with_overrides", skip_all)]
     fn resolve_with_overrides(
         &self,
         props: &EditorConfigProperties,

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -42,7 +42,7 @@ pub struct Oxfmtrc {
     pub end_of_line: Option<EndOfLineConfig>,
     /// Specify the line length that the printer will wrap on.
     ///
-    /// If you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
+    /// If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
     ///
     /// - Default: `100`
     /// - Overrides `.editorconfig.max_line_length`

--- a/apps/oxfmt/src/core/utils.rs
+++ b/apps/oxfmt/src/core/utils.rs
@@ -8,7 +8,7 @@ use std::{
 /// `OXC_LOG=oxc_formatter oxfmt`
 /// # Panics
 pub fn init_tracing() {
-    use tracing_subscriber::{filter::Targets, prelude::*};
+    use tracing_subscriber::{filter::Targets, fmt::format::FmtSpan, prelude::*};
 
     // Usage without the `regex` feature.
     // <https://github.com/tokio-rs/tracing/issues/1436#issuecomment-918528013>
@@ -22,6 +22,8 @@ pub fn init_tracing() {
         ))
         .with(
             tracing_subscriber::fmt::layer()
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::CLOSE)
                 // https://github.com/tokio-rs/tracing/issues/2492
                 .with_writer(std::io::stderr),
         )

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -379,9 +379,9 @@
       "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
     },
     "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "format": "uint16",
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "minimum": 0.0,
       "type": [
         "integer",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -383,9 +383,9 @@ expression: json
       "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
     },
     "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "format": "uint16",
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "minimum": 0.0,
       "type": [
         "integer",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -414,7 +414,7 @@ type: `integer`
 
 Specify the line length that the printer will wrap on.
 
-If you don’t want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
+If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
 
 - Default: `100`
 - Overrides `.editorconfig.max_line_length`


### PR DESCRIPTION
`’` -> `'` 🙈 