### PR TITLE
refactor(linter, mangler): get reference scope by `reference.scope_id()`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -154,8 +154,7 @@ fn run_for_all_references(
     ctx.scoping()
         .get_resolved_references(*symbol)
         .filter(|reference| {
-            let reference_scope_id = ctx.nodes().get_node(reference.node_id()).scope_id();
-
+            let reference_scope_id = reference.scope_id();
             reference_scope_id != node.scope_id() && !scope_ids.contains(&reference_scope_id)
         })
         .for_each(|reference| {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -83,7 +83,7 @@ impl Rule for NoUndef {
                 if name == "arguments"
                     && ctx
                         .scoping()
-                        .scope_ancestors(ctx.nodes().get_node(reference.node_id()).scope_id())
+                        .scope_ancestors(reference.scope_id())
                         .map(|id| ctx.scoping().scope_flags(id))
                         .any(|scope_flags| scope_flags.is_function() && !scope_flags.is_arrow())
                 {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -466,7 +466,7 @@ impl<'a> Symbol<'_, 'a> {
                                 //   cancel = cancel?.();  // `cancel` is used
                                 // }
                                 // ```
-                                if self.get_parent_variable_scope(self.get_ref_scope(reference))
+                                if self.get_parent_variable_scope(Symbol::get_ref_scope(reference))
                                     != self.get_parent_variable_scope(self.scope_id())
                                 {
                                     return false;
@@ -831,8 +831,8 @@ impl<'a> Symbol<'_, 'a> {
 
     /// Get the [`ScopeId`] where a [`Reference`] is located.
     #[inline]
-    fn get_ref_scope(&self, reference: &Reference) -> ScopeId {
-        self.nodes().get_node(reference.node_id()).scope_id()
+    fn get_ref_scope(reference: &Reference) -> ScopeId {
+        reference.scope_id()
     }
 
     /// Get the [`Span`] covering the [`AstNode`] containing a [`Reference`].

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -10,7 +10,7 @@ use base54::base54;
 use oxc_allocator::{Allocator, BitSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
-use oxc_semantic::{AstNodes, Scoping, Semantic, SemanticBuilder, SymbolId};
+use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, SymbolId};
 use oxc_span::{Atom, CompactStr};
 
 pub(crate) mod base54;
@@ -406,9 +406,8 @@ impl<'t> Mangler<'t> {
                     .iter()
                     .map(|r| ast_nodes.get_node(r.declaration).scope_id());
 
-                let referenced_scope_ids = scoping
-                    .get_resolved_references(symbol_id)
-                    .map(|reference| ast_nodes.get_node(reference.node_id()).scope_id());
+                let referenced_scope_ids =
+                    scoping.get_resolved_references(symbol_id).map(Reference::scope_id);
 
                 // Calculate the scope ids that this symbol is alive in.
                 // For each used_scope_id, we walk up the ancestor chain and collect scopes


### PR DESCRIPTION
Simplify the use cases mentioned in #18053. After that PR, we can access the `scope_id` directly from the `Reference`, eliminating the need for an intermediate step to get the node first.

😅: I didn't expect there would be a lot of performance improvement in the Mangler.