### PR TITLE
fix(linter): Update react/jsx-max-depth to raise an error if provided invalid config options.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
@@ -36,8 +36,9 @@ impl std::ops::Deref for JsxMaxDepth {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxMaxDepthConfig {
+    /// The maximum allowed depth of nested JSX elements and fragments.
     pub max: usize,
 }
 
@@ -89,9 +90,7 @@ declare_oxc_lint!(
 
 impl Rule for JsxMaxDepth {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .map(DefaultRuleConfig::into_inner)
-            .unwrap_or_default())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
This was not handled by #18104 as the rule was using a slightly different pattern for the from_configuration method compared to other rules, so it was missed by the scripts I used.

Also add docs, why not.