### PR TITLE
fix(linter): Update `react/no-will-update-set-state` to error on invalid config options

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_will_update_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_will_update_set_state.rs
@@ -76,9 +76,7 @@ declare_oxc_lint!(
 
 impl Rule for NoWillUpdateSetState {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -243,6 +241,23 @@ fn test() {
 			      ",
             None,
             Some(serde_json::json!({ "settings": { "react": { "version": "16.2.0" } } })),
+        ),
+        // Test to ensure that not providing a value for the config works fine and does not error.
+        (
+            "
+			        var Hello = createReactClass({
+			          componentWillUpdate: function() {
+			            function handleEvent(data) {
+			              this.setState({
+			                data: data
+			              });
+			            }
+			            someClass.onSomeEvent(handleEvent)
+			          }
+			        });
+			      ",
+            Some(serde_json::json!([])),
+            None,
         ),
     ];
 


### PR DESCRIPTION
The options for this rule are a bit weird, as it has a `serde(skip)` on the default enum option. I've added a test to validate that this works fine when unset.

Passing `allowed` will now fail, but [the docs don't mention any config options anyway](https://oxc.rs/docs/guide/usage/linter/rules/react/no-will-update-set-state.html) because they can't handle serializing this config shape. We should probably consider removing the `serde(skip)` on the Allowed enum option for the rule, as it doesn't really harm anything to _allow_ the config option to be set (plus it'll fix the docs rendering).