### PR TITLE
refactor(linter): rename setup configs to setup rule configs

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -43,7 +43,7 @@ export type JsLoadPluginCb =
   ((arg0: string, arg1: string | undefined | null, arg2: boolean) => Promise<string>)
 
 /** JS callback to setup configs. */
-export type JsSetupConfigsCb =
+export type JsSetupRuleConfigsCb =
   ((arg: string) => string | null)
 
 /**
@@ -52,12 +52,12 @@ export type JsSetupConfigsCb =
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
  * 2. `load_plugin`: Load a JS plugin from a file path.
- * 3. `setup_configs`: Setup configuration options.
+ * 3. `setup_rule_configs`: Setup configuration options.
  * 4. `lint_file`: Lint a file.
  *
  * Returns `true` if linting succeeded without errors, `false` otherwise.
  */
-export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupConfigs: JsSetupConfigsCb, lintFile: JsLintFileCb): Promise<boolean>
+export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb): Promise<boolean>
 
 /**
  * Parse AST into provided `Uint8Array` buffer, synchronously.

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -5,7 +5,7 @@ import { debugAssertIsNonNull } from "./utils/asserts.ts";
 // Using `typeof wrapper` here makes TS check that the function signatures of `loadPlugin` and `loadPluginWrapper`
 // are identical. Ditto `lintFile` and `lintFileWrapper`.
 let loadPlugin: typeof loadPluginWrapper | null = null;
-let setupConfigs: typeof setupConfigsWrapper | null = null;
+let setupRuleConfigs: typeof setupRuleConfigsWrapper | null = null;
 let lintFile: typeof lintFileWrapper | null = null;
 
 /**
@@ -27,7 +27,7 @@ function loadPluginWrapper(
     // Use promises here instead of making `loadPluginWrapper` an async function,
     // to avoid a micro-tick and extra wrapper `Promise` in all later calls to `loadPluginWrapper`
     return import("./plugins/index.ts").then((mod) => {
-      ({ loadPlugin, lintFile, setupConfigs } = mod);
+      ({ loadPlugin, lintFile, setupRuleConfigs } = mod);
       return loadPlugin(path, pluginName, pluginNameIsAlias);
     });
   }
@@ -38,14 +38,14 @@ function loadPluginWrapper(
 /**
  * Bootstrap configuration options.
  *
- * Delegates to `setupConfigs`, which was lazy-loaded by `loadPluginWrapper`.
+ * Delegates to `setupRuleConfigs`, which was lazy-loaded by `loadPluginWrapper`.
  *
  * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
  * @returns `null` if success, or error message string
  */
-function setupConfigsWrapper(optionsJSON: string): string | null {
-  debugAssertIsNonNull(setupConfigs);
-  return setupConfigs(optionsJSON);
+function setupRuleConfigsWrapper(optionsJSON: string): string | null {
+  debugAssertIsNonNull(setupRuleConfigs);
+  return setupRuleConfigs(optionsJSON);
 }
 
 /**
@@ -80,8 +80,8 @@ function lintFileWrapper(
 // Get command line arguments, skipping first 2 (node binary and script path)
 const args = process.argv.slice(2);
 
-// Call Rust, passing `loadPlugin`, `setupConfigs`, and `lintFile` as callbacks, and CLI arguments
-const success = await lint(args, loadPluginWrapper, setupConfigsWrapper, lintFileWrapper);
+// Call Rust, passing `loadPlugin`, `setupRuleConfigs`, and `lintFile` as callbacks, and CLI arguments
+const success = await lint(args, loadPluginWrapper, setupRuleConfigsWrapper, lintFileWrapper);
 
 // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxlint/src-js/plugins/config.ts
+++ b/apps/oxlint/src-js/plugins/config.ts
@@ -5,14 +5,14 @@ import { getErrorMessage } from "../utils/utils.ts";
  * Populates Rust-resolved configuration options on the JS side.
  * Called from Rust side after all configuration options have been resolved.
  *
- * Note: the name `setupConfigs` is currently incorrect, as we only populate rule options.
+ * Note: the name `setupRuleConfigs` is currently incorrect, as we only populate rule options.
  * The intention is for this function to transfer all configurations in a multi-config workspace.
  * The configuration relevant to each file would then be resolved on the JS side.
  *
  * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
  * @returns `null` if success, or error message string
  */
-export function setupConfigs(optionsJSON: string): string | null {
+export function setupRuleConfigs(optionsJSON: string): string | null {
   // TODO: Setup settings and globals using this function
   try {
     setOptions(optionsJSON);

--- a/apps/oxlint/src-js/plugins/index.ts
+++ b/apps/oxlint/src-js/plugins/index.ts
@@ -1,3 +1,3 @@
 export { lintFile } from "./lint.ts";
 export { loadPlugin } from "./load.ts";
-export { setupConfigs } from "./config.ts";
+export { setupRuleConfigs } from "./config.ts";

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -10,25 +10,25 @@ use serde::Deserialize;
 use oxc_allocator::{Allocator, free_fixed_size_allocator};
 use oxc_linter::{
     ExternalLinter, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
-    ExternalLinterSetupConfigsCb, LintFileResult, LoadPluginResult,
+    ExternalLinterSetupRuleConfigsCb, LintFileResult, LoadPluginResult,
 };
 
 use crate::{
     generated::raw_transfer_constants::{BLOCK_ALIGN, BUFFER_SIZE},
-    run::{JsLintFileCb, JsLoadPluginCb, JsSetupConfigsCb},
+    run::{JsLintFileCb, JsLoadPluginCb, JsSetupRuleConfigsCb},
 };
 
 /// Wrap JS callbacks as normal Rust functions, and create [`ExternalLinter`].
 pub fn create_external_linter(
     load_plugin: JsLoadPluginCb,
-    setup_configs: JsSetupConfigsCb,
+    setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
 ) -> ExternalLinter {
     let rust_load_plugin = wrap_load_plugin(load_plugin);
-    let rust_setup_configs = wrap_setup_configs(setup_configs);
+    let rust_setup_rule_configs = wrap_setup_rule_configs(setup_rule_configs);
     let rust_lint_file = wrap_lint_file(lint_file);
 
-    ExternalLinter::new(rust_load_plugin, rust_setup_configs, rust_lint_file)
+    ExternalLinter::new(rust_load_plugin, rust_setup_rule_configs, rust_lint_file)
 }
 
 /// Result returned by `loadPlugin` JS callback.
@@ -74,12 +74,12 @@ fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
     })
 }
 
-/// Wrap `setupConfigs` JS callback as a normal Rust function.
+/// Wrap `setupRuleConfigs` JS callback as a normal Rust function.
 ///
-/// The JS-side `setupConfigs` function is synchronous, but it's wrapped in a `ThreadsafeFunction`,
+/// The JS-side `setupRuleConfigs` function is synchronous, but it's wrapped in a `ThreadsafeFunction`,
 /// so cannot be called synchronously. Use an `mpsc::channel` to wait for the result from JS side,
-/// and block current thread until `setupConfigs` completes execution.
-fn wrap_setup_configs(cb: JsSetupConfigsCb) -> ExternalLinterSetupConfigsCb {
+/// and block current thread until `setupRuleConfigs` completes execution.
+fn wrap_setup_rule_configs(cb: JsSetupRuleConfigsCb) -> ExternalLinterSetupRuleConfigsCb {
     Box::new(move |options_json: String| {
         let (tx, rx) = channel();
 
@@ -92,7 +92,7 @@ fn wrap_setup_configs(cb: JsSetupConfigsCb) -> ExternalLinterSetupConfigsCb {
                 // This closure is a `FnOnce`, so it can't be called more than once, so only 1 message can be sent.
                 // Therefore, `rx` cannot be dropped before this call.
                 let res = tx.send(result);
-                debug_assert!(res.is_ok(), "Failed to send result of `setupConfigs`");
+                debug_assert!(res.is_ok(), "Failed to send result of `setupRuleConfigs`");
                 Ok(())
             },
         );
@@ -103,15 +103,15 @@ fn wrap_setup_configs(cb: JsSetupConfigsCb) -> ExternalLinterSetupConfigsCb {
                 Ok(Ok(None)) => Ok(()),
                 // Setup failed
                 Ok(Ok(Some(err))) => Err(err),
-                // `setupConfigs` threw an error - should be impossible because it should be infallible
-                Ok(Err(err)) => Err(format!("`setupConfigs` threw an error: {err}")),
+                // `setupRuleConfigs` threw an error - should be impossible because it should be infallible
+                Ok(Err(err)) => Err(format!("`setupRuleConfigs` threw an error: {err}")),
                 // Sender "hung up" - should be impossible because closure passed to `call_with_return_value`
                 // takes ownership of the sender `tx`. Unless NAPI-RS drops the closure without calling it,
                 // `tx.send()` always happens before `tx` is dropped.
-                Err(err) => Err(format!("`setupConfigs` did not respond: {err}")),
+                Err(err) => Err(format!("`setupRuleConfigs` did not respond: {err}")),
             }
         } else {
-            Err(format!("Failed to schedule `setupConfigs` callback: {status:?}"))
+            Err(format!("Failed to schedule `setupRuleConfigs` callback: {status:?}"))
         }
     })
 }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -342,7 +342,7 @@ impl CliRunner {
 
         // Send JS plugins config to JS side
         if let Some(external_linter) = &external_linter {
-            let res = config_store.external_plugin_store().setup_configs(external_linter);
+            let res = config_store.external_plugin_store().setup_rule_configs(external_linter);
             if let Err(err) = res {
                 print_and_flush_stdout(
                     stdout,

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -64,7 +64,7 @@ pub type JsLintFileCb = ThreadsafeFunction<
 
 /// JS callback to setup configs.
 #[napi]
-pub type JsSetupConfigsCb = ThreadsafeFunction<
+pub type JsSetupRuleConfigsCb = ThreadsafeFunction<
     // Arguments
     String, // Options array, as JSON string
     // Return value
@@ -82,7 +82,7 @@ pub type JsSetupConfigsCb = ThreadsafeFunction<
 /// JS side passes in:
 /// 1. `args`: Command line arguments (process.argv.slice(2))
 /// 2. `load_plugin`: Load a JS plugin from a file path.
-/// 3. `setup_configs`: Setup configuration options.
+/// 3. `setup_rule_configs`: Setup configuration options.
 /// 4. `lint_file`: Lint a file.
 ///
 /// Returns `true` if linting succeeded without errors, `false` otherwise.
@@ -92,17 +92,17 @@ pub type JsSetupConfigsCb = ThreadsafeFunction<
 pub async fn lint(
     args: Vec<String>,
     load_plugin: JsLoadPluginCb,
-    setup_configs: JsSetupConfigsCb,
+    setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
 ) -> bool {
-    lint_impl(args, load_plugin, setup_configs, lint_file).await.report() == ExitCode::SUCCESS
+    lint_impl(args, load_plugin, setup_rule_configs, lint_file).await.report() == ExitCode::SUCCESS
 }
 
 /// Run the linter.
 async fn lint_impl(
     args: Vec<String>,
     load_plugin: JsLoadPluginCb,
-    setup_configs: JsSetupConfigsCb,
+    setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
 ) -> CliRunResult {
     // Convert String args to OsString for compatibility with bpaf
@@ -139,10 +139,10 @@ async fn lint_impl(
     // JS plugins are only supported on 64-bit little-endian platforms at present
     #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
     let external_linter =
-        Some(crate::js_plugins::create_external_linter(load_plugin, setup_configs, lint_file));
+        Some(crate::js_plugins::create_external_linter(load_plugin, setup_rule_configs, lint_file));
     #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
     let external_linter = {
-        let (_, _, _) = (load_plugin, setup_configs, lint_file);
+        let (_, _, _) = (load_plugin, setup_rule_configs, lint_file);
         None
     };
 

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -23,7 +23,7 @@ pub type ExternalLinterLoadPluginCb = Box<
         + Sync,
 >;
 
-pub type ExternalLinterSetupConfigsCb = Box<dyn Fn(String) -> Result<(), String> + Send + Sync>;
+pub type ExternalLinterSetupRuleConfigsCb = Box<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
 pub type ExternalLinterLintFileCb = Box<
     dyn Fn(
@@ -65,17 +65,17 @@ pub struct JsFix {
 
 pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
-    pub(crate) setup_configs: ExternalLinterSetupConfigsCb,
+    pub(crate) setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,
 }
 
 impl ExternalLinter {
     pub fn new(
         load_plugin: ExternalLinterLoadPluginCb,
-        setup_configs: ExternalLinterSetupConfigsCb,
+        setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
         lint_file: ExternalLinterLintFileCb,
     ) -> Self {
-        Self { load_plugin, setup_configs, lint_file }
+        Self { load_plugin, setup_rule_configs, lint_file }
     }
 }
 

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -163,10 +163,10 @@ impl ExternalPluginStore {
     ///
     /// # Errors
     /// Returns an error if serialization of rule options fails.
-    pub fn setup_configs(&self, external_linter: &ExternalLinter) -> Result<(), String> {
+    pub fn setup_rule_configs(&self, external_linter: &ExternalLinter) -> Result<(), String> {
         let json = serde_json::to_string(&ConfigSer::new(self));
         match json {
-            Ok(options_json) => (external_linter.setup_configs)(options_json),
+            Ok(options_json) => (external_linter.setup_rule_configs)(options_json),
             Err(err) => Err(format!("Failed to serialize external plugin options: {err}")),
         }
     }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::{
     context::{ContextSubHost, LintContext},
     external_linter::{
         ExternalLinter, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
-        ExternalLinterSetupConfigsCb, JsFix, LintFileResult, LoadPluginResult,
+        ExternalLinterSetupRuleConfigsCb, JsFix, LintFileResult, LoadPluginResult,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
     fixer::{Fix, FixKind, Message, PossibleFixes},


### PR DESCRIPTION
`setupConfigs` is not very descriptive - it is unclear if this is referring to oxlint configs, or rule configs, or something else.

This commit simply renames it to be explicit (`setupRuleConfigs`).

Please see the PR ontop of this for more info.