### PR TITLE
feat(lsp): pass `Option<Range>` to `Tool.run_format` and support `textDocument/rangeFormatting`

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -243,7 +243,12 @@ impl Tool for ServerFormatter {
         }
     }
 
-    fn run_format(&self, uri: &Uri, content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+    fn run_format(
+        &self,
+        uri: &Uri,
+        content: Option<&str>,
+        _range: Option<&Range>,
+    ) -> Result<Vec<TextEdit>, String> {
         let Some(path) = uri.to_file_path() else { return Err("Invalid file URI".to_string()) };
 
         if self.is_ignored(&path) {

--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -189,6 +189,10 @@ The server will lint the file and report the diagnostics back to the client.
 
 Returns a list of [TextEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit)
 
+#### [textDocument/rangeFormatting](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rangeFormatting)
+
+Returns a list of [TextEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit) only specific for the provided range.
+
 ## Optional LSP Specifications from Client
 
 ### Client

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -91,13 +91,19 @@ pub trait Tool: Send + Sync {
 
     /// Format the content of the given URI.
     /// If `content` is `None`, the tool should read the content from the file system.
+    /// If `range` is `Some`, the tool should format only the specified range.
     /// Returns a vector of `TextEdit` representing the formatting changes.
     ///
     /// Not all tools will implement formatting, so the default implementation returns empty vector.
     ///
     /// # Errors
     /// Return [`Err`] when an error occurs, ignoring formatting should return [`Ok`] with an empty vector.
-    fn run_format(&self, _uri: &Uri, _content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+    fn run_format(
+        &self,
+        _uri: &Uri,
+        _content: Option<&str>,
+        _range: Option<&Range>,
+    ) -> Result<Vec<TextEdit>, String> {
         Ok(Vec::new())
     }
 

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -192,9 +192,10 @@ impl WorkspaceWorker {
         &self,
         uri: &Uri,
         content: Option<&str>,
+        range: Option<&Range>,
     ) -> Result<Vec<TextEdit>, String> {
         for tool in self.tools.read().await.iter() {
-            let edits = tool.run_format(uri, content)?;
+            let edits = tool.run_format(uri, content, range)?;
             // If no edits are made, continue to the next tool
             if edits.is_empty() {
                 continue;


### PR DESCRIPTION
start for https://github.com/oxc-project/oxc/issues/18129