### PR TITLE
test(transformer): add test for async arrow with super in static property

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: fc58af40
 
-Passed: 201/333
+Passed: 202/334
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -40,7 +40,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# babel-plugin-transform-class-properties (24/31)
+# babel-plugin-transform-class-properties (25/32)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/input.js
@@ -1,0 +1,3 @@
+class C {
+  static fn = async () => [this, super.staticProp];
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    "transform-async-to-generator"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-async-super/output.js
@@ -1,0 +1,9 @@
+var _C;
+class C {}
+_C = C;
+babelHelpers.defineProperty(C, "fn", (() => {
+  var _superprop_getStaticProp = () => babelHelpers.superPropGet(_C, "staticProp", _C), _this = _C;
+  return babelHelpers.asyncToGenerator(function* () {
+    return [_this, _superprop_getStaticProp()];
+  });
+})());


### PR DESCRIPTION
## Summary
- Adds a test case covering the interaction between `transform-class-properties` and `transform-async-to-generator` when `super` is accessed in an async arrow function within a static class property
- Verifies that `super` references are correctly hoisted before async transformation

## Test plan
- [x] Test passes with `cargo run -p oxc_transform_conformance -- --filter static-async-super`
- [x] Conformance tests pass with `just conformance`

Closes #8326

🤖 Generated with [Claude Code](https://claude.com/claude-code)