### PR TITLE
fix(linter): Update 5 more rules to error on invalid config options.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -17,7 +17,7 @@ fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct NoUndef {
     /// When set to `true`, warns on undefined variables used in a `typeof` expression.
     #[serde(rename = "typeof")]
@@ -53,9 +53,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUndef {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -91,9 +91,7 @@ fn is_relative_path(path: &str) -> bool {
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/first.md>
 impl Rule for First {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -153,10 +153,8 @@ fn is_valid_autocomplete_value(value: &str) -> bool {
 }
 
 impl Rule for AutocompleteValid {
-    fn from_configuration(config: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(config)
-            .unwrap_or_default()
-            .into_inner())
+    fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -20,7 +20,7 @@ fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct NoAutofocus {
     /// Determines if developer-created components are checked.
     #[serde(rename = "ignoreNonDOM")]
@@ -62,9 +62,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAutofocus {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -60,7 +60,7 @@ impl VitestFnName {
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
 pub struct ConsistentVitestConfig {
     /// Decides whether to prefer vitest function accessor
     #[serde(rename = "fn", default)]
@@ -101,9 +101,7 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentVitestVi {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
This updates a few miscellaneous rules to error on invalid config options. These were missed by the script from #18104 for various reasons (uncommon serde attributes, from_configuration using a param name other than `value`, etc).