### PR TITLE
perf(formatter): use flat storage for BestFitting variants

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -1,12 +1,11 @@
 use std::{cell::Cell, num::NonZeroU8};
 
 use Tag::{
-    EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
-    EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign, StartConditionalContent,
-    StartDedent, StartEntry, StartFill, StartGroup, StartIndent, StartIndentIfGroupBreaks,
-    StartLabelled, StartLineSuffix,
+    EndAlign, EndBestFittingEntry, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup,
+    EndIndent, EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+    StartBestFittingEntry, StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup,
+    StartIndent, StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
 };
-use oxc_allocator::Vec as ArenaVec;
 use oxc_span::{GetSpan, Span};
 
 use super::{
@@ -2535,18 +2534,13 @@ impl<'ast> Format<'ast> for BestFitting<'_, 'ast> {
         let mut buffer = VecBuffer::new(f.state_mut());
         let variants = self.variants.items();
 
-        let mut formatted_variants = Vec::with_capacity(variants.len());
-
         for variant in variants {
-            buffer.write_element(FormatElement::Tag(StartEntry));
+            buffer.write_element(FormatElement::Tag(StartBestFittingEntry));
             buffer.write_fmt(Arguments::from(variant));
-            buffer.write_element(FormatElement::Tag(EndEntry));
-
-            formatted_variants.push(buffer.take_vec().into_bump_slice());
+            buffer.write_element(FormatElement::Tag(EndBestFittingEntry));
         }
 
-        let formatted_variants =
-            ArenaVec::from_iter_in(formatted_variants, f.context().allocator());
+        let formatted_variants = buffer.take_vec().into_bump_slice();
 
         // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,
         // safe to call into the unsafe `from_vec_unchecked` function

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -181,10 +181,10 @@ impl std::fmt::Display for Document<'_> {
 impl<'a> Format<'a> for &[FormatElement<'a>] {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         use Tag::{
-            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
-            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
-            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
-            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+            EndAlign, EndBestFittingEntry, EndConditionalContent, EndDedent, EndEntry, EndFill,
+            EndGroup, EndIndent, EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartBestFittingEntry, StartConditionalContent, StartDedent, StartEntry, StartFill,
+            StartGroup, StartIndent, StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
         };
 
         write!(f, [ContentArrayStart]);
@@ -278,7 +278,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                     ]);
 
                     for variant in best_fitting.variants() {
-                        write!(f, [&**variant, hard_line_break()]);
+                        write!(f, [variant, hard_line_break()]);
                     }
 
                     f.write_elements([
@@ -499,10 +499,10 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             write!(f, [token("fill(")]);
                         }
 
-                        StartEntry => {
+                        StartEntry | StartBestFittingEntry => {
                             // handled after the match for all start tags
                         }
-                        EndEntry => write!(f, [ContentArrayEnd]),
+                        EndEntry | EndBestFittingEntry => write!(f, [ContentArrayEnd]),
 
                         EndFill
                         | EndLabelled

--- a/crates/oxc_formatter/src/formatter/format_element/tag.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/tag.rs
@@ -62,6 +62,11 @@ pub enum Tag {
     /// See [crate::builders::labelled] for documentation.
     StartLabelled(LabelId),
     EndLabelled,
+
+    /// Marks the start of a best fitting variant entry.
+    StartBestFittingEntry,
+    /// Marks the end of a best fitting variant entry.
+    EndBestFittingEntry,
 }
 
 impl Tag {
@@ -79,6 +84,7 @@ impl Tag {
                 | Tag::StartEntry
                 | Tag::StartLineSuffix
                 | Tag::StartLabelled(_)
+                | Tag::StartBestFittingEntry
         )
     }
 
@@ -89,10 +95,10 @@ impl Tag {
 
     pub const fn kind(&self) -> TagKind {
         use Tag::{
-            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
-            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
-            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
-            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+            EndAlign, EndBestFittingEntry, EndConditionalContent, EndDedent, EndEntry, EndFill,
+            EndGroup, EndIndent, EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartBestFittingEntry, StartConditionalContent, StartDedent, StartEntry, StartFill,
+            StartGroup, StartIndent, StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
         };
 
         match self {
@@ -106,6 +112,7 @@ impl Tag {
             StartEntry | EndEntry => TagKind::Entry,
             StartLineSuffix | EndLineSuffix => TagKind::LineSuffix,
             StartLabelled(_) | EndLabelled => TagKind::Labelled,
+            StartBestFittingEntry | EndBestFittingEntry => TagKind::BestFittingEntry,
         }
     }
 }
@@ -126,6 +133,7 @@ pub enum TagKind {
     LineSuffix,
     Labelled,
     TailwindClass,
+    BestFittingEntry,
 }
 
 #[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

Port of https://github.com/astral-sh/ruff/pull/7411 to oxc_formatter.

This optimizes memory allocation for `BestFitting` elements by using a flat storage structure with marker tags instead of nested allocations.

### Key Changes

1. **New Tags** (`tag.rs`):
   - Added `StartBestFittingEntry` and `EndBestFittingEntry` to the `Tag` enum
   - Added `BestFittingEntry` to `TagKind` enum

2. **Flat Storage Structure** (`format_element/mod.rs`):
   - Changed `BestFittingElement` from storing `&'a [&'a [FormatElement<'a>]]` (nested slices) to `&'a [FormatElement<'a>]` (flat slice)
   - Variants are now delimited by `StartBestFittingEntry`/`EndBestFittingEntry` tags
   - Added `BestFittingVariantsIter` iterator to parse variants from the flat structure

3. **Builder Update** (`builders.rs`):
   - Updated `BestFitting::fmt` to write all variants to a single buffer with entry tags

4. **Printer Updates** (`printer/mod.rs`):
   - Added `print_best_fitting_entry` function to handle the new entry tags
   - Updated `print_best_fitting` to use the iterator and call the new entry printer
   - Updated tag handling throughout the printer for the new tags

5. **Document Display** (`document.rs`):
   - Updated to handle `StartBestFittingEntry`/`EndBestFittingEntry` tags

6. **Direct API Usage** (`arguments.rs`):
   - Updated the call site that directly constructs `BestFittingElement` to use the new flat structure

### Benefits

- Reduces memory allocations by avoiding per-variant heap allocations
- All variant content is stored in a single contiguous buffer

## Test plan

- [x] All 144 formatter tests pass
- [x] Prettier conformance unchanged (97.77% JS, 96.37% TS)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.ai/code)