### PR TITLE
fix(linter): fix stack overflow in `no-unreachable` rule on large files

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -3,7 +3,7 @@ use oxc_cfg::{
     EdgeType, ErrorEdgeKind, Instruction, InstructionKind,
     graph::{
         Direction,
-        visit::{Control, DfsEvent, EdgeRef, depth_first_search},
+        visit::{Control, DfsEvent, EdgeRef, set_depth_first_search},
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -77,7 +77,7 @@ impl Rule for NoUnreachable {
         // In our first path we first check if each block is definitely unreachable, If it is then
         // we set it as such, If we encounter an infinite loop we keep its end block since it can
         // prevent other reachable blocks from ever getting executed.
-        let _: Control<()> = depth_first_search(graph, Some(root_cfg_id), |event| {
+        let _: Control<()> = set_depth_first_search(graph, Some(root_cfg_id), |event| {
             if let DfsEvent::Finish(node, _) = event {
                 let unreachable = cfg.basic_block(node).is_unreachable();
                 unreachables[node.index()] = unreachable;
@@ -115,7 +115,7 @@ impl Rule for NoUnreachable {
                 .collect();
 
             // Search with all `Normal` edges as starting point(s).
-            let _: Control<()> = depth_first_search(graph, starts, |event| match event {
+            let _: Control<()> = set_depth_first_search(graph, starts, |event| match event {
                 DfsEvent::Discover(node, _) => {
                     let mut incoming = graph.edges_directed(node, Direction::Incoming);
                     if incoming.any(|e| match e.weight() {


### PR DESCRIPTION
## Summary

- Convert `set_depth_first_search` in `oxc_cfg` from recursive to iterative implementation using an explicit stack
- Update `no-unreachable` rule to use the iterative DFS instead of petgraph's recursive `depth_first_search`

This fixes stack overflow when linting large files with many basic blocks in the control flow graph.

Closes #11250

## Test plan

- [x] All 916 linter tests pass
- [x] Verified fix with reduced stack size: `RUST_MIN_STACK=262144 ./target/debug/oxlint -A all -D no-unreachable large_file.js`
- [x] Also tested with 128KB stack size successfully

🤖 Generated with [Claude Code](https://claude.ai/code)