### PR TITLE
feat(rulegen): Error upon generating an unsupported rule with rulegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "proc-macro2",
  "rustc-hash",
  "serde",
+ "serde_json",
  "syn",
 ]
 

--- a/tasks/rulegen/Cargo.toml
+++ b/tasks/rulegen/Cargo.toml
@@ -26,6 +26,7 @@ handlebars = { workspace = true }
 lazy-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing", "printing"] }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 


### PR DESCRIPTION
Fix #18045.

To avoid any contributors trying to generate rules that are not possible/that we don't want, don't want to waste people's time if we can avoid it.

Examples:

```
connorshea@Connors-MacBook-Pro oxc % just new-n-rule no-hide-core-modules
cargo run -p rulegen no-hide-core-modules n
   Compiling rulegen v0.0.0 (/Users/connorshea/code/oxc/tasks/rulegen)
    Finished `dev` profile [unoptimized] target(s) in 1.61s
     Running `target/debug/rulegen no-hide-core-modules n`

Error: This rule is either not planned or not possible to implement in Oxlint.
The rule 'n/no-hide-core-modules' will not be implemented for the following reason:
> This rule is deprecated in eslint-plugin-n for being inherently incorrect, no need for us to implement it.

error: Recipe `new-rule` failed on line 157 with exit code 1
```

```
connorshea@Connors-MacBook-Pro oxc % just new-rule no-dupe-args          
cargo run -p rulegen no-dupe-args eslint
    Finished `dev` profile [unoptimized] target(s) in 0.21s
     Running `target/debug/rulegen no-dupe-args eslint`

Error: This rule is either not planned or not possible to implement in Oxlint.
The rule 'eslint/no-dupe-args' will not be implemented for the following reason:
> Superseded by strict mode.

error: Recipe `new-rule` failed on line 157 with exit code 1
```

And generating a valid rule like `just new-react-rule no-multi-comp` still works:

```
Reading test file from https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-react/master/tests/lib/rules/no-multi-comp.js
File parsed and 16 pass cases, 20 fail cases are found
Reading rule source file from https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-react/master/lib/rules/no-multi-comp.js
Rule config parsed.
Saved file to crates/oxc_linter/src/rules/react/no_multi_comp.rs
Formatted rule file
Updated crates/oxc_linter/src/rules.rs
Generating RuleRunner impl...
```