### PR TITLE
fix(linter): sort paths by length instead of alphabetically for depth heuristic

### DIFF
--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -394,7 +394,9 @@ impl Runtime {
 
         // Create a sorted copy of paths for processing
         let mut sorted_paths: Vec<_> = paths.iter().cloned().collect();
-        sorted_paths.par_sort_unstable_by(|a, b| Path::new(b).cmp(Path::new(a)));
+        // Sort by path length descending - longer paths tend to be deeper in the directory tree.
+        // This achieves the "deeper paths first" heuristic described above in O(1) per comparison.
+        sorted_paths.par_sort_unstable_by(|a, b| b.len().cmp(&a.len()));
 
         // The general idea is processing `sorted_paths` and their dependencies in groups. We start from a group of modules
         // in `sorted_paths` that is small enough to hold in memory but big enough to make use of the rayon thread pool.


### PR DESCRIPTION
## Summary

Fixes the path sorting bug identified in #15924 where the linter's path sorting was intended to process "deeper" paths first (so leaf modules can be processed and released from memory earlier), but was actually sorting in reverse alphabetical order.

**Example of the bug:**
- `src/a/b/c/d.js` (4 levels deep) vs `src/z.js` (1 level)
- Alphabetically: `src/a/...` < `src/z.js` (because 'a' < 'z')
- With reverse sort: `src/z.js` came BEFORE the deeper path (wrong!)

**The fix:** Sort by path length descending instead (`b.len().cmp(&a.len())`), which is a good proxy for depth and achieves O(1) comparison cost per the comment in #15924.

Closes #15924

## Test plan

- [x] `cargo check -p oxc_linter` passes
- [x] `cargo test -p oxc_linter` passes
- [x] `just fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)