### PR TITLE
feat(linter): Update 125 rules to raise errors when provided with invalid config options.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -32,7 +32,7 @@ fn getter_without_setter_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AccessorPairsConfig {
     /// Report a setter without a getter.
     set_without_get: bool,
@@ -122,9 +122,7 @@ declare_oxc_lint!(
 
 impl Rule for AccessorPairs {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -35,7 +35,7 @@ fn expect_no_return(method_name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ArrayCallbackReturn {
     /// When set to true, rule will also report forEach callbacks that return a value.
     check_for_each: bool,
@@ -82,9 +82,7 @@ declare_oxc_lint!(
 
 impl Rule for ArrayCallbackReturn {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -32,7 +32,7 @@ fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct GetterReturn {
     /// When set to `true`, allows getters to implicitly return `undefined` with a `return` statement containing no expression.
     pub allow_implicit: bool,
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for GetterReturn {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -23,7 +23,7 @@ fn no_bitwise_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
 pub struct NoBitwise(Box<NoBitwiseConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBitwiseConfig {
     /// The `allow` option permits the given list of bitwise operators to be used
     /// as exceptions to this rule.
@@ -99,9 +99,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBitwise {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -26,7 +26,7 @@ fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
 pub struct NoConsole(Box<NoConsoleConfig>);
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoConsoleConfig {
     /// The `allow` option permits the given list of console methods to be used as exceptions to
     /// this rule.
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for NoConsole {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -39,7 +39,7 @@ fn no_duplicate_exports_diagnostic(
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicateImports {
     /// When `true` this rule will also look at exports to see if there is both a re-export of a
     /// module as in `export ... from 'module'` and also a standard import statement for the same
@@ -140,9 +140,7 @@ enum ModuleType {
 
 impl Rule for NoDuplicateImports {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -22,7 +22,7 @@ fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagno
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoElseReturn {
     /// Whether to allow `else if` blocks after a return statement.
     ///
@@ -339,9 +339,7 @@ fn check_if_without_else(ctx: &LintContext, node: &AstNode) {
 
 impl Rule for NoElseReturn {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -18,7 +18,7 @@ fn no_empty_diagnostic(stmt_kind: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEmpty {
     /// If set to `true`, allows an empty `catch` block without triggering the linter.
     allow_empty_catch: bool,
@@ -58,9 +58,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEmpty {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -18,7 +18,7 @@ fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEval {
     /// This `allowIndirect` option allows indirect `eval()` calls.
     ///
@@ -94,9 +94,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEval {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct NoExtendNative(Box<NoExtendNativeConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtendNativeConfig {
     /// A list of objects which are allowed to be exceptions to the rule.
     exceptions: Vec<CompactStr>,
@@ -80,9 +80,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExtendNative {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -32,7 +32,7 @@ fn no_extra_boolean_cast_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtraBooleanCast {
     /// when set to `true`, in addition to checking default contexts, checks
     /// whether extra boolean casts are present in expressions whose result is
@@ -87,9 +87,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExtraBooleanCast {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -19,7 +19,7 @@ fn no_global_assign_diagnostic(global_name: &str, span: Span) -> OxcDiagnostic {
 pub struct NoGlobalAssign(Box<NoGlobalAssignConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoGlobalAssignConfig {
     /// List of global variable names to exclude from this rule.
     /// Globals listed here can be assigned to without triggering warnings.
@@ -57,9 +57,7 @@ declare_oxc_lint!(
 
 impl Rule for NoGlobalAssign {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -51,7 +51,7 @@ fn report_coercion(ctx: &LintContext, span: Span, kind: CoercionKind, operand: &
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoImplicitCoercionConfig {
     /// When `true`, warns on implicit boolean coercion (e.g., `!!foo`).
     boolean: bool,
@@ -180,9 +180,7 @@ declare_oxc_lint!(
 
 impl Rule for NoImplicitCoercion {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -74,7 +74,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoInvalidRegexpConfig {
     /// Case-sensitive array of flags that will be allowed.
     allow_constructor_flags: Vec<char>,
@@ -82,9 +82,7 @@ struct NoInvalidRegexpConfig {
 
 impl Rule for NoInvalidRegexp {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -20,7 +20,7 @@ fn no_labels_diagnostic(message: &'static str, label_span: Span) -> OxcDiagnosti
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoLabels {
     /// If set to `true`, this rule ignores labels which are sticking to loop statements.
     /// Examples of **correct** code with this option set to `true`:
@@ -120,9 +120,7 @@ declare_oxc_lint!(
 
 impl Rule for NoLabels {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -37,7 +37,7 @@ fn zwj_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMisleadingCharacterClass {
     /// When set to `true`, the rule allows any grouping of code points
     /// inside a character class as long as they are written using escape sequences.
@@ -150,9 +150,7 @@ impl<'ast> Visit<'ast> for CharacterSequenceCollector<'ast> {
 
 impl Rule for NoMisleadingCharacterClass {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
@@ -18,7 +18,7 @@ fn no_multi_assign_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMultiAssign {
     /// When set to `true`, the rule allows chains that don't include initializing a variable in a declaration or initializing a class field.
     ///
@@ -109,9 +109,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMultiAssign {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -29,7 +29,7 @@ fn no_plusplus_diagnostic(span: Span, operator: UpdateOperator) -> OxcDiagnostic
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoPlusplus {
     /// Whether to allow `++` and `--` in for loop afterthoughts.
     allow_for_loop_afterthoughts: bool,
@@ -95,9 +95,7 @@ declare_oxc_lint!(
 
 impl Rule for NoPlusplus {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_promise_executor_return.rs
@@ -26,7 +26,7 @@ fn no_promise_executor_return_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoPromiseExecutorReturn(Box<NoPromiseExecutorReturnConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoPromiseExecutorReturnConfig {
     /// If `true`, allows returning `void` expressions (e.g., `return void resolve()`).
     allow_void: bool,
@@ -121,9 +121,7 @@ declare_oxc_lint!(
 
 impl Rule for NoPromiseExecutorReturn {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -24,7 +24,7 @@ fn no_redeclare_as_builtin_in_diagnostic(name: &str, span: Span) -> OxcDiagnosti
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRedeclare {
     /// When set `true`, it flags redeclaring built-in globals (e.g., `let Object = 1;`).
     builtin_globals: bool,
@@ -68,9 +68,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRedeclare {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -24,7 +24,7 @@ fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoSelfAssign {
     /// The `props` option when set to `false`, disables the checking of properties.
     ///
@@ -104,9 +104,7 @@ declare_oxc_lint!(
 
 impl Rule for NoSelfAssign {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -14,7 +14,7 @@ fn no_sequences_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoSequences {
     /// If this option is set to `false`, this rule disallows the comma operator
     /// even when the expression sequence is explicitly wrapped in parentheses.
@@ -81,9 +81,7 @@ declare_oxc_lint!(
 
 impl Rule for NoSequences {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -22,7 +22,7 @@ fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> Oxc
 pub struct NoShadowRestrictedNames(Box<NoShadowRestrictedNamesConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoShadowRestrictedNamesConfig {
     /// If true, also report shadowing of `globalThis`.
     report_global_this: bool,
@@ -91,9 +91,7 @@ declare_oxc_lint!(
 
 impl Rule for NoShadowRestrictedNames {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
@@ -26,7 +26,7 @@ fn no_unneeded_ternary_conditional_expression_diagnostic(span: Span) -> OxcDiagn
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnneededTernary {
     /// Whether to allow the default assignment pattern `x ? x : y`.
     ///
@@ -81,9 +81,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnneededTernary {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -24,7 +24,7 @@ fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeNegation {
     /// The `enforceForOrderingRelations` option determines whether negation is allowed
     /// on the left-hand side of ordering relational operators (<, >, <=, >=).
@@ -73,9 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeNegation {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -28,7 +28,7 @@ fn no_unsafe_arithmetic_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeOptionalChaining {
     /// Disallow arithmetic operations on optional chaining expressions.
     /// If this is true, this rule warns arithmetic operations on optional chaining expressions, which possibly result in NaN.
@@ -65,9 +65,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeOptionalChaining {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -25,7 +25,7 @@ fn no_unused_expressions_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoUnusedExpressions(Box<NoUnusedExpressionsConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnusedExpressionsConfig {
     /// When set to `true`, allows short circuit evaluations in expressions.
     allow_short_circuit: bool,
@@ -80,9 +80,7 @@ impl Rule for NoUnusedExpressions {
     }
 
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -22,7 +22,7 @@ fn no_useless_computed_key_diagnostic(span: Span, raw: Option<Atom>) -> OxcDiagn
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessComputedKey {
     /// The `enforceForClassMembers` option controls whether the rule applies to
     /// class members (methods and properties).
@@ -119,9 +119,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessComputedKey {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -33,7 +33,7 @@ impl std::ops::Deref for NoUselessEscape {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessEscapeConfig {
     /// An array of characters that are allowed to be escaped unnecessarily in regexes.
     /// For example, setting this to `["#"]` allows `\#` in regexes.
@@ -144,9 +144,7 @@ impl Rule for NoUselessEscape {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -30,7 +30,7 @@ fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoUselessRename(Box<NoUselessRenameConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessRenameConfig {
     /// When set to `true`, allows using the same name in destructurings.
     ignore_destructuring: bool,
@@ -81,9 +81,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessRename {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -20,7 +20,7 @@ fn no_void_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoVoid {
     /// If set to `true`, using `void` as a standalone statement is allowed.
     pub allow_as_statement: bool,
@@ -59,9 +59,7 @@ declare_oxc_lint!(
 
 impl Rule for NoVoid {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -38,7 +38,7 @@ fn missing_catch_parameter_diagnostic(span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(rename_all = "camelCase")]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct PreserveCaughtErrorOptions {
     /// When set to `true`, requires that catch clauses always have a parameter.
     require_catch_parameter: bool,
@@ -305,9 +305,7 @@ impl PreserveCaughtError {
 
 impl Rule for PreserveCaughtError {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -35,7 +35,7 @@ fn invalid_radix(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct Radix(RadixType);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
@@ -86,9 +86,7 @@ declare_oxc_lint!(
 
 impl Rule for Radix {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -42,7 +42,7 @@ fn index_of_na_n(method_name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct UseIsnan {
     /// Whether to disallow NaN in switch cases and discriminants
     enforce_for_switch_case: bool,
@@ -144,9 +144,7 @@ impl Rule for UseIsnan {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -30,7 +30,7 @@ fn invalid_value(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ValidTypeof {
     /// The `requireStringLiterals` option when set to `true`, allows the comparison of `typeof`
     /// expressions with only string literals or other `typeof` expressions, and disallows
@@ -159,9 +159,7 @@ impl Rule for ValidTypeof {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -49,7 +49,7 @@ fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct Namespace {
     /// Whether to allow computed references to an imported namespace.
     allow_computed: bool,
@@ -113,9 +113,7 @@ declare_oxc_lint!(
 
 impl Rule for Namespace {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -24,7 +24,7 @@ fn no_absolute_path_diagnostic(span: Span) -> OxcDiagnostic {
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoAbsolutePath {
     /// If set to `true`, dependency paths for ES module import statements will be resolved:
     ///
@@ -108,9 +108,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAbsolutePath {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -21,7 +21,7 @@ fn no_anonymous_default_export_diagnostic(span: Span, msg: &'static str) -> OxcD
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoAnonymousDefaultExport {
     /// Allow anonymous array as default export.
     allow_array: bool,
@@ -122,9 +122,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAnonymousDefaultExport {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -21,7 +21,7 @@ fn no_commonjs_diagnostic(span: Span, name: &str, actual: &str) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoCommonjs {
     /// If `allowPrimitiveModules` option is set to true, the following is valid:
     ///
@@ -130,9 +130,7 @@ fn is_conditional(parent_node: &AstNode, ctx: &LintContext) -> bool {
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-commonjs.md>
 impl Rule for NoCommonjs {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -39,7 +39,7 @@ where
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-duplicates.md>
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicates {
     /// When set to `true`, prefer inline type imports instead of separate type import
     /// statements for TypeScript code.
@@ -93,9 +93,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicates {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -18,7 +18,7 @@ fn no_dnyamic_require_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDynamicRequire {
     /// When `true`, also check `import()` expressions for dynamic module specifiers.
     esmodule: bool,
@@ -58,9 +58,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDynamicRequire {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -22,7 +22,7 @@ fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoNamespace(Box<NoNamespaceConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNamespaceConfig {
     /// An array of glob strings for modules that should be ignored by the rule.
     /// For example, `["*.json"]` will ignore all JSON imports.
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-namespace.md>
 impl Rule for NoNamespace {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/prefer_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/prefer_default_export.rs
@@ -29,7 +29,7 @@ enum Target {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferDefaultExport {
     /// Configuration option to specify the target type for preferring default exports.
     /// - `"single"`: Prefer default export when there is only one export in the module.
@@ -79,9 +79,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferDefaultExport {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -20,7 +20,7 @@ fn exceeded_max_assertion(count: usize, max: usize, span: Span) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxExpects {
     /// Maximum number of `expect()` assertion calls allowed within a single test.
     pub max: usize,
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxExpects {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -23,7 +23,7 @@ fn exceeded_max_depth(current: usize, max: usize, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[schemars(default)]
 pub struct MaxNestedDescribe {
     /// Maximum allowed depth of nested describe calls.
@@ -139,9 +139,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxNestedDescribe {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -32,7 +32,7 @@ fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoStandaloneExpect(Box<NoStandaloneExpectConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoStandaloneExpectConfig {
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,
@@ -90,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for NoStandaloneExpect {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -26,7 +26,7 @@ fn use_hook(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireHookConfig {
     /// An array of function names that are allowed to be called outside of hooks.
     allowed_function_calls: Vec<CompactStr>,
@@ -178,9 +178,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireHook {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -37,7 +37,7 @@ fn unexpected_hook(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireTopLevelDescribe {
     /// The maximum number of top-level `describe` blocks allowed in a test file.
     pub max_number_of_top_level_describes: usize,
@@ -119,9 +119,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireTopLevelDescribe {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct CheckTagNamesConfig {
     /// Additional tag names to allow.
     defined_tags: Vec<String>,
@@ -232,9 +232,7 @@ const OUTSIDE_AMBIENT_INVALID_TAGS_IF_TYPED: [&str; 27] = [
 
 impl Rule for CheckTagNames {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -88,7 +88,7 @@ const EMPTY_TAGS: [&str; 18] = [
 ];
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct EmptyTagsConfig {
     /// Additional tags to check for their descriptions.
     tags: Vec<String>,
@@ -96,9 +96,7 @@ struct EmptyTagsConfig {
 
 impl Rule for EmptyTags {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoDefaultsConfig {
     /// If true, report the presence of optional param names (square brackets) on `@param` tags.
     no_optional_param_names: bool,
@@ -61,9 +61,7 @@ struct NoDefaultsConfig {
 
 impl Rule for NoDefaults {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -36,7 +36,7 @@ fn duplicate_returns_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct RequireReturns(Box<RequireReturnsConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct RequireReturnsConfig {
     /// Tags that exempt functions from requiring `@returns`.
     exempted_by: Vec<String>,
@@ -99,9 +99,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireReturns {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -49,7 +49,7 @@ impl Deref for RequireYields {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireYieldsConfig {
     /// Functions with these tags will be exempted from the lint rule.
     exempted_by: Vec<String>,
@@ -105,9 +105,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireYields {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -32,7 +32,7 @@ fn anchor_has_ambiguous_text(span: Span, text: &CompactStr) -> OxcDiagnostic {
 pub struct AnchorAmbiguousText(Box<AnchorAmbiguousTextConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AnchorAmbiguousTextConfig {
     /// List of ambiguous words or phrases that should be flagged in anchor text.
     words: Vec<CompactStr>,
@@ -97,9 +97,7 @@ declare_oxc_lint!(
 
 impl Rule for AnchorAmbiguousText {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -28,7 +28,7 @@ fn aria_role_diagnostic(span: Span, help_suffix: &str) -> OxcDiagnostic {
 pub struct AriaRole(Box<AriaRoleConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AriaRoleConfig {
     /// Determines if developer-created components are checked.
     #[serde(rename = "ignoreNonDOM")]
@@ -103,9 +103,7 @@ declare_oxc_lint!(
 
 impl Rule for AriaRole {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -24,7 +24,7 @@ fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct HeadingHasContent(Box<HeadingHasContentConfig>);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct HeadingHasContentConfig {
     /// Additional custom component names to treat as heading elements.
     /// These will be validated in addition to the standard h1-h6 elements.
@@ -75,9 +75,7 @@ const DEFAULT_COMPONENTS: [&str; 6] = ["h1", "h2", "h3", "h4", "h5", "h6"];
 
 impl Rule for HeadingHasContent {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -31,7 +31,7 @@ fn miss_on_blur(span: Span, attr_name: &str) -> OxcDiagnostic {
 pub struct MouseEventsHaveKeyEvents(Box<MouseEventsHaveKeyEventsConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MouseEventsHaveKeyEventsConfig {
     /// List of hover-in mouse event handlers that require corresponding keyboard event handlers.
     hover_in_handlers: Vec<CompactStr>,
@@ -77,9 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for MouseEventsHaveKeyEvents {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -42,7 +42,7 @@ impl std::ops::Deref for NoStaticElementInteractions {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoStaticElementInteractionsConfig {
     /// An array of event handler names that should trigger this rule (e.g., `onClick`, `onKeyDown`).
     handlers: Option<Vec<CompactStr>>,
@@ -159,9 +159,7 @@ const NON_INTERACTIVE_ROLES: [&str; 43] = [
 
 impl Rule for NoStaticElementInteractions {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -20,7 +20,7 @@ fn no_process_env_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoProcessEnvConfig {
     /// Variable names which are allowed to be accessed on `process.env`.
     allowed_variables: FxHashSet<CompactStr>,
@@ -71,9 +71,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
 
 impl Rule for NoProcessEnv {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -20,7 +20,7 @@ fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> O
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBarrelFile {
     /// The maximum number of modules that can be re-exported via `export *`
     /// before the rule is triggered.
@@ -76,9 +76,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBarrelFile {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -24,7 +24,7 @@ fn no_optional_chaining_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
 pub struct NoOptionalChaining(Box<NoOptionalChainingConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoOptionalChainingConfig {
     /// A custom help message to display when optional chaining is found.
     /// For example, "Our output target is ES2016, and optional chaining results in verbose
@@ -73,9 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoOptionalChaining {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -22,7 +22,7 @@ fn no_rest_spread_properties_diagnostic(
 pub struct NoRestSpreadProperties(Box<NoRestSpreadPropertiesOptions>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRestSpreadPropertiesOptions {
     /// A message to display when object spread properties are found.
     object_spread_message: String,
@@ -66,9 +66,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRestSpreadProperties {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -33,7 +33,7 @@ fn always_return_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct AlwaysReturn(Box<AlwaysReturnConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct AlwaysReturnConfig {
     /// You can pass an `{ ignoreLastCallback: true }` as an option to this rule so that
     /// the last `then()` callback in a promise chain does not warn if it does not have
@@ -190,9 +190,7 @@ const PROCESS_METHODS: [&str; 2] = ["exit", "abort"];
 
 impl Rule for AlwaysReturn {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -30,7 +30,7 @@ fn no_return_wrap_diagnostic(span: Span, issue: &ReturnWrapper) -> OxcDiagnostic
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoReturnWrap {
     /// `allowReject` allows returning `Promise.reject` inside a promise handler.
     ///
@@ -137,9 +137,7 @@ declare_oxc_lint!(
 
 impl Rule for NoReturnWrap {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -28,7 +28,7 @@ impl std::ops::Deref for PreferAwaitToThen {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferAwaitToThenConfig {
     /// If true, enforces the rule even after an `await` or `yield` expression.
     strict: bool,
@@ -74,9 +74,7 @@ fn is_inside_yield_or_await(node: &AstNode) -> bool {
 
 impl Rule for PreferAwaitToThen {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -21,7 +21,7 @@ fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
 pub struct SpecOnly(Box<SpecOnlyConfig>);
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SpecOnlyConfig {
     /// List of Promise static methods that are allowed to be used.
     allowed_methods: Option<FxHashSet<CompactStr>>,
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for SpecOnly {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -32,7 +32,7 @@ fn invalid_type_prop(span: Span, allowed_types: &str) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ButtonHasType {
     /// If true, allow `type="button"`.
     button: bool,
@@ -80,9 +80,7 @@ declare_oxc_lint!(
 
 impl Rule for ButtonHasType {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -28,7 +28,7 @@ fn exclusive_checked_attribute(checked_span: Span, default_checked_span: Span) -
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct CheckedRequiresOnchangeOrReadonly {
     /// Ignore the requirement to provide either `onChange` or `readOnly` when the `checked` prop is present.
     ignore_missing_properties: bool,
@@ -200,9 +200,7 @@ impl Rule for CheckedRequiresOnchangeOrReadonly {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -57,7 +57,7 @@ fn duplicate_key_prop(key_value: &str, span: Span) -> OxcDiagnostic {
 pub struct JsxKey(Box<JsxKeyConfig>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[derive(Default)]
 pub struct JsxKeyConfig {
     /// When true, require key prop to be placed before any spread props
@@ -109,9 +109,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxKey {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -38,7 +38,7 @@ fn explicit_props_in_spread_attributes(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxNoTargetBlank {
     /// Whether to enforce dynamic links or enforce static links.
     enforce_dynamic_links: EnforceDynamicLinksEnum,
@@ -145,9 +145,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxNoTargetBlank {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -29,7 +29,7 @@ fn child_of_html_element(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxNoUselessFragment {
     /// Allow fragments with a single expression child.
     allow_expressions: bool,
@@ -69,9 +69,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxNoUselessFragment {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -30,7 +30,7 @@ fn jsx_pascal_case_diagnostic(
 pub struct JsxPascalCase(Box<JsxPascalCaseConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxPascalCaseConfig {
     /// Whether to allow all-caps component names.
     pub allow_all_caps: bool,
@@ -111,9 +111,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxPascalCase {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -29,7 +29,7 @@ enum IgnoreEnforceOption {
 }
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxPropsNoSpreadingConfig {
     /// `html` set to `ignore` will ignore all html jsx tags like `div`, `img` etc. Default is set to `enforce`.
     html: IgnoreEnforceOption,
@@ -91,9 +91,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxPropsNoSpreading {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -31,7 +31,7 @@ fn string_in_ref_deprecated(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoStringRefs {
     /// Disallow template literals in addition to string literals.
     no_template_literals: bool,
@@ -115,9 +115,7 @@ fn is_literal_ref_attribute(attr: &JSXAttribute, no_template_literals: bool) -> 
 
 impl Rule for NoStringRefs {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -52,7 +52,7 @@ fn unknown_prop(span: Span) -> OxcDiagnostic {
 pub struct NoUnknownProperty(Box<NoUnknownPropertyConfig>);
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnknownPropertyConfig {
     /// List of properties to ignore.
     ignore: FxHashSet<Cow<'static, str>>,
@@ -474,9 +474,7 @@ fn has_uppercase(name: &str) -> bool {
 
 impl Rule for NoUnknownProperty {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unsafe.rs
+++ b/crates/oxc_linter/src/rules/react/no_unsafe.rs
@@ -31,7 +31,7 @@ fn no_unsafe_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoUnsafeConfig {
     /// Whether to check for the non-prefixed lifecycle methods.
     /// If `true`, this means `componentWillMount`, `componentWillReceiveProps`,
@@ -91,9 +91,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafe {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -22,7 +22,7 @@ fn self_closing_comp_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SelfClosingComp {
     /// Whether to enforce self-closing for custom components.
     component: bool,
@@ -77,9 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for SelfClosingComp {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -27,7 +27,7 @@ fn style_prop_object_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct StylePropObject(Box<StylePropObjectConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct StylePropObjectConfig {
     /// List of component names on which to allow `style` prop values of any type.
     allow: Vec<CompactStr>,
@@ -146,9 +146,7 @@ fn is_invalid_style_attribute<'a>(attribute: &JSXAttribute<'a>, ctx: &LintContex
 
 impl Rule for StylePropObject {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -22,7 +22,7 @@ use crate::{
 pub struct ArrayType(Box<ArrayTypeConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ArrayTypeConfig {
     /// The array type expected for mutable cases.
     default: ArrayOption,
@@ -138,9 +138,7 @@ fn array_simple(
 
 impl Rule for ArrayType {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -51,7 +51,7 @@ impl Deref for ConsistentTypeImports {
 
 // <https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ConsistentTypeImportsConfig {
     /// Disallow using `import()` in type annotations, like `type T = import('foo')`
     disallow_type_annotations: bool,
@@ -173,9 +173,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentTypeImports {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct ExplicitFunctionReturnType(Box<ExplicitFunctionReturnTypeConfig>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExplicitFunctionReturnTypeConfig {
     /// Whether to allow expressions as function return types. When `true`, allows functions that immediately return an expression without a return type annotation.
     allow_expressions: bool,
@@ -147,9 +147,7 @@ fn explicit_function_return_type_diagnostic(span: Span) -> OxcDiagnostic {
 
 impl Rule for ExplicitFunctionReturnType {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -46,7 +46,7 @@ impl Deref for ExplicitModuleBoundaryTypes {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExplicitModuleBoundaryTypesConfig {
     /// Whether to ignore arguments that are explicitly typed as `any`.
     allow_arguments_explicitly_typed_as_any: bool,
@@ -163,9 +163,7 @@ declare_oxc_lint!(
 
 impl Rule for ExplicitModuleBoundaryTypes {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoBaseToString(Box<NoBaseToStringConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoBaseToStringConfig {
     /// Whether to also check values of type `unknown`.
     /// When `true`, calling toString on `unknown` values will be flagged.
@@ -84,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for NoBaseToString {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoConfusingVoidExpression(Box<NoConfusingVoidExpressionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoConfusingVoidExpressionConfig {
     /// Whether to ignore arrow function shorthand that returns void.
     /// When true, allows expressions like `() => someVoidFunction()`.
@@ -74,9 +74,7 @@ declare_oxc_lint!(
 
 impl Rule for NoConfusingVoidExpression {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_deprecated.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoDeprecated(Box<NoDeprecatedConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDeprecatedConfig {
     /// An array of type or value specifiers that are allowed to be used even if deprecated.
     /// Use this to allow specific deprecated APIs that you intentionally want to continue using.
@@ -67,9 +67,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDeprecated {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoDuplicateTypeConstituents(Box<NoDuplicateTypeConstituentsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDuplicateTypeConstituentsConfig {
     /// Whether to ignore duplicate types in intersection types.
     /// When true, allows `type T = A & A`.
@@ -69,9 +69,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateTypeConstituents {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -22,7 +22,7 @@ fn no_empty_interface_extend_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoEmptyInterface {
     /// When set to `true`, allows empty interfaces that extend a single interface.
     #[serde(alias = "allow_single_extends")]
@@ -66,9 +66,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyInterface {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -19,7 +19,7 @@ fn no_explicit_any_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExplicitAny {
     /// Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type.
     fix_to_unknown: bool,
@@ -78,9 +78,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExplicitAny {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoExtraneousClass {
     /// Allow classes that only have a constructor.
     allow_constructor_only: bool,
@@ -114,9 +114,7 @@ fn only_constructor_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic 
 
 impl Rule for NoExtraneousClass {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoFloatingPromises(Box<NoFloatingPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoFloatingPromisesConfig {
     /// Allows specific calls to be ignored, specified as type or value specifiers.
     pub allow_for_known_safe_calls: Vec<TypeOrValueSpecifier>,
@@ -112,9 +112,7 @@ declare_oxc_lint!(
 
 impl Rule for NoFloatingPromises {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -24,7 +24,7 @@ fn no_inferrable_types_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoInferrableTypes {
     /// When set to `true`, ignores type annotations on function parameters.
     ignore_parameters: bool,
@@ -67,9 +67,7 @@ declare_oxc_lint!(
 
 impl Rule for NoInferrableTypes {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct NoMeaninglessVoidOperator(Box<NoMeaninglessVoidOperatorConfig>);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMeaninglessVoidOperatorConfig {
     /// Whether to check `void` applied to expressions of type `never`.
     pub check_never: bool,
@@ -65,9 +65,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMeaninglessVoidOperator {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -12,7 +12,7 @@ fn default_checks_void_return() -> ChecksVoidReturn {
 pub struct NoMisusedPromises(Box<NoMisusedPromisesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[expect(clippy::struct_field_names)]
 pub struct NoMisusedPromisesConfig {
     /// Whether to check if Promises are used in conditionals.
@@ -45,7 +45,7 @@ pub enum ChecksVoidReturn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ChecksVoidReturnOptions {
     /// Whether to check Promise-returning functions passed as arguments to void-returning functions.
     pub arguments: bool,
@@ -131,9 +131,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMisusedPromises {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_spread.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct NoMisusedSpread(Box<NoMisusedSpreadConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoMisusedSpreadConfig {
     /// An array of type or value specifiers that are allowed to be spread
     /// even if they would normally be flagged as misused.
@@ -71,9 +71,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMisusedSpread {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -18,7 +18,7 @@ fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNamespace {
     /// Whether to allow declare with custom TypeScript namespaces.
     ///
@@ -117,9 +117,7 @@ declare_oxc_lint!(
 
 impl Rule for NoNamespace {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -27,7 +27,7 @@ fn no_require_imports_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoRequireImports(Box<NoRequireImportsConfig>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRequireImportsConfig {
     /// These strings will be compiled into regular expressions with the u flag and be used to test against the imported path.
     /// A common use case is to allow importing `package.json`. This is because `package.json` commonly lives outside of the TS root directory,
@@ -125,9 +125,7 @@ fn match_argument_value_with_regex(allow: &[CompactStr], argument_value: &str) -
 
 impl Rule for NoRequireImports {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -33,7 +33,7 @@ fn no_this_destructure_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoThisAlias(Box<NoThisAliasConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoThisAliasConfig {
     /// Whether to allow destructuring of `this` to local variables.
     allow_destructuring: bool,
@@ -100,9 +100,7 @@ declare_oxc_lint!(
 
 impl Rule for NoThisAlias {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnnecessaryBooleanLiteralCompare(Box<NoUnnecessaryBooleanLiteralCompareConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnnecessaryBooleanLiteralCompareConfig {
     /// Whether to allow comparing nullable boolean expressions to `false`.
     /// When false, `x === false` where x is `boolean | null` will be flagged.
@@ -92,9 +92,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnnecessaryBooleanLiteralCompare {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnnecessaryTypeAssertion(Box<NoUnnecessaryTypeAssertionConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnnecessaryTypeAssertionConfig {
     /// Whether to check literal const assertions like `'foo' as const`.
     /// When `false` (default), const assertions on literal types are not flagged.
@@ -72,9 +72,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnnecessaryTypeAssertion {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct NoUnsafeMemberAccess(Box<NoUnsafeMemberAccessConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnsafeMemberAccessConfig {
     /// Whether to allow `?.` optional chains on `any` values.
     /// When `true`, optional chaining on `any` values will not be flagged.
@@ -68,9 +68,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeMemberAccess {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct OnlyThrowError(Box<OnlyThrowErrorConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct OnlyThrowErrorConfig {
     /// An array of type or value specifiers for additional types that are allowed to be thrown.
     /// Use this to allow throwing custom error types.
@@ -94,9 +94,7 @@ declare_oxc_lint!(
 
 impl Rule for OnlyThrowError {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -21,7 +21,7 @@ fn prefer_literal_enum_member_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferLiteralEnumMember {
     /// When set to `true`, allows bitwise expressions in enum member initializers.
     /// This includes bitwise NOT (`~`), AND (`&`), OR (`|`), XOR (`^`), and shift operators (`<<`, `>>`, `>>>`).
@@ -59,9 +59,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferLiteralEnumMember {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
@@ -9,7 +9,7 @@ pub struct PreferNullishCoalescing(Box<PreferNullishCoalescingConfig>);
 
 /// Options for ignoring specific primitive types.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct IgnorePrimitivesOptions {
     /// Ignore bigint primitive types.
     pub bigint: bool,
@@ -41,7 +41,7 @@ impl Default for IgnorePrimitives {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferNullishCoalescingConfig {
     /// Unless this is set to `true`, the rule will error on every file whose
     /// `tsconfig.json` does _not_ have the `strictNullChecks` compiler option
@@ -140,9 +140,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferNullishCoalescing {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct PreferOptionalChain(Box<PreferOptionalChainConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferOptionalChainConfig {
     /// Allow autofixers that will change the return type of the expression.
     /// This option is considered unsafe as it may break the build.
@@ -100,9 +100,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferOptionalChain {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct PreferPromiseRejectErrors(Box<PreferPromiseRejectErrorsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferPromiseRejectErrorsConfig {
     /// Whether to allow calling `Promise.reject()` with no arguments.
     pub allow_empty_reject: bool,
@@ -77,9 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferPromiseRejectErrors {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
+++ b/crates/oxc_linter/src/rules/typescript/promise_function_async.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct PromiseFunctionAsync(Box<PromiseFunctionAsyncConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PromiseFunctionAsyncConfig {
     /// Whether to allow functions returning `any` type without requiring `async`.
     pub allow_any: bool,
@@ -109,9 +109,7 @@ declare_oxc_lint!(
 
 impl Rule for PromiseFunctionAsync {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct RequireArraySortCompare(Box<RequireArraySortCompareConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RequireArraySortCompareConfig {
     /// Whether to ignore arrays in which all elements are strings.
     pub ignore_string_arrays: bool,
@@ -79,9 +79,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireArraySortCompare {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct RestrictPlusOperands(Box<RestrictPlusOperandsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RestrictPlusOperandsConfig {
     /// Whether to allow `any` type in plus operations.
     pub allow_any: bool,
@@ -98,9 +98,7 @@ declare_oxc_lint!(
 
 impl Rule for RestrictPlusOperands {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -22,7 +22,7 @@ fn default_restrict_template_allow() -> Vec<TypeOrValueSpecifier> {
 pub struct RestrictTemplateExpressions(Box<RestrictTemplateExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct RestrictTemplateExpressionsConfig {
     /// Whether to allow `any` typed values in template expressions.
     pub allow_any: bool,
@@ -128,9 +128,7 @@ declare_oxc_lint!(
 
 impl Rule for RestrictTemplateExpressions {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct StrictBooleanExpressions(Box<StrictBooleanExpressionsConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct StrictBooleanExpressionsConfig {
     /// Whether to allow `any` type in boolean contexts.
     pub allow_any: bool,
@@ -128,9 +128,7 @@ declare_oxc_lint!(
 
 impl Rule for StrictBooleanExpressions {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct SwitchExhaustivenessCheck(Box<SwitchExhaustivenessCheckConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct SwitchExhaustivenessCheckConfig {
     /// Whether to allow default cases on switches that are not exhaustive.
     /// When false, requires exhaustive switch statements without default cases.
@@ -139,9 +139,7 @@ declare_oxc_lint!(
 
 impl Rule for SwitchExhaustivenessCheck {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -21,7 +21,7 @@ fn triple_slash_reference_diagnostic(ref_kind: &str, span: Span) -> OxcDiagnosti
 pub struct TripleSlashReference(Box<TripleSlashReferenceConfig>);
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct TripleSlashReferenceConfig {
     /// What to enforce for `/// <reference lib="..." />` references.
     lib: LibOption,
@@ -102,9 +102,7 @@ declare_oxc_lint!(
 
 impl Rule for TripleSlashReference {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/typescript/unbound_method.rs
+++ b/crates/oxc_linter/src/rules/typescript/unbound_method.rs
@@ -8,7 +8,7 @@ use crate::rule::{DefaultRuleConfig, Rule};
 pub struct UnboundMethod(Box<UnboundMethodConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct UnboundMethodConfig {
     /// Whether to ignore unbound methods that are static.
     /// When true, static methods can be referenced without binding.
@@ -102,9 +102,7 @@ declare_oxc_lint!(
 
 impl Rule for UnboundMethod {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -54,7 +54,7 @@ fn consistent_function_scoping(
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ConsistentFunctionScoping {
     /// Whether to check scoping with arrow functions.
     check_arrow_functions: bool,
@@ -161,9 +161,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentFunctionScoping {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -25,7 +25,7 @@ fn no_array_reduce_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArrayReduce {
     /// When set to `true`, allows simple operations (like summing numbers) in `reduce` and `reduceRight` calls.
     pub allow_simple_operations: bool,
@@ -63,9 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArrayReduce {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
@@ -22,7 +22,7 @@ fn no_array_reverse_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArrayReverse {
     /// This rule allows `array.reverse()` as an expression statement by default.
     /// Set to `false` to forbid `Array#reverse()` even if it's an expression statement.
@@ -70,9 +70,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArrayReverse {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -22,7 +22,7 @@ fn no_array_sort_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoArraySort {
     /// When set to `true` (default), allows `array.sort()` as an expression statement.
     /// Set to `false` to forbid `Array#sort()` even if it's an expression statement.
@@ -70,9 +70,7 @@ declare_oxc_lint!(
 
 impl Rule for NoArraySort {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -26,7 +26,7 @@ fn no_null_diagnostic(null: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNull {
     /// When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.
     check_strict_equality: bool,
@@ -173,9 +173,7 @@ fn match_call_expression_pass_case(null_literal: &NullLiteral, call_expr: &CallE
 
 impl Rule for NoNull {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -19,7 +19,7 @@ fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoTypeofUndefined {
     /// If set to `true`, also report `typeof x === "undefined"` when `x` may be a global
     /// variable that is not declared (commonly checked via `typeof foo === "undefined"`).
@@ -89,9 +89,7 @@ impl Rule for NoTypeofUndefined {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -32,7 +32,7 @@ fn reject(span: Span, preferred: &str) -> OxcDiagnostic {
 pub struct NoUselessPromiseResolveReject(Box<NoUselessPromiseResolveRejectOptions>);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessPromiseResolveRejectOptions {
     /// If set to `true`, allows the use of `Promise.reject` in async functions and promise callbacks.
     pub allow_reject: bool,
@@ -67,9 +67,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessPromiseResolveReject {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -29,7 +29,7 @@ fn no_useless_undefined_diagnostic_spans(spans: Vec<Span>) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUselessUndefined {
     /// Whether to check for useless `undefined` in function call arguments.
     check_arguments: bool,
@@ -153,9 +153,7 @@ fn is_has_function_return_type(node: &AstNode, ctx: &LintContext<'_>) -> bool {
 
 impl Rule for NoUselessUndefined {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -34,7 +34,7 @@ impl std::ops::Deref for PreferNumberProperties {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferNumberPropertiesConfig {
     /// If set to `true`, checks for usage of `Infinity` and `-Infinity` as global variables.
     check_infinity: bool,
@@ -88,9 +88,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferNumberProperties {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -28,7 +28,7 @@ fn prefer_structured_clone_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct PreferStructuredClone(Box<PreferStructuredCloneConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferStructuredCloneConfig {
     /// List of functions that are allowed to be used for deep cloning instead of structuredClone.
     functions: Vec<String>,
@@ -79,9 +79,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferStructuredClone {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
@@ -35,7 +35,7 @@ enum Destructure {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct DefinePropsDestructuring {
     /// Require or prohibit destructuring.
     destructure: Destructure,
@@ -82,9 +82,7 @@ declare_oxc_lint!(
 
 impl Rule for DefinePropsDestructuring {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -30,7 +30,7 @@ fn max_props_diagnostic(span: Span, cur: usize, limit: usize) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxProps {
     /// The maximum number of props allowed in a Vue Single File Component (SFC).
     max_props: usize,
@@ -80,9 +80,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxProps {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
Ran oxc-ecosystem-ci and it passed fine, no diff vs. main: https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/21199291772

<img width="1344" height="116" alt="image" src="https://github.com/user-attachments/assets/2aa5780d-18b0-4696-bf21-0adb857bdb73" />

Trial by fire, I guess. If this is too big of a change, we can split it up into batches of 25 each.

This builds on top of the changes from #17600 and various changes we've made over the last few months to adopt DefaultRuleConfig and other validations for the rule configuration logic.

Note that I was not able to make this change for `jest/prefer-lowercase-title` or `import/no-cycle`, as both have some tests using incorrect types in their tests, and so those tests begin failing if I try to expose invalid config options.

This should probably be fixed by removing the relevant tests that allow those values, as the values already are treated as invalid, or by updating the config struct for the rules to allow the currently-invalid values if we really want to support them. But that is a separate concern.

Note that `eslint/prefer-promise-reject-errors` is also not updated by this PR, as that is already covered by #18103.

Part of the goal of this change is to implement some of #17854, and also to prevent users from shooting themselves in the foot with a bad config hallucinated by AI tooling.

I used AI to create a quick little script and a bunch of invalid oxlint configs for some rules from this PR (and other PRs I opened today), see https://github.com/connorshea/oxlint-issue-repro-template/tree/invalid-configs. The result is printed below.

<details>

<summary>Invalid configs output</summary>

```
============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/eslint-no-bitwise.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/eslint-no-bitwise.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `no-bitwise`: invalid type: string "not-an-array", expected a sequence, received `{ "allow": "not-an-array" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/eslint-no-cond-assign.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/eslint-no-cond-assign.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `no-cond-assign`: unknown variant `exceptions`, expected `except-parens` or `always`, received `{ "exceptions": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/eslint-no-unused-expressions.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/eslint-no-unused-expressions.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `no-unused-expressions`: invalid type: string "not-boolean", expected a boolean, received `{ "allowShortCircuit": "not-boolean" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/eslint-unicode-bom.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/eslint-unicode-bom.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `unicode-bom`: unknown variant `require`, expected `always` or `never`, received `{ "require": 0 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/import-consistent-type-specifier-style.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/import-consistent-type-specifier-style.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `import/consistent-type-specifier-style`: unknown variant `specifierStyle`, expected `prefer-top-level` or `prefer-inline`, received `{ "specifierStyle": 42 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/import-no-absolute-path.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/import-no-absolute-path.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `import/no-absolute-path`: unknown field `allow`, expected one of `esmodule`, `commonjs`, `amd`, received `{ "allow": "yes" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/import-no-duplicates.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/import-no-duplicates.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `import/no-duplicates`: unknown field `preferInlineType`, expected `prefer-inline` or `preferInline`, received `{ "preferInlineType": "maybe" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/import-no-unassigned-import.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/import-no-unassigned-import.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `import/no-unassigned-import`: invalid type: integer `123`, expected a sequence, received `{ "allow": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/import-prefer-default-export.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/import-prefer-default-export.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `import/prefer-default-export`: invalid type: integer `123`, expected string or map, received `{ "target": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/jsdoc-require-returns.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/jsdoc-require-returns.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `jsdoc/require-returns`: invalid type: integer `999`, expected a sequence, received `{ "exemptedBy": 999 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/jsx-fragments.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/jsx-fragments.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `react/jsx-fragments`: data did not match any variant of untagged enum JsxFragments, received `{ "eventHandlerPrefix": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/react-jsx-no-target-blank.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/react-jsx-no-target-blank.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `react/jsx-no-target-blank`: unknown field `enforce_dynamic_links`, expected one of `enforceDynamicLinks`, `warnOnSpreadAttributes`, `allowReferrer`, `links`, `forms`, received `{ "enforce_dynamic_links": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/react-prefer-es6-class.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/react-prefer-es6-class.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `react/prefer-es6-class`: unknown variant `allow`, expected `always` or `never`, received `{ "allow": 1 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/react-state-in-constructor.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/react-state-in-constructor.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `react/state-in-constructor`: unknown variant `mode`, expected `always` or `never`, received `{ "mode": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/typescript-consistent-indexed-object-style.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/typescript-consistent-indexed-object-style.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `typescript/consistent-indexed-object-style`: unknown variant `style`, expected `record` or `index-signature`, received `{ "style": true }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/typescript-consistent-type-definitions.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/typescript-consistent-type-definitions.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `typescript/consistent-type-definitions`: unknown variant `style`, expected `interface` or `type`, received `{ "style": 456 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/typescript-no-explicit-any.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/typescript-no-explicit-any.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `typescript/no-explicit-any`: invalid type: string "maybe", expected a boolean, received `{ "fixToUnknown": "maybe" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/typescript-prefer-nullish-coalescing.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/typescript-prefer-nullish-coalescing.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `typescript/prefer-nullish-coalescing`: data did not match any variant of untagged enum IgnorePrimitives, received `{ "ignorePrimitives": "not-an-object" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/typescript-return-await.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/typescript-return-await.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `typescript/return-await`: unknown variant `allowIn`, expected one of `in-try-catch`, `always`, `error-handling-correctness-only`, `never`, received `{ "allowIn": 1 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/unicorn-explicit-length-check.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/unicorn-explicit-length-check.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `unicorn/explicit-length-check`: unknown field `allowedTypes`, expected `non-zero`, received `{ "allowedTypes": 456 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/unicorn-no-array-reverse.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/unicorn-no-array-reverse.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `unicorn/no-array-reverse`: unknown field `allow_as_expression`, expected `allowExpressionStatement`, received `{ "allow_as_expression": "nope" }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/unicorn-switch-case-braces.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/unicorn-switch-case-braces.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `unicorn/switch-case-braces`: unknown variant `caseBraces`, expected `always` or `avoid`, received `{ "caseBraces": 123 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/vue-define-emits-declaration.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/vue-define-emits-declaration.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `vue/define-emits-declaration`: unknown variant `declaration`, expected one of `type-based`, `type-literal`, `runtime`, received `{ "declaration": 0 }`
------------------------------------------------------------
Exit code: 1

============================================================
Config: <code-dir>/oxlint-invalid-configs/configs/vue-define-props-declaration.json
Command: node <code-dir>/oxc/apps/oxlint/dist/cli.js -c=<code-dir>/oxlint-invalid-configs/configs/vue-define-props-declaration.json
------------------------------------------------------------
   Failed to parse oxlint configuration file.
     x Invalid configuration for rule `vue/define-props-declaration`: unknown variant `declaration`, expected `type-based` or `runtime`, received `{ "declaration": false }`
------------------------------------------------------------
Exit code: 1

Done.
```
</details>

------

AI Disclosure: This changeset was produced using Node.js scripts which I generated using AI, to find specific patterns in the codebase and then perform the replacements in the code accordingly, the two scripts are included below. I have gone through the 125 changes and confirmed that all 125 are identical to one another, and are the intended end-result code.

Basically, they look for rules which have code like this, and then perform the updates only on those rules:

```rs
    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
            .unwrap_or_default()
            .into_inner())
    }
```

This avoids needing to go through manually and decide which of these rules to update, and also ensures that all 125 of these rules were safe to update - as the configuration has already been updated to use DefaultRuleConfig, which means the unit tests have validated that the shape of the JSON schema for the rule matches the actual values ingested by the rule.

<details>
<summary>Node scripts for editing the rule files</summary>

`add-deny-unknown-fields.js`:

```js
#!/usr/bin/env node
/*
Add `deny_unknown_fields` to `#[serde(...)]` attributes in files under `rules/`.

Usage:
  node scripts/add_deny_unknown_fields.js [--apply] [--base PATH]

- Scans for Rust files under any `rules/` directory.
- For files that contain the token `DefaultRuleConfig` and a `#[serde(...)]`
  attribute containing `rename_all = "camelCase"` and `default`, it will
  add `deny_unknown_fields` to that serde attribute if missing.

This is conservative and only modifies attributes that match those
conditions and currently do not include `deny_unknown_fields`.

Examples:
  # Preview changes (dry-run):
  node scripts/add_deny_unknown_fields.js

  # Apply changes in-place:
  node scripts/add_deny_unknown_fields.js --apply
*/

const fs = require("fs").promises;
const path = require("path");

const ATTR_RE = /(#\s*\[\s*serde\(([^)]*)\)\s*\])/gs; // s flag to allow newlines (node 12+)
const RENAME_RE = /rename_all\s*=\s*"camelCase"/;

async function findRuleFiles(base) {
  const results = [];
  const rulesDir = path.join(base, "crates", "oxc_linter", "src", "rules");
  try {
    const stat = await fs.stat(rulesDir);
    if (!stat.isDirectory()) return results;
  } catch (e) {
    // No rules directory found; return empty list
    return results;
  }

  async function walk(dir) {
    const entries = await fs.readdir(dir, { withFileTypes: true });
    for (const ent of entries) {
      const res = path.join(dir, ent.name);
      if (ent.isDirectory()) {
        // skip node_modules and target for speed
        if (ent.name === "node_modules" || ent.name === "target") continue;
        await walk(res);
      } else if (ent.isFile() && res.endsWith(".rs")) {
        results.push(res);
      }
    }
  }
  await walk(rulesDir);
  return results;
}

function updateSerdeAttribute(full, inner) {
  // inner is the content inside serde(...)
  const hasRename = RENAME_RE.test(inner);
  const hasDefault = /\bdefault\b/.test(inner);
  const hasDeny = /deny_unknown_fields/.test(inner);
  if (hasRename && hasDefault && !hasDeny) {
    // normalize tokens by splitting on commas
    const tokens = inner
      .split(",")
      .map((t) => t.trim())
      .filter(Boolean);
    if (!tokens.includes("deny_unknown_fields")) tokens.push("deny_unknown_fields");
    const newInner = tokens.join(", ");
    const newFull = full.replace("(" + inner + ")", "(" + newInner + ")");
    return { newFull, newInner };
  }
  return null;
}

async function processFile(filePath, apply) {
  const text = await fs.readFile(filePath, "utf8");

  const FROM_CONF_SNIPPET = `fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
            .unwrap_or_default()
            .into_inner())
    }`;

  const FROM_CONF_SNIPPET_ALT = `fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
            .unwrap_or_default()
            .into_inner())
    }`;

  // Only process files that contain the exact from_configuration method above
  if (!text.includes(FROM_CONF_SNIPPET) && !text.includes(FROM_CONF_SNIPPET_ALT)) return false;

  let changed = false;
  let out = text;
  const edits = [];
  let m;
  while ((m = ATTR_RE.exec(text)) !== null) {
    const full = m[1];
    const inner = m[2];
    const upd = updateSerdeAttribute(full, inner);
    if (upd) {
      edits.push({ full, newFull: upd.newFull });
    }
  }

  if (edits.length > 0) {
    for (const e of edits) {
      out = out.replace(e.full, e.newFull);
      changed = true;
      console.log(`Will update: ${filePath}:`);
      console.log(`  - ${e.full.trim()}`);
      console.log(`  + ${e.newFull.trim()}`);
      console.log("");
    }
    if (apply) {
      await fs.writeFile(filePath, out, "utf8");
      console.log(`Applied changes to ${filePath}\n`);
    }
  }
  return changed;
}

async function main() {
  const args = process.argv.slice(2);
  const apply = args.includes("--apply");
  const quiet = args.includes("--quiet");
  const baseIndex = args.findIndex((a) => a === "--base");
  let base = process.cwd();
  if (baseIndex !== -1 && args.length > baseIndex + 1) base = path.resolve(args[baseIndex + 1]);

  try {
    const files = await findRuleFiles(base);
    if (!files.length) {
      if (!quiet) console.log("No files found in crates/oxc_linter/src/rules/.");
      return;
    }

    let changedAny = false;
    const editedFiles = [];
    for (const f of files) {
      try {
        const changed = await processFile(f, apply);
        if (changed) {
          changedAny = true;
          if (apply) editedFiles.push(f);
        }
      } catch (err) {
        console.error(`Error processing ${f}: ${err}`);
      }
    }

    if (!changedAny && !quiet)
      console.log("No matching serde attributes found that needed changes.");
    if (changedAny && !apply) console.log("\nRun with --apply to make the changes.");

    if (apply && editedFiles.length > 0) {
      if (!quiet) {
        console.log("\nEdited files:");
        for (const ef of editedFiles) console.log(`  - ${ef}`);
      }
    } else if (apply && !quiet) {
      console.log("\nNo files were changed.");
    }
  } catch (err) {
    console.error(err);
    process.exit(2);
  }
}

if (require.main === module) main();
```

`update-from-configuration.js`:

```js
#!/usr/bin/env node
/*
Update `from_configuration` implementations in rule files that include `deny_unknown_fields`.

Usage:
  node scripts/update_from_configuration.js [--apply] [--base PATH]

- Scans for Rust files under `crates/oxc_linter/src/rules`.
- For files that contain the token `deny_unknown_fields` and the exact
  `from_configuration` method form that uses `unwrap_or_default().into_inner()`,
  it replaces that method body with a shorter `map(DefaultRuleConfig::into_inner)`
  call as described in the repo's style.

Examples:
  # Preview changes (dry-run):
  node scripts/update_from_configuration.js

  # Apply changes in-place:
  node scripts/update_from_configuration.js --apply
*/

const fs = require("fs").promises;
const path = require("path");

async function findRuleFiles(base) {
  const results = [];
  const rulesDir = path.join(base, "crates", "oxc_linter", "src", "rules");
  try {
    const stat = await fs.stat(rulesDir);
    if (!stat.isDirectory()) return results;
  } catch (e) {
    return results;
  }

  async function walk(dir) {
    const entries = await fs.readdir(dir, { withFileTypes: true });
    for (const ent of entries) {
      const res = path.join(dir, ent.name);
      if (ent.isDirectory()) {
        if (ent.name === "node_modules" || ent.name === "target") continue;
        await walk(res);
      } else if (ent.isFile() && res.endsWith(".rs")) {
        results.push(res);
      }
    }
  }
  await walk(rulesDir);
  return results;
}

async function processFile(filePath, apply) {
  const text = await fs.readFile(filePath, "utf8");

  // Only handle files that mention deny_unknown_fields
  if (!text.includes("deny_unknown_fields")) return false;

  const FROM_CONF_SNIPPET = `fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
            .unwrap_or_default()
            .into_inner())
    }`;

  const FROM_CONF_SNIPPET_ALT = `fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
            .unwrap_or_default()
            .into_inner())
    }`;

  const REPLACEMENT = `fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
    }`;

  const REPLACEMENT_ALT = `fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
    }`;

  if (!text.includes(FROM_CONF_SNIPPET) && !text.includes(FROM_CONF_SNIPPET_ALT)) return false;

  let out = text;
  let changed = false;

  if (out.includes(FROM_CONF_SNIPPET)) {
    out = out.replace(FROM_CONF_SNIPPET, REPLACEMENT);
    changed = true;
    console.log(`Will update: ${filePath} - replace serde_json::Value form`);
  }

  if (out.includes(FROM_CONF_SNIPPET_ALT)) {
    out = out.replace(FROM_CONF_SNIPPET_ALT, REPLACEMENT_ALT);
    changed = true;
    console.log(`Will update: ${filePath} - replace Value form`);
  }

  if (changed && apply) {
    await fs.writeFile(filePath, out, "utf8");
    console.log(`Applied changes to ${filePath}\n`);
  }

  return changed;
}

async function main() {
  const args = process.argv.slice(2);
  const apply = args.includes("--apply");
  const quiet = args.includes("--quiet");
  const baseIndex = args.findIndex((a) => a === "--base");
  let base = process.cwd();
  if (baseIndex !== -1 && args.length > baseIndex + 1) base = path.resolve(args[baseIndex + 1]);

  try {
    const files = await findRuleFiles(base);
    if (!files.length) {
      if (!quiet) console.log("No files found in crates/oxc_linter/src/rules/.");
      return;
    }

    let changedAny = false;
    const editedFiles = [];
    for (const f of files) {
      try {
        const changed = await processFile(f, apply);
        if (changed) {
          changedAny = true;
          if (apply) editedFiles.push(f);
        }
      } catch (err) {
        console.error(`Error processing ${f}: ${err}`);
      }
    }

    if (!changedAny && !quiet)
      console.log("No matching from_configuration methods found that needed changes.");
    if (changedAny && !apply) console.log("\nRun with --apply to make the changes.");

    if (apply && editedFiles.length > 0) {
      if (!quiet) {
        console.log("\nEdited files:");
        for (const ef of editedFiles) console.log(`  - ${ef}`);
      }
    } else if (apply && !quiet) {
      console.log("\nNo files were changed.");
    }
  } catch (err) {
    console.error(err);
    process.exit(2);
  }
}

if (require.main === module) main();
```

</details>