### PR TITLE
refactor(rulegen): Update the rulegen template to error on an invalid config

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -78,14 +78,16 @@ pub trait Rule: Sized + Default + fmt::Debug {
 /// the actual rule configuration. This type automatically extracts and deserializes
 /// that first element. If the array is empty, it uses the default value.
 ///
+/// If the configuration is invalid (e.g. does not match the expected type, has a
+/// field that does not exist), it will return a deserialization error that is
+/// handled by the linter and reported to the user.
+///
 /// # Examples
 ///
 /// ```ignore
 /// impl Rule for MyRule {
 ///     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-///         Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-///             .unwrap_or_default()
-///             .into_inner())
+///         serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
 ///     }
 /// }
 /// ```

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -733,7 +733,7 @@ impl RuleConfigOutput {
                 output.push_str(
                     "#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]\n",
                 );
-                output.push_str("#[schemars(untagged, rename_all = \"camelCase\")]\n");
+                output.push_str("#[serde(untagged, rename_all = \"camelCase\")]\n");
                 let _ = writeln!(output, "enum {enum_name} {{");
                 let mut unlabeled_enum_value_count = 0;
                 let mut added_default = false;
@@ -798,7 +798,7 @@ impl RuleConfigOutput {
                             if !schemars_tags.is_empty() {
                                 let _ = writeln!(
                                     enum_fields,
-                                    "    #[schemars({})]",
+                                    "    #[serde({})]",
                                     schemars_tags.join(", ")
                                 );
                             }
@@ -842,7 +842,9 @@ impl RuleConfigOutput {
                 let mut output = String::from(
                     "#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]\n",
                 );
-                output.push_str("#[schemars(rename_all = \"camelCase\")]\n");
+                output.push_str(
+                    "#[serde(rename_all = \"camelCase\", default, deny_unknown_fields)]\n",
+                );
                 let _ = writeln!(output, "struct {struct_name} {{");
                 let mut fields_output = String::new();
                 for (raw_key, value) in hash_map {

--- a/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
+++ b/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
@@ -23,7 +23,7 @@ fn my_rule_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct ConfigObject {
     pub foo: String,
     pub bar: Option<i32>,
@@ -65,7 +65,7 @@ declare_oxc_lint!(
 
 impl Rule for MyRule {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -91,7 +91,7 @@ mod tests {
         .with_fix_cases("(\"fixed\")".to_string())
         .with_rule_config(
             r#"#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct ConfigObject {
     pub foo: String,
     pub bar: Option<i32>,

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -67,7 +67,7 @@ declare_oxc_lint!(
 impl Rule for {{pascal_rule_name}} {
 {{#if rule_config}}
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value).unwrap_or_default().into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
 {{/if}}


### PR DESCRIPTION
New rules created with this tooling will now be generated to error when the config is invalid, rather than falling back to a default config.

Also use `serde` attributes for deserialization, and ensure we set `default` for serde. Also prefer to use `serde` over schemars in the template.