### PR TITLE
feat(formatter): add `best_fit_parenthesize` IR

### DIFF
--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -181,10 +181,10 @@ impl std::fmt::Display for Document<'_> {
 impl<'a> Format<'a> for &[FormatElement<'a>] {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         use Tag::{
-            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
-            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
-            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
-            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+            EndAlign, EndBestFitParenthesize, EndConditionalContent, EndDedent, EndEntry, EndFill,
+            EndGroup, EndIndent, EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartBestFitParenthesize, StartConditionalContent, StartDedent, StartEntry, StartFill,
+            StartGroup, StartIndent, StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
         };
 
         write!(f, [ContentArrayStart]);
@@ -499,6 +499,25 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                             write!(f, [token("fill(")]);
                         }
 
+                        StartBestFitParenthesize { id } => {
+                            write!(f, [token("best_fit_parenthesize(")]);
+
+                            if let Some(group_id) = id {
+                                write!(
+                                    f,
+                                    [
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("\"{group_id:?}\"")),
+                                        ),
+                                        token(","),
+                                        space(),
+                                    ]
+                                );
+                            }
+                        }
+
                         StartEntry => {
                             // handled after the match for all start tags
                         }
@@ -512,7 +531,8 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         | EndIndent
                         | EndGroup
                         | EndLineSuffix
-                        | EndDedent(_) => {
+                        | EndDedent(_)
+                        | EndBestFitParenthesize => {
                             write!(f, [ContentArrayEnd, token(")")]);
                         }
                     }


### PR DESCRIPTION
## Summary

Ports the `best_fit_parenthesize` IR from Ruff ([astral-sh/ruff#7475](https://github.com/astral-sh/ruff/pull/7475)).

This is an optimized alternative to using `best_fitting!` for the common pattern of choosing between flat content and parenthesized content:

```rust
// Instead of:
best_fitting![
    content,
    format_args!(token("("), block_indent(&content), token(")"))
]

// You can now use:
best_fit_parenthesize(&content)
```

**Behavior:**
- If content fits on a single line: prints without parentheses  
- If content doesn't fit: adds parentheses with indented content on its own line

**Features:**
- Supports optional `group_id` for conditional content that depends on whether parentheses are rendered
- Integrates with existing `if_group_breaks`/`if_group_fits_on_line`

### Changes

- Added `StartBestFitParenthesize` and `EndBestFitParenthesize` tags
- Added `best_fit_parenthesize()` builder function with `with_group_id()` support
- Added printer handling for the new tags
- Added fits measurement handling
- Added 4 test cases

## Test plan

- [x] All existing formatter tests pass (144 tests)
- [x] New `best_fit_parenthesize_*` tests added and passing
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.ai/code)