### PR TITLE
test(linter): Remove ansi colors/escape codes from linter output in apps/oxlint snapshots.

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -6,14 +6,14 @@ arguments: --ignore-path fixtures/linter/.customignore --no-ignore fixtures/lint
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/linter/nan.js:1:1]
  1 | 123 == NaN;
    : ^^^^^^^^^^^
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
+  ! eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --vitest-plugin -c fixtures/eslintrc_vitest_replace/eslintrc.json fix
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-disabled-tests.html\eslint-plugin-jest(no-disabled-tests)]8;;\: Disabled test
+  x eslint-plugin-jest(no-disabled-tests): Disabled test
    ,-[fixtures/eslintrc_vitest_replace/foo.test.js:1:1]
  1 | test.skip('foo', () => {
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -D correctness fixtures/linter/debugger.js
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W no-undef -c fixtures/eslintrc_env/eslintrc_no_env.json fixtures/es
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-undef.html\eslint(no-undef)]8;;\: 'console' is not defined.
+  ! eslint(no-undef): 'console' is not defined.
    ,-[fixtures/eslintrc_env/test.js:1:1]
  1 | console.log('')
    : ^^^^^^^

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W no-undef -c fixtures/no_undef/eslintrc.json fixtures/no_undef/test
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-undef.html\eslint(no-undef)]8;;\: 'console' is not defined.
+  ! eslint(no-undef): 'console' is not defined.
    ,-[fixtures/no_undef/test.js:1:1]
  1 | console.log(foo)
    : ^^^^^^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-empty-file.html\eslint-plugin-unicorn(no-empty-file)]8;;\: Empty files are not allowed.
+  ! eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ,-[fixtures/config_ignore_patterns/ignore_extension/main.ts:1:1]
    `----
   help: Delete this file or add some code to it.

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_off/eslintrc.json fixtures/eslintrc_off/test.js
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-empty-file.html\eslint-plugin-unicorn(no-empty-file)]8;;\: Empty files are not allowed.
+  ! eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ,-[fixtures/eslintrc_off/test.js:1:1]
    `----
   help: Delete this file or add some code to it.

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/linter/eslintrc.json fixtures/linter/debugger.js
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_disallow_empty_catch/eslintrc.json -W no-empty f
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-empty.html\eslint(no-empty)]8;;\: Unexpected empty block statements
+  ! eslint(no-empty): Unexpected empty block statements
    ,-[fixtures/no_empty_disallow_empty_catch/test.js:1:29]
  1 | try { console.log() } catch {}
    :                             ^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/overrides/.oxlintrc.json fixtures/overrides/test.js
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html\eslint(no-var)]8;;\: Unexpected var, use let or const instead.
+  x eslint(no-var): Unexpected var, use let or const instead.
    ,-[fixtures/overrides/test.js:1:1]
  1 | var msg = "hello";
    : ^^^
@@ -25,7 +25,7 @@ arguments: -c fixtures/overrides/.oxlintrc.json fixtures/overrides/test.ts
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html\eslint(no-var)]8;;\: Unexpected var, use let or const instead.
+  x eslint(no-var): Unexpected var, use let or const instead.
    ,-[fixtures/overrides/test.ts:1:1]
  1 | var msg = "hello";
    : ^^^
@@ -33,7 +33,7 @@ working directory:
    `----
   help: Replace var with let or const
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
    ,-[fixtures/overrides/test.ts:2:1]
  1 | var msg = "hello";
  2 | console.log(msg);
@@ -52,7 +52,7 @@ arguments: -c fixtures/overrides/.oxlintrc.json fixtures/overrides/other.jsx
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html\eslint(no-var)]8;;\: Unexpected var, use let or const instead.
+  x eslint(no-var): Unexpected var, use let or const instead.
    ,-[fixtures/overrides/other.jsx:1:1]
  1 | var msg = "hello";
    : ^^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -6,28 +6,28 @@ arguments: -c fixtures/overrides/directories-config.json fixtures/overrides
 working directory: 
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/overrides/lib/index.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/overrides/lib/tests/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/overrides/src/oxlint.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/overrides/src/tests/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/typescript_eslint/eslintrc.json --disable-typescript-plug
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'X' is declared but never used.
+  ! eslint(no-unused-vars): Variable 'X' is declared but never used.
    ,-[fixtures/typescript_eslint/test.ts:1:11]
  1 | namespace X {
    :           |
@@ -15,14 +15,14 @@ working directory:
    `----
   help: Consider removing this declaration.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+  x eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/typescript_eslint/eslintrc.json fixtures/typescript_eslin
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-namespace.html\typescript-eslint(no-namespace)]8;;\: ES2015 module syntax is preferred over namespaces.
+  ! typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
    ,-[fixtures/typescript_eslint/test.ts:1:1]
  1 | namespace X {
    : ^^^^^^^^^
@@ -14,7 +14,7 @@ working directory:
    `----
   help: Replace the namespace with an ES2015 module or use `declare module`
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'X' is declared but never used.
+  ! eslint(no-unused-vars): Variable 'X' is declared but never used.
    ,-[fixtures/typescript_eslint/test.ts:1:11]
  1 | namespace X {
    :           |
@@ -23,14 +23,14 @@ working directory:
    `----
   help: Consider removing this declaration.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+  x eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/astro/debugger.astro
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/astro/debugger.astro:2:1]
  1 | ---
  2 | debugger
@@ -15,7 +15,7 @@ working directory:
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:11:3]
  10 | <script asdf >
  11 |   debugger
@@ -24,7 +24,7 @@ working directory:
     `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:15:3]
  14 | <script asdf>
  15 |   debugger
@@ -33,7 +33,7 @@ working directory:
     `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:19:3]
  18 | <script>
  19 |   debugger

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -6,14 +6,14 @@ arguments: fixtures/linter
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/js_as_jsx.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -21,14 +21,14 @@ working directory:
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/linter/nan.js:1:1]
  1 | 123 == NaN;
    : ^^^^^^^^^^^
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
+  ! eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -6,21 +6,21 @@ arguments: fixtures/linter/debugger.js fixtures/linter/nan.js
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/linter/nan.js:1:1]
  1 | 123 == NaN;
    : ^^^^^^^^^^^
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to `isNaN()` when checking for NaN
+  ! eslint(use-isnan): Requires calls to `isNaN()` when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]
  1 | 123 == NaN;
    :        ^^^

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/linter/debugger.js
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/linter/js_as_jsx.js
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/linter/js_as_jsx.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/svelte/debugger.svelte
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/svelte/debugger.svelte:2:2]
  1 | <script>
  2 |     debugger;
@@ -15,7 +15,7 @@ working directory:
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html\eslint(no-unassigned-vars)]8;;\: 'title' is always 'undefined' because it's never assigned.
+  ! eslint(no-unassigned-vars): 'title' is always 'undefined' because it's never assigned.
    ,-[fixtures/svelte/debugger.svelte:4:13]
  3 | 
  4 |     export let title;
@@ -24,7 +24,7 @@ working directory:
    `----
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html\eslint(no-unassigned-vars)]8;;\: 'person' is always 'undefined' because it's never assigned.
+  ! eslint(no-unassigned-vars): 'person' is always 'undefined' because it's never assigned.
    ,-[fixtures/svelte/debugger.svelte:5:13]
  4 |     export let title;
  5 |     export let person;

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/debugger.vue
 working directory: 
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[fixtures/vue/debugger.vue:6:5]
  5 | <script>
  6 |     debugger
@@ -15,7 +15,7 @@ working directory:
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[fixtures/vue/debugger.vue:11:5]
  10 |     let foo: T; // test ts syntax
  11 |     debugger;

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: debugger.js
 working directory: fixtures/auto_config_detection
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c eslintrc.json
 working directory: fixtures/config_ignore_patterns/ignore_directory
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-empty-file.html\eslint-plugin-unicorn(no-empty-file)]8;;\: Empty files are not allowed.
+  ! eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ,-[main.js:1:1]
  1 | 
    : ^

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_extended_config_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cross_module_extended_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[dep-a.ts:2:19]
  1 | // should report cycle detected
  2 | import { b } from './dep-b.ts';
@@ -20,7 +20,7 @@ working directory: fixtures/cross_module_extended_config
            │    ./dep-a.ts (fixtures/cross_module_extended_config/dep-a.ts)
            ╰─────────╯ imports the current file
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[dep-b.ts:2:8]
  1 | // this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
  2 | import './dep-a.ts';

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cross_module_nested_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[folder/folder-dep-a.ts:2:19]
  1 | // should report cycle detected
  2 | import { b } from './folder-dep-b.ts';
@@ -20,7 +20,7 @@ working directory: fixtures/cross_module_nested_config
            │    ./folder-dep-a.ts (fixtures/cross_module_nested_config/folder/folder-dep-a.ts)
            ╰─────────╯ imports the current file
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[folder/folder-dep-b.ts:2:8]
  1 | // this file is also included in folder-dep-a.ts and folder-dep-a.ts should report a no-cycle diagnostic
  2 | import './folder-dep-a.ts';

--- a/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-vitest.json --report-unused-disable-directives test.js
 working directory: fixtures/disable_vitest_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-jest-methods.html\eslint-plugin-jest(no-restricted-jest-methods)]8;;\: Use of `advanceTimersByTime` is not allowed
+  x eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ,-[test.js:7:6]
  6 | it('calls the callback after 1 second via advanceTimersByTime', () => {
  7 |   vi.advanceTimersByTime(1000);

--- a/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/dot_folder
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[.a_dot_folder/index.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c oxlint-eslint.json test.js
 working directory: fixtures/eslint_and_typescript_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-magic-numbers.html\eslint(no-magic-numbers)]8;;\: No magic number: 0.19
+  x eslint(no-magic-numbers): No magic number: 0.19
    ,-[test.js:4:32]
  3 | const price = 200;
  4 | const price_with_tax = price * 0.19; // taxes are expensive
@@ -25,7 +25,7 @@ arguments: -c oxlint-typescript.json test.js
 working directory: fixtures/eslint_and_typescript_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-magic-numbers.html\eslint(no-magic-numbers)]8;;\: No magic number: 0.19
+  x eslint(no-magic-numbers): No magic number: 0.19
    ,-[test.js:4:32]
  3 | const price = 200;
  4 | const price_with_tax = price * 0.19; // taxes are expensive

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --config extends_rules_config.json console.js
 working directory: fixtures/extends_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[console.js:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --config relative_paths/extends_extends_config.json console.js
 working directory: fixtures/extends_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[console.js:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --disable-nested-config
 working directory: fixtures/extends_config
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'x' is declared but never used. Unused variables should start with a '_'.
+  ! eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
    ,-[overrides/test.ts:1:7]
  1 | const x: any = 3;
    :       |
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
    `----
   help: Consider removing this declaration.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Function 'component' is declared but never used.
+  ! eslint(no-unused-vars): Function 'component' is declared but never used.
    ,-[overrides/test.tsx:1:10]
  1 | function component(): any {
    :          ^^^^|^^^^
@@ -23,7 +23,7 @@ working directory: fixtures/extends_config
    `----
   help: Consider removing this declaration.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[overrides_same_directory/config/test.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -6,14 +6,14 @@ arguments: overrides
 working directory: fixtures/extends_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected `any`. Specify a different type.
+  x typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[overrides/test.ts:1:10]
  1 | const x: any = 3;
    :          ^^^
    `----
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected `any`. Specify a different type.
+  x typescript-eslint(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[overrides/test.tsx:1:23]
  1 | function component(): any {
    :                       ^^^
@@ -21,7 +21,7 @@ working directory: fixtures/extends_config
    `----
   help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/anchor-ambiguous-text.html\eslint-plugin-jsx-a11y(anchor-ambiguous-text)]8;;\: Ambiguous text within anchor, screen reader users rely on link text for context.
+  x eslint-plugin-jsx-a11y(anchor-ambiguous-text): Ambiguous text within anchor, screen reader users rely on link text for context.
    ,-[overrides/test.tsx:2:10]
  1 | function component(): any {
  2 |   return <a>click here</a>;
@@ -30,7 +30,7 @@ working directory: fixtures/extends_config
    `----
   help: Avoid using ambiguous text like "click here", replace it with more descriptive text that provides context.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/anchor-is-valid.html\eslint-plugin-jsx-a11y(anchor-is-valid)]8;;\: Missing `href` attribute for the `a` element.
+  ! eslint-plugin-jsx-a11y(anchor-is-valid): Missing `href` attribute for the `a` element.
    ,-[overrides/test.tsx:2:11]
  1 | function component(): any {
  2 |   return <a>click here</a>;

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
@@ -6,7 +6,7 @@ arguments: overrides_same_directory
 working directory: fixtures/extends_config
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[overrides_same_directory/config/test.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_empty_nested_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_empty_nested_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_patterns_empty_nested
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[another_config/not-ignored-file.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -25,7 +25,7 @@ arguments: .
 working directory: fixtures/ignore_patterns_empty_nested
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[another_config/not-ignored-file.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_relative_ .@oxlint.snap
@@ -6,14 +6,14 @@ arguments:
 working directory: fixtures/ignore_patterns_relative
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[nested/should_not_be_ignored.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[should_not_be_ignored.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -31,14 +31,14 @@ arguments: .
 working directory: fixtures/ignore_patterns_relative
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[nested/should_not_be_ignored.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[should_not_be_ignored.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_whitelist_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_patterns_whitelist
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[index.whitelist.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -24,7 +24,7 @@ arguments: .
 working directory: fixtures/ignore_patterns_whitelist
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[index.whitelist.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -D import/no-cycle
 working directory: fixtures/import-cycle
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[a.ts:1:19]
  1 | import { B } from "./b";
    :                   ^^^^^
@@ -19,7 +19,7 @@ working directory: fixtures/import-cycle
            │    ./a (fixtures/import-cycle/a.ts)
            ╰─────────╯ imports the current file
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[b.ts:1:19]
  1 | import { A } from "./a";
    :                   ^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/import
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-default-export.html\eslint-plugin-import(no-default-export)]8;;\: Prefer named exports
+  x eslint-plugin-import(no-default-export): Prefer named exports
    ,-[test.js:7:8]
  6 | // import/no-default-export
  7 | export default function () { }
@@ -25,7 +25,7 @@ arguments: -c .oxlintrc-import-x.json test.js
 working directory: fixtures/import
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-default-export.html\eslint-plugin-import(no-default-export)]8;;\: Prefer named exports
+  x eslint-plugin-import(no-default-export): Prefer named exports
    ,-[test.js:7:8]
  6 | // import/no-default-export
  7 | export default function () { }

--- a/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/issue_10394
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/valid-title.html\eslint-plugin-jest(valid-title)]8;;\: Should not have an empty title
+  ! eslint-plugin-jest(valid-title): Should not have an empty title
    ,-[foo.test.ts:1:10]
  1 | describe("", () => {
    :          ^^

--- a/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__jest_and_vitest_alias_rules_-c oxlint-jest.json test.js -c oxlint-vitest.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c oxlint-jest.json test.js
 working directory: fixtures/jest_and_vitest_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-identical-title.html\eslint-plugin-jest(no-identical-title)]8;;\: Test title is used multiple times in the same describe block.
+  x eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ,-[test.js:3:6]
  2 |   it("works", () => {});
  3 |   it("works", () => {});
@@ -26,7 +26,7 @@ arguments: -c oxlint-vitest.json test.js
 working directory: fixtures/jest_and_vitest_alias_rules
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/no-identical-title.html\eslint-plugin-jest(no-identical-title)]8;;\: Test title is used multiple times in the same describe block.
+  x eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ,-[test.js:3:6]
  2 |   it("works", () => {});
  3 |   it("works", () => {});

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: debugger.js
 working directory: fixtures/linter
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
@@ -6,28 +6,28 @@ arguments: --config oxlint-no-console.json
 working directory: fixtures/nested_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[console.ts:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^
    `----
   help: Delete this console statement.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package1-empty-config/console.ts:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^
    `----
   help: Delete this console statement.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package2-no-config/console.ts:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^
    `----
   help: Delete this console statement.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package3-deep-config/src/components/component.js:2:3]
  1 | export function Component() {
  2 |   console.log("hello");

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
@@ -6,14 +6,14 @@ arguments: -A no-console
 working directory: fixtures/nested_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[package2-no-config/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
@@ -6,35 +6,35 @@ arguments:
 working directory: fixtures/nested_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[console.ts:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^
    `----
   help: Delete this console statement.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package2-no-config/console.ts:1:1]
  1 | console.log("test");
    : ^^^^^^^^^^^
    `----
   help: Delete this console statement.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[package2-no-config/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package3-deep-config/src/components/component.js:2:3]
  1 | export function Component() {
  2 |   console.log("hello");

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_package3-deep-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_package3-deep-config@oxlint.snap
@@ -6,7 +6,7 @@ arguments: package3-deep-config
 working directory: fixtures/nested_config
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  x eslint(no-console): Unexpected console statement.
    ,-[package3-deep-config/src/components/component.js:2:3]
  1 | export function Component() {
  2 |   console.log("hello");

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --format=default test.js
 working directory: fixtures/output_formatter_diagnostic
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Function 'foo' is declared but never used.
+  ! eslint(no-unused-vars): Function 'foo' is declared but never used.
    ,-[test.js:1:10]
  1 | function foo(a, b) {
    :          ^|^
@@ -15,7 +15,7 @@ working directory: fixtures/output_formatter_diagnostic
    `----
   help: Consider removing this declaration.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+  ! eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
    ,-[test.js:1:17]
  1 | function foo(a, b) {
    :                 |
@@ -24,7 +24,7 @@ working directory: fixtures/output_formatter_diagnostic
    `----
   help: Consider removing this parameter.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[test.js:5:1]
  4 | 
  5 | debugger;

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish test.js@oxlint.snap
@@ -6,12 +6,12 @@ arguments: --format=stylish test.js
 working directory: fixtures/output_formatter_diagnostic
 ----------
 
-[4mtest.js[0m
-  [2m1:10[0m  [33mwarning[0m  Function 'foo' is declared but never used.  [2meslint(no-unused-vars)[0m
-  [2m1:17[0m  [33mwarning[0m  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  [2meslint(no-unused-vars)[0m
-  [2m5:1 [0m  [31merror[0m  `debugger` statement is not allowed  [2meslint(no-debugger)[0m
+test.js
+  1:10  warning  Function 'foo' is declared but never used.  eslint(no-unused-vars)
+  1:17  warning  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  eslint(no-unused-vars)
+  5:1   error  `debugger` statement is not allowed  eslint(no-debugger)
 
-[31m✖ 3 problems (1 error, 2 warnings)[0m
+✖ 3 problems (1 error, 2 warnings)
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json .
 working directory: fixtures/overrides_env_globals
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+  ! eslint(no-global-assign): Read-only global 'globalThis' should not be modified.
    ,-[src/test.js:2:1]
  1 | // for env detection
  2 | globalThis = 'abc';
@@ -15,7 +15,7 @@ working directory: fixtures/overrides_env_globals
  3 | $ = 'abc';
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+  ! eslint(no-global-assign): Read-only global 'globalThis' should not be modified.
    ,-[test.js:2:1]
  1 | // for env detection
  2 | globalThis = 'abc';
@@ -24,7 +24,7 @@ working directory: fixtures/overrides_env_globals
  3 | $ = 'abc';
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global '$' should not be modified.
+  ! eslint(no-global-assign): Read-only global '$' should not be modified.
    ,-[test.js:3:1]
  2 | globalThis = 'abc';
  3 | $ = 'abc';
@@ -33,7 +33,7 @@ working directory: fixtures/overrides_env_globals
  4 | 
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'Foo' should not be modified.
+  ! eslint(no-global-assign): Read-only global 'Foo' should not be modified.
    ,-[test.js:6:1]
  5 | // for globals detection
  6 | Foo = 'readable';
@@ -41,7 +41,7 @@ working directory: fixtures/overrides_env_globals
    :  `-- Read-only global 'Foo' should not be modified.
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+  ! eslint(no-global-assign): Read-only global 'globalThis' should not be modified.
    ,-[test.ts:2:1]
  1 | // for env detection
  2 | globalThis = 'abc';

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json
 working directory: fixtures/overrides_with_plugin
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/valid-title.html\eslint-plugin-jest(valid-title)]8;;\: Should not have an empty title
+  x eslint-plugin-jest(valid-title): Should not have an empty title
    ,-[index.test.ts:1:10]
  1 | describe("", () => {
    :          ^^
@@ -14,7 +14,7 @@ working directory: fixtures/overrides_with_plugin
    `----
   help: Write a meaningful title for your test
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/expect-expect.html\eslint-plugin-jest(expect-expect)]8;;\: Test has no assertions
+  ! eslint-plugin-jest(expect-expect): Test has no assertions
    ,-[index.test.ts:4:3]
  3 | 
  4 |   it("", () => {});
@@ -23,7 +23,7 @@ working directory: fixtures/overrides_with_plugin
    `----
   help: Add assertion(s) in this Test
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jest/valid-title.html\eslint-plugin-jest(valid-title)]8;;\: Should not have an empty title
+  x eslint-plugin-jest(valid-title): Should not have an empty title
    ,-[index.test.ts:4:6]
  3 | 
  4 |   it("", () => {});
@@ -32,7 +32,7 @@ working directory: fixtures/overrides_with_plugin
    `----
   help: Write a meaningful title for your test
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'foo' is declared but never used. Unused variables should start with a '_'.
+  ! eslint(no-unused-vars): Variable 'foo' is declared but never used. Unused variables should start with a '_'.
    ,-[index.ts:1:7]
  1 | const foo = 123;
    :       ^|^

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/report_unused_directives
  7 | console.log('regular script');
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
    ,-[test-multiple-scripts.vue:7:1]
  6 | // eslint-disable-next-line no-debugger
  7 | console.log('regular script');
@@ -31,7 +31,7 @@ working directory: fixtures/report_unused_directives
  10 | debugger;
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[test-multiple-scripts.vue:10:1]
   9 | // eslint-disable-next-line no-console
  10 | debugger;
@@ -56,7 +56,7 @@ working directory: fixtures/report_unused_directives
  31 | console.log("complete line");
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
     ,-[test-multiple-scripts.vue:31:1]
  30 | // oxlint-disable-next-line no-debugger, no-for-loop
  31 | console.log("complete line");
@@ -81,7 +81,7 @@ working directory: fixtures/report_unused_directives
  11 | debugger;
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[test.astro:11:1]
  10 | // eslint-disable-next-line no-console
  11 | debugger;
@@ -114,7 +114,7 @@ working directory: fixtures/report_unused_directives
  32 | console.log("complete line");
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
     ,-[test.astro:32:1]
  31 | // oxlint-disable-next-line no-debugger, no-for-loop
  32 | console.log("complete line");
@@ -147,7 +147,7 @@ working directory: fixtures/report_unused_directives
  10 | debugger;
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[test.js:10:1]
   9 | // eslint-disable-next-line no-console
  10 | debugger;
@@ -172,7 +172,7 @@ working directory: fixtures/report_unused_directives
  27 | console.log("complete line");
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
     ,-[test.js:27:1]
  26 | // oxlint-disable-next-line no-debugger, no-for-loop
  27 | console.log("complete line");
@@ -204,7 +204,7 @@ working directory: fixtures/report_unused_directives
  11 | debugger;
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[test.svelte:11:1]
  10 | // eslint-disable-next-line no-console
  11 | debugger;
@@ -237,7 +237,7 @@ working directory: fixtures/report_unused_directives
  28 | console.log("complete line");
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
     ,-[test.svelte:28:1]
  27 | // oxlint-disable-next-line no-debugger, no-for-loop
  28 | console.log("complete line");
@@ -270,7 +270,7 @@ working directory: fixtures/report_unused_directives
  15 | debugger;
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
     ,-[test.vue:15:1]
  14 | // eslint-disable-next-line no-console
  15 | debugger;
@@ -303,7 +303,7 @@ working directory: fixtures/report_unused_directives
  32 | console.log("complete line");
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: Unexpected console statement.
+  ! eslint(no-console): Unexpected console statement.
     ,-[test.vue:32:1]
  31 | // oxlint-disable-next-line no-debugger, no-for-loop
  32 | console.log("complete line");

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware -c config-test.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware -c config-test.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --type-aware -c config-test.json
 working directory: fixtures/tsgolint
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  ! typescript-eslint(no-floating-promises): Promises must be awaited.
    ,-[no-floating-promises.ts:2:1]
  1 | const promise = new Promise((resolve, _reject) => resolve("value"));
  2 | promise;
@@ -15,7 +15,7 @@ working directory: fixtures/tsgolint
    `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[non-tsgolint.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -23,14 +23,14 @@ working directory: fixtures/tsgolint
    `----
   help: Remove the debugger statement
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  ! typescript-eslint(no-floating-promises): Promises must be awaited.
    ,-[prefer-promise-reject-errors.ts:1:1]
  1 | Promise.reject('error');
    : ^^^^^^^^^^^^^^^^^^^^^^^^
    `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[test.svelte:2:2]
  1 | <script>
  2 |     debugger;

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware test.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware test.svelte@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --type-aware test.svelte
 working directory: fixtures/tsgolint
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[test.svelte:2:2]
  1 | <script>
  2 |     debugger;

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
@@ -6,27 +6,27 @@ arguments: --type-aware
 working directory: fixtures/tsgolint
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/await-thenable.html\typescript-eslint(await-thenable)]8;;\: Unexpected `await` of a non-Promise (non-"Thenable") value.
+  x typescript-eslint(await-thenable): Unexpected `await` of a non-Promise (non-"Thenable") value.
    ,-[await-thenable.ts:1:1]
  1 | await 12;
    : ^^^^^^^^
  2 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-array-delete.html\typescript-eslint(no-array-delete)]8;;\: Using the `delete` operator with an array expression is unsafe.
+  x typescript-eslint(no-array-delete): Using the `delete` operator with an array expression is unsafe.
    ,-[no-array-delete.ts:2:1]
  1 | declare const arr: number[];
  2 | delete arr[0];
    : ^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-base-to-string.html\typescript-eslint(no-base-to-string)]8;;\: '({})' will use Object's default stringification format ('[object Object]') when stringified.
+  x typescript-eslint(no-base-to-string): '({})' will use Object's default stringification format ('[object Object]') when stringified.
    ,-[no-base-to-string.ts:1:1]
  1 | ({}).toString();
    : ^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-meaningless-void-operator.html\typescript-eslint(no-meaningless-void-operator)]8;;\: void operator shouldn't be used on void; it should convey that a return value is being ignored
+  x typescript-eslint(no-meaningless-void-operator): void operator shouldn't be used on void; it should convey that a return value is being ignored
    ,-[no-confusing-void-expression.ts:2:19]
  1 | declare function bar(): void;
  2 | const foo = () => void bar();
@@ -34,7 +34,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-confusing-void-expression.html\typescript-eslint(no-confusing-void-expression)]8;;\: Placing a void expression inside another expression is forbidden. Move it to its own statement instead.
+  x typescript-eslint(no-confusing-void-expression): Placing a void expression inside another expression is forbidden. Move it to its own statement instead.
    ,-[no-confusing-void-expression.ts:2:24]
  1 | declare function bar(): void;
  2 | const foo = () => void bar();
@@ -42,28 +42,28 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-deprecated.html\typescript-eslint(no-deprecated)]8;;\: `getVersion` is deprecated. Use apiV2 instead.
+  x typescript-eslint(no-deprecated): `getVersion` is deprecated. Use apiV2 instead.
    ,-[no-deprecated.ts:8:1]
  7 | 
  8 | getVersion();
    : ^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-duplicate-type-constituents.html\typescript-eslint(no-duplicate-type-constituents)]8;;\: Union type constituent is duplicated with  'A'.
+  x typescript-eslint(no-duplicate-type-constituents): Union type constituent is duplicated with  'A'.
    ,-[no-duplicate-type-constituents.ts:1:17]
  1 | type T1 = 'A' | 'A';
    :                 ^^^
  2 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-confusing-void-expression.html\typescript-eslint(no-confusing-void-expression)]8;;\: Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.
+  x typescript-eslint(no-confusing-void-expression): Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.
    ,-[no-floating-promises.ts:1:51]
  1 | const promise = new Promise((resolve, _reject) => resolve("value"));
    :                                                   ^^^^^^^^^^^^^^^^
  2 | promise;
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  x typescript-eslint(no-floating-promises): Promises must be awaited.
    ,-[no-floating-promises.ts:2:1]
  1 | const promise = new Promise((resolve, _reject) => resolve("value"));
  2 | promise;
@@ -72,7 +72,7 @@ working directory: fixtures/tsgolint
    `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-for-in-array.html\typescript-eslint(no-for-in-array)]8;;\: For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a
+  x typescript-eslint(no-for-in-array): For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a
   | more robust iteration method such as for-of or array.forEach instead.
    ,-[no-for-in-array.ts:2:1]
  1 | const arr = [1, 2, 3];
@@ -81,13 +81,13 @@ working directory: fixtures/tsgolint
  3 |   console.log(arr[i]);
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-implied-eval.html\typescript-eslint(no-implied-eval)]8;;\: Implied eval. Consider passing a function.
+  x typescript-eslint(no-implied-eval): Implied eval. Consider passing a function.
    ,-[no-implied-eval.ts:1:12]
  1 | setTimeout('alert("Hi!");', 100);
    :            ^^^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-meaningless-void-operator.html\typescript-eslint(no-meaningless-void-operator)]8;;\: void operator shouldn't be used on void; it should convey that a return value is being ignored
+  x typescript-eslint(no-meaningless-void-operator): void operator shouldn't be used on void; it should convey that a return value is being ignored
    ,-[no-meaningless-void-operator.ts:4:1]
  3 | }
  4 | void foo();
@@ -95,7 +95,7 @@ working directory: fixtures/tsgolint
  5 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-confusing-void-expression.html\typescript-eslint(no-confusing-void-expression)]8;;\: Placing a void expression inside another expression is forbidden. Move it to its own statement instead.
+  x typescript-eslint(no-confusing-void-expression): Placing a void expression inside another expression is forbidden. Move it to its own statement instead.
    ,-[no-meaningless-void-operator.ts:4:6]
  3 | }
  4 | void foo();
@@ -103,14 +103,14 @@ working directory: fixtures/tsgolint
  5 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-misused-spread.html\typescript-eslint(no-misused-spread)]8;;\: Using the spread operator on Promise in an object can cause unexpected behavior. Did you forget to await the promise?
+  x typescript-eslint(no-misused-spread): Using the spread operator on Promise in an object can cause unexpected behavior. Did you forget to await the promise?
    ,-[no-misused-spread.ts:2:25]
  1 | declare const promise: Promise<number>;
  2 | const spreadPromise = { ...promise };
    :                         ^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-mixed-enums.html\typescript-eslint(no-mixed-enums)]8;;\: Mixing number and string enums can be confusing.
+  x typescript-eslint(no-mixed-enums): Mixing number and string enums can be confusing.
    ,-[no-mixed-enums.ts:3:12]
  2 |   Open = 1,
  3 |   Closed = 'closed',
@@ -118,13 +118,13 @@ working directory: fixtures/tsgolint
  4 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-redundant-type-constituents.html\typescript-eslint(no-redundant-type-constituents)]8;;\: 'unknown' overrides all other types in this union type.
+  x typescript-eslint(no-redundant-type-constituents): 'unknown' overrides all other types in this union type.
    ,-[no-redundant-type-constituents.ts:1:20]
  1 | type T1 = string | unknown;
    :                    ^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-boolean-literal-compare.html\typescript-eslint(no-unnecessary-boolean-literal-compare)]8;;\: This expression unnecessarily compares a boolean value to a boolean instead of using it
+  x typescript-eslint(no-unnecessary-boolean-literal-compare): This expression unnecessarily compares a boolean value to a boolean instead of using it
   | directly.
    ,-[no-unnecessary-boolean-literal-compare.ts:2:5]
  1 | declare const someCondition: boolean;
@@ -133,7 +133,7 @@ working directory: fixtures/tsgolint
  3 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-template-expression.html\typescript-eslint(no-unnecessary-template-expression)]8;;\: Template literal expression is unnecessary and can be simplified.
+  x typescript-eslint(no-unnecessary-template-expression): Template literal expression is unnecessary and can be simplified.
    ,-[no-unnecessary-template-expression.ts:2:18]
  1 | const text = 'hello';
  2 | const wrapped = `${text}`;
@@ -141,14 +141,14 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-type-arguments.html\typescript-eslint(no-unnecessary-type-arguments)]8;;\: This is the default value for this type parameter, so it can be omitted.
+  x typescript-eslint(no-unnecessary-type-arguments): This is the default value for this type parameter, so it can be omitted.
    ,-[no-unnecessary-type-arguments.ts:4:25]
  3 | }
  4 | const result = identity<string>('hello');
    :                         ^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-type-assertion.html\typescript-eslint(no-unnecessary-type-assertion)]8;;\: This assertion is unnecessary since it does not change the type of the expression.
+  x typescript-eslint(no-unnecessary-type-assertion): This assertion is unnecessary since it does not change the type of the expression.
    ,-[no-unnecessary-type-assertion.ts:2:19]
  1 | const str: string = 'hello';
  2 | const redundant = str as string;
@@ -156,7 +156,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-argument.html\typescript-eslint(no-unsafe-argument)]8;;\: Unsafe argument of type any assigned to a parameter of type string.
+  x typescript-eslint(no-unsafe-argument): Unsafe argument of type any assigned to a parameter of type string.
    ,-[no-unsafe-argument.ts:3:13]
  2 | function takesString(str: string): void {}
  3 | takesString(anyValue);
@@ -164,7 +164,7 @@ working directory: fixtures/tsgolint
  4 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-assignment.html\typescript-eslint(no-unsafe-assignment)]8;;\: Unsafe assignment of an any value.
+  x typescript-eslint(no-unsafe-assignment): Unsafe assignment of an any value.
    ,-[no-unsafe-assignment.ts:2:7]
  1 | declare const anyValue: any;
  2 | const str: string = anyValue;
@@ -172,7 +172,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-call.html\typescript-eslint(no-unsafe-call)]8;;\: Unsafe call of a(n) `any` typed value.
+  x typescript-eslint(no-unsafe-call): Unsafe call of a(n) `any` typed value.
    ,-[no-unsafe-call.ts:2:1]
  1 | declare const anyValue: any;
  2 | anyValue();
@@ -180,7 +180,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-enum-comparison.html\typescript-eslint(no-unsafe-enum-comparison)]8;;\: The two values in this comparison do not have a shared enum type.
+  x typescript-eslint(no-unsafe-enum-comparison): The two values in this comparison do not have a shared enum type.
     ,-[no-unsafe-enum-comparison.ts:9:20]
   8 | }
   9 | const comparison = Status.Open === Color.Red;
@@ -188,7 +188,7 @@ working directory: fixtures/tsgolint
  10 | 
     `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-member-access.html\typescript-eslint(no-unsafe-member-access)]8;;\: Unsafe member access .foo on an `any` value.
+  x typescript-eslint(no-unsafe-member-access): Unsafe member access .foo on an `any` value.
    ,-[no-unsafe-member-access.ts:2:10]
  1 | declare const anyValue: any;
  2 | anyValue.foo;
@@ -196,7 +196,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-return.html\typescript-eslint(no-unsafe-return)]8;;\: Unsafe return of a value of type `any`.
+  x typescript-eslint(no-unsafe-return): Unsafe return of a value of type `any`.
    ,-[no-unsafe-return.ts:3:3]
  2 | function getString(): string {
  3 |   return anyValue;
@@ -204,7 +204,7 @@ working directory: fixtures/tsgolint
  4 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-assignment.html\typescript-eslint(no-unsafe-assignment)]8;;\: Unsafe assignment of an any value.
+  x typescript-eslint(no-unsafe-assignment): Unsafe assignment of an any value.
    ,-[no-unsafe-type-assertion.ts:2:7]
  1 | declare const value: unknown;
  2 | const str = value as any;
@@ -212,7 +212,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-type-assertion.html\typescript-eslint(no-unsafe-type-assertion)]8;;\: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+  x typescript-eslint(no-unsafe-type-assertion): Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    ,-[no-unsafe-type-assertion.ts:2:13]
  1 | declare const value: unknown;
  2 | const str = value as any;
@@ -220,7 +220,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-type-assertion.html\typescript-eslint(no-unsafe-type-assertion)]8;;\: Unsafe type assertion: type 'string' is more narrow than the original type.
+  x typescript-eslint(no-unsafe-type-assertion): Unsafe type assertion: type 'string' is more narrow than the original type.
    ,-[non-nullable-type-assertion-style.ts:2:17]
  1 | declare const value: string | null;
  2 | const result1 = value as string;
@@ -228,7 +228,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/non-nullable-type-assertion-style.html\typescript-eslint(non-nullable-type-assertion-style)]8;;\: Use a ! assertion to more succinctly remove null and undefined from the type.
+  x typescript-eslint(non-nullable-type-assertion-style): Use a ! assertion to more succinctly remove null and undefined from the type.
    ,-[non-nullable-type-assertion-style.ts:2:17]
  1 | declare const value: string | null;
  2 | const result1 = value as string;
@@ -236,7 +236,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[non-tsgolint.ts:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -244,14 +244,14 @@ working directory: fixtures/tsgolint
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/only-throw-error.html\typescript-eslint(only-throw-error)]8;;\: Expected an error object to be thrown.
+  x typescript-eslint(only-throw-error): Expected an error object to be thrown.
    ,-[only-throw-error.ts:1:7]
  1 | throw 'error';
    :       ^^^^^^^
  2 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-includes.html\typescript-eslint(prefer-includes)]8;;\: Use 'includes()' method instead.
+  x typescript-eslint(prefer-includes): Use 'includes()' method instead.
    ,-[prefer-includes.ts:2:5]
  1 | const text = 'hello';
  2 | if (text.indexOf('h') !== -1) {
@@ -259,7 +259,7 @@ working directory: fixtures/tsgolint
  3 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-includes.html\typescript-eslint(prefer-includes)]8;;\: Use 'includes()' method instead.
+  x typescript-eslint(prefer-includes): Use 'includes()' method instead.
    ,-[prefer-includes.ts:6:5]
  5 | const items = [1, 2];
  6 | if (items.indexOf(1) !== -1) {
@@ -267,7 +267,7 @@ working directory: fixtures/tsgolint
  7 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-includes.html\typescript-eslint(prefer-includes)]8;;\: Use `String#includes()` method with a string instead.
+  x typescript-eslint(prefer-includes): Use `String#includes()` method with a string instead.
     ,-[prefer-includes.ts:9:5]
   8 | 
   9 | if (/test/.test(text)) {
@@ -275,34 +275,34 @@ working directory: fixtures/tsgolint
  10 | }
     `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-nullish-coalescing.html\typescript-eslint(prefer-nullish-coalescing)]8;;\: Prefer using nullish coalescing operator (`??`) instead of a ternary expression, as it is simpler to read.
+  x typescript-eslint(prefer-nullish-coalescing): Prefer using nullish coalescing operator (`??`) instead of a ternary expression, as it is simpler to read.
    ,-[prefer-nullish-coalescing.ts:2:23]
  1 | declare const nullableString: string | null;
  2 | const nullishResult = nullableString !== null && nullableString !== undefined ? nullableString : 'default';
    :                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-optional-chain.html\typescript-eslint(prefer-optional-chain)]8;;\: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+  x typescript-eslint(prefer-optional-chain): Prefer using an optional chain expression instead, as it's more concise and easier to read.
    ,-[prefer-optional-chain.ts:3:1]
  2 | declare const fooOptC: { bar: number } | null | undefined;
  3 | fooOptC && fooOptC.bar;
    : ^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-promise-reject-errors.html\typescript-eslint(prefer-promise-reject-errors)]8;;\: Expected the Promise rejection reason to be an Error.
+  x typescript-eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error.
    ,-[prefer-promise-reject-errors.ts:1:1]
  1 | Promise.reject('error');
    : ^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  x typescript-eslint(no-floating-promises): Promises must be awaited.
    ,-[prefer-promise-reject-errors.ts:1:1]
  1 | Promise.reject('error');
    : ^^^^^^^^^^^^^^^^^^^^^^^^
    `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-type-assertion.html\typescript-eslint(no-unnecessary-type-assertion)]8;;\: This assertion is unnecessary since it does not change the type of the expression.
+  x typescript-eslint(no-unnecessary-type-assertion): This assertion is unnecessary since it does not change the type of the expression.
    ,-[prefer-reduce-type-parameter.ts:2:13]
  1 | const numbers = [1, 2, 3];
  2 | const sum = numbers.reduce((acc, val) => acc + val, 0) as number;
@@ -310,7 +310,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-return-this-type.html\typescript-eslint(prefer-return-this-type)]8;;\: Use `this` type instead.
+  x typescript-eslint(prefer-return-this-type): Use `this` type instead.
    ,-[prefer-return-this-type.ts:3:28]
  2 |   private value: string = '';
  3 |   setValue(value: string): Builder {
@@ -318,7 +318,7 @@ working directory: fixtures/tsgolint
  4 |     this.value = value;
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/promise-function-async.html\typescript-eslint(promise-function-async)]8;;\: Functions that return promises must be async.
+  x typescript-eslint(promise-function-async): Functions that return promises must be async.
    ,-[promise-function-async.ts:2:1]
  1 |     declare function fetch(url: string): Promise<Response>;
  2 | ,-> function fetchData(): Promise<string> {
@@ -327,7 +327,7 @@ working directory: fixtures/tsgolint
  5 |     
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/promise-function-async.html\typescript-eslint(promise-function-async)]8;;\: Functions that return promises must be async.
+  x typescript-eslint(promise-function-async): Functions that return promises must be async.
    ,-[promise-function-async.ts:3:34]
  2 | function fetchData(): Promise<string> {
  3 |   return fetch('/api/data').then(res => res.text());
@@ -335,7 +335,7 @@ working directory: fixtures/tsgolint
  4 | }
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/related-getter-setter-pairs.html\typescript-eslint(related-getter-setter-pairs)]8;;\: `get()` type should be assignable to its equivalent `set()` type.
+  x typescript-eslint(related-getter-setter-pairs): `get()` type should be assignable to its equivalent `set()` type.
    ,-[related-getter-setter-pairs.ts:3:16]
  2 |   private _value: number = 0;
  3 |   get value(): string {
@@ -343,7 +343,7 @@ working directory: fixtures/tsgolint
  4 |     return this._value.toString();
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/require-array-sort-compare.html\typescript-eslint(require-array-sort-compare)]8;;\: Require 'compare' argument.
+  x typescript-eslint(require-array-sort-compare): Require 'compare' argument.
    ,-[require-array-sort-compare.ts:2:1]
  1 | const numbers = [3, 1, 4, 1, 5];
  2 | numbers.sort();
@@ -351,19 +351,19 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-assignment.html\typescript-eslint(no-unsafe-assignment)]8;;\: Unsafe assignment of an any value.
+  x typescript-eslint(no-unsafe-assignment): Unsafe assignment of an any value.
    ,-[restrict-plus-operands.ts:1:5]
  1 | let foo = 1n + 1;
    :     ^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/restrict-plus-operands.html\typescript-eslint(restrict-plus-operands)]8;;\: Numeric '+' operations must either be both bigints or both numbers. Got `bigint` + `number`.
+  x typescript-eslint(restrict-plus-operands): Numeric '+' operations must either be both bigints or both numbers. Got `bigint` + `number`.
    ,-[restrict-plus-operands.ts:1:11]
  1 | let foo = 1n + 1;
    :           ^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-base-to-string.html\typescript-eslint(no-base-to-string)]8;;\: 'obj' will use Object's default stringification format ('[object Object]') when stringified.
+  x typescript-eslint(no-base-to-string): 'obj' will use Object's default stringification format ('[object Object]') when stringified.
    ,-[restrict-template-expressions.ts:2:24]
  1 | declare const obj: object;
  2 | const str1 = `Value: ${obj}`;
@@ -371,7 +371,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/restrict-template-expressions.html\typescript-eslint(restrict-template-expressions)]8;;\: Invalid type "object" of template literal expression.
+  x typescript-eslint(restrict-template-expressions): Invalid type "object" of template literal expression.
    ,-[restrict-template-expressions.ts:2:24]
  1 | declare const obj: object;
  2 | const str1 = `Value: ${obj}`;
@@ -379,7 +379,7 @@ working directory: fixtures/tsgolint
  3 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/switch-exhaustiveness-check.html\typescript-eslint(switch-exhaustiveness-check)]8;;\: Switch is not exhaustive
+  x typescript-eslint(switch-exhaustiveness-check): Switch is not exhaustive
    ,-[switch-exhaustiveness-check.ts:3:11]
  2 | function handleStatus(status: Status) {
  3 |   switch (status) {
@@ -387,7 +387,7 @@ working directory: fixtures/tsgolint
  4 |     case 'pending':
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[test.svelte:2:2]
  1 | <script>
  2 |     debugger;
@@ -396,7 +396,7 @@ working directory: fixtures/tsgolint
    `----
   help: Remove the debugger statement
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/unbound-method.html\typescript-eslint(unbound-method)]8;;\: Avoid referencing unbound methods which may cause unintentional scoping of `this`.
+  x typescript-eslint(unbound-method): Avoid referencing unbound methods which may cause unintentional scoping of `this`.
   | If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
    ,-[unbound-method.ts:9:19]
  8 | const calc = new Calculator();

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --type-aware --report-unused-disable-directives unused.ts
 working directory: fixtures/tsgolint_disable_directives
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[unused.ts:6:1]
  5 | // oxlint-disable-next-line typescript/no-floating-promises
  6 | myPromise
@@ -31,7 +31,7 @@ working directory: fixtures/tsgolint_disable_directives
  14 | myPromise
     `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[unused.ts:14:1]
  13 | // oxlint-disable-next-line typescript/no-unsafe-assignment
  14 | myPromise
@@ -40,7 +40,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  ! typescript-eslint(no-floating-promises): Promises must be awaited.
     ,-[unused.ts:14:1]
  13 | // oxlint-disable-next-line typescript/no-unsafe-assignment
  14 | myPromise
@@ -49,7 +49,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[unused.ts:18:1]
  17 | /* eslint-disable @typescript-eslint/no-floating-promises */
  18 | myPromise
@@ -58,7 +58,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'x' is declared but never used. Unused variables should start with a '_'.
+  ! eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
     ,-[unused.ts:23:7]
  22 | /* eslint-disable @typescript-eslint/no-floating-promises */
  23 | const x = 1 + 2

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --type-aware test.ts
 working directory: fixtures/tsgolint_disable_directives
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
    ,-[test.ts:6:1]
  5 | // oxlint-disable-next-line typescript/no-floating-promises
  6 | myPromise
@@ -15,7 +15,7 @@ working directory: fixtures/tsgolint_disable_directives
    `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:10:1]
   9 | // eslint-disable-next-line @typescript-eslint/no-floating-promises
  10 | myPromise
@@ -24,7 +24,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:14:1]
  13 | /* oxlint-disable typescript/no-floating-promises */
  14 | myPromise
@@ -33,7 +33,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:15:1]
  14 | myPromise
  15 | myPromise
@@ -42,7 +42,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:19:1]
  18 | // This should still report an error (no disable directive)
  19 | myPromise
@@ -51,7 +51,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  ! typescript-eslint(no-floating-promises): Promises must be awaited.
     ,-[test.ts:19:1]
  18 | // This should still report an error (no disable directive)
  19 | myPromise
@@ -60,7 +60,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:23:1]
  22 | // oxlint-disable-next-line no-floating-promises
  23 | myPromise
@@ -69,7 +69,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:26:1]
  25 | // eslint-disable-next-line typescript-eslint/no-floating-promises
  26 | myPromise
@@ -78,7 +78,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-expressions.html\eslint(no-unused-expressions)]8;;\: Expected expression to be used
+  ! eslint(no-unused-expressions): Expected expression to be used
     ,-[test.ts:29:1]
  28 | // Test disable-line variant
  29 | myPromise // oxlint-disable-line typescript/no-floating-promises
@@ -87,7 +87,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
   help: Consider using this expression or removing it
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-floating-promises.html\typescript-eslint(no-floating-promises)]8;;\: Promises must be awaited.
+  ! typescript-eslint(no-floating-promises): Promises must be awaited.
     ,-[test.ts:39:1]
  38 | // Should report error
  39 | Promise.resolve(4)

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_rule_options_--type-aware@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --type-aware
 working directory: fixtures/tsgolint_rule_options
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-deprecated.html\typescript-eslint(no-deprecated)]8;;\: `notAllowedDeprecated` is deprecated. Use anotherNewFunction instead
+  x typescript-eslint(no-deprecated): `notAllowedDeprecated` is deprecated. Use anotherNewFunction instead
     ,-[test.ts:36:1]
  35 | // This SHOULD error because notAllowedDeprecated is NOT in the allow list
  36 | notAllowedDeprecated();
@@ -14,7 +14,7 @@ working directory: fixtures/tsgolint_rule_options
  37 | 
     `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-misused-spread.html\typescript-eslint(no-misused-spread)]8;;\: Using the spread operator on a function without additional properties can cause unexpected behavior. Did you forget to call the function?
+  x typescript-eslint(no-misused-spread): Using the spread operator on a function without additional properties can cause unexpected behavior. Did you forget to call the function?
     ,-[test.ts:47:28]
  46 | // This SHOULD error because notAllowedFunc is NOT in the allow list
  47 | const notAllowedSpread = { ...notAllowedFunc };
@@ -22,7 +22,7 @@ working directory: fixtures/tsgolint_rule_options
  48 | 
     `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-member-access.html\typescript-eslint(no-unsafe-member-access)]8;;\: Unsafe member access .bar on an `any` value.
+  x typescript-eslint(no-unsafe-member-access): Unsafe member access .bar on an `any` value.
     ,-[test.ts:58:31]
  57 | // This SHOULD error because it's not using optional chaining
  58 | const unsafeAccess = anyValue.bar;
@@ -30,7 +30,7 @@ working directory: fixtures/tsgolint_rule_options
  59 | 
     `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-base-to-string.html\typescript-eslint(no-base-to-string)]8;;\: 'unknownValue' may use Object's default stringification format ('[object Object]') when stringified.
+  x typescript-eslint(no-base-to-string): 'unknownValue' may use Object's default stringification format ('[object Object]') when stringified.
     ,-[test.ts:63:20]
  62 | // This SHOULD error because checkUnknown is true
  63 | const unknownStr = unknownValue.toString();

--- a/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
@@ -6,7 +6,7 @@ arguments: issue_10054
 working directory: fixtures
 ----------
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[issue_10054/a.ts:1:19]
  1 | import { b } from "./b";
    :                   ^^^^^
@@ -19,7 +19,7 @@ working directory: fixtures
            │    ./a (fixtures/issue_10054/a.ts)
            ╰─────────╯ imports the current file
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+  x eslint-plugin-import(no-cycle): Dependency cycle detected
    ,-[issue_10054/b.ts:1:8]
  1 | import "./a";
    :        ^^^^^


### PR DESCRIPTION
This adds regexes to remove ANSI escape codes from the linter output in the snapshots.

I used AI to generate the regexes, but all of the tests that were updated seem completely correct and the regexes seem to be pretty good based on some basic manual testing I did.

We should maybe consider a more robust/safe option of using the strip-ansi-escapes crate, but I didn't want to add a dependency for this without talking about it more first.

The biggest downside of this approach is that it could remove data we technically _want_ in a test, if we were testing some very weird results, but *shrug*.

I can't fix this in the same way we do for crates/oxc_linter/src/tester because we don't have the ability to mess with the GraphicalReportHandler as easily here, as far as I can tell. But that is an option we could explore as an alternative.