### PR TITLE
refactor(minifier): consolidate DeadCodeElimination into PeepholeOptimizations

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -5,7 +5,7 @@ use oxc_traverse::ReusableTraverseCtx;
 
 use crate::{
     CompressOptions,
-    peephole::{DeadCodeElimination, Normalize, NormalizeOptions, PeepholeOptimizations},
+    peephole::{Normalize, NormalizeOptions, PeepholeOptimizations},
     state::MinifierState,
 };
 
@@ -63,6 +63,6 @@ impl<'a> Compressor<'a> {
             remove_unnecessary_use_strict: false,
         };
         Normalize::new(normalize_options).build(program, &mut ctx);
-        DeadCodeElimination::new(max_iterations).run_in_loop(program, &mut ctx)
+        PeepholeOptimizations::new_dce(max_iterations).run_in_loop(program, &mut ctx)
     }
 }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -40,11 +40,17 @@ pub struct PeepholeOptimizations {
     /// in the previous walk.
     iteration: u8,
     changed: bool,
+    /// When true, only run dead code elimination passes (subset of full peephole optimizations).
+    dce: bool,
 }
 
 impl<'a> PeepholeOptimizations {
     pub fn new(max_iterations: Option<u8>) -> Self {
-        Self { max_iterations, iteration: 0, changed: false }
+        Self { max_iterations, iteration: 0, changed: false, dce: false }
+    }
+
+    pub fn new_dce(max_iterations: Option<u8>) -> Self {
+        Self { max_iterations, iteration: 0, changed: false, dce: true }
     }
 
     fn run_once(
@@ -167,7 +173,8 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
                 ctx.scoping_mut().delete_reference(*reference_id_to_remove);
             }
         }
-        debug_assert!(ctx.state.class_symbols_stack.is_exhausted());
+        // Only check class_symbols_stack in full optimization mode (not DCE mode)
+        debug_assert!(self.dce || ctx.state.class_symbols_stack.is_exhausted());
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
@@ -176,55 +183,87 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::keep_track_of_pure_functions(stmt, ctx);
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let ctx = &mut Ctx::new(ctx);
-        match stmt {
-            Statement::BlockStatement(_) => Self::try_optimize_block(stmt, ctx),
-            Statement::IfStatement(s) => {
-                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
-                Self::try_fold_if(stmt, ctx);
-                if let Statement::IfStatement(if_stmt) = stmt
-                    && let Some(folded_stmt) = Self::try_minimize_if(if_stmt, ctx)
-                {
-                    *stmt = folded_stmt;
-                    ctx.state.changed = true;
+        if self.dce {
+            match stmt {
+                Statement::BlockStatement(_) => Self::try_optimize_block(stmt, ctx),
+                Statement::IfStatement(_) => Self::try_fold_if(stmt, ctx),
+                Statement::ForStatement(_) => Self::try_fold_for(stmt, ctx),
+                Statement::TryStatement(_) => Self::try_fold_try(stmt, ctx),
+                Statement::LabeledStatement(_) => Self::try_fold_labeled(stmt, ctx),
+                Statement::FunctionDeclaration(_) => {
+                    Self::remove_unused_function_declaration(stmt, ctx);
                 }
-            }
-            Statement::WhileStatement(s) => {
-                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
-            }
-            Statement::ForStatement(s) => {
-                if let Some(test) = &mut s.test {
-                    Self::minimize_expression_in_boolean_context(test, ctx);
+                Statement::ClassDeclaration(_) => {
+                    Self::remove_unused_class_declaration(stmt, ctx);
                 }
-                Self::try_fold_for(stmt, ctx);
+                Statement::ExpressionStatement(_) => {
+                    Self::try_fold_expression_stmt(stmt, ctx);
+                }
+                Statement::ImportDeclaration(_) => {
+                    Self::remove_unused_import_specifiers(stmt, ctx);
+                }
+                _ => {}
             }
-            Statement::DoWhileStatement(s) => {
-                Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
+        } else {
+            match stmt {
+                Statement::BlockStatement(_) => Self::try_optimize_block(stmt, ctx),
+                Statement::IfStatement(s) => {
+                    Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
+                    Self::try_fold_if(stmt, ctx);
+                    if let Statement::IfStatement(if_stmt) = stmt
+                        && let Some(folded_stmt) = Self::try_minimize_if(if_stmt, ctx)
+                    {
+                        *stmt = folded_stmt;
+                        ctx.state.changed = true;
+                    }
+                }
+                Statement::WhileStatement(s) => {
+                    Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
+                }
+                Statement::ForStatement(s) => {
+                    if let Some(test) = &mut s.test {
+                        Self::minimize_expression_in_boolean_context(test, ctx);
+                    }
+                    Self::try_fold_for(stmt, ctx);
+                }
+                Statement::DoWhileStatement(s) => {
+                    Self::minimize_expression_in_boolean_context(&mut s.test, ctx);
+                }
+                Statement::TryStatement(_) => Self::try_fold_try(stmt, ctx),
+                Statement::LabeledStatement(_) => Self::try_fold_labeled(stmt, ctx),
+                Statement::FunctionDeclaration(_) => {
+                    Self::remove_unused_function_declaration(stmt, ctx);
+                }
+                Statement::ClassDeclaration(_) => Self::remove_unused_class_declaration(stmt, ctx),
+                Statement::ImportDeclaration(_) => Self::remove_unused_import_specifiers(stmt, ctx),
+                _ => {}
             }
-            Statement::TryStatement(_) => Self::try_fold_try(stmt, ctx),
-            Statement::LabeledStatement(_) => Self::try_fold_labeled(stmt, ctx),
-            Statement::FunctionDeclaration(_) => {
-                Self::remove_unused_function_declaration(stmt, ctx);
-            }
-            Statement::ClassDeclaration(_) => Self::remove_unused_class_declaration(stmt, ctx),
-            Statement::ImportDeclaration(_) => Self::remove_unused_import_specifiers(stmt, ctx),
-            _ => {}
+            Self::try_fold_expression_stmt(stmt, ctx);
         }
-        Self::try_fold_expression_stmt(stmt, ctx);
     }
 
     fn exit_for_statement(&mut self, stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_for_statement(stmt, ctx);
         Self::minimize_for_statement(stmt, ctx);
     }
 
     fn exit_return_statement(&mut self, stmt: &mut ReturnStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_return_statement(stmt, ctx);
     }
@@ -234,6 +273,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         decl: &mut VariableDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_variable_declaration(decl, ctx);
     }
@@ -249,85 +291,126 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
 
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let ctx = &mut Ctx::new(ctx);
-        match expr {
-            Expression::TemplateLiteral(t) => {
-                Self::inline_template_literal(t, ctx);
-                Self::substitute_template_literal(expr, ctx);
-            }
-            Expression::ObjectExpression(e) => Self::fold_object_exp(e, ctx),
-            Expression::BinaryExpression(e) => {
-                Self::substitute_swap_binary_expressions(e);
-                Self::fold_binary_expr(expr, ctx);
-                Self::fold_binary_typeof_comparison(expr, ctx);
-                Self::minimize_loose_boolean(expr, ctx);
-                Self::minimize_binary(expr, ctx);
-                Self::substitute_loose_equals_undefined(expr, ctx);
-                Self::substitute_typeof_undefined(expr, ctx);
-                Self::substitute_rotate_binary_expression(expr, ctx);
-            }
-            Expression::UnaryExpression(_) => {
-                Self::fold_unary_expr(expr, ctx);
-                Self::minimize_unary(expr, ctx);
-                Self::substitute_unary_plus(expr, ctx);
-            }
-            Expression::StaticMemberExpression(_) => {
-                Self::fold_static_member_expr(expr, ctx);
-                Self::replace_known_property_access(expr, ctx);
-            }
-            Expression::ComputedMemberExpression(_) => {
-                Self::fold_computed_member_expr(expr, ctx);
-                Self::replace_known_property_access(expr, ctx);
-            }
-            Expression::LogicalExpression(_) => {
-                Self::fold_logical_expr(expr, ctx);
-                Self::minimize_logical_expression(expr, ctx);
-                Self::substitute_is_object_and_not_null(expr, ctx);
-                Self::substitute_rotate_logical_expression(expr, ctx);
-            }
-            Expression::ChainExpression(_) => {
-                Self::fold_chain_expr(expr, ctx);
-                Self::substitute_chain_expression(expr, ctx);
-            }
-            Expression::CallExpression(_) => {
-                Self::fold_call_expression(expr, ctx);
-                Self::substitute_iife_call(expr, ctx);
-                Self::remove_dead_code_call_expression(expr, ctx);
-                Self::replace_concat_chain(expr, ctx);
-                Self::replace_known_global_methods(expr, ctx);
-                Self::substitute_simple_function_call(expr, ctx);
-                Self::substitute_object_or_array_constructor(expr, ctx);
-            }
-            Expression::ConditionalExpression(logical_expr) => {
-                Self::minimize_expression_in_boolean_context(&mut logical_expr.test, ctx);
-                if let Some(changed) = Self::minimize_conditional_expression(logical_expr, ctx) {
-                    *expr = changed;
-                    ctx.state.changed = true;
+        if self.dce {
+            match expr {
+                Expression::TemplateLiteral(t) => {
+                    Self::inline_template_literal(t, ctx);
                 }
-                Self::try_fold_conditional_expression(expr, ctx);
+                Expression::ObjectExpression(e) => Self::fold_object_exp(e, ctx),
+                Expression::BinaryExpression(_) => {
+                    Self::fold_binary_expr(expr, ctx);
+                    Self::fold_binary_typeof_comparison(expr, ctx);
+                }
+                Expression::UnaryExpression(_) => Self::fold_unary_expr(expr, ctx),
+                Expression::StaticMemberExpression(_) => {
+                    Self::fold_static_member_expr(expr, ctx);
+                }
+                Expression::ComputedMemberExpression(_) => {
+                    Self::fold_computed_member_expr(expr, ctx);
+                }
+                Expression::LogicalExpression(_) => Self::fold_logical_expr(expr, ctx),
+                Expression::ChainExpression(_) => Self::fold_chain_expr(expr, ctx),
+                Expression::CallExpression(_) => {
+                    Self::fold_call_expression(expr, ctx);
+                    Self::substitute_iife_call(expr, ctx);
+                    Self::remove_dead_code_call_expression(expr, ctx);
+                }
+                Expression::ConditionalExpression(_) => {
+                    Self::try_fold_conditional_expression(expr, ctx);
+                }
+                Expression::SequenceExpression(_) => {
+                    Self::remove_sequence_expression(expr, ctx);
+                }
+                Expression::AssignmentExpression(_) => {
+                    Self::remove_unused_assignment_expr(expr, ctx);
+                }
+                _ => {}
             }
-            Expression::AssignmentExpression(e) => {
-                Self::minimize_normal_assignment_to_combined_logical_assignment(e, ctx);
-                Self::minimize_normal_assignment_to_combined_assignment(e, ctx);
-                Self::minimize_assignment_to_update_expression(expr, ctx);
-                Self::remove_unused_assignment_expr(expr, ctx);
+        } else {
+            match expr {
+                Expression::TemplateLiteral(t) => {
+                    Self::inline_template_literal(t, ctx);
+                    Self::substitute_template_literal(expr, ctx);
+                }
+                Expression::ObjectExpression(e) => Self::fold_object_exp(e, ctx),
+                Expression::BinaryExpression(e) => {
+                    Self::substitute_swap_binary_expressions(e);
+                    Self::fold_binary_expr(expr, ctx);
+                    Self::fold_binary_typeof_comparison(expr, ctx);
+                    Self::minimize_loose_boolean(expr, ctx);
+                    Self::minimize_binary(expr, ctx);
+                    Self::substitute_loose_equals_undefined(expr, ctx);
+                    Self::substitute_typeof_undefined(expr, ctx);
+                    Self::substitute_rotate_binary_expression(expr, ctx);
+                }
+                Expression::UnaryExpression(_) => {
+                    Self::fold_unary_expr(expr, ctx);
+                    Self::minimize_unary(expr, ctx);
+                    Self::substitute_unary_plus(expr, ctx);
+                }
+                Expression::StaticMemberExpression(_) => {
+                    Self::fold_static_member_expr(expr, ctx);
+                    Self::replace_known_property_access(expr, ctx);
+                }
+                Expression::ComputedMemberExpression(_) => {
+                    Self::fold_computed_member_expr(expr, ctx);
+                    Self::replace_known_property_access(expr, ctx);
+                }
+                Expression::LogicalExpression(_) => {
+                    Self::fold_logical_expr(expr, ctx);
+                    Self::minimize_logical_expression(expr, ctx);
+                    Self::substitute_is_object_and_not_null(expr, ctx);
+                    Self::substitute_rotate_logical_expression(expr, ctx);
+                }
+                Expression::ChainExpression(_) => {
+                    Self::fold_chain_expr(expr, ctx);
+                    Self::substitute_chain_expression(expr, ctx);
+                }
+                Expression::CallExpression(_) => {
+                    Self::fold_call_expression(expr, ctx);
+                    Self::substitute_iife_call(expr, ctx);
+                    Self::remove_dead_code_call_expression(expr, ctx);
+                    Self::replace_concat_chain(expr, ctx);
+                    Self::replace_known_global_methods(expr, ctx);
+                    Self::substitute_simple_function_call(expr, ctx);
+                    Self::substitute_object_or_array_constructor(expr, ctx);
+                }
+                Expression::ConditionalExpression(logical_expr) => {
+                    Self::minimize_expression_in_boolean_context(&mut logical_expr.test, ctx);
+                    if let Some(changed) = Self::minimize_conditional_expression(logical_expr, ctx)
+                    {
+                        *expr = changed;
+                        ctx.state.changed = true;
+                    }
+                    Self::try_fold_conditional_expression(expr, ctx);
+                }
+                Expression::AssignmentExpression(e) => {
+                    Self::minimize_normal_assignment_to_combined_logical_assignment(e, ctx);
+                    Self::minimize_normal_assignment_to_combined_assignment(e, ctx);
+                    Self::minimize_assignment_to_update_expression(expr, ctx);
+                    Self::remove_unused_assignment_expr(expr, ctx);
+                }
+                Expression::SequenceExpression(_) => Self::remove_sequence_expression(expr, ctx),
+                Expression::ArrowFunctionExpression(e) => Self::substitute_arrow_expression(e, ctx),
+                Expression::FunctionExpression(e) => Self::try_remove_name_from_functions(e, ctx),
+                Expression::ClassExpression(e) => Self::try_remove_name_from_classes(e, ctx),
+                Expression::NewExpression(e) => {
+                    Self::substitute_typed_array_constructor(e, ctx);
+                    Self::substitute_global_new_expression(expr, ctx);
+                    Self::substitute_object_or_array_constructor(expr, ctx);
+                }
+                Expression::BooleanLiteral(_) => Self::substitute_boolean(expr, ctx),
+                Expression::ArrayExpression(_) => Self::substitute_array_expression(expr, ctx),
+                Expression::Identifier(_) => Self::inline_identifier_reference(expr, ctx),
+                _ => {}
             }
-            Expression::SequenceExpression(_) => Self::remove_sequence_expression(expr, ctx),
-            Expression::ArrowFunctionExpression(e) => Self::substitute_arrow_expression(e, ctx),
-            Expression::FunctionExpression(e) => Self::try_remove_name_from_functions(e, ctx),
-            Expression::ClassExpression(e) => Self::try_remove_name_from_classes(e, ctx),
-            Expression::NewExpression(e) => {
-                Self::substitute_typed_array_constructor(e, ctx);
-                Self::substitute_global_new_expression(expr, ctx);
-                Self::substitute_object_or_array_constructor(expr, ctx);
-            }
-            Expression::BooleanLiteral(_) => Self::substitute_boolean(expr, ctx),
-            Expression::ArrayExpression(_) => Self::substitute_array_expression(expr, ctx),
-            Expression::Identifier(_) => Self::inline_identifier_reference(expr, ctx),
-            _ => {}
         }
     }
 
     fn exit_unary_expression(&mut self, expr: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         if expr.operator.is_not() {
             let ctx = &mut Ctx::new(ctx);
             Self::minimize_expression_in_boolean_context(&mut expr.argument, ctx);
@@ -335,18 +418,27 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn exit_call_expression(&mut self, e: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_call_expression(e, ctx);
         Self::remove_empty_spread_arguments(&mut e.arguments);
     }
 
     fn exit_new_expression(&mut self, e: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_new_expression(e, ctx);
         Self::remove_empty_spread_arguments(&mut e.arguments);
     }
 
     fn exit_object_property(&mut self, prop: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_object_property(prop, ctx);
     }
@@ -356,6 +448,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         node: &mut AssignmentTargetProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_assignment_target_property(node, ctx);
     }
@@ -365,11 +460,17 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut AssignmentTargetPropertyProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_assignment_target_property_property(prop, ctx);
     }
 
     fn exit_binding_property(&mut self, prop: &mut BindingProperty<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_binding_property(prop, ctx);
     }
@@ -379,6 +480,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_method_definition(prop, ctx);
     }
@@ -388,6 +492,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_property_definition(prop, ctx);
     }
@@ -397,6 +504,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         prop: &mut AccessorProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::substitute_accessor_property(prop, ctx);
     }
@@ -406,15 +516,24 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         expr: &mut MemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         let ctx = Ctx::new(ctx);
         Self::convert_to_dotted_properties(expr, &ctx);
     }
 
     fn enter_class_body(&mut self, _body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         ctx.state.class_symbols_stack.push_class_scope();
     }
 
     fn exit_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = &mut Ctx::new(ctx);
         Self::remove_dead_code_exit_class_body(body, ctx);
         Self::remove_unused_private_members(body, ctx);
@@ -422,6 +541,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
     }
 
     fn exit_catch_clause(&mut self, catch: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.dce {
+            return;
+        }
         let ctx = Ctx::new(ctx);
         Self::substitute_catch_clause(catch, &ctx);
     }
@@ -431,6 +553,9 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         node: &mut PrivateFieldExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         ctx.state.class_symbols_stack.push_private_member_to_current_class(node.field.name);
     }
 
@@ -439,148 +564,10 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         node: &mut PrivateInExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        if self.dce {
+            return;
+        }
         ctx.state.class_symbols_stack.push_private_member_to_current_class(node.left.name);
-    }
-}
-
-pub struct DeadCodeElimination {
-    max_iterations: Option<u8>,
-    iteration: u8,
-    changed: bool,
-}
-
-impl<'a> DeadCodeElimination {
-    pub fn new(max_iterations: Option<u8>) -> Self {
-        Self { max_iterations, iteration: 0, changed: false }
-    }
-
-    fn run_once(
-        &mut self,
-        program: &mut Program<'a>,
-        ctx: &mut ReusableTraverseCtx<'a, MinifierState<'a>>,
-    ) {
-        traverse_mut_with_ctx(self, program, ctx);
-    }
-
-    pub fn run_in_loop(
-        &mut self,
-        program: &mut Program<'a>,
-        ctx: &mut ReusableTraverseCtx<'a, MinifierState<'a>>,
-    ) -> u8 {
-        loop {
-            self.changed = false;
-            self.run_once(program, ctx);
-            if !self.changed {
-                break;
-            }
-            if let Some(max_iterations) = self.max_iterations {
-                if self.iteration >= max_iterations {
-                    break;
-                }
-            } else if self.iteration > 10 {
-                debug_assert!(false, "Ran loop more than 10 times.");
-                break;
-            }
-            self.iteration += 1;
-        }
-        self.iteration
-    }
-}
-
-impl<'a> Traverse<'a, MinifierState<'a>> for DeadCodeElimination {
-    fn enter_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.symbol_values.clear();
-        ctx.state.changed = false;
-    }
-
-    fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.changed = ctx.state.changed;
-        if self.changed {
-            // Remove unused references by visiting the AST again and diff the collected references.
-            let refs_before =
-                ctx.scoping().resolved_references().flatten().copied().collect::<FxHashSet<_>>();
-            let mut counter = ReferencesCounter::default();
-            counter.visit_program(program);
-            for reference_id_to_remove in refs_before.difference(&counter.refs) {
-                ctx.scoping_mut().delete_reference(*reference_id_to_remove);
-            }
-        }
-    }
-
-    fn exit_variable_declarator(
-        &mut self,
-        decl: &mut VariableDeclarator<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        let ctx = &mut Ctx::new(ctx);
-        PeepholeOptimizations::init_symbol_value(decl, ctx);
-    }
-
-    fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        let ctx = &mut Ctx::new(ctx);
-        match stmt {
-            Statement::BlockStatement(_) => PeepholeOptimizations::try_optimize_block(stmt, ctx),
-            Statement::IfStatement(_) => PeepholeOptimizations::try_fold_if(stmt, ctx),
-            Statement::ForStatement(_) => PeepholeOptimizations::try_fold_for(stmt, ctx),
-            Statement::TryStatement(_) => PeepholeOptimizations::try_fold_try(stmt, ctx),
-            Statement::LabeledStatement(_) => PeepholeOptimizations::try_fold_labeled(stmt, ctx),
-            Statement::FunctionDeclaration(_) => {
-                PeepholeOptimizations::remove_unused_function_declaration(stmt, ctx);
-            }
-            Statement::ClassDeclaration(_) => {
-                PeepholeOptimizations::remove_unused_class_declaration(stmt, ctx);
-            }
-            Statement::ExpressionStatement(_) => {
-                PeepholeOptimizations::try_fold_expression_stmt(stmt, ctx);
-            }
-            Statement::ImportDeclaration(_) => {
-                PeepholeOptimizations::remove_unused_import_specifiers(stmt, ctx);
-            }
-            _ => {}
-        }
-    }
-
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        let ctx = &mut Ctx::new(ctx);
-        PeepholeOptimizations::minimize_statements(stmts, ctx);
-    }
-
-    fn exit_expression(&mut self, e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let ctx = &mut Ctx::new(ctx);
-        match e {
-            Expression::TemplateLiteral(t) => {
-                PeepholeOptimizations::inline_template_literal(t, ctx);
-            }
-            Expression::ObjectExpression(e) => PeepholeOptimizations::fold_object_exp(e, ctx),
-            Expression::BinaryExpression(_) => {
-                PeepholeOptimizations::fold_binary_expr(e, ctx);
-                PeepholeOptimizations::fold_binary_typeof_comparison(e, ctx);
-            }
-            Expression::UnaryExpression(_) => PeepholeOptimizations::fold_unary_expr(e, ctx),
-            Expression::StaticMemberExpression(_) => {
-                PeepholeOptimizations::fold_static_member_expr(e, ctx);
-            }
-            Expression::ComputedMemberExpression(_) => {
-                PeepholeOptimizations::fold_computed_member_expr(e, ctx);
-            }
-            Expression::LogicalExpression(_) => PeepholeOptimizations::fold_logical_expr(e, ctx),
-            Expression::ChainExpression(_) => PeepholeOptimizations::fold_chain_expr(e, ctx),
-            Expression::CallExpression(_) => {
-                PeepholeOptimizations::fold_call_expression(e, ctx);
-                PeepholeOptimizations::substitute_iife_call(e, ctx);
-                PeepholeOptimizations::remove_dead_code_call_expression(e, ctx);
-            }
-            Expression::ConditionalExpression(_) => {
-                PeepholeOptimizations::try_fold_conditional_expression(e, ctx);
-            }
-            Expression::SequenceExpression(_) => {
-                PeepholeOptimizations::remove_sequence_expression(e, ctx);
-            }
-            Expression::AssignmentExpression(_) => {
-                PeepholeOptimizations::remove_unused_assignment_expr(e, ctx);
-            }
-            _ => {}
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove duplicated `DeadCodeElimination` struct and consolidate into `PeepholeOptimizations`
- Add internal `dce: bool` flag to differentiate between full peephole optimizations and DCE-only mode
- Remove ~140 lines of duplicated code while maintaining identical behavior

## Test plan
- [x] All 466 minifier tests pass
- [x] Conformance tests pass
- [x] Code formatted with `just fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)