### PR TITLE
fix(formatter): fix comment placement in arrow functions with empty params and sequence expressions

### DIFF
--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -130,7 +130,8 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                     FormatMaybeCachedFunctionBody {
                         body,
                         mode: self.options.cache_mode,
-                        expression: false
+                        expression: false,
+                        params_span: None,
                     }
                 ]
             );

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,10 +1,9 @@
-js compatibility: 744/761 (97.77%)
+js compatibility: 746/761 (98.03%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| js/arrows/comment.js | 💥💥 | 88.89% |
 | js/comments/15661.js | 💥💥 | 55.17% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
@@ -13,11 +12,10 @@ js compatibility: 744/761 (97.77%)
 | js/for/9812-unstable.js | 💥 | 63.64% |
 | js/for/for-in-with-initializer.js | 💥 | 37.50% |
 | js/for/parentheses.js | 💥 | 97.96% |
-| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/quotes/objects.js | 💥💥 | 80.00% |
-| js/sequence-expression/ignored.js | 💥 | 25.00% |
+| js/sequence-expression/ignored.js | 💥 | 66.67% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
 | jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |


### PR DESCRIPTION
## Summary
- For arrow functions with empty params, block comments (`/* */`) stay inside parens while line comments (`//`) are promoted to the body
- Fix leading comments before sequence expression bodies to print before the opening paren, not inside
- Improves JS Prettier conformance from 97.50% to 98.03% (742/761 → 746/761)

## Test plan
- [x] `cargo run -p oxc_prettier_conformance -- --filter empty-paren-comment` passes
- [x] `cargo run -p oxc_prettier_conformance -- --filter dangling-comment-in-arrow` passes  
- [x] `cargo run -p oxc_prettier_conformance -- --filter arrows/comment` passes
- [x] Full conformance suite shows improvement

🤖 Generated with [Claude Code](https://claude.ai/code)