### PR TITLE
fix(formatter): preserve whitespace structure in FBT elements

### DIFF
--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -141,6 +141,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
                     let children = self.children();
                     let format_children = FormatJsxChildList::default()
                         .with_options(list_layout)
+                        .with_fbt(self.is_fbt())
                         .fmt_children(children, f);
 
                     match format_children {
@@ -244,6 +245,20 @@ pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
 }
 
 impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
+    /// Returns `true` if this is a Facebook Translation (`<fbt>`) element.
+    /// FBT elements have special whitespace handling to preserve structure for translators.
+    fn is_fbt(&self) -> bool {
+        match self {
+            Self::Element(element) => {
+                matches!(
+                    &element.opening_element.name,
+                    oxc_ast::ast::JSXElementName::Identifier(ident) if ident.name == "fbt"
+                )
+            }
+            Self::Fragment(_) => false,
+        }
+    }
+
     fn fmt_opening(&self, f: &mut Formatter<'_, 'a>) {
         match self {
             Self::Element(element) => {

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -265,6 +265,7 @@ impl FusedIterator for JsxSplitChunksIterator<'_> {}
 pub fn jsx_split_children<'a, 'b>(
     children: &'b AstNode<'a, ArenaVec<'a, JSXChild<'a>>>,
     comments: &Comments<'a>,
+    preserve_newlines: bool,
 ) -> Vec<JsxChild<'a, 'b>> {
     let mut builder = JsxSplitChildrenBuilder::new();
 
@@ -297,6 +298,9 @@ pub fn jsx_split_children<'a, 'b>(
                                     // ```
                                     if newlines > 1 {
                                         builder.entry(JsxChild::EmptyLine);
+                                    } else if preserve_newlines {
+                                        // For FBT elements, preserve single newlines to maintain structure for translators
+                                        builder.entry(JsxChild::Newline);
                                     }
 
                                     continue;

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 743/761 (97.63%)
+js compatibility: 744/761 (97.77%)
 
 # Failed
 
@@ -19,6 +19,5 @@ js compatibility: 743/761 (97.63%)
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
-| jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,10 +1,9 @@
-ts compatibility: 579/606 (95.54%)
+ts compatibility: 580/606 (95.71%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/ignore/spread.js | 💥 | 83.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |


### PR DESCRIPTION
## Summary
- Add special handling for Facebook Translation (`<fbt>`) elements to preserve whitespace structure for translators, matching Prettier's behavior
- Use NoFill layout for FBT elements to preserve exact formatting
- Preserve single newlines in FBT elements (vs. collapsing them)

## Test plan
- `jsx/fbt/test.js` now passes in prettier conformance
- Verified `jsx/ignore/jsx_ignore.js` still passes (no regression)
- Ran `cargo test -p oxc_formatter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)