### PR TITLE
test(linter): Update some snapshots to update less frequently

### DIFF
--- a/apps/oxlint/fixtures/eslintrc_vitest_replace/eslintrc.json
+++ b/apps/oxlint/fixtures/eslintrc_vitest_replace/eslintrc.json
@@ -1,5 +1,8 @@
 {
-    "rules": {
-        "vitest/no-disabled-tests": "error"
-    }
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "vitest/no-disabled-tests": "error"
+  }
 }

--- a/apps/oxlint/fixtures/issue_10054/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_10054/.oxlintrc.json
@@ -1,5 +1,8 @@
 {
   "plugins": ["import"],
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
     "import/no-cycle": "error"
   }

--- a/apps/oxlint/fixtures/issue_11054/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_11054/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
     "no-unused-vars": [
       2,

--- a/apps/oxlint/fixtures/no_empty_allow_empty_catch/eslintrc.json
+++ b/apps/oxlint/fixtures/no_empty_allow_empty_catch/eslintrc.json
@@ -1,5 +1,13 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
-    "no-empty": ["error", { "allowEmptyCatch": true }]
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ]
   }
 }

--- a/apps/oxlint/fixtures/no_empty_disallow_empty_catch/eslintrc.json
+++ b/apps/oxlint/fixtures/no_empty_disallow_empty_catch/eslintrc.json
@@ -1,5 +1,13 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "rules": {
-    "no-empty": ["warn", { "allowEmptyCatch": false }]
+    "no-empty": [
+      "warn",
+      {
+        "allowEmptyCatch": false
+      }
+    ]
   }
 }

--- a/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
+++ b/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
@@ -1,9 +1,15 @@
 {
+  "categories": {
+    "correctness": "off"
+  },
   "env": {
     "jquery": true
   },
   "globals": {
     "Foo": "readonly"
+  },
+  "rules": {
+    "no-global-assign": "warn"
   },
   "overrides": [
     {

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,14 +6,6 @@ arguments: --vitest-plugin -c fixtures/eslintrc_vitest_replace/eslintrc.json fix
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/expect-expect.html\eslint-plugin-jest(expect-expect)]8;;\: Test has no assertions
-   ,-[fixtures/eslintrc_vitest_replace/foo.test.js:1:1]
- 1 | test.skip('foo', () => {
-   : ^^^^^^^^^
- 2 |   // ...
-   `----
-  help: Add assertion(s) in this Test
-
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-disabled-tests.html\eslint-plugin-jest(no-disabled-tests)]8;;\: Disabled test
    ,-[fixtures/eslintrc_vitest_replace/foo.test.js:1:1]
  1 | test.skip('foo', () => {
@@ -22,8 +14,8 @@ working directory:
    `----
   help: Remove the appending `.skip`
 
-Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 105 rules using 1 threads.
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 0 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_11054_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_11054
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 90 rules using 1 threads.
+Finished in <variable>ms on 3 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------


### PR DESCRIPTION
These have no reason to use all the rules, when they really only need the ones they defined explicitly.