### PR TITLE
fix(oxc_minifier): enable sourcemap feature in dev mode

### DIFF
--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -40,7 +40,7 @@ cow-utils = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
-oxc_codegen = { workspace = true }
+oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
 oxc_sourcemap = { workspace = true }
 


### PR DESCRIPTION
re-enable sourcemap feature in dev mode

in #18116 `features = ["sourcemap"]` has been removed and minifier package test can't be run in isolation

```sh
cargo test --package oxc_minifier
```

```rs
error[E0609]: no field `map` on type `CodegenReturn`
  --> crates/oxc_minifier/examples/minifier.rs:68:28
   |
68 |     if let Some(map) = ret.map {
   |                            ^^^ unknown field
   |
   = note: available fields are: `code`, `legal_comments`
```

note: ci enables all feature flags for tests, 
```sh
cargo test --workspace --all-features
```

ref https://github.com/oxc-project/oxc/pull/18116/changes#r2700925895