### PR TITLE
fix(formatter): move comments to correct position in TS empty body methods

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 579/606 (95.54%)
+ts compatibility: 580/606 (95.71%)
 
 # Failed
 
@@ -13,7 +13,6 @@ ts compatibility: 579/606 (95.54%)
 | typescript/chain-expression/call-expression.ts | 💥 | 68.75% |
 | typescript/chain-expression/member-expression.ts | 💥 | 65.67% |
 | typescript/chain-expression/test.ts | 💥 | 0.00% |
-| typescript/class/empty-method-body.ts | 💥 | 80.00% |
 | typescript/class/quoted-property.ts | 💥 | 66.67% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |


### PR DESCRIPTION
## Summary

- Fixed comment placement in TypeScript methods with empty bodies (`TSEmptyBodyFunctionExpression`)
- Comments after the params/return type are now correctly moved before the params to match Prettier's behavior
- Example: `bar() /* bat */;` now formats to `bar /* bat */();`

## Technical Details

This fix handles the tricky case of out-of-order comment printing:

1. Collects comments that appear after params but before the semicolon
2. Prints them before the params (without incrementing `printed_count` yet)
3. After params are formatted, increments `printed_count` to skip these comments
4. This ensures comments inside params (like `/* 2 */` in `foo (/* 2 */) /* 3 */;`) are still printed correctly

## Test plan

- [x] `cargo run -p oxc_prettier_conformance -- --filter empty-method-body` passes
- [x] `cargo test -p oxc_formatter` passes
- [x] No regressions in overall conformance

🤖 Generated with [Claude Code](https://claude.ai/code)