### PR TITLE
perf(formatter): use binary search for comment position lookups

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -455,8 +455,8 @@ impl<'a> Comments<'a> {
         let original_limit = self.view_limit;
 
         // Binary search: find first comment where span.start >= end_pos
-        let relative_index = self.inner[self.printed_count..]
-            .partition_point(|c| c.span.start < end_pos);
+        let relative_index =
+            self.inner[self.printed_count..].partition_point(|c| c.span.start < end_pos);
         let limit_index = self.printed_count + relative_index;
 
         // Only update if we're actually limiting the view


### PR DESCRIPTION
## Summary

- Replace O(n) linear searches with O(log n) binary searches in comment position queries
- Comments are sorted by span position (maintained by parser), enabling use of `partition_point` for efficient lookups

## Methods Optimized

| Method | Before | After |
|--------|--------|-------|
| `comments_before()` | `.iter().take_while().count()` | `partition_point()` |
| `comments_after()` | `.iter().take_while().count()` | `partition_point()` |
| `comments_in_range()` | `.iter().take_while().count()` | `partition_point()` |
| `has_comment_in_range()` | `.iter().any()` | `partition_point()` + single lookup |
| `limit_comments_up_to()` | `.iter().position()` | `partition_point()` |

## Impact

Files with many comments (e.g., heavily documented code) will see speedup in formatting. These methods are called frequently during comment association, so the improvement compounds.

## Test plan

- [x] `cargo test -p oxc_formatter` passes
- [x] Prettier conformance unchanged (97.77% js, 96.37% ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)