### PR TITLE
test(linter): Strip control characters from output in vitest snapshot tests

### DIFF
--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -9,7 +9,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
@@ -9,7 +9,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/01.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -22,7 +22,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/02.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -35,7 +35,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/03.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -48,7 +48,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/04.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -61,7 +61,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/05.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -74,7 +74,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/06.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -87,7 +87,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/07.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -100,7 +100,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/08.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -113,7 +113,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/09.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -126,7 +126,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/10.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -139,7 +139,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/11.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -152,7 +152,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/12.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -165,7 +165,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/13.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -178,7 +178,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/14.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -191,7 +191,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/15.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -204,7 +204,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/16.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -217,7 +217,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/17.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -230,7 +230,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/18.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -243,7 +243,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/19.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
@@ -256,7 +256,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/20.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
@@ -17,7 +17,7 @@
  2 | 
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
@@ -9,7 +9,7 @@
    : ^^^^^^^^^
    `----
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/built_in_errors/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/disable_directives/output.snap.md
@@ -10,7 +10,7 @@
  2 | 
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  x eslint(no-debugger): `debugger` statement is not allowed
     ,-[files/index.js:10:1]
   9 | // should trigger an error
  10 | debugger;

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+  ! eslint(no-debugger): `debugger` statement is not allowed
    ,-[files/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^

--- a/apps/oxlint/test/fixtures/plugin_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name/output.snap.md
@@ -80,7 +80,7 @@
    : ^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-param.html\eslint-plugin-jsdoc(require-param)]8;;\: Missing JSDoc `@param` declaration for function parameters.
+  x eslint-plugin-jsdoc(require-param): Missing JSDoc `@param` declaration for function parameters.
    ,-[files/index.js:4:17]
  3 |  */
  4 | function f(foo, bar) {}

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join as pathJoin, sep as pathSep } from "node:path";
 
 import { execa } from "execa";
+import { stripVTControlCharacters } from "node:util";
 import { expect as defaultExpect, type ExpectStatic } from "vitest";
 
 // Replace backslashes with forward slashes on Windows. Do nothing on Mac/Linux.
@@ -251,6 +252,9 @@ function normalizeStdout(stdout: string, fixtureName: string, isESLint: boolean)
 
     return [line];
   });
+
+  // Strip ANSI/control characters using Node to avoid noise in snapshot results.
+  lines = lines.map(stripVTControlCharacters);
 
   if (lines.length === 0) return "";
   return lines.join("\n") + "\n";


### PR DESCRIPTION
Similar to #18055, but for the vitest snapshots.

This uses the built-in node util [stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr).