### PR TITLE
perf(transformer/typescript): reduce `scope_id()` calls

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -110,7 +110,7 @@ impl<'a> TypeScriptEnum<'a> {
         });
 
         let statements = self.transform_ts_enum_members(
-            decl.body.scope_id(),
+            func_scope_id,
             &mut decl.body.members,
             &param_binding,
             ctx,


### PR DESCRIPTION
Tiny optimization. Calling `EnumBody::scope_id` has a cost (a panicking branch). We already called it earlier in this function and have the scope ID in a local var. Use that value, rather then calling `scope_id()` again.