### PR TITLE
fix(formatter): handle quoteProps: "consistent" for identifier and numeric keys

### DIFF
--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -26,7 +26,7 @@ oxc_data_structures = { workspace = true, features = ["stack", "code_buffer"] }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true }
-oxc_syntax = { workspace = true }
+oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
 cow-utils = { workspace = true }
 natord = { workspace = true }

--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -61,7 +61,7 @@ struct FormatNumberLiteralExponent {
 
 // Regex-free version of https://github.com/prettier/prettier/blob/ca246afacee8e6d5db508dae01730c9523bbff1d/src/common/util.js#L341-L356
 // TODO: Use arena String to construct the cleaned text.
-fn format_trimmed_number(text: &str, options: NumberFormatOptions) -> Cow<'_, str> {
+pub fn format_trimmed_number(text: &str, options: NumberFormatOptions) -> Cow<'_, str> {
     use FormatNumberLiteralState::{DecimalPart, Exponent, IntegerPart};
 
     let text = text.cow_to_ascii_lowercase();

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -41,14 +41,14 @@ pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Forma
         PropertyKey::StaticIdentifier(ident) if should_quote_for_consistency => {
             // Quote the identifier: foo → "foo" or 'foo'
             let quote = f.options().quote_style.as_str();
-            let quoted = std::format!("{quote}{}{quote}", ident.name);
+            let quoted = format!("{quote}{}{quote}", ident.name);
             text(f.context().allocator().alloc_str(&quoted)).fmt(f);
         }
         PropertyKey::NumericLiteral(num) if should_quote_for_consistency => {
             // Check if this is a simple number that can be quoted
             if let Some(value_str) = can_quote_numeric_literal(num, f) {
                 let quote = f.options().quote_style.as_str();
-                let quoted = std::format!("{quote}{value_str}{quote}");
+                let quoted = format!("{quote}{value_str}{quote}");
                 text(f.context().allocator().alloc_str(&quoted)).fmt(f);
             } else {
                 // Complex number representation - don't quote
@@ -90,7 +90,7 @@ pub fn write_member_name<'a>(
         PropertyKey::StaticIdentifier(ident) if should_quote_for_consistency => {
             // Quote the identifier: foo → "foo" or 'foo'
             let quote = f.options().quote_style.as_str();
-            let quoted = std::format!("{quote}{}{quote}", ident.name);
+            let quoted = format!("{quote}{}{quote}", ident.name);
             let width = quoted.len();
             text(f.context().allocator().alloc_str(&quoted)).fmt(f);
             width
@@ -99,7 +99,7 @@ pub fn write_member_name<'a>(
             // Check if this is a simple number that can be quoted
             if let Some(value_str) = can_quote_numeric_literal(num, f) {
                 let quote = f.options().quote_style.as_str();
-                let quoted = std::format!("{quote}{value_str}{quote}");
+                let quoted = format!("{quote}{value_str}{quote}");
                 let width = quoted.len();
                 text(f.context().allocator().alloc_str(&quoted)).fmt(f);
                 width

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -1,36 +1,63 @@
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
+use oxc_syntax::number::ToJsString;
 
 use crate::{
     Buffer, Format,
     ast_nodes::{AstNode, AstNodes},
-    formatter::Formatter,
+    formatter::token::number::{NumberFormatOptions, format_trimmed_number},
+    formatter::{Formatter, prelude::text},
     utils::string::{
         FormatLiteralStringToken, StringLiteralParentKind, is_identifier_name_patched,
+        is_simple_numeric_string,
     },
     write,
 };
 
+/// Format a property key, handling quoteProps: "consistent" mode.
 pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
-    if let PropertyKey::StringLiteral(s) = key.as_ref() {
-        // `"constructor"` property in the class should be kept quoted
-        let kind = if matches!(key.parent, AstNodes::PropertyDefinition(_))
-            && matches!(key.as_ref(), PropertyKey::StringLiteral(string) if string.value == "constructor")
-        {
-            StringLiteralParentKind::Expression
-        } else {
-            StringLiteralParentKind::Member
-        };
+    let should_quote_for_consistency =
+        f.options().quote_properties.is_consistent() && f.context().is_quote_needed();
 
-        FormatLiteralStringToken::new(
-            f.source_text().text_for(s.as_ref()),
-            /* jsx */
-            false,
-            kind,
-        )
-        .fmt(f);
-    } else {
-        write!(f, key);
+    match key.as_ref() {
+        PropertyKey::StringLiteral(s) => {
+            // `"constructor"` property in the class should be kept quoted
+            let kind = if matches!(key.parent, AstNodes::PropertyDefinition(_))
+                && matches!(key.as_ref(), PropertyKey::StringLiteral(string) if string.value == "constructor")
+            {
+                StringLiteralParentKind::Expression
+            } else {
+                StringLiteralParentKind::Member
+            };
+
+            FormatLiteralStringToken::new(
+                f.source_text().text_for(s.as_ref()),
+                /* jsx */
+                false,
+                kind,
+            )
+            .fmt(f);
+        }
+        PropertyKey::StaticIdentifier(ident) if should_quote_for_consistency => {
+            // Quote the identifier: foo → "foo" or 'foo'
+            let quote = f.options().quote_style.as_str();
+            let quoted = std::format!("{quote}{}{quote}", ident.name);
+            text(f.context().allocator().alloc_str(&quoted)).fmt(f);
+        }
+        PropertyKey::NumericLiteral(num) if should_quote_for_consistency => {
+            // Check if this is a simple number that can be quoted
+            if let Some(value_str) = can_quote_numeric_literal(num, f) {
+                let quote = f.options().quote_style.as_str();
+                let quoted = std::format!("{quote}{value_str}{quote}");
+                text(f.context().allocator().alloc_str(&quoted)).fmt(f);
+            } else {
+                // Complex number representation - don't quote
+                write!(f, key);
+            }
+        }
+        _ => {
+            write!(f, key);
+        }
     }
 }
 
@@ -38,30 +65,115 @@ pub fn write_member_name<'a>(
     key: &AstNode<'a, PropertyKey<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> usize {
-    if let AstNodes::StringLiteral(string) = key.as_ast_nodes() {
-        let format = FormatLiteralStringToken::new(
-            f.source_text().text_for(string),
-            false,
-            StringLiteralParentKind::Member,
-        )
-        .clean_text(f);
+    // Check if we need to quote this key for quoteProps: "consistent"
+    let should_quote_for_consistency =
+        f.options().quote_properties.is_consistent() && f.context().is_quote_needed();
 
-        string.format_leading_comments(f);
-        write!(f, format);
-        string.format_trailing_comments(f);
+    match key.as_ref() {
+        PropertyKey::StringLiteral(string) => {
+            let format = FormatLiteralStringToken::new(
+                f.source_text().text_for(string.as_ref()),
+                false,
+                StringLiteralParentKind::Member,
+            )
+            .clean_text(f);
 
-        format.width()
-    } else {
-        write!(f, key);
+            let string_node = key.as_ast_nodes();
+            if let AstNodes::StringLiteral(s) = string_node {
+                s.format_leading_comments(f);
+                write!(f, format);
+                s.format_trailing_comments(f);
+            }
 
-        f.source_text().span_width(key.span())
+            format.width()
+        }
+        PropertyKey::StaticIdentifier(ident) if should_quote_for_consistency => {
+            // Quote the identifier: foo → "foo" or 'foo'
+            let quote = f.options().quote_style.as_str();
+            let quoted = std::format!("{quote}{}{quote}", ident.name);
+            let width = quoted.len();
+            text(f.context().allocator().alloc_str(&quoted)).fmt(f);
+            width
+        }
+        PropertyKey::NumericLiteral(num) if should_quote_for_consistency => {
+            // Check if this is a simple number that can be quoted
+            if let Some(value_str) = can_quote_numeric_literal(num, f) {
+                let quote = f.options().quote_style.as_str();
+                let quoted = std::format!("{quote}{value_str}{quote}");
+                let width = quoted.len();
+                text(f.context().allocator().alloc_str(&quoted)).fmt(f);
+                width
+            } else {
+                // Complex number representation - don't quote
+                write!(f, key);
+                f.source_text().span_width(key.span())
+            }
+        }
+        _ => {
+            write!(f, key);
+            f.source_text().span_width(key.span())
+        }
     }
 }
 
-/// Determine if the property key string literal should preserve its quotes
+/// Determine if the property key string literal should preserve its quotes.
+/// Returns true if the key requires quotes and cannot be safely unquoted.
+///
+/// A string key can be safely unquoted if:
+/// - It's a valid JavaScript identifier (e.g., "foo" → foo), OR
+/// - It's a simple numeric string that round-trips (e.g., "5" → 5, "1.5" → 1.5)
 pub fn should_preserve_quote(key: &PropertyKey<'_>, f: &Formatter<'_, '_>) -> bool {
     matches!(&key, PropertyKey::StringLiteral(string) if {
         let quote_less_content = f.source_text().text_for(&string.span.shrink(1));
-        !is_identifier_name_patched(quote_less_content)
+        !is_string_key_safe_to_unquote(quote_less_content)
     })
+}
+
+/// Check if a string key content can be safely unquoted.
+/// Returns true if the key can become an identifier or a simple numeric literal.
+fn is_string_key_safe_to_unquote(content: &str) -> bool {
+    // Check if it's a valid identifier
+    if is_identifier_name_patched(content) {
+        return true;
+    }
+
+    // Check if it's a simple numeric string that round-trips correctly
+    is_simple_numeric_string(content)
+}
+
+/// Check if a numeric literal can be quoted for quoteProps: "consistent".
+///
+/// A numeric literal can be quoted if its JavaScript string representation
+/// (String(value)) matches the normalized printed form. This means simple
+/// numbers like 1, 1.5, 0.1 can be quoted, but complex representations
+/// like 1e2, 0b10, 0xf, 1.0 cannot.
+///
+/// Returns `Some(value_str)` if the number can be quoted, where `value_str`
+/// is the string to use as the quoted key content.
+fn can_quote_numeric_literal(num: &NumericLiteral<'_>, f: &Formatter<'_, '_>) -> Option<String> {
+    let value = num.value;
+
+    // NaN and Infinity cannot be represented as numeric literals
+    if value.is_nan() || value.is_infinite() {
+        return None;
+    }
+
+    // Get the JavaScript string representation using proper JS number-to-string conversion
+    let value_str = value.to_js_string();
+
+    // Get the normalized printed form using the same normalization as codegen
+    let raw_text = f.source_text().text_for(num);
+    let normalized =
+        format_trimmed_number(raw_text, NumberFormatOptions::keep_one_trailing_decimal_zero());
+
+    // They must match for the number to be quotable
+    // For example:
+    // - 1 → normalized "1", String(1) = "1" → match ✓
+    // - 1.5 → normalized "1.5", String(1.5) = "1.5" → match ✓
+    // - .1 → normalized "0.1", String(0.1) = "0.1" → match ✓
+    // - 1. → normalized "1", String(1) = "1" → match ✓
+    // - 1.0 → normalized "1.0", String(1) = "1" → no match ✗
+    // - 1e2 → normalized "1e2", String(100) = "100" → no match ✗
+    // - 0b10 → normalized "0b10", String(2) = "2" → no match ✗
+    if value_str == normalized.as_ref() { Some(value_str) } else { None }
 }

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, ops::Deref};
 
 use oxc_span::SourceType;
 use oxc_syntax::identifier::{is_identifier_part, is_identifier_start};
+use oxc_syntax::number::ToJsString;
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
@@ -428,8 +429,6 @@ pub fn is_identifier_name_patched(content: &str) -> bool {
 /// - `".1"` → false (parses to 0.1, String(0.1) = "0.1" ≠ ".1")
 /// - `"1.0"` → false (parses to 1, String(1) = "1" ≠ "1.0")
 /// - `"0xf"` → false (not a simple decimal number)
-///
-/// <https://github.com/prettier/prettier/blob/52829385bcc4d785e58ae2602c0b098a643523c9/src/language-js/print/property.js#L42-L82>
 pub fn is_simple_numeric_string(content: &str) -> bool {
     // Only allow simple decimal numbers (digits and at most one dot)
     if content.is_empty()
@@ -439,8 +438,8 @@ pub fn is_simple_numeric_string(content: &str) -> bool {
         return false;
     }
 
-    // Try to parse and check round-trip
-    if let Ok(num) = content.parse::<f64>() { num.to_string() == content } else { false }
+    // Try to parse and check round-trip using JS number-to-string semantics
+    if let Ok(num) = content.parse::<f64>() { num.to_js_string() == content } else { false }
 }
 
 #[cfg(test)]

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -440,11 +440,7 @@ pub fn is_simple_numeric_string(content: &str) -> bool {
     }
 
     // Try to parse and check round-trip
-    if let Ok(num) = content.parse::<f64>() {
-        num.to_string() == content
-    } else {
-        false
-    }
+    if let Ok(num) = content.parse::<f64>() { num.to_string() == content } else { false }
 }
 
 #[cfg(test)]

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 744/761 (97.77%)
+js compatibility: 746/761 (98.03%)
 
 # Failed
 
@@ -14,8 +14,6 @@ js compatibility: 744/761 (97.77%)
 | js/for/for-in-with-initializer.js | 💥 | 37.50% |
 | js/for/parentheses.js | 💥 | 97.96% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
-| js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
-| js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |


### PR DESCRIPTION
## Summary
- Quote identifier keys (`foo` → `"foo"`) when `quoteProps: "consistent"` requires it
- Quote simple numeric keys (`1` → `"1"`) when consistency requires it  
- Use `oxc_syntax::number::ToJsString` for proper JS number-to-string conversion
- Add `is_simple_numeric_string` helper for checking if string keys can be unquoted

## Test plan
- All quote-props conformance tests pass (27 tests)
- JS compatibility improved from 97.77% to 98.03%

🤖 Generated with [Claude Code](https://claude.ai/code)