### PR TITLE
feat(linter): Add support for no constructed context values

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2323,6 +2323,14 @@ impl RuleRunner for crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentT
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::react::jsx_no_constructed_context_values::JsxNoConstructedContextValues
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -392,6 +392,7 @@ pub use crate::rules::react::jsx_handler_names::JsxHandlerNames as ReactJsxHandl
 pub use crate::rules::react::jsx_key::JsxKey as ReactJsxKey;
 pub use crate::rules::react::jsx_max_depth::JsxMaxDepth as ReactJsxMaxDepth;
 pub use crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes as ReactJsxNoCommentTextnodes;
+pub use crate::rules::react::jsx_no_constructed_context_values::JsxNoConstructedContextValues as ReactJsxNoConstructedContextValues;
 pub use crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps as ReactJsxNoDuplicateProps;
 pub use crate::rules::react::jsx_no_script_url::JsxNoScriptUrl as ReactJsxNoScriptUrl;
 pub use crate::rules::react::jsx_no_target_blank::JsxNoTargetBlank as ReactJsxNoTargetBlank;
@@ -1051,6 +1052,7 @@ pub enum RuleEnum {
     ReactJsxKey(ReactJsxKey),
     ReactJsxMaxDepth(ReactJsxMaxDepth),
     ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes),
+    ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues),
     ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps),
     ReactJsxNoScriptUrl(ReactJsxNoScriptUrl),
     ReactJsxNoTargetBlank(ReactJsxNoTargetBlank),
@@ -1766,7 +1768,9 @@ const REACT_JSX_HANDLER_NAMES_ID: usize = REACT_JSX_FRAGMENTS_ID + 1usize;
 const REACT_JSX_KEY_ID: usize = REACT_JSX_HANDLER_NAMES_ID + 1usize;
 const REACT_JSX_MAX_DEPTH_ID: usize = REACT_JSX_KEY_ID + 1usize;
 const REACT_JSX_NO_COMMENT_TEXTNODES_ID: usize = REACT_JSX_MAX_DEPTH_ID + 1usize;
-const REACT_JSX_NO_DUPLICATE_PROPS_ID: usize = REACT_JSX_NO_COMMENT_TEXTNODES_ID + 1usize;
+const REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID: usize =
+    REACT_JSX_NO_COMMENT_TEXTNODES_ID + 1usize;
+const REACT_JSX_NO_DUPLICATE_PROPS_ID: usize = REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID + 1usize;
 const REACT_JSX_NO_SCRIPT_URL_ID: usize = REACT_JSX_NO_DUPLICATE_PROPS_ID + 1usize;
 const REACT_JSX_NO_TARGET_BLANK_ID: usize = REACT_JSX_NO_SCRIPT_URL_ID + 1usize;
 const REACT_JSX_NO_UNDEF_ID: usize = REACT_JSX_NO_TARGET_BLANK_ID + 1usize;
@@ -2538,6 +2542,9 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => REACT_JSX_KEY_ID,
             Self::ReactJsxMaxDepth(_) => REACT_JSX_MAX_DEPTH_ID,
             Self::ReactJsxNoCommentTextnodes(_) => REACT_JSX_NO_COMMENT_TEXTNODES_ID,
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID
+            }
             Self::ReactJsxNoDuplicateProps(_) => REACT_JSX_NO_DUPLICATE_PROPS_ID,
             Self::ReactJsxNoScriptUrl(_) => REACT_JSX_NO_SCRIPT_URL_ID,
             Self::ReactJsxNoTargetBlank(_) => REACT_JSX_NO_TARGET_BLANK_ID,
@@ -3305,6 +3312,7 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::NAME,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::NAME,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::NAME,
+            Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::NAME,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::NAME,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::NAME,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::NAME,
@@ -4090,6 +4098,9 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::CATEGORY,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::CATEGORY,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::CATEGORY,
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                ReactJsxNoConstructedContextValues::CATEGORY
+            }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::CATEGORY,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::CATEGORY,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::CATEGORY,
@@ -4872,6 +4883,7 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::FIX,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::FIX,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::FIX,
+            Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::FIX,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::FIX,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::FIX,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::FIX,
@@ -5720,6 +5732,9 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::documentation(),
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::documentation(),
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::documentation(),
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                ReactJsxNoConstructedContextValues::documentation()
+            }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::documentation(),
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::documentation(),
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::documentation(),
@@ -7171,6 +7186,10 @@ impl RuleEnum {
                 ReactJsxNoCommentTextnodes::config_schema(generator)
                     .or_else(|| ReactJsxNoCommentTextnodes::schema(generator))
             }
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                ReactJsxNoConstructedContextValues::config_schema(generator)
+                    .or_else(|| ReactJsxNoConstructedContextValues::schema(generator))
+            }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::config_schema(generator)
                 .or_else(|| ReactJsxNoDuplicateProps::schema(generator)),
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::config_schema(generator)
@@ -8422,6 +8441,7 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => "react",
             Self::ReactJsxMaxDepth(_) => "react",
             Self::ReactJsxNoCommentTextnodes(_) => "react",
+            Self::ReactJsxNoConstructedContextValues(_) => "react",
             Self::ReactJsxNoDuplicateProps(_) => "react",
             Self::ReactJsxNoScriptUrl(_) => "react",
             Self::ReactJsxNoTargetBlank(_) => "react",
@@ -9894,6 +9914,11 @@ impl RuleEnum {
             Self::ReactJsxNoCommentTextnodes(_) => Ok(Self::ReactJsxNoCommentTextnodes(
                 ReactJsxNoCommentTextnodes::from_configuration(value)?,
             )),
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                Ok(Self::ReactJsxNoConstructedContextValues(
+                    ReactJsxNoConstructedContextValues::from_configuration(value)?,
+                ))
+            }
             Self::ReactJsxNoDuplicateProps(_) => Ok(Self::ReactJsxNoDuplicateProps(
                 ReactJsxNoDuplicateProps::from_configuration(value)?,
             )),
@@ -11249,6 +11274,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.to_configuration(),
             Self::ReactJsxMaxDepth(rule) => rule.to_configuration(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.to_configuration(),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.to_configuration(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.to_configuration(),
             Self::ReactJsxNoScriptUrl(rule) => rule.to_configuration(),
             Self::ReactJsxNoTargetBlank(rule) => rule.to_configuration(),
@@ -11926,6 +11952,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.run(node, ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run(node, ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run(node, ctx),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.run(node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run(node, ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run(node, ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run(node, ctx),
@@ -12601,6 +12628,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.run_once(ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run_once(ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_once(ctx),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.run_once(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_once(ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_once(ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_once(ctx),
@@ -13336,6 +13364,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14041,6 +14070,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.should_run(ctx),
             Self::ReactJsxMaxDepth(rule) => rule.should_run(ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.should_run(ctx),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.should_run(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.should_run(ctx),
             Self::ReactJsxNoScriptUrl(rule) => rule.should_run(ctx),
             Self::ReactJsxNoTargetBlank(rule) => rule.should_run(ctx),
@@ -14858,6 +14888,9 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::IS_TSGOLINT_RULE,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::IS_TSGOLINT_RULE,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::IS_TSGOLINT_RULE,
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                ReactJsxNoConstructedContextValues::IS_TSGOLINT_RULE
+            }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::IS_TSGOLINT_RULE,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::IS_TSGOLINT_RULE,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::IS_TSGOLINT_RULE,
@@ -15754,6 +15787,9 @@ impl RuleEnum {
             Self::ReactJsxKey(_) => ReactJsxKey::HAS_CONFIG,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::HAS_CONFIG,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::HAS_CONFIG,
+            Self::ReactJsxNoConstructedContextValues(_) => {
+                ReactJsxNoConstructedContextValues::HAS_CONFIG
+            }
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::HAS_CONFIG,
             Self::ReactJsxNoScriptUrl(_) => ReactJsxNoScriptUrl::HAS_CONFIG,
             Self::ReactJsxNoTargetBlank(_) => ReactJsxNoTargetBlank::HAS_CONFIG,
@@ -16491,6 +16527,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.types_info(),
             Self::ReactJsxMaxDepth(rule) => rule.types_info(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.types_info(),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.types_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.types_info(),
             Self::ReactJsxNoScriptUrl(rule) => rule.types_info(),
             Self::ReactJsxNoTargetBlank(rule) => rule.types_info(),
@@ -17166,6 +17203,7 @@ impl RuleEnum {
             Self::ReactJsxKey(rule) => rule.run_info(),
             Self::ReactJsxMaxDepth(rule) => rule.run_info(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_info(),
+            Self::ReactJsxNoConstructedContextValues(rule) => rule.run_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_info(),
             Self::ReactJsxNoScriptUrl(rule) => rule.run_info(),
             Self::ReactJsxNoTargetBlank(rule) => rule.run_info(),
@@ -17919,6 +17957,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactJsxKey(ReactJsxKey::default()),
         RuleEnum::ReactJsxMaxDepth(ReactJsxMaxDepth::default()),
         RuleEnum::ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes::default()),
+        RuleEnum::ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues::default()),
         RuleEnum::ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps::default()),
         RuleEnum::ReactJsxNoScriptUrl(ReactJsxNoScriptUrl::default()),
         RuleEnum::ReactJsxNoTargetBlank(ReactJsxNoTargetBlank::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -378,6 +378,7 @@ pub(crate) mod react {
     pub mod jsx_key;
     pub mod jsx_max_depth;
     pub mod jsx_no_comment_textnodes;
+    pub mod jsx_no_constructed_context_values;
     pub mod jsx_no_duplicate_props;
     pub mod jsx_no_script_url;
     pub mod jsx_no_target_blank;

--- a/crates/oxc_linter/src/rules/react/jsx_no_constructed_context_values.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_constructed_context_values.rs
@@ -1,0 +1,574 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        Expression, IdentifierReference, JSXAttributeItem, JSXAttributeName, JSXAttributeValue,
+        JSXOpeningElement,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::Rule,
+};
+
+fn jsx_no_constructed_context_values(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The Context `value` prop should not be constructed.")
+        .with_help("Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.\nAlternatively, move the value outside the render function if it doesn't depend on props or state.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsxNoConstructedContextValues;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows JSX context provider values from taking values that will cause needless rerenders.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// React Context and all its child nodes and Consumers are rerendered whenever the value prop
+    /// changes. Because each JavaScript object carries its own identity, things like object
+    /// expressions (`{foo: 'bar'}`) or function expressions get a new identity on every render.
+    /// This makes the context think it has gotten a new object and can cause needless rerenders
+    /// and unintended consequences.
+    ///
+    /// This can be a large performance hit because not only will it cause the context providers
+    /// and consumers to rerender with all the elements in its subtree, the processing for the
+    /// tree scan React does to render the provider and find consumers is also wasted.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// return (
+    ///   <SomeContext.Provider value={{foo: 'bar'}}>
+    ///     ...
+    ///   </SomeContext.Provider>
+    /// )
+    /// ```
+    ///
+    /// ```jsx
+    /// function Component() {
+    ///   function foo() {}
+    ///   return <MyContext.Provider value={foo} />
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const foo = useMemo(() => ({foo: 'bar'}), []);
+    /// return (
+    ///   <SomeContext.Provider value={foo}>
+    ///     ...
+    ///   </SomeContext.Provider>
+    /// )
+    /// ```
+    ///
+    /// ```jsx
+    /// const MyContext = createContext();
+    /// const Component = () => <MyContext.Provider value="Some string" />
+    /// ```
+    JsxNoConstructedContextValues,
+    react,
+    perf,
+);
+
+impl Rule for JsxNoConstructedContextValues {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a Context.Provider component or a createContext() context
+        if !is_context_provider(jsx_opening_elem, ctx) {
+            return;
+        }
+
+        // Check if we're inside a function component (not a top-level render call)
+        if !is_inside_component(node, ctx) {
+            return;
+        }
+
+        // Find the "value" prop
+        for attr in &jsx_opening_elem.attributes {
+            let JSXAttributeItem::Attribute(attr) = attr else {
+                continue;
+            };
+
+            let JSXAttributeName::Identifier(attr_name) = &attr.name else {
+                continue;
+            };
+
+            if attr_name.name != "value" {
+                continue;
+            }
+
+            if let Some(attr_value) = &attr.value
+                && is_constructed_value(attr_value, ctx)
+            {
+                ctx.diagnostic(jsx_no_constructed_context_values(attr.span()));
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+fn is_context_provider(jsx_opening_elem: &JSXOpeningElement, ctx: &LintContext<'_>) -> bool {
+    match &jsx_opening_elem.name {
+        oxc_ast::ast::JSXElementName::MemberExpression(member_expr) => {
+            &member_expr.property.name == "Provider"
+        }
+        name @ (oxc_ast::ast::JSXElementName::Identifier(_)
+        | oxc_ast::ast::JSXElementName::IdentifierReference(_)) => {
+            // Check if this identifier refers to a context created with createContext()
+            name.get_identifier().is_some_and(|ident| is_react_context(ident, ctx))
+        }
+        _ => false,
+    }
+}
+
+/// Checks if an identifier refers to a React context created with createContext()
+fn is_react_context(ident: &IdentifierReference, ctx: &LintContext) -> bool {
+    let reference = ctx.scoping().get_reference(ident.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+
+    // Get the symbol's declaration
+    let declaration_node_id = ctx.scoping().symbol_declaration(symbol_id);
+    let declaration_node = ctx.nodes().get_node(declaration_node_id);
+
+    // Check if it's a variable declarator with createContext() initializer
+    let AstKind::VariableDeclarator(decl) = declaration_node.kind() else {
+        return false;
+    };
+
+    let Some(init) = &decl.init else {
+        return false;
+    };
+
+    is_create_context_call(init)
+}
+
+/// Checks if an expression is a call to createContext() or React.createContext()
+fn is_create_context_call(expr: &Expression) -> bool {
+    let Expression::CallExpression(call_expr) = expr else {
+        return false;
+    };
+
+    match &call_expr.callee {
+        // Direct call: createContext()
+        Expression::Identifier(ident) => ident.name == "createContext",
+        // Member call: React.createContext()
+        Expression::StaticMemberExpression(member) => {
+            if let Expression::Identifier(obj) = &member.object {
+                obj.name == "React" && member.property.name == "createContext"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Checks if the JSX element is inside a React component (function or class).
+/// Top-level render calls like `ReactDOM.createRoot(...).render()` should not trigger the rule.
+fn is_inside_component(node: &AstNode, ctx: &LintContext) -> bool {
+    for parent_id in ctx.nodes().ancestor_ids(node.id()).skip(1) {
+        let parent = ctx.nodes().get_node(parent_id);
+        match parent.kind() {
+            // Arrow function, regular function, or class method - likely a component
+            AstKind::ArrowFunctionExpression(_)
+            | AstKind::Function(_)
+            | AstKind::MethodDefinition(_) => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn is_constructed_value(attr_value: &JSXAttributeValue, ctx: &LintContext) -> bool {
+    match attr_value {
+        JSXAttributeValue::ExpressionContainer(container) => {
+            if let Some(expr) = container.expression.as_expression() {
+                is_constructed_expression(expr, ctx)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_constructed_expression(expr: &Expression, ctx: &LintContext) -> bool {
+    let expr = expr.get_inner_expression();
+    match expr {
+        Expression::ObjectExpression(_)
+        | Expression::ArrayExpression(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::JSXElement(_)
+        | Expression::JSXFragment(_)
+        | Expression::ClassExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::UpdateExpression(_)
+        | Expression::AssignmentExpression(_)
+        | Expression::TaggedTemplateExpression(_)
+        | Expression::AwaitExpression(_)
+        | Expression::YieldExpression(_)
+        | Expression::ImportExpression(_) => true,
+
+        Expression::CallExpression(call_expr) => {
+            if let Expression::Identifier(ident) = &call_expr.callee {
+                let name = ident.name.as_str();
+                if name == "useMemo" || name == "useCallback" {
+                    return false;
+                }
+            }
+            true
+        }
+
+        Expression::TemplateLiteral(template) => !template.expressions.is_empty(),
+
+        Expression::BinaryExpression(bin_expr) => {
+            is_constructed_expression(&bin_expr.left, ctx)
+                || is_constructed_expression(&bin_expr.right, ctx)
+        }
+
+        Expression::LogicalExpression(log_expr) => {
+            is_constructed_expression(&log_expr.left, ctx)
+                || is_constructed_expression(&log_expr.right, ctx)
+        }
+
+        Expression::ConditionalExpression(cond_expr) => {
+            is_constructed_expression(&cond_expr.consequent, ctx)
+                || is_constructed_expression(&cond_expr.alternate, ctx)
+        }
+
+        Expression::UnaryExpression(unary_expr) => {
+            is_constructed_expression(&unary_expr.argument, ctx)
+        }
+
+        Expression::SequenceExpression(seq_expr) => {
+            seq_expr.expressions.iter().any(|e| is_constructed_expression(e, ctx))
+        }
+
+        Expression::Identifier(ident) => is_identifier_a_constructed_value(ident, ctx),
+
+        Expression::ChainExpression(chain_expr) => match &chain_expr.expression {
+            oxc_ast::ast::ChainElement::CallExpression(call) => {
+                if let Expression::Identifier(ident) = &call.callee {
+                    let name = ident.name.as_str();
+                    if name == "useMemo" || name == "useCallback" {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => false,
+        },
+
+        _ => false,
+    }
+}
+
+/// Checks if an identifier refers to a constructed value defined within the current component.
+/// Constructed values are recreated on every render, causing unnecessary re-renders.
+fn is_identifier_a_constructed_value(ident: &IdentifierReference, ctx: &LintContext) -> bool {
+    let reference = ctx.scoping().get_reference(ident.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+
+    // Check if the symbol is declared at module/top level (not inside a function)
+    // Top-level declarations are stable and don't get recreated on each render
+    let symbol_scope_id = ctx.scoping().symbol_scope_id(symbol_id);
+    if ctx.scoping().scope_flags(symbol_scope_id).is_top() {
+        return false;
+    }
+
+    let declaration_node_id = ctx.scoping().symbol_declaration(symbol_id);
+    let declaration_node = ctx.nodes().get_node(declaration_node_id);
+
+    match declaration_node.kind() {
+        // Function declarations and class declarations
+        AstKind::Function(_) | AstKind::Class(_) => true,
+        // Variable declarations - check the initializer for constructed values
+        AstKind::VariableDeclarator(decl) => {
+            if let Some(init) = &decl.init {
+                is_construction_expression(init, ctx)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Checks if an expression is a construction that creates a new object identity.
+/// This is used for checking variable initializers.
+fn is_construction_expression(expr: &Expression, ctx: &LintContext) -> bool {
+    let expr = expr.get_inner_expression();
+    match expr {
+        // Direct constructions and regex literals create new objects
+        Expression::ObjectExpression(_)
+        | Expression::ArrayExpression(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::ClassExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::JSXElement(_)
+        | Expression::JSXFragment(_)
+        | Expression::RegExpLiteral(_) => true,
+
+        // Conditional/logical expressions - check if any branch is a construction
+        Expression::ConditionalExpression(cond_expr) => {
+            is_construction_expression(&cond_expr.consequent, ctx)
+                || is_construction_expression(&cond_expr.alternate, ctx)
+        }
+        Expression::LogicalExpression(log_expr) => {
+            is_construction_expression(&log_expr.left, ctx)
+                || is_construction_expression(&log_expr.right, ctx)
+        }
+
+        // Assignment expressions - check the right side
+        Expression::AssignmentExpression(assign_expr) => {
+            is_construction_expression(&assign_expr.right, ctx)
+        }
+
+        // For identifiers, recursively check if they refer to constructed values
+        Expression::Identifier(ident) => is_identifier_a_constructed_value(ident, ctx),
+
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Original eslint-plugin-react tests
+        "const Component = () => <Context.Provider value={props}></Context.Provider>",
+        "const Component = () => <Context.Provider value={100}></Context.Provider>",
+        r#"const Component = () => <Context.Provider value="Some string"></Context.Provider>"#,
+        "function Component() { const foo = useMemo(() => { return {} }, []); return (<Context.Provider value={foo}></Context.Provider>)}",
+        "
+            function Component({oneProp, twoProp, redProp, blueProp,}) {
+              return (
+                <NewContext.Provider value={twoProp}></NewContext.Provider>
+              );
+            }
+        ",
+        "
+            function Foo(section) {
+              const foo = section.section_components?.edges;
+              return (
+                <Context.Provider value={foo}></Context.Provider>
+              )
+            }
+        ",
+        "
+            import foo from 'foo';
+            function innerContext() {
+              return (
+                <Context.Provider value={foo.something}></Context.Provider>
+              )
+            }
+        ",
+        "
+            // Passes because the lint rule doesn't handle JSX spread attributes
+            function innerContext() {
+              const foo = {value: 'something'}
+              return (
+                <Context.Provider {...foo}></Context.Provider>
+              )
+            }
+        ",
+        "
+            // Passes because the lint rule doesn't handle JSX spread attributes
+            function innerContext() {
+              const foo = useMemo(() => {
+                return bar;
+              })
+              return (
+                <Context.Provider value={foo}></Context.Provider>
+              )
+            }
+        ",
+        "
+            // Passes because we can't statically check if it's using the default value
+            function Component({ a = {} }) {
+              return (<Context.Provider value={a}></Context.Provider>);
+            }
+        ",
+        "
+            import React from 'react';
+            import MyContext from './MyContext';
+
+            const value = '';
+
+            function ContextProvider(props) {
+                return (
+                    <MyContext.Provider value={value as any}>
+                        {props.children}
+                    </MyContext.Provider>
+                )
+            }
+        ",
+        "
+            import React from 'react';
+            import BooleanContext from './BooleanContext';
+
+            function ContextProvider(props) {
+                return (
+                    <BooleanContext.Provider value>
+                        {props.children}
+                    </BooleanContext.Provider>
+                )
+            }
+        ",
+        "
+            const root = ReactDOM.createRoot(document.getElementById('root'));
+            root.render(
+              <AppContext.Provider value={{}}>
+                <AppView />
+              </AppContext.Provider>
+            );
+        ",
+        "
+            // Passes because the context is not a provider
+            function Component() {
+              return <MyContext.Consumer value={{ foo: 'bar' }} />;
+            }
+        ",
+        // Tests for createContext() - contexts used directly without .Provider
+        // These should pass because they're not inside components or don't use constructed values
+        "
+            import React from 'react';
+
+            const MyContext = React.createContext();
+            const Component = () => <MyContext value={props}></MyContext>;
+        ",
+        "
+            import React from 'react';
+
+            const MyContext = React.createContext();
+            const Component = () => <MyContext value={100}></MyContext>;
+        ",
+        "
+            const SomeContext = createContext();
+            const Component = () => <SomeContext value=\"Some string\"></SomeContext>;
+        ",
+        "
+            // Passes because MyContext is not a variable declarator
+            function Component({ MyContext }) {
+              return <MyContext value={{ foo: \"bar\" }} />;
+            }
+        ",
+    ];
+
+    let fail = vec![
+        // Invalid because object construction creates a new identity
+        "function Component() { const foo = {}; return (<Context.Provider value={foo}></Context.Provider>) }",
+        // Invalid because array construction creates a new identity
+        "function Component() { const foo = []; return (<Context.Provider value={foo}></Context.Provider>) }",
+        // Invalid because arrow Function creates a new identity
+        "function Component() { const foo = () => {}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because function expression creates a new identity
+        "function Component() { const foo = function bar(){}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because class expression creates a new identity
+        "function Component() { const foo = class SomeClass{}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because new expression creates a new identity
+        "function Component() { const foo = new SomeClass(); return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because function declaration creates a new identity
+        "function Component() { function foo() {}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because the object value of the ternary will create a new identity
+        r#"function Component() { const foo = true ? {} : "fine"; return (<Context.Provider value={foo}></Context.Provider>)}"#,
+        // Invalid because the object value of the logical OR will create a new identity
+        "function Component() { const foo = bar || {}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because the object value of the logical AND will create a new identity
+        "function Component() { const foo = bar && {}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because the object value of the nested ternary will create a new identity
+        "function Component() { const foo = bar ? baz ? {} : null : null; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Invalid because the object value will create a new identity (let)
+        "function Component() { let foo = {}; return (<Context.Provider value={foo}></Context.Provider>) }",
+        // Invalid because the object value will create a new identity (var)
+        "function Component() { var foo = {}; return (<Context.Provider value={foo}></Context.Provider>)}",
+        // Variable reassignment - currently reports the object identity
+        "
+            function Component() {
+              let a = {};
+              a = 10;
+              return (<Context.Provider value={a}></Context.Provider>);
+            }
+        ",
+        // Invalid variable reassignment from parameter because bar is an object identity
+        "
+            function Component() {
+              const foo = {};
+              const bar = foo;
+              return (<Context.Provider value={bar}></Context.Provider>);
+            }
+        ",
+        // Invalid because the object expression possibly returned from the ternary will create a new identity
+        "
+            function Component(foo) {
+              let bar = true ? foo : {};
+              return (<Context.Provider value={bar}></Context.Provider>);
+            }
+        ",
+        // Invalid because inline object construction will create a new identity
+        r#"function Component() { return (<Context.Provider value={{foo: "bar"}}></Context.Provider>);}"#,
+        // Invalid because Wrapper returns JSX which has a new identity
+        "function Component() { const Wrapper = (<SomeComp />); return (<Context.Provider value={Wrapper}></Context.Provider>);}",
+        // Invalid because RegEx returns a new object which has a new identity
+        "function Component() { const someRegex = /HelloWorld/; return (<Context.Provider value={someRegex}></Context.Provider>);}",
+        // Invalid because the right hand side of the assignment expression contains a function
+        "
+            function Component() {
+              let foo = null;
+              let bar = x = () => {};
+              return (<Context.Provider value={bar}></Context.Provider>);
+            }
+        ",
+        // Invalid because function declaration creates a new identity - with createContext
+        "
+            import React from 'react';
+
+            const Context = React.createContext();
+            function Component() {
+              function foo() {};
+              return (<Context value={foo}></Context>)
+            }
+        ",
+        // Invalid because the object value will create a new identity - with createContext
+        "
+            const MyContext = createContext();
+            function Component() { const foo = {}; return (<MyContext value={foo}></MyContext>) }
+        ",
+        // Invalid because inline object construction will create a new identity - with createContext
+        "
+            const MyContext = createContext();
+            function Component() { return (<MyContext value={{foo: \"bar\"}}></MyContext>); }
+        ",
+    ];
+
+    Tester::new(
+        JsxNoConstructedContextValues::NAME,
+        JsxNoConstructedContextValues::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_constructed_context_values.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_constructed_context_values.snap
@@ -1,0 +1,201 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:66]
+ 1 │ function Component() { const foo = {}; return (<Context.Provider value={foo}></Context.Provider>) }
+   ·                                                                  ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:66]
+ 1 │ function Component() { const foo = []; return (<Context.Provider value={foo}></Context.Provider>) }
+   ·                                                                  ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:72]
+ 1 │ function Component() { const foo = () => {}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                        ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:80]
+ 1 │ function Component() { const foo = function bar(){}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                                ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:81]
+ 1 │ function Component() { const foo = class SomeClass{}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                                 ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:79]
+ 1 │ function Component() { const foo = new SomeClass(); return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                               ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:69]
+ 1 │ function Component() { function foo() {}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                     ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:82]
+ 1 │ function Component() { const foo = true ? {} : "fine"; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                                  ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:73]
+ 1 │ function Component() { const foo = bar || {}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                         ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:73]
+ 1 │ function Component() { const foo = bar && {}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                         ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:92]
+ 1 │ function Component() { const foo = bar ? baz ? {} : null : null; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                                            ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:64]
+ 1 │ function Component() { let foo = {}; return (<Context.Provider value={foo}></Context.Provider>) }
+   ·                                                                ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:64]
+ 1 │ function Component() { var foo = {}; return (<Context.Provider value={foo}></Context.Provider>)}
+   ·                                                                ───────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:5:41]
+ 4 │               a = 10;
+ 5 │               return (<Context.Provider value={a}></Context.Provider>);
+   ·                                         ─────────
+ 6 │             }
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:5:41]
+ 4 │               const bar = foo;
+ 5 │               return (<Context.Provider value={bar}></Context.Provider>);
+   ·                                         ───────────
+ 6 │             }
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:4:41]
+ 3 │               let bar = true ? foo : {};
+ 4 │               return (<Context.Provider value={bar}></Context.Provider>);
+   ·                                         ───────────
+ 5 │             }
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:50]
+ 1 │ function Component() { return (<Context.Provider value={{foo: "bar"}}></Context.Provider>);}
+   ·                                                  ────────────────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:82]
+ 1 │ function Component() { const Wrapper = (<SomeComp />); return (<Context.Provider value={Wrapper}></Context.Provider>);}
+   ·                                                                                  ───────────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:1:82]
+ 1 │ function Component() { const someRegex = /HelloWorld/; return (<Context.Provider value={someRegex}></Context.Provider>);}
+   ·                                                                                  ─────────────────
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:5:41]
+ 4 │               let bar = x = () => {};
+ 5 │               return (<Context.Provider value={bar}></Context.Provider>);
+   ·                                         ───────────
+ 6 │             }
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:7:32]
+ 6 │               function foo() {};
+ 7 │               return (<Context value={foo}></Context>)
+   ·                                ───────────
+ 8 │             }
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:3:71]
+ 2 │             const MyContext = createContext();
+ 3 │             function Component() { const foo = {}; return (<MyContext value={foo}></MyContext>) }
+   ·                                                                       ───────────
+ 4 │         
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.
+
+  ⚠ eslint-plugin-react(jsx-no-constructed-context-values): The Context `value` prop should not be constructed.
+   ╭─[jsx_no_constructed_context_values.tsx:3:55]
+ 2 │             const MyContext = createContext();
+ 3 │             function Component() { return (<MyContext value={{foo: "bar"}}></MyContext>); }
+   ·                                                       ────────────────────
+ 4 │         
+   ╰────
+  help: Wrap the `value` prop in useMemo() or useCallback(), or use a constant value to prevent unnecessary rerenders.
+        Alternatively, move the value outside the render function if it doesn't depend on props or state.


### PR DESCRIPTION
Relates to https://github.com/oxc-project/oxc/issues/1022

This rule is quite important for performance reasons, when we always create a new object/array/... in the `value` property it means we'll be propagating updates to all subscribers every time the Provider component re-renders. 