### PR TITLE
ci(release_vscode): package & release once for all platform

### DIFF
--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -37,29 +37,8 @@ jobs:
     if: needs.check.outputs.version_changed == 'true'
     env:
       version: ${{ needs.check.outputs.version }}
-    strategy:
-      matrix:
-        include:
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            code-target: win32-x64
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-            code-target: win32-arm64
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            code-target: linux-x64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            code-target: linux-arm64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            code-target: darwin-x64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            code-target: darwin-arm64
-    name: Package ${{ matrix.code-target }}
-    runs-on: ${{ matrix.os }}
+    name: Package
+    runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@afad4df3ab3122b166e8226ac83be4d981fb64e8 # v1.3.2
 
@@ -74,14 +53,14 @@ jobs:
       - name: Package Extension
         working-directory: editors/vscode
         run: |
-          pnpm exec vsce package -o "../../oxc_language_server-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+          pnpm exec vsce package -o "../../oxc_language_server.vsix"
 
       - name: Upload VSCode extension artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           if-no-files-found: error
-          name: packages-${{ matrix.code-target }}
-          path: ./oxc_language_server-${{ matrix.code-target }}.vsix
+          name: packages
+          path: ./oxc_language_server.vsix
 
   publish-vsce:
     name: Publish to Microsoft Marketplace
@@ -103,7 +82,7 @@ jobs:
 
       - name: Publish to Microsoft Marketplace
         working-directory: editors/vscode
-        run: pnpm exec vsce publish --packagePath oxc_language_server-*.vsix
+        run: pnpm exec vsce publish --packagePath oxc_language_server.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
 
@@ -128,6 +107,6 @@ jobs:
 
       - name: Publish to Open VSX Registry
         working-directory: editors/vscode
-        run: pnpm exec ovsx publish --packagePath oxc_language_server-*.vsix
+        run: pnpm exec ovsx publish --packagePath oxc_language_server.vsix
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}


### PR DESCRIPTION
> Platform-specific extensions are published as separate packages containing platform-specific content. You can specify the target platform by passing the [--target flag](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_publishing). **If you don't pass this flag, that package will be used as a fallback for all platforms that have no platform-specific package.**

_https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions_

closes https://github.com/oxc-project/oxc/issues/18027

Because VSCode only uses now JavaScript, there is no need to package and release them for each platform. The language server is not built-in anymore.