### PR TITLE
docs(vcode): add example for `editor.formatOnSave` with `editor.formatOnSaveMode`

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -30,7 +30,9 @@ To enable it as your default formatter, use a VS Code `settings.json` like:
 
 ```json
 {
-  "editor.defaultFormatter": "oxc.oxc-vscode"
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file" // tell oxfmt to format the whole file, not only the modified lines
   // Or enable it for specific file types:
   // "[javascript]": {
   //   "editor.defaultFormatter": "oxc.oxc-vscode"


### PR DESCRIPTION
VS Code can handle formatting on save in different ways. The configuration `editor.formatOnSaveMode` is responsible for it.
The default value "file" will format the whole file.
https://code.visualstudio.com/updates/v1_49#_only-format-modified-text

Other values like `modifications` are not supported by `oxfmt` for the moment, because the missing LSP specs:
- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rangeFormatting
- (or)  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_onTypeFormatting

Problem found in https://discord.com/channels/1079625926024900739/1461131443215405305/1461160171890938043