### PR TITLE
fix(linter): Update `react/jsx-fragments` rule to raise an error on invalid configuration options

### DIFF
--- a/apps/oxlint/fixtures/invalid_config_complex_enum/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_complex_enum/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["react"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    // Invalid config, valid options are "syntax" or "element" (or an object).
+    "react/jsx-fragments": ["error", "somethingelse"]
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1517,4 +1517,11 @@ export { redundant };
     fn test_valid_complex_config() {
         Tester::new().with_cwd("fixtures/valid_complex_config".into()).test_and_snapshot(&[]);
     }
+
+    #[test]
+    fn test_invalid_config_invalid_config_complex_enum() {
+        Tester::new()
+            .with_cwd("fixtures/invalid_config_complex_enum".into())
+            .test_and_snapshot(&[]);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_complex_enum_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_complex_enum_@oxlint.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/invalid_config_complex_enum
+----------
+Failed to parse oxlint configuration file.
+
+  x Invalid configuration for rule `react/jsx-fragments`: data did not match any variant of untagged enum JsxFragments, received `"somethingelse"`
+
+----------
+CLI result: InvalidOptionConfig
+----------

--- a/crates/oxc_linter/src/rules/react/jsx_fragments.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_fragments.rs
@@ -27,6 +27,8 @@ fn jsx_fragments_diagnostic(span: Span, mode: FragmentMode) -> OxcDiagnostic {
     OxcDiagnostic::warn(msg).with_help(help).with_label(span)
 }
 
+// Generally we should prefer the string-only syntax for compatibility with the original ESLint rule,
+// but we originally implemented the rule with only the object syntax, so we support both now.
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(untagged)]
 pub enum JsxFragments {
@@ -104,12 +106,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxFragments {
-    // Generally we should prefer the string-only syntax for compatibility with the original ESLint rule,
-    // but we originally implemented the rule with only the object syntax, so we support both now.
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
And add a snapshot test for the result of an invalid configuration option passed to a complex enum type like this. Unfortunately, the error message could be better, but for now it's _okay_.

Right now, the error message is a bit crap because the shape of the rule config allows an object OR an enum string, for backwards-compatibility:

```rs
#[derive(Debug, Clone, JsonSchema, Deserialize)]
#[serde(untagged)]
pub enum JsxFragments {
    Mode(FragmentMode),
    Object { mode: FragmentMode },
}
```