### PR TITLE
test(formatter): ignore typescript multiparser tests

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 579/607 (95.39%)
+ts compatibility: 579/606 (95.54%)
 
 # Failed
 
@@ -24,7 +24,6 @@ ts compatibility: 579/607 (95.39%)
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/mapped-type/break-mode/break-mode.ts | 💥 | 68.75% |
-| typescript/multiparser-css/issue-6259.ts | 💥 | 57.14% |
 | typescript/non-null/optional-chain.ts | 💥 | 72.22% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/union/union-parens.ts | 💥 | 92.59% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -86,6 +86,7 @@ pub const IGNORE_TESTS: &[&str] = &[
     "js/module-blocks",
     // embedded
     "js/multiparser",
+    "typescript/multiparser",
     "typescript/angular-component-examples",
     "js/partial-application",
     "js/pipeline-operator",


### PR DESCRIPTION
## Summary
- Ignore `typescript/multiparser` tests in prettier conformance since they require parsing embedded languages (CSS, HTML, etc.) which is not supported

## Test plan
- `cargo run -p oxc_prettier_conformance` shows these tests are now skipped

🤖 Generated with [Claude Code](https://claude.ai/code)