### PR TITLE
test(linter): Fix a mistake in the test porting.

### DIFF
--- a/apps/oxlint/fixtures/invalid_config_with_rule_alias/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_with_rule_alias/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["vitest"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    // Invalid config, `allow` should only have string values
+    "vitest/no-hooks": ["error", { "allow": 123 }]
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1486,13 +1486,24 @@ export { redundant };
     }
 
     #[test]
+    // Ensure the config validation works with vitest/no-hooks, which
+    // is an alias of jest/no-hooks.
+    fn test_invalid_config_invalid_config_with_rule_alias() {
+        Tester::new()
+            .with_cwd("fixtures/invalid_config_with_rule_alias".into())
+            .test_and_snapshot(&[]);
+    }
+
+    #[test]
     fn test_invalid_config_invalid_config_in_override() {
         Tester::new().with_cwd("fixtures/invalid_config_in_override".into()).test_and_snapshot(&[]);
     }
 
     #[test]
     fn test_invalid_config_invalid_config_multiple_rules() {
-        Tester::new().with_cwd("fixtures/invalid_config_in_override".into()).test_and_snapshot(&[]);
+        Tester::new()
+            .with_cwd("fixtures/invalid_config_multiple_rules".into())
+            .test_and_snapshot(&[]);
     }
 
     #[test]

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/invalid_config_multiple_rules
+----------
+Failed to parse oxlint configuration file.
+
+  x Invalid configuration for rule `jest/no-hooks`: unknown field `foo`, expected `allow`, received `{ "foo": "bar" }`
+  | Invalid configuration for rule `no-return-assign`: unknown variant `foobar`, expected `always` or `except-parens`, received `"foobar"`
+
+----------
+CLI result: InvalidOptionConfig
+----------

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_with_rule_alias_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_with_rule_alias_@oxlint.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/invalid_config_with_rule_alias
+----------
+Failed to parse oxlint configuration file.
+
+  x Invalid configuration for rule `vitest/no-hooks`: invalid type: integer `123`, expected a sequence, received `{ "allow": 123 }`
+
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
We want to test the output that results from multiple invalid rules, so we are doing that now.

This was a mistake made in #17600.

Also add a test for rule alias support, to make sure vitest/no-hooks has the same config option validation.