### PR TITLE
perf(transformer/tagged-template): add `#[cold]` hint to unlikely path

### DIFF
--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -76,6 +76,7 @@ impl<'a, 'ctx> TaggedTemplateTransform<'a, 'ctx> {
     }
 
     /// Transform a tagged template expression to use the [`Helper::TaggedTemplateLiteral`] helper function.
+    #[cold] // Tagged template expressions are rare
     fn transform_tagged_template(&self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         debug_assert!(matches!(expr, Expression::TaggedTemplateExpression(_)));
 


### PR DESCRIPTION
Follow-on after #15834. Tiny perf optimization. Tagged template literals are pretty rare. Add `#[cold]` attr to `transform_tagged_template` to hint to compiler that the branch for "yes, it's a tagged template" in `enter_expression` is unlikely to be taken. This should make the compiler make "not a tagged template" the default path.