### PR TITLE
refactor(apps,website): Use the same `generate_schema_json()` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,6 @@ dependencies = [
  "oxc_syntax",
  "papaya",
  "phf",
- "project-root",
  "rayon",
  "rust-lapper",
  "rustc-hash",

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -77,4 +77,3 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 markdown = { workspace = true }
-project-root = { workspace = true }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -693,25 +693,3 @@ impl RawTransferMetadata {
         Self { data_offset, is_ts: false, _padding: 0 }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use std::fs;
-
-    use project_root::get_project_root;
-
-    use crate::Oxlintrc;
-
-    #[test]
-    fn test_schema_json() {
-        let path = get_project_root().unwrap().join("npm/oxlint/configuration_schema.json");
-        let json = Oxlintrc::generate_schema_json();
-        let existing_json = fs::read_to_string(&path).unwrap_or_default();
-        if existing_json.trim() != json.trim() {
-            std::fs::write(&path, &json).unwrap();
-        }
-        insta::with_settings!({ prepend_module_to_snapshot => false }, {
-            insta::assert_snapshot!(json);
-        });
-    }
-}

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -1,60 +1,300 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Oxfmtrc",
+  "description": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
+  "type": "object",
+  "properties": {
+    "arrowParens": {
+      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ArrowParensConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+    },
+    "bracketSameLine": {
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+    },
+    "bracketSpacing": {
+      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+    },
+    "embeddedLanguageFormatting": {
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`"
+    },
+    "endOfLine": {
+      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EndOfLineConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+    },
+    "experimentalSortImports": {
+      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "experimentalSortPackageJson": {
+      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortPackageJsonUserConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+    },
+    "experimentalTailwindcss": {
+      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TailwindcssConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "htmlWhitespaceSensitivity": {
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+    },
+    "ignorePatterns": {
+      "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`"
+    },
+    "insertFinalNewline": {
+      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+    },
+    "jsxSingleQuote": {
+      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+    },
+    "objectWrap": {
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ObjectWrapConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+    },
+    "printWidth": {
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0,
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+    },
+    "proseWrap": {
+      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ProseWrapConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+    },
+    "quoteProps": {
+      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/QuotePropsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+    },
+    "semi": {
+      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+    },
+    "singleAttributePerLine": {
+      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+    },
+    "singleQuote": {
+      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+    },
+    "tabWidth": {
+      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0,
+      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
+    },
+    "trailingComma": {
+      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TrailingCommaConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+    },
+    "useTabs": {
+      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+    },
+    "vueIndentScriptAndStyle": {
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+    }
+  },
   "allowComments": true,
   "allowTrailingCommas": true,
   "definitions": {
     "ArrowParensConfig": {
+      "type": "string",
       "enum": [
         "always",
         "avoid"
-      ],
-      "type": "string"
+      ]
     },
     "EmbeddedLanguageFormattingConfig": {
+      "type": "string",
       "enum": [
         "auto",
         "off"
-      ],
-      "type": "string"
+      ]
     },
     "EndOfLineConfig": {
+      "type": "string",
       "enum": [
         "lf",
         "crlf",
         "cr"
-      ],
-      "type": "string"
+      ]
     },
     "HtmlWhitespaceSensitivityConfig": {
+      "type": "string",
       "enum": [
         "css",
         "strict",
         "ignore"
-      ],
-      "type": "string"
+      ]
     },
     "ObjectWrapConfig": {
+      "type": "string",
       "enum": [
         "preserve",
         "collapse"
-      ],
-      "type": "string"
+      ]
     },
     "ProseWrapConfig": {
+      "type": "string",
       "enum": [
         "always",
         "never",
         "preserve"
-      ],
-      "type": "string"
+      ]
     },
     "QuotePropsConfig": {
+      "type": "string",
       "enum": [
         "as-needed",
         "consistent",
         "preserve"
-      ],
-      "type": "string"
+      ]
     },
     "SortGroupItemConfig": {
       "anyOf": [
@@ -62,54 +302,56 @@
           "type": "string"
         },
         {
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         }
       ]
     },
     "SortImportsConfig": {
+      "type": "object",
       "properties": {
         "groups": {
           "description": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/SortGroupItemConfig"
           },
-          "markdownDescription": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```",
-          "type": [
-            "array",
-            "null"
-          ]
+          "markdownDescription": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```"
         },
         "ignoreCase": {
           "description": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
-          "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
           "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`"
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
-          "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`"
         },
         "order": {
+          "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/SortOrderConfig"
@@ -118,55 +360,53 @@
               "type": "null"
             }
           ],
-          "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
           "markdownDescription": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`"
         },
         "partitionByComment": {
           "description": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "partitionByNewline": {
           "description": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "sortSideEffects": {
           "description": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
-          "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
-      },
-      "type": "object"
+      }
     },
     "SortOrderConfig": {
+      "type": "string",
       "enum": [
         "asc",
         "desc"
-      ],
-      "type": "string"
+      ]
     },
     "SortPackageJsonConfig": {
+      "type": "object",
       "properties": {
         "sortScripts": {
           "description": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
-          "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`"
         }
-      },
-      "type": "object"
+      }
     },
     "SortPackageJsonUserConfig": {
       "anyOf": [
@@ -179,312 +419,72 @@
       ]
     },
     "TailwindcssConfig": {
+      "type": "object",
       "properties": {
         "attributes": {
           "description": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`"
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
-          "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
           "description": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",
-          "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`"
         },
         "preserveWhitespace": {
           "description": "Preserve whitespace around classes.\n\n- Default: `false`",
-          "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`"
         },
         "stylesheet": {
           "description": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
-          "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`"
         }
-      },
-      "type": "object"
+      }
     },
     "TrailingCommaConfig": {
+      "type": "string",
       "enum": [
         "all",
         "es5",
         "none"
-      ],
-      "type": "string"
-    }
-  },
-  "description": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
-  "markdownDescription": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
-  "properties": {
-    "arrowParens": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ArrowParensConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
-    },
-    "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "bracketSpacing": {
-      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "embeddedLanguageFormatting": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`",
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`"
-    },
-    "endOfLine": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/EndOfLineConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
-    },
-    "experimentalSortImports": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "experimentalSortPackageJson": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-    },
-    "experimentalTailwindcss": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TailwindcssConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "htmlWhitespaceSensitivity": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
-    },
-    "ignorePatterns": {
-      "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "items": {
-        "type": "string"
-      },
-      "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ]
-    },
-    "insertFinalNewline": {
-      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "jsxSingleQuote": {
-      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "objectWrap": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ObjectWrapConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
-    },
-    "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "format": "uint16",
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "minimum": 0.0,
-      "type": [
-        "integer",
-        "null"
-      ]
-    },
-    "proseWrap": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ProseWrapConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
-    },
-    "quoteProps": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/QuotePropsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
-    },
-    "semi": {
-      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "singleQuote": {
-      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "tabWidth": {
-      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "format": "uint8",
-      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "minimum": 0.0,
-      "type": [
-        "integer",
-        "null"
-      ]
-    },
-    "trailingComma": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TrailingCommaConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
-    },
-    "useTabs": {
-      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "vueIndentScriptAndStyle": {
-      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
       ]
     }
   },
-  "title": "Oxfmtrc",
-  "type": "object"
+  "markdownDescription": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions."
 }

--- a/tasks/website_common/src/lib.rs
+++ b/tasks/website_common/src/lib.rs
@@ -1,5 +1,7 @@
+mod schema_json;
 mod schema_markdown;
 
+pub use schema_json::generate_schema_json;
 pub use schema_markdown::{Renderer, Section};
 
 /// Generate CLI documentation from bpaf-generated markdown.

--- a/tasks/website_common/src/schema_json.rs
+++ b/tasks/website_common/src/schema_json.rs
@@ -1,0 +1,55 @@
+use schemars::{JsonSchema, schema_for};
+use serde_json::Value;
+
+/// Generates the JSON schema for a configuration type.
+///
+/// This function:
+/// 1. Generates the schema using `schemars`
+/// 2. Adds `allowComments` and `allowTrailingCommas` for vscode-json-languageservice
+/// 3. Injects `markdownDescription` fields for better editor support
+///
+/// # Panics
+/// Panics if the schema generation fails.
+pub fn generate_schema_json<T: JsonSchema>() -> String {
+    let mut schema = schema_for!(T);
+
+    // Allow comments and trailing commas for vscode-json-languageservice
+    // NOTE: This is NOT part of standard JSON Schema specification
+    // https://github.com/microsoft/vscode-json-languageservice/blob/fb83547762901f32d8449d57e24666573016b10c/src/jsonLanguageTypes.ts#L151-L159
+    schema.schema.extensions.insert("allowComments".to_string(), Value::Bool(true));
+    schema.schema.extensions.insert("allowTrailingCommas".to_string(), Value::Bool(true));
+
+    // Inject markdownDescription fields for better editor support (e.g., VS Code)
+    let mut json = serde_json::to_value(&schema).unwrap();
+    inject_markdown_descriptions(&mut json);
+
+    serde_json::to_string_pretty(&json).unwrap()
+}
+
+/// Recursively inject `markdownDescription` fields into the JSON schema.
+/// This is a non-standard field that some editors (like VS Code) use to render
+/// markdown in hover tooltips.
+fn inject_markdown_descriptions(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            // If this object has a `description` field, copy it to `markdownDescription`
+            if let Some(Value::String(desc_str)) = map.get("description") {
+                map.insert("markdownDescription".to_string(), Value::String(desc_str.clone()));
+            }
+
+            // Recursively process all values in the object
+            for value in map.values_mut() {
+                inject_markdown_descriptions(value);
+            }
+        }
+        Value::Array(items) => {
+            // Recursively process all items in the array
+            for item in items {
+                inject_markdown_descriptions(item);
+            }
+        }
+        _ => {
+            // Primitive values don't need processing
+        }
+    }
+}

--- a/tasks/website_formatter/src/json_schema.rs
+++ b/tasks/website_formatter/src/json_schema.rs
@@ -1,10 +1,10 @@
 use oxfmt::oxfmtrc::Oxfmtrc;
 use schemars::schema_for;
-use website_common::Renderer;
+use website_common::{Renderer, generate_schema_json};
 
 #[expect(clippy::print_stdout)]
 pub fn print_schema_json() {
-    println!("{}", Oxfmtrc::generate_schema_json());
+    println!("{}", generate_schema_json::<Oxfmtrc>());
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn test_schema_json() {
     use std::fs;
 
     let path = get_project_root().unwrap().join("npm/oxfmt/configuration_schema.json");
-    let json = Oxfmtrc::generate_schema_json();
+    let json = generate_schema_json::<Oxfmtrc>();
     let existing_json = fs::read_to_string(&path).unwrap_or_default();
     if existing_json.trim() != json.trim() {
         fs::write(&path, &json).unwrap();

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -4,61 +4,301 @@ expression: json
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Oxfmtrc",
+  "description": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
+  "type": "object",
+  "properties": {
+    "arrowParens": {
+      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ArrowParensConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+    },
+    "bracketSameLine": {
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+    },
+    "bracketSpacing": {
+      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+    },
+    "embeddedLanguageFormatting": {
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`"
+    },
+    "endOfLine": {
+      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EndOfLineConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+    },
+    "experimentalSortImports": {
+      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "experimentalSortPackageJson": {
+      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortPackageJsonUserConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+    },
+    "experimentalTailwindcss": {
+      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TailwindcssConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "htmlWhitespaceSensitivity": {
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+    },
+    "ignorePatterns": {
+      "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`"
+    },
+    "insertFinalNewline": {
+      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+    },
+    "jsxSingleQuote": {
+      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+    },
+    "objectWrap": {
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ObjectWrapConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+    },
+    "printWidth": {
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0,
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+    },
+    "proseWrap": {
+      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ProseWrapConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+    },
+    "quoteProps": {
+      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/QuotePropsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+    },
+    "semi": {
+      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+    },
+    "singleAttributePerLine": {
+      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+    },
+    "singleQuote": {
+      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+    },
+    "tabWidth": {
+      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0,
+      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
+    },
+    "trailingComma": {
+      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TrailingCommaConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+    },
+    "useTabs": {
+      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+    },
+    "vueIndentScriptAndStyle": {
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+    }
+  },
   "allowComments": true,
   "allowTrailingCommas": true,
   "definitions": {
     "ArrowParensConfig": {
+      "type": "string",
       "enum": [
         "always",
         "avoid"
-      ],
-      "type": "string"
+      ]
     },
     "EmbeddedLanguageFormattingConfig": {
+      "type": "string",
       "enum": [
         "auto",
         "off"
-      ],
-      "type": "string"
+      ]
     },
     "EndOfLineConfig": {
+      "type": "string",
       "enum": [
         "lf",
         "crlf",
         "cr"
-      ],
-      "type": "string"
+      ]
     },
     "HtmlWhitespaceSensitivityConfig": {
+      "type": "string",
       "enum": [
         "css",
         "strict",
         "ignore"
-      ],
-      "type": "string"
+      ]
     },
     "ObjectWrapConfig": {
+      "type": "string",
       "enum": [
         "preserve",
         "collapse"
-      ],
-      "type": "string"
+      ]
     },
     "ProseWrapConfig": {
+      "type": "string",
       "enum": [
         "always",
         "never",
         "preserve"
-      ],
-      "type": "string"
+      ]
     },
     "QuotePropsConfig": {
+      "type": "string",
       "enum": [
         "as-needed",
         "consistent",
         "preserve"
-      ],
-      "type": "string"
+      ]
     },
     "SortGroupItemConfig": {
       "anyOf": [
@@ -66,54 +306,56 @@ expression: json
           "type": "string"
         },
         {
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         }
       ]
     },
     "SortImportsConfig": {
+      "type": "object",
       "properties": {
         "groups": {
           "description": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/SortGroupItemConfig"
           },
-          "markdownDescription": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```",
-          "type": [
-            "array",
-            "null"
-          ]
+          "markdownDescription": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side-effect-style` — Side effect style imports.\n- `side-effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side-effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n- `multiline` — Imports on multiple lines.\n- `singleline` — Imports on a single line.\n\nSee also <https://perfectionist.dev/rules/sort-imports#groups> for details.\nNOTE: `customGroups` is not implemented yet.\n\n- Default: See below\n```json\n[\n\"type-import\",\n[\"value-builtin\", \"value-external\"],\n\"type-internal\",\n\"value-internal\",\n[\"type-parent\", \"type-sibling\", \"type-index\"],\n[\"value-parent\", \"value-sibling\", \"value-index\"],\n\"unknown\",\n]\n```"
         },
         "ignoreCase": {
           "description": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
-          "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
           "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`"
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
-          "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`"
         },
         "order": {
+          "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/SortOrderConfig"
@@ -122,55 +364,53 @@ expression: json
               "type": "null"
             }
           ],
-          "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
           "markdownDescription": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`"
         },
         "partitionByComment": {
           "description": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "partitionByNewline": {
           "description": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "sortSideEffects": {
           "description": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
-          "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
-      },
-      "type": "object"
+      }
     },
     "SortOrderConfig": {
+      "type": "string",
       "enum": [
         "asc",
         "desc"
-      ],
-      "type": "string"
+      ]
     },
     "SortPackageJsonConfig": {
+      "type": "object",
       "properties": {
         "sortScripts": {
           "description": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
-          "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`"
         }
-      },
-      "type": "object"
+      }
     },
     "SortPackageJsonUserConfig": {
       "anyOf": [
@@ -183,312 +423,72 @@ expression: json
       ]
     },
     "TailwindcssConfig": {
+      "type": "object",
       "properties": {
         "attributes": {
           "description": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`"
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
-          "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
           "description": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",
-          "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`"
         },
         "preserveWhitespace": {
           "description": "Preserve whitespace around classes.\n\n- Default: `false`",
-          "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`"
         },
         "stylesheet": {
           "description": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
-          "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`"
         }
-      },
-      "type": "object"
+      }
     },
     "TrailingCommaConfig": {
+      "type": "string",
       "enum": [
         "all",
         "es5",
         "none"
-      ],
-      "type": "string"
-    }
-  },
-  "description": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
-  "markdownDescription": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions.",
-  "properties": {
-    "arrowParens": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ArrowParensConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
-    },
-    "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "bracketSpacing": {
-      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "embeddedLanguageFormatting": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`",
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\nJS-in-XXX is fully supported but still be handled by Prettier.\n\n- Default: `\"auto\"`"
-    },
-    "endOfLine": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/EndOfLineConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
-    },
-    "experimentalSortImports": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "experimentalSortPackageJson": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-    },
-    "experimentalTailwindcss": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TailwindcssConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "htmlWhitespaceSensitivity": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
-    },
-    "ignorePatterns": {
-      "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "items": {
-        "type": "string"
-      },
-      "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ]
-    },
-    "insertFinalNewline": {
-      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "jsxSingleQuote": {
-      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "objectWrap": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ObjectWrapConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
-    },
-    "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "format": "uint16",
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "minimum": 0.0,
-      "type": [
-        "integer",
-        "null"
-      ]
-    },
-    "proseWrap": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ProseWrapConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
-    },
-    "quoteProps": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/QuotePropsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
-    },
-    "semi": {
-      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "singleQuote": {
-      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "tabWidth": {
-      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "format": "uint8",
-      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "minimum": 0.0,
-      "type": [
-        "integer",
-        "null"
-      ]
-    },
-    "trailingComma": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TrailingCommaConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
-    },
-    "useTabs": {
-      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "vueIndentScriptAndStyle": {
-      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
       ]
     }
   },
-  "title": "Oxfmtrc",
-  "type": "object"
+  "markdownDescription": "Configuration options for the Oxfmt.\n\nMost options are the same as Prettier's options, but not all of them.\nIn addition, some options are our own extensions."
 }

--- a/tasks/website_linter/src/json_schema.rs
+++ b/tasks/website_linter/src/json_schema.rs
@@ -1,10 +1,26 @@
 use oxc_linter::Oxlintrc;
 use schemars::schema_for;
-use website_common::Renderer;
+use website_common::{Renderer, generate_schema_json};
 
 #[expect(clippy::print_stdout)]
 pub fn print_schema_json() {
-    println!("{}", Oxlintrc::generate_schema_json());
+    println!("{}", generate_schema_json::<Oxlintrc>());
+}
+
+#[test]
+fn test_schema_json() {
+    use project_root::get_project_root;
+    use std::fs;
+
+    let path = get_project_root().unwrap().join("npm/oxlint/configuration_schema.json");
+    let json = generate_schema_json::<Oxlintrc>();
+    let existing_json = fs::read_to_string(&path).unwrap_or_default();
+    if existing_json.trim() != json.trim() {
+        fs::write(&path, &json).unwrap();
+    }
+    insta::with_settings!({ prepend_module_to_snapshot => false }, {
+        insta::assert_snapshot!(json);
+    });
 }
 
 #[test]

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1,3 +1,7 @@
+---
+source: tasks/website_linter/src/json_schema.rs
+expression: json
+---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Oxlintrc",


### PR DESCRIPTION
The initial goal was to extract the schema generation utility from `oxfmtrc.rs`.

However, I found that `oxc_linter` also defines a similar function, so I unified them into `website_common`.

- Added `generate_schema_json<T>()` to `website_common`
- Removed duplicated implementations from `oxfmtrc.rs` and `oxlintrc.rs`
- Moved `test_schema_json` from `oxc_linter` to `website_linter` too

NOTE: When running `cargo t -p oxc_linter`, it previously generated `npm/oxlint/configuration_schema.json`. Now use `just linter-schema-json` instead.