### PR TITLE
feat(semantic): store `scope_id` in `Reference`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2492,7 +2492,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 impl<'a> SemanticBuilder<'a> {
     fn reference_identifier(&mut self, ident: &IdentifierReference<'a>) {
         let flags = self.resolve_reference_usages();
-        let reference = Reference::new(self.current_node_id, flags);
+        let reference = Reference::new(self.current_node_id, self.current_scope_id, flags);
         let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/array.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/array.snap
@@ -19,13 +19,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/array.js
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "read",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "read",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 0
           }
         ]
       },
@@ -39,13 +41,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/array.js
             "flags": "ReferenceFlags(Write)",
             "id": 0,
             "name": "write",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "write",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/nested-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/nested-assignment.snap
@@ -19,25 +19,29 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/nested-assignm
             "flags": "ReferenceFlags(Write)",
             "id": 0,
             "name": "y",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 1,
             "name": "y",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "y",
-            "node_id": 30
+            "node_id": 30,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "y",
-            "node_id": 37
+            "node_id": 37,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/object.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/object.snap
@@ -19,19 +19,22 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/object.js
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "read",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 5,
             "name": "read",
-            "node_id": 26
+            "node_id": 26,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 6,
             "name": "read",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 0
           }
         ]
       },
@@ -45,13 +48,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/object.js
             "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "write",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 3,
             "name": "write",
-            "node_id": 23
+            "node_id": 23,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/read-write-operators.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/read-write-operators.snap
@@ -19,97 +19,113 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/read-write-ope
             "flags": "ReferenceFlags(Write)",
             "id": 0,
             "name": "Foo",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 1,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 2,
             "name": "Foo",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 3,
             "name": "Foo",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 4,
             "name": "Foo",
-            "node_id": 23
+            "node_id": 23,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 5,
             "name": "Foo",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 6,
             "name": "Foo",
-            "node_id": 31
+            "node_id": 31,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 7,
             "name": "Foo",
-            "node_id": 35
+            "node_id": 35,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 8,
             "name": "Foo",
-            "node_id": 39
+            "node_id": 39,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 9,
             "name": "Foo",
-            "node_id": 43
+            "node_id": 43,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 10,
             "name": "Foo",
-            "node_id": 47
+            "node_id": 47,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 11,
             "name": "Foo",
-            "node_id": 51
+            "node_id": 51,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 12,
             "name": "Foo",
-            "node_id": 55
+            "node_id": 55,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 13,
             "name": "Foo",
-            "node_id": 59
+            "node_id": 59,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 14,
             "name": "Foo",
-            "node_id": 63
+            "node_id": 63,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 15,
             "name": "Foo",
-            "node_id": 67
+            "node_id": 67,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
@@ -19,25 +19,29 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-express
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "num",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 1,
             "name": "num",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 2,
             "name": "num",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read | Write)",
             "id": 3,
             "name": "num",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       },
@@ -51,25 +55,29 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-express
             "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "obj",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 5,
             "name": "obj",
-            "node_id": 32
+            "node_id": 32,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 6,
             "name": "obj",
-            "node_id": 37
+            "node_id": 37,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 7,
             "name": "obj",
-            "node_id": 42
+            "node_id": 42,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.js
                     "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
-                    "node_id": 22
+                    "node_id": 22,
+                    "scope_id": 2
                   }
                 ]
               },
@@ -78,7 +79,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.js
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 2
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-var.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/with-same-name-v
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
-            "node_id": 22
+            "node_id": 22,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.jsx
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Component",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Component",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.snap
@@ -19,13 +19,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.jsx
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "A",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
@@ -19,49 +19,57 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.ts
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "Foo",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 1,
             "name": "Foo",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "Foo",
-            "node_id": 21
+            "node_id": 21,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Write)",
             "id": 3,
             "name": "Foo",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "Foo",
-            "node_id": 34
+            "node_id": 34,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 5,
             "name": "Foo",
-            "node_id": 42
+            "node_id": 42,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 6,
             "name": "Foo",
-            "node_id": 49
+            "node_id": 49,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 7,
             "name": "Foo",
-            "node_id": 57
+            "node_id": 57,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 5
+            "node_id": 5,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-heritage.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-heritage.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/interface-he
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "forwardRef",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "ToastViewport",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           }
         ]
       },
@@ -41,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/named/type-and-non
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "ToastProps",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/return-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/return-type.snap
@@ -73,13 +73,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/functions/return-type.ts
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 24
+            "node_id": 24,
+            "scope_id": 4
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/property-with-type-import.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/property-with-type-import.snap
@@ -41,13 +41,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/property-with-t
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "X",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "X",
-            "node_id": 23
+            "node_id": 23,
+            "scope_id": 3
           }
         ]
       },
@@ -61,13 +63,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/interfaces/property-with-t
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "B",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 3,
             "name": "B",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/issue-7879.ts
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Bar",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.snap
@@ -57,13 +57,15 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/namespaces/value-module.ts
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "N1",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "N1",
-            "node_id": 24
+            "node_id": 24,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 1
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "foo",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 0
           }
         ]
       },
@@ -47,13 +49,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "a",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 3
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "e",
-                    "node_id": 8
+                    "node_id": 8,
+                    "scope_id": 3
                   }
                 ]
               },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 1
           }
         ]
       },
@@ -49,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -49,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 3
           }
         ]
       },
@@ -63,7 +64,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
-                "node_id": 10
+                "node_id": 10,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
@@ -49,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 3
           }
         ]
       },
@@ -63,7 +64,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Bar",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 2
           }
         ]
       },
@@ -48,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Foo",
-            "node_id": 26
+            "node_id": 26,
+            "scope_id": 2
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "printName",
-                    "node_id": 16
+                    "node_id": 16,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -45,7 +46,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                     "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "printerName",
-                    "node_id": 34
+                    "node_id": 34,
+                    "scope_id": 3
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
@@ -23,13 +23,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
-                    "node_id": 23
+                    "node_id": 23,
+                    "scope_id": 2
                   },
                   {
                     "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
-                    "node_id": 28
+                    "node_id": 28,
+                    "scope_id": 2
                   }
                 ]
               },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
@@ -30,13 +30,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
-                    "node_id": 23
+                    "node_id": 23,
+                    "scope_id": 3
                   },
                   {
                     "flags": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
-                    "node_id": 36
+                    "node_id": 36,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -98,7 +100,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
-            "node_id": 26
+            "node_id": 26,
+            "scope_id": 3
           }
         ]
       },
@@ -112,7 +115,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
-            "node_id": 33
+            "node_id": 33,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
@@ -49,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 4
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -41,19 +41,22 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "A",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "A",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 1
           }
         ]
       },
@@ -49,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
@@ -23,13 +23,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
-                    "node_id": 25
+                    "node_id": 25,
+                    "scope_id": 2
                   },
                   {
                     "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
-                    "node_id": 30
+                    "node_id": 30,
+                    "scope_id": 2
                   }
                 ]
               },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
@@ -30,13 +30,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                     "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
-                    "node_id": 25
+                    "node_id": 25,
+                    "scope_id": 3
                   },
                   {
                     "flags": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
-                    "node_id": 38
+                    "node_id": 38,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -98,7 +100,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
-            "node_id": 28
+            "node_id": 28,
+            "scope_id": 3
           }
         ]
       },
@@ -112,7 +115,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
-            "node_id": 35
+            "node_id": 35,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "A",
-                "node_id": 6
+                "node_id": 6,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
@@ -57,13 +57,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
@@ -58,7 +58,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "deco",
-            "node_id": 22
+            "node_id": 22,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
@@ -57,13 +57,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
@@ -71,25 +71,29 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "decorator",
-            "node_id": 23
+            "node_id": 23,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "decorator",
-            "node_id": 30
+            "node_id": 30,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "obj",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 0
           }
         ]
       },
@@ -33,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
             "flags": "ReferenceFlags(Write)",
             "id": 1,
             "name": "b",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       },
@@ -47,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
             "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "c",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "obj",
-            "node_id": 20
+            "node_id": 20,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "V",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inl
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -43,7 +43,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
@@ -21,13 +21,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 23
+                "node_id": 23,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
-                "node_id": 31
+                "node_id": 31,
+                "scope_id": 1
               }
             ]
           },
@@ -90,7 +92,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
-            "node_id": 26
+            "node_id": 26,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
-                "node_id": 16
+                "node_id": 16,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 15
+                "node_id": 15,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 13
+                "node_id": 13,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 19
+                "node_id": 19,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 23
+                "node_id": 23,
+                "scope_id": 2
               }
             ]
           }
@@ -49,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
@@ -43,7 +43,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
@@ -43,7 +43,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 17
+                "node_id": 17,
+                "scope_id": 2
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
@@ -21,13 +21,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 23
+                "node_id": 23,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
-                "node_id": 31
+                "node_id": 31,
+                "scope_id": 1
               }
             ]
           },
@@ -90,7 +92,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
-            "node_id": 26
+            "node_id": 26,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
-                "node_id": 14
+                "node_id": 14,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 13
+                "node_id": 13,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 17
+                "node_id": 17,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 21
+                "node_id": 21,
+                "scope_id": 2
               }
             ]
           }
@@ -49,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
@@ -43,7 +43,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
@@ -21,13 +21,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 25
+                "node_id": 25,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
-                "node_id": 33
+                "node_id": 33,
+                "scope_id": 1
               }
             ]
           },
@@ -90,7 +92,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
-            "node_id": 28
+            "node_id": 28,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
-                "node_id": 16
+                "node_id": 16,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 15
+                "node_id": 15,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 13
+                "node_id": 13,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 19
+                "node_id": 19,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
-                "node_id": 23
+                "node_id": 23,
+                "scope_id": 2
               }
             ]
           }
@@ -49,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "t",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "t",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
@@ -27,13 +27,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespac
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
-            "node_id": 6
+            "node_id": 6,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }
@@ -43,7 +44,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
                 "flags": "ReferenceFlags(Type)",
                 "id": 2,
                 "name": "T",
-                "node_id": 24
+                "node_id": 24,
+                "scope_id": 2
               }
             ]
           }
@@ -64,7 +66,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
-            "node_id": 21
+            "node_id": 21,
+            "scope_id": 2
           }
         ]
       },
@@ -78,7 +81,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "Bar",
-            "node_id": 27
+            "node_id": 27,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },
@@ -35,7 +36,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "value",
-                "node_id": 17
+                "node_id": 17,
+                "scope_id": 1
               }
             ]
           }
@@ -57,7 +59,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
                 "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
-                "node_id": 27
+                "node_id": 27,
+                "scope_id": 2
               }
             ]
           }
@@ -78,13 +81,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "makeBox",
-            "node_id": 24
+            "node_id": 24,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "makeBox",
-            "node_id": 32
+            "node_id": 32,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-s
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "child",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "X",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.t
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-ch
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "child",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-typ
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -28,7 +28,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
                 "flags": "ReferenceFlags(Read)",
                 "id": 3,
                 "name": "props",
-                "node_id": 49
+                "node_id": 49,
+                "scope_id": 2
               }
             ]
           }
@@ -70,7 +71,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "FooProps",
-            "node_id": 41
+            "node_id": 41,
+            "scope_id": 2
           }
         ]
       },
@@ -84,13 +86,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
-            "node_id": 21
+            "node_id": 21,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
@@ -19,31 +19,36 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expressi
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "x",
-            "node_id": 21
+            "node_id": 21,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "x",
-            "node_id": 28
+            "node_id": 28,
+            "scope_id": 0
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "x",
-            "node_id": 35
+            "node_id": 35,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       },
@@ -41,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/externa
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-re
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 1
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -35,13 +35,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "Foo",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -35,7 +35,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 1
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           }
         ]
       },
@@ -41,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       },
@@ -41,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
@@ -19,7 +19,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
@@ -27,7 +27,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 0
           }
         ]
       },
@@ -41,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 0
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "U",
-                    "node_id": 16
+                    "node_id": 16,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -45,7 +46,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 5,
                     "name": "U",
-                    "node_id": 27
+                    "node_id": 27,
+                    "scope_id": 3
                   }
                 ]
               }
@@ -66,13 +68,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
-                "node_id": 19
+                "node_id": 19,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "V",
-                    "node_id": 13
+                    "node_id": 13,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -44,7 +45,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 9
+                    "node_id": 9,
+                    "scope_id": 2
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -39,7 +39,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
-                    "node_id": 20
+                    "node_id": 20,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -60,7 +61,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
-                    "node_id": 19
+                    "node_id": 19,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -44,7 +45,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -55,7 +55,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
-                    "node_id": 33
+                    "node_id": 33,
+                    "scope_id": 2
                   }
                 ]
               }
@@ -76,7 +77,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 8
+                "node_id": 8,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
@@ -34,13 +34,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "dual",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 2
           },
           {
             "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "dual",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
@@ -44,7 +44,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 16
+                "node_id": 16,
+                "scope_id": 3
               }
             ]
           }
@@ -65,7 +66,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 16
+                    "node_id": 16,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -64,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
@@ -50,13 +50,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
@@ -44,7 +44,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 16
+                "node_id": 16,
+                "scope_id": 3
               }
             ]
           }
@@ -65,7 +66,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 16
+                    "node_id": 16,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -64,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
@@ -50,13 +50,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -23,7 +23,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "arg",
-                    "node_id": 15
+                    "node_id": 15,
+                    "scope_id": 2
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
@@ -37,7 +37,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
-                "node_id": 15
+                "node_id": 15,
+                "scope_id": 2
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
@@ -37,7 +37,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
-                "node_id": 20
+                "node_id": 20,
+                "scope_id": 2
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
@@ -37,7 +37,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
-                "node_id": 15
+                "node_id": 15,
+                "scope_id": 2
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Param",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
@@ -41,7 +41,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 3
           }
         ]
       },
@@ -55,7 +56,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "K",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           }
         ]
       },
@@ -48,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "k",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "Id",
-                    "node_id": 24
+                    "node_id": 24,
+                    "scope_id": 3
                   }
                 ]
               }
@@ -51,7 +52,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 13
+                "node_id": 13,
+                "scope_id": 2
               }
             ]
           }
@@ -72,7 +74,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "X",
-            "node_id": 22
+            "node_id": 22,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Parent",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
@@ -64,7 +64,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Member",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 4
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 7
+            "node_id": 7,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
@@ -41,7 +41,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Color",
-            "node_id": 24
+            "node_id": 24,
+            "scope_id": 3
           }
         ]
       },
@@ -55,7 +56,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Quantity",
-            "node_id": 22
+            "node_id": 22,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
@@ -21,25 +21,29 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
-                "node_id": 17
+                "node_id": 17,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
-                "node_id": 22
+                "node_id": 22,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Type)",
                 "id": 5,
                 "name": "T",
-                "node_id": 27
+                "node_id": 27,
+                "scope_id": 1
               },
               {
                 "flags": "ReferenceFlags(Type)",
                 "id": 7,
                 "name": "T",
-                "node_id": 32
+                "node_id": 32,
+                "scope_id": 1
               }
             ]
           }
@@ -67,7 +71,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 8,
             "name": "EnthusiasticGreeting",
-            "node_id": 36
+            "node_id": 36,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -49,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "VerticalAlignment",
-            "node_id": 30
+            "node_id": 30,
+            "scope_id": 3
           }
         ]
       },
@@ -63,7 +64,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "HorizontalAlignment",
-            "node_id": 32
+            "node_id": 32,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -30,13 +30,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "k",
-                    "node_id": 14
+                    "node_id": 14,
+                    "scope_id": 3
                   },
                   {
                     "flags": "ReferenceFlags(Type)",
                     "id": 3,
                     "name": "k",
-                    "node_id": 19
+                    "node_id": 19,
+                    "scope_id": 3
                   }
                 ]
               }
@@ -63,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "k",
-                    "node_id": 17
+                    "node_id": 17,
+                    "scope_id": 3
                   }
                 ]
               }
@@ -57,7 +58,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 17
+                    "node_id": 17,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -64,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 20
+            "node_id": 20,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
@@ -50,13 +50,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 17
+                    "node_id": 17,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -64,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 20
+            "node_id": 20,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
@@ -50,13 +50,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 17
+            "node_id": 17,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 14
+            "node_id": 14,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 3
           }
         ]
       },
@@ -64,13 +65,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
-            "node_id": 22
+            "node_id": 22,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
@@ -50,7 +50,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -30,7 +30,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "U",
-                    "node_id": 21
+                    "node_id": 21,
+                    "scope_id": 3
                   }
                 ]
               },
@@ -64,7 +65,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
@@ -50,13 +50,15 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 3
           },
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 18
+            "node_id": 18,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           }
         ]
       },
@@ -48,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
@@ -42,7 +42,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
-            "node_id": 11
+            "node_id": 11,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 12
+            "node_id": 12,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
@@ -41,7 +41,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T1",
-            "node_id": 15
+            "node_id": 15,
+            "scope_id": 3
           }
         ]
       },
@@ -55,7 +56,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T2",
-            "node_id": 19
+            "node_id": 19,
+            "scope_id": 3
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 10
+            "node_id": 10,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 9
+            "node_id": 9,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -36,7 +36,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
-                "node_id": 16
+                "node_id": 16,
+                "scope_id": 2
               }
             ]
           }
@@ -57,7 +58,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 13
+            "node_id": 13,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
@@ -49,7 +49,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "StyledPaymentProps",
-            "node_id": 28
+            "node_id": 28,
+            "scope_id": 0
           }
         ]
       },
@@ -63,7 +64,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "div",
-            "node_id": 25
+            "node_id": 25,
+            "scope_id": 0
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 7
+                "node_id": 7,
+                "scope_id": 1
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 9
+                "node_id": 9,
+                "scope_id": 1
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -21,7 +21,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 11
+                "node_id": 11,
+                "scope_id": 1
               }
             ]
           },
@@ -35,7 +36,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "y",
-                "node_id": 17
+                "node_id": 17,
+                "scope_id": 1
               }
             ]
           }
@@ -57,7 +59,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
-                "node_id": 28
+                "node_id": 28,
+                "scope_id": 2
               }
             ]
           }
@@ -78,7 +81,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "foo",
-            "node_id": 25
+            "node_id": 25,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 1
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 8
+            "node_id": 8,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
@@ -34,7 +34,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 16
+            "node_id": 16,
+            "scope_id": 2
           }
         ]
       },

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -90,7 +90,10 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
                             format!("\"name\": {:?},", semantic.reference_name(reference)).as_str(),
                         );
                         result.push_str(
-                            format!("\"node_id\": {}", reference.node_id().index()).as_str(),
+                            format!("\"node_id\": {},", reference.node_id().index()).as_str(),
+                        );
+                        result.push_str(
+                            format!("\"scope_id\": {}", reference.scope_id().index()).as_str(),
                         );
                         result.push('}');
                     });

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use oxc_allocator::{Allocator, CloneIn};
 
-use crate::{node::NodeId, symbol::SymbolId};
+use crate::{node::NodeId, scope::ScopeId, symbol::SymbolId};
 
 use oxc_ast_macros::ast;
 
@@ -227,6 +227,8 @@ pub struct Reference {
     /// the reference's scope tree. Usually this indicates a global variable or
     /// a reference to a non-existent symbol.
     symbol_id: Option<SymbolId>,
+    /// The scope in which this reference occurs.
+    scope_id: ScopeId,
     /// Describes how this referenced is used by other AST nodes. References can
     /// be reads, writes, or both.
     flags: ReferenceFlags,
@@ -235,14 +237,19 @@ pub struct Reference {
 impl Reference {
     /// Create a new unresolved reference.
     #[inline]
-    pub fn new(node_id: NodeId, flags: ReferenceFlags) -> Self {
-        Self { node_id, symbol_id: None, flags }
+    pub fn new(node_id: NodeId, scope_id: ScopeId, flags: ReferenceFlags) -> Self {
+        Self { node_id, symbol_id: None, scope_id, flags }
     }
 
     /// Create a new resolved reference on a symbol.
     #[inline]
-    pub fn new_with_symbol_id(node_id: NodeId, symbol_id: SymbolId, flags: ReferenceFlags) -> Self {
-        Self { node_id, symbol_id: Some(symbol_id), flags }
+    pub fn new_with_symbol_id(
+        node_id: NodeId,
+        symbol_id: SymbolId,
+        scope_id: ScopeId,
+        flags: ReferenceFlags,
+    ) -> Self {
+        Self { node_id, symbol_id: Some(symbol_id), scope_id, flags }
     }
 
     /// Get the id of the node that is referencing the symbol.
@@ -262,6 +269,12 @@ impl Reference {
     #[inline]
     pub fn set_symbol_id(&mut self, symbol_id: SymbolId) {
         self.symbol_id = Some(symbol_id);
+    }
+
+    /// Get the id of the scope in which this reference occurs.
+    #[inline]
+    pub fn scope_id(&self) -> ScopeId {
+        self.scope_id
     }
 
     #[inline]

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -299,7 +299,8 @@ impl<'a> TraverseScoping<'a> {
         symbol_id: SymbolId,
         flags: ReferenceFlags,
     ) -> ReferenceId {
-        let reference = Reference::new_with_symbol_id(NodeId::DUMMY, symbol_id, flags);
+        let reference =
+            Reference::new_with_symbol_id(NodeId::DUMMY, symbol_id, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
         self.scoping.add_resolved_reference(symbol_id, reference_id);
         reference_id
@@ -307,7 +308,7 @@ impl<'a> TraverseScoping<'a> {
 
     /// Create an unbound reference
     pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
-        let reference = Reference::new(NodeId::DUMMY, flags);
+        let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
         self.scoping.add_root_unresolved_reference(name, reference_id);
         reference_id


### PR DESCRIPTION
https://github.com/rolldown/rolldown/pull/7936 relies on this. You can see how Rolldown uses this at description of that PR.

Additionally, it can also simplify the use case when you want to get the scope ID where the `Reference` occurs. See follow-up PR #18059