### PR TITLE
feat(codegen): add `ascii_only` option

### DIFF
--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -15,6 +15,17 @@ pub struct CodegenOptions {
     /// Default is `false`.
     pub minify: bool,
 
+    /// Escape non-ASCII characters as `\uXXXX` or `\u{XXXXXX}`.
+    ///
+    /// When enabled, all non-ASCII characters in strings and identifiers will be escaped
+    /// using Unicode escape sequences. This is useful for environments that don't handle
+    /// UTF-8 properly or for ensuring ASCII-only output.
+    ///
+    /// This is equivalent to esbuild's `--charset=ascii` option.
+    ///
+    /// Default is `false`.
+    pub ascii_only: bool,
+
     /// Print comments?
     ///
     /// At present, only some leading comments are preserved.
@@ -50,6 +61,7 @@ impl Default for CodegenOptions {
         Self {
             single_quote: false,
             minify: false,
+            ascii_only: false,
             comments: CommentOptions::default(),
             source_map_path: None,
             indent_char: IndentChar::default(),
@@ -65,6 +77,7 @@ impl CodegenOptions {
         Self {
             single_quote: false,
             minify: true,
+            ascii_only: false,
             comments: CommentOptions::disabled(),
             source_map_path: None,
             indent_char: IndentChar::default(),

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -78,6 +78,38 @@ pub fn test_minify_same(source_text: &str) {
     test_minify(source_text, source_text);
 }
 
+/// Test with `ascii_only: true` option
+#[track_caller]
+pub fn test_ascii(source_text: &str, expected: &str) {
+    let source_type = SourceType::tsx();
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    let result = Codegen::new()
+        .with_options(CodegenOptions { ascii_only: true, ..default_options() })
+        .build(&ret.program)
+        .code;
+    assert_eq!(result, expected, "\nfor ascii source: {source_text:?}");
+}
+
+/// Test with `ascii_only: true` and `minify: true` options
+#[track_caller]
+pub fn test_minify_ascii(source_text: &str, expected: &str) {
+    let source_type = SourceType::tsx();
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, source_type).parse();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    let result = Codegen::new()
+        .with_options(CodegenOptions {
+            ascii_only: true,
+            minify: true,
+            ..CodegenOptions::default()
+        })
+        .build(&ret.program)
+        .code;
+    assert_eq!(result, expected, "\nfor minify ascii source: {source_text:?}");
+}
+
 #[track_caller]
 pub fn codegen(source_text: &str) -> String {
     codegen_options(source_text, &default_options()).code

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -7,6 +7,14 @@ export interface CodegenOptions {
    * @default true
    */
   removeWhitespace?: boolean
+  /**
+   * Escape non-ASCII characters as `\uXXXX` or `\u{XXXXXX}`.
+   *
+   * This is equivalent to esbuild's `--charset=ascii` option.
+   *
+   * @default false
+   */
+  asciiOnly?: boolean
 }
 
 export interface CompressOptions {

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -255,21 +255,34 @@ pub struct CodegenOptions {
     ///
     /// @default true
     pub remove_whitespace: Option<bool>,
+
+    /// Escape non-ASCII characters as `\uXXXX` or `\u{XXXXXX}`.
+    ///
+    /// This is equivalent to esbuild's `--charset=ascii` option.
+    ///
+    /// @default false
+    pub ascii_only: Option<bool>,
 }
 
 impl Default for CodegenOptions {
     fn default() -> Self {
-        Self { remove_whitespace: Some(true) }
+        Self { remove_whitespace: Some(true), ascii_only: Some(false) }
     }
 }
 
 impl From<&CodegenOptions> for oxc_codegen::CodegenOptions {
     fn from(o: &CodegenOptions) -> Self {
-        if o.remove_whitespace.is_some_and(|b| b) {
-            oxc_codegen::CodegenOptions::minify()
+        let minify = o.remove_whitespace.unwrap_or(true);
+        let ascii_only = o.ascii_only.unwrap_or(false);
+        if minify {
+            oxc_codegen::CodegenOptions { ascii_only, ..oxc_codegen::CodegenOptions::minify() }
         } else {
             // Need to remove all comments.
-            oxc_codegen::CodegenOptions { minify: false, ..oxc_codegen::CodegenOptions::minify() }
+            oxc_codegen::CodegenOptions {
+                minify: false,
+                ascii_only,
+                ..oxc_codegen::CodegenOptions::minify()
+            }
         }
     }
 }

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -184,8 +184,14 @@ describe("asciiOnly option", () => {
       // Non-BMP identifiers (\u{XXXXXX})
       { input: "var 𐀀", expected: "var \\u{10000};", description: "Non-BMP identifier" },
 
+      // BMP property access (identifier syntax preserved with \uXXXX)
+      { input: "x.π", expected: "x.\\u03C0;", description: "BMP property access" },
+
       // Non-BMP property access -> computed syntax
       { input: "x.𐀀", expected: 'x["\\u{10000}"];', description: "Non-BMP property access" },
+
+      // BMP object keys (identifier syntax preserved with \uXXXX)
+      { input: "({π: 1})", expected: "({\\u03C0:1});", description: "BMP object key" },
 
       // Non-BMP object keys -> string keys
       { input: "({𐀀: 1})", expected: '({"\\u{10000}":1});', description: "Non-BMP object key" },

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -174,12 +174,12 @@ describe("asciiOnly option", () => {
       },
 
       // BMP characters in strings (\uXXXX)
-      { input: "'π'", expected: "`\\u03C0`;", description: "BMP string" },
-      { input: "'中文'", expected: "`\\u4E2D\\u6587`;", description: "CJK string" },
+      { input: "'π'", expected: '"\\u03C0";', description: "BMP string" },
+      { input: "'中文'", expected: '"\\u4E2D\\u6587";', description: "CJK string" },
 
       // Non-BMP characters in strings (\u{XXXXXX})
-      { input: "'🐈'", expected: "`\\u{1F408}`;", description: "Non-BMP emoji string" },
-      { input: "'𐀀'", expected: "`\\u{10000}`;", description: "Non-BMP string" },
+      { input: "'🐈'", expected: '"\\u{1F408}";', description: "Non-BMP emoji string" },
+      { input: "'𐀀'", expected: '"\\u{10000}";', description: "Non-BMP string" },
 
       // Non-BMP identifiers (\u{XXXXXX})
       { input: "var 𐀀", expected: "var \\u{10000};", description: "Non-BMP identifier" },
@@ -191,17 +191,28 @@ describe("asciiOnly option", () => {
       { input: "x.𐀀", expected: 'x["\\u{10000}"];', description: "Non-BMP property access" },
 
       // BMP object keys (identifier syntax preserved with \uXXXX)
-      { input: "({π: 1})", expected: "({\\u03C0:1});", description: "BMP object key" },
+      // Use assignment to prevent dead code elimination
+      {
+        input: "const x = {π: 1}",
+        expected: "const x={\\u03C0:1};",
+        description: "BMP object key",
+      },
 
       // Non-BMP object keys -> string keys
-      { input: "({𐀀: 1})", expected: '({"\\u{10000}":1});', description: "Non-BMP object key" },
+      {
+        input: "const x = {𐀀: 1}",
+        expected: 'const x={"\\u{10000}":1};',
+        description: "Non-BMP object key",
+      },
 
-      // Always escaped characters (regardless of asciiOnly)
-      { input: "'\uFEFF'", expected: "`\\uFEFF`;", description: "BOM always escaped" },
-      { input: "'\u2028'", expected: "`\\u2028`;", description: "Line separator always escaped" },
+      // BOM (U+FEFF) - only escaped in ascii_only mode
+      { input: "'\uFEFF'", expected: '"\\uFEFF";', description: "BOM" },
+
+      // Always escaped characters (regardless of asciiOnly) - line terminators in JS
+      { input: "'\u2028'", expected: '"\\u2028";', description: "Line separator always escaped" },
       {
         input: "'\u2029'",
-        expected: "`\\u2029`;",
+        expected: '"\\u2029";',
         description: "Paragraph separator always escaped",
       },
     ];

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -154,3 +154,59 @@ describe("worker", () => {
     expect(code).toBe(0);
   });
 });
+
+// ASCII-only mode comprehensive test
+// See: https://github.com/oxc-project/oxc/issues/17068
+describe("asciiOnly option", () => {
+  it("escapes all non-ASCII variants", () => {
+    const testCases: Array<{ input: string; expected: string; description: string }> = [
+      // BMP characters in identifiers (\uXXXX)
+      { input: "let π = 1", expected: "let \\u03C0=1;", description: "BMP identifier" },
+      {
+        input: "let _π = 1",
+        expected: "let _\\u03C0=1;",
+        description: "BMP identifier with underscore prefix",
+      },
+      {
+        input: "let π_ = 1",
+        expected: "let \\u03C0_=1;",
+        description: "BMP identifier with underscore suffix",
+      },
+
+      // BMP characters in strings (\uXXXX)
+      { input: "'π'", expected: "`\\u03C0`;", description: "BMP string" },
+      { input: "'中文'", expected: "`\\u4E2D\\u6587`;", description: "CJK string" },
+
+      // Non-BMP characters in strings (\u{XXXXXX})
+      { input: "'🐈'", expected: "`\\u{1F408}`;", description: "Non-BMP emoji string" },
+      { input: "'𐀀'", expected: "`\\u{10000}`;", description: "Non-BMP string" },
+
+      // Non-BMP identifiers (\u{XXXXXX})
+      { input: "var 𐀀", expected: "var \\u{10000};", description: "Non-BMP identifier" },
+
+      // Non-BMP property access -> computed syntax
+      { input: "x.𐀀", expected: 'x["\\u{10000}"];', description: "Non-BMP property access" },
+
+      // Non-BMP object keys -> string keys
+      { input: "({𐀀: 1})", expected: '({"\\u{10000}":1});', description: "Non-BMP object key" },
+
+      // Always escaped characters (regardless of asciiOnly)
+      { input: "'\uFEFF'", expected: "`\\uFEFF`;", description: "BOM always escaped" },
+      { input: "'\u2028'", expected: "`\\u2028`;", description: "Line separator always escaped" },
+      {
+        input: "'\u2029'",
+        expected: "`\\u2029`;",
+        description: "Paragraph separator always escaped",
+      },
+    ];
+
+    for (const { input, expected, description } of testCases) {
+      const ret = minifySync("test.js", input, {
+        mangle: false,
+        codegen: { asciiOnly: true },
+      });
+      expect(ret.code, description).toBe(expected);
+      expect(ret.errors.length, `${description} should have no errors`).toBe(0);
+    }
+  });
+});

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -32,6 +32,7 @@ pub struct Driver {
     pub compress: Option<CompressOptions>,
     pub remove_whitespace: bool,
     pub codegen: bool,
+    pub ascii_only: bool,
     pub check_semantic: bool,
     pub allow_return_outside_function: bool,
     // results
@@ -63,11 +64,13 @@ impl CompilerInterface for Driver {
 
     fn codegen_options(&self) -> Option<CodegenOptions> {
         self.codegen.then(|| {
-            if self.remove_whitespace {
+            let mut options = if self.remove_whitespace {
                 CodegenOptions::minify()
             } else {
                 CodegenOptions::default()
-            }
+            };
+            options.ascii_only = self.ascii_only;
+            options
         })
     }
 


### PR DESCRIPTION
## Summary

Add the `ascii_only` field to `CodegenOptions` for escaping non-ASCII characters. This is equivalent to esbuild's `--charset=ascii` option.

Closes #17068

## Implementation

### `crates/oxc_codegen/src/str.rs`

- **`contains_non_bmp(s: &str)`** - Check if string contains non-BMP characters (bytes >= 0xF0)
- **`print_identifier(name: &str)`** - Print identifier with non-ASCII chars escaped when `ascii_only`
- **`print_string_value(s: &str)`** - Print string content with non-ASCII chars escaped when `ascii_only`
- **`print_unicode_escape(code_point: u32)`** - Print `\uXXXX` for BMP or `\u{XXXXXX}` for non-BMP
- Modified string printing to escape all non-ASCII when `ascii_only` is enabled
- **Always escape** U+2028 (Line Separator), U+2029 (Paragraph Separator) regardless of `ascii_only`

### `crates/oxc_codegen/src/gen.rs`

- **Identifiers**: When `ascii_only`, escape non-ASCII characters using `\uXXXX` or `\u{XXXXXX}`
- **`StaticMemberExpression`**: When `ascii_only`, convert non-BMP property access to computed syntax (`x.𐀀` → `x["\u{10000}"]`)
- **`ObjectProperty`**: When `ascii_only`, convert non-BMP keys to escaped string literals (`{𐀀: 0}` → `{"\u{10000}": 0}`)
- **`Directive`**: Escape non-ASCII characters when `ascii_only`
- **JSX**: Element names, attribute names, and text content are **NOT** escaped (JSX lacks escape syntax)

## Behavior Summary

| Scenario | Without `ascii_only` | With `ascii_only` |
|----------|---------------------|-------------------|
| BMP in strings (U+0080-U+FFFF) | Keep as-is | `\uXXXX` |
| Non-BMP in strings (U+10000+) | Keep as-is | `\u{XXXXXX}` |
| BMP in identifiers | Keep as-is | `\uXXXX` |
| Non-BMP in identifiers | Keep as-is | `\u{XXXXXX}` |
| Non-BMP property access | Keep as-is | Convert to computed + escape `x["\u{10000}"]` |
| Non-BMP object keys | Keep as-is | Convert to string + escape `{"\u{10000}": 0}` |
| U+2028, U+2029 | **Always escape** | **Always escape** |
| JSX names/text | Keep as-is | **Keep as-is** (no escaping) |

## Test plan

- [x] Added Rust integration tests for ASCII-only mode
- [x] Added tests for non-BMP property access and object keys
- [x] Added tests for always-escaped characters (U+2028, U+2029)
- [x] Added JSX ASCII-only mode tests
- [x] Added NAPI integration test with all ASCII variants
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)