### PR TITLE
refactor(parser): shorten raw transfer deserializer code for non-range variants

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -206,8 +206,8 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -216,8 +216,8 @@ function deserializeIdentifierName(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -228,8 +228,8 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -238,8 +238,8 @@ function deserializeIdentifierReference(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -250,8 +250,8 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -260,8 +260,8 @@ function deserializeBindingIdentifier(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -272,8 +272,8 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -282,8 +282,8 @@ function deserializeLabelIdentifier(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -294,28 +294,27 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "ThisExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -426,15 +425,15 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -455,8 +454,8 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -468,8 +467,8 @@ function deserializeObjectProperty(pos) {
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -591,16 +590,16 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -611,8 +610,8 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -620,8 +619,8 @@ function deserializeTaggedTemplateExpression(pos) {
       tag: null,
       typeArguments: null,
       quasi: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -662,8 +661,8 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -672,8 +671,8 @@ function deserializeComputedMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -685,8 +684,8 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -695,8 +694,8 @@ function deserializeStaticMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -708,8 +707,8 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -718,8 +717,8 @@ function deserializePrivateFieldExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -731,8 +730,8 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -741,8 +740,8 @@ function deserializeCallExpression(pos) {
       typeArguments: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -754,8 +753,8 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -763,8 +762,8 @@ function deserializeNewExpression(pos) {
       callee: null,
       typeArguments: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -776,16 +775,16 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -796,15 +795,15 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -909,8 +908,8 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -918,8 +917,8 @@ function deserializeUpdateExpression(pos) {
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -929,8 +928,8 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -938,8 +937,8 @@ function deserializeUnaryExpression(pos) {
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -950,8 +949,8 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -959,8 +958,8 @@ function deserializeBinaryExpression(pos) {
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -971,8 +970,8 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -980,8 +979,8 @@ function deserializePrivateInExpression(pos) {
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -993,8 +992,8 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1002,8 +1001,8 @@ function deserializeLogicalExpression(pos) {
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1014,8 +1013,8 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1023,8 +1022,8 @@ function deserializeConditionalExpression(pos) {
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1036,8 +1035,8 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1045,8 +1044,8 @@ function deserializeAssignmentExpression(pos) {
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1107,8 +1106,8 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1117,8 +1116,8 @@ function deserializeArrayAssignmentTarget(pos) {
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1133,8 +1132,8 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1143,8 +1142,8 @@ function deserializeObjectAssignmentTarget(pos) {
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1159,8 +1158,8 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1170,8 +1169,8 @@ function deserializeAssignmentTargetRest(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1212,8 +1211,8 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1223,8 +1222,8 @@ function deserializeAssignmentTargetWithDefault(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1312,8 +1311,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1325,8 +1324,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       shorthand: null,
       computed: deserializeBool(pos + 40),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1341,15 +1340,15 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1359,28 +1358,27 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "Super",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1390,15 +1388,15 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1504,16 +1502,16 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1523,29 +1521,28 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1580,8 +1577,8 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1589,8 +1586,8 @@ function deserializeVariableDeclaration(pos) {
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
       declare: deserializeBool(pos + 33),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1647,29 +1644,28 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "EmptyStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ExpressionStatement",
       expression: null,
       directive: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1679,8 +1675,8 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1688,8 +1684,8 @@ function deserializeIfStatement(pos) {
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1701,16 +1697,16 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1721,16 +1717,16 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1741,8 +1737,8 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1751,8 +1747,8 @@ function deserializeForStatement(pos) {
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1860,8 +1856,8 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1869,8 +1865,8 @@ function deserializeForInStatement(pos) {
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1911,8 +1907,8 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -1921,8 +1917,8 @@ function deserializeForOfStatement(pos) {
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1934,15 +1930,15 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1952,15 +1948,15 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1970,15 +1966,15 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1988,16 +1984,16 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2008,16 +2004,16 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2028,16 +2024,16 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2048,16 +2044,16 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2068,15 +2064,15 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2086,8 +2082,8 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2095,8 +2091,8 @@ function deserializeTryStatement(pos) {
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2108,16 +2104,16 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2144,13 +2140,12 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "DebuggerStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -2172,8 +2167,8 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2183,8 +2178,8 @@ function deserializeAssignmentPattern(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2197,8 +2192,8 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2207,8 +2202,8 @@ function deserializeObjectPattern(pos) {
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2223,8 +2218,8 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2236,8 +2231,8 @@ function deserializeBindingProperty(pos) {
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2251,8 +2246,8 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2261,8 +2256,8 @@ function deserializeArrayPattern(pos) {
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2277,8 +2272,8 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2288,8 +2283,8 @@ function deserializeBindingRestElement(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2301,8 +2296,8 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2316,8 +2311,8 @@ function deserializeFunction(pos) {
       returnType: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2514,15 +2509,15 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2535,8 +2530,8 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+    start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2549,8 +2544,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2569,16 +2564,16 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2588,8 +2583,8 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2603,8 +2598,8 @@ function deserializeClass(pos) {
       body: null,
       abstract: deserializeBool(pos + 133),
       declare: deserializeBool(pos + 134),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2631,15 +2626,15 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2666,8 +2661,8 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2681,8 +2676,8 @@ function deserializeMethodDefinition(pos) {
       override: deserializeBool(pos + 60),
       optional: deserializeBool(pos + 61),
       accessibility: deserializeOptionTSAccessibility(pos + 62),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2705,8 +2700,8 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2723,8 +2718,8 @@ function deserializePropertyDefinition(pos) {
       definite: deserializeBool(pos + 78),
       readonly: deserializeBool(pos + 79),
       accessibility: deserializeOptionTSAccessibility(pos + 80),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2763,29 +2758,28 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2806,8 +2800,8 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2824,8 +2818,8 @@ function deserializeAccessorProperty(pos) {
       declare: null,
       optional: null,
       readonly: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2841,8 +2835,8 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2850,8 +2844,8 @@ function deserializeImportExpression(pos) {
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2862,8 +2856,8 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2873,8 +2867,8 @@ function deserializeImportDeclaration(pos) {
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
       importKind: deserializeImportOrExportKind(pos + 89),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2913,8 +2907,8 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -2922,8 +2916,8 @@ function deserializeImportSpecifier(pos) {
       imported: null,
       local: null,
       importKind: deserializeImportOrExportKind(pos + 96),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2934,15 +2928,15 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2952,15 +2946,15 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2974,16 +2968,16 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3005,8 +2999,8 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3016,8 +3010,8 @@ function deserializeExportNamedDeclaration(pos) {
       source: null,
       exportKind: deserializeImportOrExportKind(pos + 104),
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3031,16 +3025,16 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "ExportDefaultDeclaration",
       declaration: null,
       exportKind: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3051,8 +3045,8 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3061,8 +3055,8 @@ function deserializeExportAllDeclaration(pos) {
       source: null,
       attributes: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3075,8 +3069,8 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3084,8 +3078,8 @@ function deserializeExportSpecifier(pos) {
       local: null,
       exported: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3208,16 +3202,16 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3267,31 +3261,30 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3304,8 +3297,8 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3313,8 +3306,8 @@ function deserializeBigIntLiteral(pos) {
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3326,8 +3319,8 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3335,8 +3328,8 @@ function deserializeRegExpLiteral(pos) {
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3374,8 +3367,8 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3383,8 +3376,8 @@ function deserializeJSXElement(pos) {
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3399,8 +3392,8 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3409,8 +3402,8 @@ function deserializeJSXOpeningElement(pos) {
       typeArguments: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3423,15 +3416,15 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3441,8 +3434,8 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3450,8 +3443,8 @@ function deserializeJSXFragment(pos) {
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3463,14 +3456,14 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXOpeningFragment",
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3479,13 +3472,12 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "JSXClosingFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3527,16 +3519,16 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3547,16 +3539,16 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3598,15 +3590,15 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3711,13 +3703,12 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "JSXEmptyExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3735,16 +3726,16 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3755,15 +3746,15 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3799,14 +3790,13 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3830,15 +3820,15 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3848,23 +3838,22 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3873,8 +3862,8 @@ function deserializeTSThisParameter(pos) {
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3887,8 +3876,8 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3897,8 +3886,8 @@ function deserializeTSEnumDeclaration(pos) {
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3909,15 +3898,15 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3927,8 +3916,8 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -3936,8 +3925,8 @@ function deserializeTSEnumMember(pos) {
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3964,15 +3953,15 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3982,15 +3971,15 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4100,8 +4089,8 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4110,8 +4099,8 @@ function deserializeTSConditionalType(pos) {
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4124,15 +4113,15 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4142,15 +4131,15 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4166,16 +4155,16 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4198,15 +4187,15 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4216,16 +4205,16 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4236,15 +4225,15 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4254,8 +4243,8 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4263,8 +4252,8 @@ function deserializeTSNamedTupleMember(pos) {
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4275,15 +4264,15 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4293,15 +4282,15 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4396,198 +4385,184 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSAnyKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSStringKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSBooleanKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSNumberKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSNeverKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSIntrinsicKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSUnknownKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSNullKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSUndefinedKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSVoidKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSSymbolKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSThisType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSObjectKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSBigIntKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4611,16 +4586,16 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4631,15 +4606,15 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4649,8 +4624,8 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4661,8 +4636,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4674,15 +4649,15 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4692,8 +4667,8 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4702,8 +4677,8 @@ function deserializeTSTypeAliasDeclaration(pos) {
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4728,16 +4703,16 @@ function deserializeTSAccessibility(pos) {
 }
 
 function deserializeTSClassImplements(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSClassImplements",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4789,8 +4764,8 @@ function deserializeTSClassImplements(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4800,8 +4775,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4814,15 +4789,15 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4832,8 +4807,8 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4845,8 +4820,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4875,8 +4850,8 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4886,8 +4861,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4898,8 +4873,8 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4907,8 +4882,8 @@ function deserializeTSCallSignatureDeclaration(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4936,8 +4911,8 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4952,8 +4927,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4971,8 +4946,8 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -4980,8 +4955,8 @@ function deserializeTSConstructSignatureDeclaration(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4993,8 +4968,8 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5003,8 +4978,8 @@ function deserializeTSIndexSignatureName(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5016,16 +4991,16 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5036,8 +5011,8 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5045,8 +5020,8 @@ function deserializeTSTypePredicate(pos) {
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5198,8 +5173,8 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5209,8 +5184,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5236,15 +5211,15 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5256,15 +5231,15 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5274,15 +5249,15 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5292,16 +5267,16 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5327,8 +5302,8 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5337,8 +5312,8 @@ function deserializeTSImportType(pos) {
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5362,16 +5337,16 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5382,8 +5357,8 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5391,8 +5366,8 @@ function deserializeTSFunctionType(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5407,8 +5382,8 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5417,8 +5392,8 @@ function deserializeTSConstructorType(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5430,8 +5405,8 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5442,8 +5417,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5472,16 +5447,16 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5492,16 +5467,16 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5512,16 +5487,16 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5532,16 +5507,16 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5552,8 +5527,8 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
@@ -5561,8 +5536,8 @@ function deserializeTSImportEqualsDeclaration(pos) {
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5588,15 +5563,15 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5606,15 +5581,15 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5624,15 +5599,15 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5642,15 +5617,15 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5660,15 +5635,15 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5678,16 +5653,16 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5709,16 +5684,16 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5728,16 +5703,16 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5747,13 +5722,12 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     __proto__: NodeProto,
     type: "TSJSDocUnknownType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -138,46 +138,38 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -324,19 +316,17 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: deserializePropertyKind(pos + 40),
-      key: null,
-      value: null,
-      method: deserializeBool(pos + 41),
-      shorthand: deserializeBool(pos + 42),
-      computed: deserializeBool(pos + 43),
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: deserializePropertyKind(pos + 40),
+    key: null,
+    value: null,
+    method: deserializeBool(pos + 41),
+    shorthand: deserializeBool(pos + 42),
+    computed: deserializeBool(pos + 43),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   return node;
@@ -505,17 +495,15 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 40),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 40),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -523,17 +511,15 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 48),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 48),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -541,17 +527,15 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 48),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 48),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -559,16 +543,14 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "CallExpression",
-      callee: null,
-      arguments: null,
-      optional: deserializeBool(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "CallExpression",
+    callee: null,
+    arguments: null,
+    optional: deserializeBool(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.callee = deserializeExpression(pos + 8);
   node.arguments = deserializeVecArgument(pos + 32);
   return node;
@@ -707,47 +689,41 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "UpdateExpression",
-      operator: deserializeUpdateOperator(pos + 24),
-      prefix: deserializeBool(pos + 25),
-      argument: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "UpdateExpression",
+    operator: deserializeUpdateOperator(pos + 24),
+    prefix: deserializeBool(pos + 25),
+    argument: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   return node;
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "UnaryExpression",
-      operator: deserializeUnaryOperator(pos + 24),
-      argument: null,
-      prefix: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "UnaryExpression",
+    operator: deserializeUnaryOperator(pos + 24),
+    argument: null,
+    prefix: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   return node;
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "BinaryExpression",
-      left: null,
-      operator: deserializeBinaryOperator(pos + 40),
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "BinaryExpression",
+    left: null,
+    operator: deserializeBinaryOperator(pos + 40),
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -769,16 +745,14 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "LogicalExpression",
-      left: null,
-      operator: deserializeLogicalOperator(pos + 40),
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "LogicalExpression",
+    left: null,
+    operator: deserializeLogicalOperator(pos + 40),
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -800,16 +774,14 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "AssignmentExpression",
-      operator: deserializeAssignmentOperator(pos + 40),
-      left: null,
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "AssignmentExpression",
+    operator: deserializeAssignmentOperator(pos + 40),
+    left: null,
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -997,19 +969,17 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: null,
-      key: null,
-      value: null,
-      method: null,
-      shorthand: null,
-      computed: deserializeBool(pos + 40),
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: null,
+    key: null,
+    value: null,
+    method: null,
+    shorthand: null,
+    computed: deserializeBool(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.kind = "init";
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1162,27 +1132,23 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ExpressionStatement",
-      expression: null,
-      directive: deserializeStr(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "ExpressionStatement",
+    expression: null,
+    directive: deserializeStr(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.expression = deserializeStringLiteral(pos + 8);
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1223,15 +1189,13 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "VariableDeclaration",
-      kind: deserializeVariableDeclarationKind(pos + 32),
-      declarations: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "VariableDeclaration",
+    kind: deserializeVariableDeclarationKind(pos + 32),
+    declarations: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   return node;
 }
@@ -1483,17 +1447,15 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ForOfStatement",
-      await: deserializeBool(pos + 60),
-      left: null,
-      right: null,
-      body: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "ForOfStatement",
+    await: deserializeBool(pos + 60),
+    left: null,
+    right: null,
+    body: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1679,19 +1641,17 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: null,
-      key: null,
-      value: null,
-      method: null,
-      shorthand: deserializeBool(pos + 40),
-      computed: deserializeBool(pos + 41),
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: null,
+    key: null,
+    value: null,
+    method: null,
+    shorthand: deserializeBool(pos + 40),
+    computed: deserializeBool(pos + 41),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.kind = "init";
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -1725,9 +1685,7 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -1735,8 +1693,8 @@ function deserializeFunction(pos) {
       params: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     params = deserializeBoxFormalParameters(pos + 56);
   node.id = deserializeOptionBindingIdentifier(pos + 8);
@@ -1808,8 +1766,6 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
     node = {
       type: "ArrowFunctionExpression",
       expression,
@@ -1818,8 +1774,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     body = deserializeBoxFunctionBody(pos + 32);
   expression === true && (body = body.body[0].expression);
@@ -1830,31 +1786,27 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "YieldExpression",
-      delegate: deserializeBool(pos + 24),
-      argument: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "YieldExpression",
+    delegate: deserializeBool(pos + 24),
+    argument: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeOptionExpression(pos + 8);
   return node;
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeClassType(pos + 132),
-      decorators: null,
-      id: null,
-      superClass: null,
-      body: null,
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeClassType(pos + 132),
+    decorators: null,
+    id: null,
+    superClass: null,
+    body: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.superClass = deserializeOptionExpression(pos + 72);
@@ -1902,19 +1854,17 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeMethodDefinitionType(pos + 56),
-      decorators: null,
-      key: null,
-      value: null,
-      kind: deserializeMethodDefinitionKind(pos + 57),
-      computed: deserializeBool(pos + 58),
-      static: deserializeBool(pos + 59),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeMethodDefinitionType(pos + 56),
+    decorators: null,
+    key: null,
+    value: null,
+    kind: deserializeMethodDefinitionKind(pos + 57),
+    computed: deserializeBool(pos + 58),
+    static: deserializeBool(pos + 59),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -1933,18 +1883,16 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializePropertyDefinitionType(pos + 72),
-      decorators: null,
-      key: null,
-      value: null,
-      computed: deserializeBool(pos + 73),
-      static: deserializeBool(pos + 74),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializePropertyDefinitionType(pos + 72),
+    decorators: null,
+    key: null,
+    value: null,
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -1978,13 +1926,11 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2011,18 +1957,16 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeAccessorPropertyType(pos + 72),
-      decorators: null,
-      key: null,
-      value: null,
-      computed: deserializeBool(pos + 73),
-      static: deserializeBool(pos + 74),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeAccessorPropertyType(pos + 72),
+    decorators: null,
+    key: null,
+    value: null,
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeOptionExpression(pos + 56);
@@ -2030,32 +1974,28 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ImportExpression",
-      source: null,
-      options: null,
-      phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
-    };
+  let node = {
+    type: "ImportExpression",
+    source: null,
+    options: null,
+    phase: deserializeOptionImportPhase(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   return node;
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "ImportDeclaration",
       specifiers: null,
       source: null,
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
@@ -2366,26 +2306,22 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
@@ -2395,15 +2331,13 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
@@ -2412,15 +2346,13 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     regex = deserializeRegExp(pos + 8),
     value = null;
@@ -2790,13 +2722,11 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2829,14 +2759,12 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2858,17 +2786,15 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSEnumDeclaration",
-      id: null,
-      body: null,
-      const: deserializeBool(pos + 80),
-      declare: deserializeBool(pos + 81),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSEnumDeclaration",
+    id: null,
+    body: null,
+    const: deserializeBool(pos + 80),
+    declare: deserializeBool(pos + 81),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   return node;
@@ -3089,15 +3015,13 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeOperator",
-      operator: deserializeTSTypeOperatorOperator(pos + 24),
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeOperator",
+    operator: deserializeTSTypeOperatorOperator(pos + 24),
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
@@ -3151,16 +3075,14 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSNamedTupleMember",
-      label: null,
-      elementType: null,
-      optional: deserializeBool(pos + 48),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSNamedTupleMember",
+    label: null,
+    elementType: null,
+    optional: deserializeBool(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   return node;
@@ -3436,19 +3358,17 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeParameter",
-      name: null,
-      constraint: null,
-      default: null,
-      in: deserializeBool(pos + 72),
-      out: deserializeBool(pos + 73),
-      const: deserializeBool(pos + 74),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeParameter",
+    name: null,
+    constraint: null,
+    default: null,
+    in: deserializeBool(pos + 72),
+    out: deserializeBool(pos + 73),
+    const: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -3467,17 +3387,15 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeAliasDeclaration",
-      id: null,
-      typeParameters: null,
-      typeAnnotation: null,
-      declare: deserializeBool(pos + 68),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeAliasDeclaration",
+    id: null,
+    typeParameters: null,
+    typeAnnotation: null,
+    declare: deserializeBool(pos + 68),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -3485,18 +3403,16 @@ function deserializeTSTypeAliasDeclaration(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSInterfaceDeclaration",
-      id: null,
-      typeParameters: null,
-      extends: null,
-      body: null,
-      declare: deserializeBool(pos + 84),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSInterfaceDeclaration",
+    id: null,
+    typeParameters: null,
+    extends: null,
+    body: null,
+    declare: deserializeBool(pos + 84),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -3516,20 +3432,18 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSPropertySignature",
-      computed: deserializeBool(pos + 32),
-      optional: deserializeBool(pos + 33),
-      readonly: deserializeBool(pos + 34),
-      key: null,
-      typeAnnotation: null,
-      accessibility: null,
-      static: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSPropertySignature",
+    computed: deserializeBool(pos + 32),
+    optional: deserializeBool(pos + 33),
+    readonly: deserializeBool(pos + 34),
+    key: null,
+    typeAnnotation: null,
+    accessibility: null,
+    static: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.static = false;
@@ -3554,18 +3468,16 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSIndexSignature",
-      parameters: null,
-      typeAnnotation: null,
-      readonly: deserializeBool(pos + 40),
-      static: deserializeBool(pos + 41),
-      accessibility: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSIndexSignature",
+    parameters: null,
+    typeAnnotation: null,
+    readonly: deserializeBool(pos + 40),
+    static: deserializeBool(pos + 41),
+    accessibility: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
@@ -3603,9 +3515,7 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "TSMethodSignature",
       key: null,
       computed: deserializeBool(pos + 60),
@@ -3617,8 +3527,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
@@ -3648,17 +3558,15 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -3679,16 +3587,14 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypePredicate",
-      parameterName: null,
-      asserts: deserializeBool(pos + 32),
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypePredicate",
+    parameterName: null,
+    asserts: deserializeBool(pos + 32),
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
@@ -3808,18 +3714,16 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSModuleDeclaration",
-      id: null,
-      body: null,
-      kind: null,
-      declare: deserializeBool(pos + 76),
-      global: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSModuleDeclaration",
+    id: null,
+    body: null,
+    kind: null,
+    declare: deserializeBool(pos + 76),
+    global: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = {
     type: "Identifier",
     name: "global",
@@ -3955,17 +3859,15 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSConstructorType",
-      abstract: deserializeBool(pos + 36),
-      typeParameters: null,
-      params: null,
-      returnType: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSConstructorType",
+    abstract: deserializeBool(pos + 36),
+    typeParameters: null,
+    params: null,
+    returnType: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -3973,9 +3875,7 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "TSMappedType",
       key: null,
       constraint: null,
@@ -3983,8 +3883,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
@@ -4062,16 +3962,14 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSImportEqualsDeclaration",
-      id: null,
-      moduleReference: null,
-      importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSImportEqualsDeclaration",
+    id: null,
+    moduleReference: null,
+    importKind: deserializeImportOrExportKind(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   return node;
@@ -4172,29 +4070,25 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSJSDocNullableType",
-      typeAnnotation: null,
-      postfix: deserializeBool(pos + 24),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSJSDocNullableType",
+    typeAnnotation: null,
+    postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSJSDocNonNullableType",
-      typeAnnotation: null,
-      postfix: deserializeBool(pos + 24),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSJSDocNonNullableType",
+    typeAnnotation: null,
+    postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
@@ -4233,12 +4127,10 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4281,16 +4173,14 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4391,12 +4281,10 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4588,12 +4476,10 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4608,23 +4494,19 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -146,14 +146,12 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   parent = previousParent;
@@ -161,14 +159,12 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   parent = previousParent;
@@ -176,14 +172,12 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   parent = previousParent;
@@ -191,14 +185,12 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   parent = previousParent;
@@ -215,14 +207,12 @@ function deserializeThisExpression(pos) {
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
@@ -332,14 +322,12 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
@@ -359,9 +347,7 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: deserializePropertyKind(pos + 40),
@@ -370,8 +356,8 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 41),
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 8);
@@ -491,15 +477,13 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -509,15 +493,13 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TaggedTemplateExpression",
       tag: null,
       quasi: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.tag = deserializeExpression(pos + 8);
@@ -554,17 +536,15 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -575,17 +555,15 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -596,17 +574,15 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -617,16 +593,14 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "CallExpression",
       callee: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.callee = deserializeExpression(pos + 8);
@@ -636,15 +610,13 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "NewExpression",
       callee: null,
       arguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.callee = deserializeExpression(pos + 8);
@@ -654,15 +626,13 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.meta = deserializeIdentifierName(pos + 8);
@@ -672,14 +642,12 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -783,16 +751,14 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
@@ -801,16 +767,14 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -820,16 +784,14 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeExpression(pos + 8);
@@ -839,16 +801,14 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 8);
@@ -859,16 +819,14 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeExpression(pos + 8);
@@ -878,16 +836,14 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -898,16 +854,14 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -967,14 +921,12 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
@@ -986,14 +938,12 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
@@ -1005,14 +955,12 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeAssignmentTarget(pos + 8);
@@ -1050,15 +998,13 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -1127,9 +1073,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: null,
@@ -1138,8 +1082,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       method: null,
       shorthand: null,
       computed: deserializeBool(pos + 40),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.kind = "init";
@@ -1152,14 +1096,12 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expressions = deserializeVecExpression(pos + 8);
@@ -1177,14 +1119,12 @@ function deserializeSuper(pos) {
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -1193,14 +1133,12 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeChainElement(pos + 8);
@@ -1316,15 +1254,13 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeStringLiteral(pos + 8);
@@ -1333,26 +1269,22 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecStatement(pos + 8);
@@ -1386,15 +1318,13 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
@@ -1445,14 +1375,12 @@ function deserializeEmptyStatement(pos) {
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -1461,16 +1389,14 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -1481,15 +1407,13 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeStatement(pos + 8);
@@ -1499,15 +1423,13 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -1517,17 +1439,15 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForStatement",
       init: null,
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.init = deserializeOptionForStatementInit(pos + 8);
@@ -1634,16 +1554,14 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1683,17 +1601,15 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForOfStatement",
       await: deserializeBool(pos + 60),
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1704,14 +1620,12 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1720,14 +1634,12 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1736,14 +1648,12 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeOptionExpression(pos + 8);
@@ -1752,15 +1662,13 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -1770,15 +1678,13 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.discriminant = deserializeExpression(pos + 8);
@@ -1788,15 +1694,13 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeOptionExpression(pos + 8);
@@ -1806,15 +1710,13 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeLabelIdentifier(pos + 8);
@@ -1824,14 +1726,12 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -1840,16 +1740,14 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.block = deserializeBoxBlockStatement(pos + 8);
@@ -1860,15 +1758,13 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.param = deserializeOptionCatchParameter(pos + 8);
@@ -1906,15 +1802,13 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeBindingPattern(pos + 8);
@@ -1924,14 +1818,12 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     properties = deserializeVecBindingProperty(pos + 8),
@@ -1943,9 +1835,7 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: null,
@@ -1954,8 +1844,8 @@ function deserializeBindingProperty(pos) {
       method: null,
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.kind = "init";
@@ -1967,14 +1857,12 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
@@ -1986,14 +1874,12 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeBindingPattern(pos + 8);
@@ -2002,9 +1888,7 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
@@ -2013,8 +1897,8 @@ function deserializeFunction(pos) {
       params: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 56);
@@ -2080,14 +1964,12 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeVecDirective(pos + 8);
@@ -2099,8 +1981,6 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "ArrowFunctionExpression",
@@ -2110,8 +1990,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeBoxFunctionBody(pos + 32);
@@ -2127,15 +2007,13 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeOptionExpression(pos + 8);
@@ -2144,17 +2022,15 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
       superClass: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2177,14 +2053,12 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecClassElement(pos + 8);
@@ -2210,9 +2084,7 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
@@ -2221,8 +2093,8 @@ function deserializeMethodDefinition(pos) {
       kind: deserializeMethodDefinitionKind(pos + 57),
       computed: deserializeBool(pos + 58),
       static: deserializeBool(pos + 59),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2244,9 +2116,7 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
@@ -2254,8 +2124,8 @@ function deserializePropertyDefinition(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2292,26 +2162,22 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecStatement(pos + 8);
@@ -2331,9 +2197,7 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
@@ -2341,8 +2205,8 @@ function deserializeAccessorProperty(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2353,16 +2217,14 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.source = deserializeExpression(pos + 8);
@@ -2372,17 +2234,15 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportDeclaration",
       specifiers: null,
       source: null,
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
@@ -2420,15 +2280,13 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.imported = deserializeModuleExportName(pos + 8);
@@ -2438,14 +2296,12 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2454,14 +2310,12 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2474,15 +2328,13 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializeImportAttributeKey(pos + 8);
@@ -2503,17 +2355,15 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportNamedDeclaration",
       declaration: null,
       specifiers: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
@@ -2526,14 +2376,12 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
@@ -2542,16 +2390,14 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
@@ -2563,15 +2409,13 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeModuleExportName(pos + 8);
@@ -2693,15 +2537,13 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeIdentifierName(pos + 8);
@@ -2746,28 +2588,24 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     value = deserializeStr(pos + 8);
@@ -2779,16 +2617,14 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     bigint = deserializeStr(pos + 8);
@@ -2799,16 +2635,14 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     regex = deserializeRegExp(pos + 8),
@@ -2845,16 +2679,14 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
@@ -2868,16 +2700,14 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXElementName(pos + 8);
@@ -2888,14 +2718,12 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXElementName(pos + 8);
@@ -2904,16 +2732,14 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
@@ -2924,15 +2750,13 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXOpeningFragment",
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.attributes = [];
@@ -2982,15 +2806,13 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.namespace = deserializeJSXIdentifier(pos + 8);
@@ -3000,15 +2822,13 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
@@ -3045,14 +2865,12 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeJSXExpression(pos + 8);
@@ -3176,15 +2994,13 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXAttributeName(pos + 8);
@@ -3194,14 +3010,12 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -3236,13 +3050,11 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
@@ -3265,14 +3077,12 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -3281,30 +3091,26 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -3316,17 +3122,15 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumDeclaration",
       id: null,
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3336,14 +3140,12 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.members = deserializeVecTSEnumMember(pos + 8);
@@ -3352,16 +3154,14 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeTSEnumMemberName(pos + 8);
@@ -3387,14 +3187,12 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3403,14 +3201,12 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.literal = deserializeTSLiteral(pos + 8);
@@ -3519,17 +3315,15 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConditionalType",
       checkType: null,
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.checkType = deserializeTSType(pos + 8);
@@ -3541,14 +3335,12 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.types = deserializeVecTSType(pos + 8);
@@ -3557,14 +3349,12 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.types = deserializeVecTSType(pos + 8);
@@ -3590,15 +3380,13 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3620,14 +3408,12 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elementType = deserializeTSType(pos + 8);
@@ -3636,15 +3422,13 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.objectType = deserializeTSType(pos + 8);
@@ -3654,14 +3438,12 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
@@ -3670,16 +3452,14 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeIdentifierName(pos + 8);
@@ -3689,14 +3469,12 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3705,14 +3483,12 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3932,15 +3708,13 @@ function deserializeTSBigIntKeyword(pos) {
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeName = deserializeTSTypeName(pos + 8);
@@ -3963,15 +3737,13 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeTSTypeName(pos + 8);
@@ -3981,14 +3753,12 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.params = deserializeVecTSType(pos + 8);
@@ -3997,9 +3767,7 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameter",
       name: null,
@@ -4008,8 +3776,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeBindingIdentifier(pos + 8);
@@ -4020,14 +3788,12 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.params = deserializeVecTSTypeParameter(pos + 8);
@@ -4036,17 +3802,15 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAliasDeclaration",
       id: null,
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4057,9 +3821,7 @@ function deserializeTSTypeAliasDeclaration(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceDeclaration",
       id: null,
@@ -4067,8 +3829,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4080,14 +3842,12 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecTSSignature(pos + 8);
@@ -4096,9 +3856,7 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSPropertySignature",
       computed: deserializeBool(pos + 32),
@@ -4108,8 +3866,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 8);
@@ -4137,9 +3895,7 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIndexSignature",
       parameters: null,
@@ -4147,8 +3903,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
@@ -4158,16 +3914,14 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4194,9 +3948,7 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSMethodSignature",
       key: null,
@@ -4209,8 +3961,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 40),
@@ -4227,16 +3979,14 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4247,17 +3997,15 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -4268,15 +4016,13 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4286,16 +4032,14 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
@@ -4435,9 +4179,7 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSModuleDeclaration",
       id: null,
@@ -4445,8 +4187,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = {
@@ -4464,14 +4206,12 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeVecDirective(pos + 8);
@@ -4482,14 +4222,12 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.members = deserializeVecTSSignature(pos + 8);
@@ -4498,14 +4236,12 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
@@ -4514,15 +4250,13 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
@@ -4547,17 +4281,15 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSImportType",
       source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.source = deserializeStringLiteral(pos + 8);
@@ -4580,15 +4312,13 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
@@ -4598,16 +4328,14 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4621,17 +4349,15 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConstructorType",
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4642,9 +4368,7 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSMappedType",
       key: null,
@@ -4653,8 +4377,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
@@ -4682,15 +4406,13 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -4700,15 +4422,13 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4718,15 +4438,13 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4736,15 +4454,13 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4754,16 +4470,14 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4788,14 +4502,12 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeStringLiteral(pos + 8);
@@ -4804,14 +4516,12 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4820,14 +4530,12 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4836,14 +4544,12 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4852,14 +4558,12 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeIdentifierName(pos + 8);
@@ -4868,15 +4572,13 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4897,15 +4599,13 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4914,15 +4614,13 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4965,12 +4663,10 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5013,16 +4709,14 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5123,12 +4817,10 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5320,12 +5012,10 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5340,23 +5030,19 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -139,72 +139,67 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Identifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "ThisExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
@@ -313,13 +308,13 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
@@ -338,8 +333,8 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: deserializePropertyKind(pos + 40),
@@ -348,8 +343,8 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 41),
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 8);
@@ -468,14 +463,14 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -484,14 +479,14 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TaggedTemplateExpression",
       tag: null,
       quasi: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.tag = deserializeExpression(pos + 8);
@@ -527,16 +522,16 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -546,16 +541,16 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -565,16 +560,16 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -584,15 +579,15 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "CallExpression",
       callee: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.callee = deserializeExpression(pos + 8);
@@ -601,14 +596,14 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "NewExpression",
       callee: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.callee = deserializeExpression(pos + 8);
@@ -617,14 +612,14 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.meta = deserializeIdentifierName(pos + 8);
@@ -633,13 +628,13 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -742,15 +737,15 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
@@ -758,15 +753,15 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -775,15 +770,15 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeExpression(pos + 8);
@@ -792,15 +787,15 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializePrivateIdentifier(pos + 8);
@@ -810,15 +805,15 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeExpression(pos + 8);
@@ -827,15 +822,15 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -845,15 +840,15 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -912,13 +907,13 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
@@ -929,13 +924,13 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
@@ -946,13 +941,13 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeAssignmentTarget(pos + 8);
@@ -989,14 +984,14 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -1060,8 +1055,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: null,
@@ -1070,8 +1065,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       method: null,
       shorthand: null,
       computed: deserializeBool(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.kind = "init";
@@ -1083,13 +1078,13 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expressions = deserializeVecExpression(pos + 8);
@@ -1097,24 +1092,23 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Super",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -1122,13 +1116,13 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeChainElement(pos + 8);
@@ -1242,14 +1236,14 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeStringLiteral(pos + 8);
@@ -1257,25 +1251,24 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecStatement(pos + 8);
@@ -1308,14 +1301,14 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
@@ -1354,24 +1347,23 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "EmptyStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExpressionStatement",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -1379,15 +1371,15 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -1397,14 +1389,14 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeStatement(pos + 8);
@@ -1413,14 +1405,14 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -1429,16 +1421,16 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForStatement",
       init: null,
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.init = deserializeOptionForStatementInit(pos + 8);
@@ -1544,15 +1536,15 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1591,16 +1583,16 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForOfStatement",
       await: deserializeBool(pos + 60),
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1610,13 +1602,13 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1624,13 +1616,13 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1638,13 +1630,13 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeOptionExpression(pos + 8);
@@ -1652,14 +1644,14 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -1668,14 +1660,14 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.discriminant = deserializeExpression(pos + 8);
@@ -1684,14 +1676,14 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeOptionExpression(pos + 8);
@@ -1700,14 +1692,14 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeLabelIdentifier(pos + 8);
@@ -1716,13 +1708,13 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -1730,15 +1722,15 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.block = deserializeBoxBlockStatement(pos + 8);
@@ -1748,14 +1740,14 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.param = deserializeOptionCatchParameter(pos + 8);
@@ -1768,12 +1760,11 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "DebuggerStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -1794,14 +1785,14 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeBindingPattern(pos + 8);
@@ -1810,13 +1801,13 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     properties = deserializeVecBindingProperty(pos + 8),
@@ -1827,8 +1818,8 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: null,
@@ -1837,8 +1828,8 @@ function deserializeBindingProperty(pos) {
       method: null,
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.kind = "init";
@@ -1849,13 +1840,13 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     elements = deserializeVecOptionBindingPattern(pos + 8),
@@ -1866,13 +1857,13 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeBindingPattern(pos + 8);
@@ -1880,8 +1871,8 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeFunctionType(pos + 84),
       id: null,
@@ -1890,8 +1881,8 @@ function deserializeFunction(pos) {
       params: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 56);
@@ -1955,13 +1946,13 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeVecDirective(pos + 8);
@@ -1972,8 +1963,8 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+    start,
+    end,
     node = {
       type: "ArrowFunctionExpression",
       expression,
@@ -1982,8 +1973,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeBoxFunctionBody(pos + 32);
@@ -1995,14 +1986,14 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeOptionExpression(pos + 8);
@@ -2010,16 +2001,16 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeClassType(pos + 132),
       decorators: null,
       id: null,
       superClass: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2041,13 +2032,13 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecClassElement(pos + 8);
@@ -2072,8 +2063,8 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
@@ -2082,8 +2073,8 @@ function deserializeMethodDefinition(pos) {
       kind: deserializeMethodDefinitionKind(pos + 57),
       computed: deserializeBool(pos + 58),
       static: deserializeBool(pos + 59),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2104,8 +2095,8 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
@@ -2113,8 +2104,8 @@ function deserializePropertyDefinition(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2150,25 +2141,24 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecStatement(pos + 8);
@@ -2187,8 +2177,8 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
@@ -2196,8 +2186,8 @@ function deserializeAccessorProperty(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2207,15 +2197,15 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.source = deserializeExpression(pos + 8);
@@ -2224,16 +2214,16 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportDeclaration",
       specifiers: null,
       source: null,
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
@@ -2270,14 +2260,14 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.imported = deserializeModuleExportName(pos + 8);
@@ -2286,13 +2276,13 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2300,13 +2290,13 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2318,14 +2308,14 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializeImportAttributeKey(pos + 8);
@@ -2345,16 +2335,16 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportNamedDeclaration",
       declaration: null,
       specifiers: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     withClause = deserializeOptionBoxWithClause(pos + 96);
@@ -2366,13 +2356,13 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
@@ -2380,15 +2370,15 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     withClause = deserializeOptionBoxWithClause(pos + 112);
@@ -2399,14 +2389,14 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeModuleExportName(pos + 8);
@@ -2527,14 +2517,14 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeIdentifierName(pos + 8);
@@ -2574,27 +2564,26 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     value = deserializeStr(pos + 8);
@@ -2605,15 +2594,15 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     bigint = deserializeStr(pos + 8);
@@ -2623,15 +2612,15 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     regex = deserializeRegExp(pos + 8),
@@ -2667,15 +2656,15 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
@@ -2688,15 +2677,15 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXElementName(pos + 8);
@@ -2706,13 +2695,13 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXElementName(pos + 8);
@@ -2720,15 +2709,15 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
@@ -2738,14 +2727,14 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXOpeningFragment",
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.attributes = [];
@@ -2754,12 +2743,11 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXClosingFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -2796,14 +2784,14 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.namespace = deserializeJSXIdentifier(pos + 8);
@@ -2812,14 +2800,14 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
@@ -2855,13 +2843,13 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeJSXExpression(pos + 8);
@@ -2964,12 +2952,11 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXEmptyExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -2986,14 +2973,14 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXAttributeName(pos + 8);
@@ -3002,13 +2989,13 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -3042,13 +3029,12 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -3071,13 +3057,13 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -3085,29 +3071,28 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -3118,16 +3103,16 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumDeclaration",
       id: null,
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3136,13 +3121,13 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.members = deserializeVecTSEnumMember(pos + 8);
@@ -3150,15 +3135,15 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeTSEnumMemberName(pos + 8);
@@ -3183,13 +3168,13 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3197,13 +3182,13 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.literal = deserializeTSLiteral(pos + 8);
@@ -3311,16 +3296,16 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConditionalType",
       checkType: null,
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.checkType = deserializeTSType(pos + 8);
@@ -3331,13 +3316,13 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.types = deserializeVecTSType(pos + 8);
@@ -3345,13 +3330,13 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.types = deserializeVecTSType(pos + 8);
@@ -3375,14 +3360,14 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3403,13 +3388,13 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elementType = deserializeTSType(pos + 8);
@@ -3417,14 +3402,14 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.objectType = deserializeTSType(pos + 8);
@@ -3433,13 +3418,13 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
@@ -3447,15 +3432,15 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeIdentifierName(pos + 8);
@@ -3464,13 +3449,13 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3478,13 +3463,13 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3577,168 +3562,154 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSAnyKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSStringKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBooleanKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNumberKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNeverKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSIntrinsicKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUnknownKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNullKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUndefinedKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSVoidKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSSymbolKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSThisType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSObjectKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBigIntKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeName = deserializeTSTypeName(pos + 8);
@@ -3760,14 +3731,14 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeTSTypeName(pos + 8);
@@ -3776,13 +3747,13 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.params = deserializeVecTSType(pos + 8);
@@ -3790,8 +3761,8 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameter",
       name: null,
@@ -3800,8 +3771,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeBindingIdentifier(pos + 8);
@@ -3811,13 +3782,13 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.params = deserializeVecTSTypeParameter(pos + 8);
@@ -3825,16 +3796,16 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAliasDeclaration",
       id: null,
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3844,8 +3815,8 @@ function deserializeTSTypeAliasDeclaration(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceDeclaration",
       id: null,
@@ -3853,8 +3824,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3865,13 +3836,13 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecTSSignature(pos + 8);
@@ -3879,8 +3850,8 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSPropertySignature",
       computed: deserializeBool(pos + 32),
@@ -3890,8 +3861,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 8);
@@ -3918,8 +3889,8 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIndexSignature",
       parameters: null,
@@ -3927,8 +3898,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
@@ -3937,15 +3908,15 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 24),
@@ -3971,8 +3942,8 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSMethodSignature",
       key: null,
@@ -3985,8 +3956,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 40),
@@ -4002,15 +3973,15 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4020,16 +3991,16 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -4039,14 +4010,14 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4055,15 +4026,15 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
@@ -4191,8 +4162,8 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSModuleDeclaration",
       id: null,
@@ -4200,8 +4171,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     keywordStart,
@@ -4220,13 +4191,13 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeVecDirective(pos + 8);
@@ -4236,13 +4207,13 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.members = deserializeVecTSSignature(pos + 8);
@@ -4250,13 +4221,13 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
@@ -4264,14 +4235,14 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
@@ -4295,16 +4266,16 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSImportType",
       source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.source = deserializeStringLiteral(pos + 8);
@@ -4326,14 +4297,14 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeTSImportTypeQualifier(pos + 8);
@@ -4342,15 +4313,15 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4363,16 +4334,16 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConstructorType",
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4382,8 +4353,8 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSMappedType",
       key: null,
@@ -4392,8 +4363,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
@@ -4420,14 +4391,14 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -4436,14 +4407,14 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4452,14 +4423,14 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4468,14 +4439,14 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4484,15 +4455,15 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4516,13 +4487,13 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeStringLiteral(pos + 8);
@@ -4530,13 +4501,13 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4544,13 +4515,13 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4558,13 +4529,13 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4572,13 +4543,13 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeIdentifierName(pos + 8);
@@ -4586,14 +4557,14 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4613,14 +4584,14 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4628,14 +4599,14 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4643,12 +4614,11 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSJSDocUnknownType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -4680,12 +4650,11 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -4732,16 +4701,15 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -4853,12 +4821,11 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5051,12 +5018,11 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5072,24 +5038,22 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -147,14 +147,14 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -163,14 +163,14 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -179,14 +179,14 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -195,14 +195,14 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
       name: deserializeStr(pos + 8),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -211,26 +211,25 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "ThisExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -341,14 +340,14 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -369,8 +368,8 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -380,8 +379,8 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 41),
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -502,15 +501,15 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -521,15 +520,15 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TaggedTemplateExpression",
       tag: null,
       quasi: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -568,8 +567,8 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -577,8 +576,8 @@ function deserializeComputedMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -590,8 +589,8 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -599,8 +598,8 @@ function deserializeStaticMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -612,8 +611,8 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -621,8 +620,8 @@ function deserializePrivateFieldExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -634,16 +633,16 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "CallExpression",
       callee: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -654,15 +653,15 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "NewExpression",
       callee: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -673,15 +672,15 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -692,14 +691,14 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -804,16 +803,16 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -823,16 +822,16 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -843,16 +842,16 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -863,16 +862,16 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -884,16 +883,16 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -904,16 +903,16 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -925,16 +924,16 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -995,14 +994,14 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1015,14 +1014,14 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1035,14 +1034,14 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1081,15 +1080,15 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1164,8 +1163,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -1175,8 +1174,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       method: null,
       shorthand: null,
       computed: deserializeBool(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1190,14 +1189,14 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1207,26 +1206,25 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Super",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1236,14 +1234,14 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1363,15 +1361,15 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1381,27 +1379,26 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1436,15 +1433,15 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1488,26 +1485,25 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "EmptyStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1517,16 +1513,16 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1538,15 +1534,15 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1557,15 +1553,15 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1576,8 +1572,8 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForStatement",
@@ -1585,8 +1581,8 @@ function deserializeForStatement(pos) {
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1694,16 +1690,16 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1744,8 +1740,8 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForOfStatement",
@@ -1753,8 +1749,8 @@ function deserializeForOfStatement(pos) {
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1766,14 +1762,14 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1783,14 +1779,14 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1800,14 +1796,14 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1817,15 +1813,15 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1836,15 +1832,15 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1855,15 +1851,15 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1874,15 +1870,15 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1893,14 +1889,14 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1910,16 +1906,16 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1931,15 +1927,15 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1954,12 +1950,11 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "DebuggerStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -1981,15 +1976,15 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2000,14 +1995,14 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2020,8 +2015,8 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -2031,8 +2026,8 @@ function deserializeBindingProperty(pos) {
       method: null,
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2045,14 +2040,14 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2065,14 +2060,14 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2082,8 +2077,8 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeFunctionType(pos + 84),
@@ -2093,8 +2088,8 @@ function deserializeFunction(pos) {
       params: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2166,14 +2161,14 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2186,8 +2181,8 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+    start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrowFunctionExpression",
@@ -2197,8 +2192,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2215,15 +2210,15 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2233,8 +2228,8 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeClassType(pos + 132),
@@ -2242,8 +2237,8 @@ function deserializeClass(pos) {
       id: null,
       superClass: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2267,14 +2262,14 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2301,8 +2296,8 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
@@ -2312,8 +2307,8 @@ function deserializeMethodDefinition(pos) {
       kind: deserializeMethodDefinitionKind(pos + 57),
       computed: deserializeBool(pos + 58),
       static: deserializeBool(pos + 59),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2336,8 +2331,8 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
@@ -2346,8 +2341,8 @@ function deserializePropertyDefinition(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2385,27 +2380,26 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2426,8 +2420,8 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
@@ -2436,8 +2430,8 @@ function deserializeAccessorProperty(pos) {
       value: null,
       computed: deserializeBool(pos + 73),
       static: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2449,16 +2443,16 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2469,8 +2463,8 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportDeclaration",
@@ -2478,8 +2472,8 @@ function deserializeImportDeclaration(pos) {
       source: null,
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2518,15 +2512,15 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2537,14 +2531,14 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2554,14 +2548,14 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2575,15 +2569,15 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2605,8 +2599,8 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportNamedDeclaration",
@@ -2614,8 +2608,8 @@ function deserializeExportNamedDeclaration(pos) {
       specifiers: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2629,14 +2623,14 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2646,16 +2640,16 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2668,15 +2662,15 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2799,15 +2793,15 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2855,29 +2849,28 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2890,16 +2883,16 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2911,16 +2904,16 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2958,16 +2951,16 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2982,16 +2975,16 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3003,14 +2996,14 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3020,16 +3013,16 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3041,15 +3034,15 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXOpeningFragment",
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3060,12 +3053,11 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXClosingFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3105,15 +3097,15 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3124,15 +3116,15 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3172,14 +3164,14 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3284,12 +3276,11 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXEmptyExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3307,15 +3298,15 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3326,14 +3317,14 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3369,13 +3360,12 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3399,14 +3389,14 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3416,22 +3406,21 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -3439,8 +3428,8 @@ function deserializeTSThisParameter(pos) {
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3453,8 +3442,8 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumDeclaration",
@@ -3462,8 +3451,8 @@ function deserializeTSEnumDeclaration(pos) {
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3474,14 +3463,14 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3491,16 +3480,16 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3527,14 +3516,14 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3544,14 +3533,14 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3661,8 +3650,8 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConditionalType",
@@ -3670,8 +3659,8 @@ function deserializeTSConditionalType(pos) {
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3684,14 +3673,14 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3701,14 +3690,14 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3738,15 +3727,15 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3769,14 +3758,14 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3786,15 +3775,15 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3805,14 +3794,14 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3822,16 +3811,16 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3842,14 +3831,14 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3859,14 +3848,14 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3961,183 +3950,169 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSAnyKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSStringKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBooleanKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNumberKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNeverKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSIntrinsicKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUnknownKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNullKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUndefinedKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSVoidKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSSymbolKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSThisType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSObjectKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBigIntKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4161,15 +4136,15 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4180,14 +4155,14 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4197,8 +4172,8 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameter",
@@ -4208,8 +4183,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4221,14 +4196,14 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4238,8 +4213,8 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAliasDeclaration",
@@ -4247,8 +4222,8 @@ function deserializeTSTypeAliasDeclaration(pos) {
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4260,8 +4235,8 @@ function deserializeTSTypeAliasDeclaration(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceDeclaration",
@@ -4270,8 +4245,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4284,14 +4259,14 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4301,8 +4276,8 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSPropertySignature",
@@ -4313,8 +4288,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4343,8 +4318,8 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIndexSignature",
@@ -4353,8 +4328,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4365,16 +4340,16 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4402,8 +4377,8 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSMethodSignature",
@@ -4417,8 +4392,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4436,16 +4411,16 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4457,8 +4432,8 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -4466,8 +4441,8 @@ function deserializeTSIndexSignatureName(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4479,15 +4454,15 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4498,16 +4473,16 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4655,8 +4630,8 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSModuleDeclaration",
@@ -4665,8 +4640,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4688,14 +4663,14 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4707,14 +4682,14 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4724,14 +4699,14 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4741,15 +4716,15 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4775,8 +4750,8 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
@@ -4784,8 +4759,8 @@ function deserializeTSImportType(pos) {
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4809,15 +4784,15 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4828,16 +4803,16 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4852,8 +4827,8 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConstructorType",
@@ -4861,8 +4836,8 @@ function deserializeTSConstructorType(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4874,8 +4849,8 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSMappedType",
@@ -4885,8 +4860,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4915,15 +4890,15 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4934,15 +4909,15 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4953,15 +4928,15 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4972,15 +4947,15 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4991,16 +4966,16 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5026,14 +5001,14 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5043,14 +5018,14 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5060,14 +5035,14 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5077,14 +5052,14 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5094,14 +5069,14 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5111,15 +5086,15 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5141,15 +5116,15 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5159,15 +5134,15 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5177,12 +5152,11 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSJSDocUnknownType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -5215,12 +5189,11 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5267,16 +5240,15 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5388,12 +5360,11 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5586,12 +5557,11 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5607,24 +5577,22 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -157,68 +157,60 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   return node;
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   return node;
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   return node;
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   return node;
@@ -367,20 +359,18 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: deserializePropertyKind(pos + 40),
-      key: null,
-      value: null,
-      method: deserializeBool(pos + 41),
-      shorthand: deserializeBool(pos + 42),
-      computed: deserializeBool(pos + 43),
-      optional: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: deserializePropertyKind(pos + 40),
+    key: null,
+    value: null,
+    method: deserializeBool(pos + 41),
+    shorthand: deserializeBool(pos + 42),
+    computed: deserializeBool(pos + 43),
+    optional: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeExpression(pos + 24);
   node.optional = false;
@@ -552,17 +542,15 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 40),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 40),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeExpression(pos + 24);
   node.computed = true;
@@ -570,17 +558,15 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 48),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 48),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializeIdentifierName(pos + 24);
   node.computed = false;
@@ -588,17 +574,15 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "MemberExpression",
-      object: null,
-      property: null,
-      optional: deserializeBool(pos + 48),
-      computed: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "MemberExpression",
+    object: null,
+    property: null,
+    optional: deserializeBool(pos + 48),
+    computed: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.object = deserializeExpression(pos + 8);
   node.property = deserializePrivateIdentifier(pos + 24);
   node.computed = false;
@@ -606,17 +590,15 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "CallExpression",
-      callee: null,
-      typeArguments: null,
-      arguments: null,
-      optional: deserializeBool(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "CallExpression",
+    callee: null,
+    typeArguments: null,
+    arguments: null,
+    optional: deserializeBool(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.callee = deserializeExpression(pos + 8);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 24);
   node.arguments = deserializeVecArgument(pos + 32);
@@ -758,47 +740,41 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "UpdateExpression",
-      operator: deserializeUpdateOperator(pos + 24),
-      prefix: deserializeBool(pos + 25),
-      argument: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "UpdateExpression",
+    operator: deserializeUpdateOperator(pos + 24),
+    prefix: deserializeBool(pos + 25),
+    argument: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
   return node;
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "UnaryExpression",
-      operator: deserializeUnaryOperator(pos + 24),
-      argument: null,
-      prefix: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "UnaryExpression",
+    operator: deserializeUnaryOperator(pos + 24),
+    argument: null,
+    prefix: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeExpression(pos + 8);
   node.prefix = true;
   return node;
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "BinaryExpression",
-      left: null,
-      operator: deserializeBinaryOperator(pos + 40),
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "BinaryExpression",
+    left: null,
+    operator: deserializeBinaryOperator(pos + 40),
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -820,16 +796,14 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "LogicalExpression",
-      left: null,
-      operator: deserializeLogicalOperator(pos + 40),
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "LogicalExpression",
+    left: null,
+    operator: deserializeLogicalOperator(pos + 40),
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeExpression(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -851,16 +825,14 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "AssignmentExpression",
-      operator: deserializeAssignmentOperator(pos + 40),
-      left: null,
-      right: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "AssignmentExpression",
+    operator: deserializeAssignmentOperator(pos + 40),
+    left: null,
+    right: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeAssignmentTarget(pos + 8);
   node.right = deserializeExpression(pos + 24);
   return node;
@@ -1077,20 +1049,18 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: null,
-      key: null,
-      value: null,
-      method: null,
-      shorthand: null,
-      computed: deserializeBool(pos + 40),
-      optional: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: null,
+    key: null,
+    value: null,
+    method: null,
+    shorthand: null,
+    computed: deserializeBool(pos + 40),
+    optional: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.kind = "init";
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 24);
@@ -1244,27 +1214,23 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ExpressionStatement",
-      expression: null,
-      directive: deserializeStr(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "ExpressionStatement",
+    expression: null,
+    directive: deserializeStr(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.expression = deserializeStringLiteral(pos + 8);
   return node;
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -1305,16 +1271,14 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "VariableDeclaration",
-      kind: deserializeVariableDeclarationKind(pos + 32),
-      declarations: null,
-      declare: deserializeBool(pos + 33),
-      start,
-      end,
-    };
+  let node = {
+    type: "VariableDeclaration",
+    kind: deserializeVariableDeclarationKind(pos + 32),
+    declarations: null,
+    declare: deserializeBool(pos + 33),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
   return node;
 }
@@ -1574,17 +1538,15 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ForOfStatement",
-      await: deserializeBool(pos + 60),
-      left: null,
-      right: null,
-      body: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "ForOfStatement",
+    await: deserializeBool(pos + 60),
+    left: null,
+    right: null,
+    body: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.left = deserializeForStatementLeft(pos + 8);
   node.right = deserializeExpression(pos + 24);
   node.body = deserializeStatement(pos + 40);
@@ -1786,20 +1748,18 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Property",
-      kind: null,
-      key: null,
-      value: null,
-      method: null,
-      shorthand: deserializeBool(pos + 40),
-      computed: deserializeBool(pos + 41),
-      optional: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Property",
+    kind: null,
+    key: null,
+    value: null,
+    method: null,
+    shorthand: deserializeBool(pos + 40),
+    computed: deserializeBool(pos + 41),
+    optional: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.kind = "init";
   node.key = deserializePropertyKey(pos + 8);
   node.value = deserializeBindingPattern(pos + 24);
@@ -1845,9 +1805,7 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: deserializeFunctionType(pos + 84),
       id: null,
       generator: deserializeBool(pos + 85),
@@ -1858,8 +1816,8 @@ function deserializeFunction(pos) {
       returnType: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     params = deserializeBoxFormalParameters(pos + 56);
   {
@@ -2021,8 +1979,6 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
     node = {
       type: "ArrowFunctionExpression",
       expression,
@@ -2033,8 +1989,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     body = deserializeBoxFunctionBody(pos + 32);
   expression === true && (body = body.body[0].expression);
@@ -2047,36 +2003,32 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "YieldExpression",
-      delegate: deserializeBool(pos + 24),
-      argument: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "YieldExpression",
+    delegate: deserializeBool(pos + 24),
+    argument: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.argument = deserializeOptionExpression(pos + 8);
   return node;
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeClassType(pos + 132),
-      decorators: null,
-      id: null,
-      typeParameters: null,
-      superClass: null,
-      superTypeArguments: null,
-      implements: null,
-      body: null,
-      abstract: deserializeBool(pos + 133),
-      declare: deserializeBool(pos + 134),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeClassType(pos + 132),
+    decorators: null,
+    id: null,
+    typeParameters: null,
+    superClass: null,
+    superTypeArguments: null,
+    implements: null,
+    body: null,
+    abstract: deserializeBool(pos + 133),
+    declare: deserializeBool(pos + 134),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.id = deserializeOptionBindingIdentifier(pos + 32);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 64);
@@ -2127,22 +2079,20 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeMethodDefinitionType(pos + 56),
-      decorators: null,
-      key: null,
-      value: null,
-      kind: deserializeMethodDefinitionKind(pos + 57),
-      computed: deserializeBool(pos + 58),
-      static: deserializeBool(pos + 59),
-      override: deserializeBool(pos + 60),
-      optional: deserializeBool(pos + 61),
-      accessibility: deserializeOptionTSAccessibility(pos + 62),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeMethodDefinitionType(pos + 56),
+    decorators: null,
+    key: null,
+    value: null,
+    kind: deserializeMethodDefinitionKind(pos + 57),
+    computed: deserializeBool(pos + 58),
+    static: deserializeBool(pos + 59),
+    override: deserializeBool(pos + 60),
+    optional: deserializeBool(pos + 61),
+    accessibility: deserializeOptionTSAccessibility(pos + 62),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.value = deserializeBoxFunction(pos + 48);
@@ -2161,25 +2111,23 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializePropertyDefinitionType(pos + 72),
-      decorators: null,
-      key: null,
-      typeAnnotation: null,
-      value: null,
-      computed: deserializeBool(pos + 73),
-      static: deserializeBool(pos + 74),
-      declare: deserializeBool(pos + 75),
-      override: deserializeBool(pos + 76),
-      optional: deserializeBool(pos + 77),
-      definite: deserializeBool(pos + 78),
-      readonly: deserializeBool(pos + 79),
-      accessibility: deserializeOptionTSAccessibility(pos + 80),
-      start,
-      end,
-    };
+  let node = {
+    type: deserializePropertyDefinitionType(pos + 72),
+    decorators: null,
+    key: null,
+    typeAnnotation: null,
+    value: null,
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
+    declare: deserializeBool(pos + 75),
+    override: deserializeBool(pos + 76),
+    optional: deserializeBool(pos + 77),
+    definite: deserializeBool(pos + 78),
+    readonly: deserializeBool(pos + 79),
+    accessibility: deserializeOptionTSAccessibility(pos + 80),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2214,13 +2162,11 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -2247,25 +2193,23 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: deserializeAccessorPropertyType(pos + 72),
-      decorators: null,
-      key: null,
-      typeAnnotation: null,
-      value: null,
-      computed: deserializeBool(pos + 73),
-      static: deserializeBool(pos + 74),
-      override: deserializeBool(pos + 75),
-      definite: deserializeBool(pos + 76),
-      accessibility: deserializeOptionTSAccessibility(pos + 77),
-      declare: null,
-      optional: null,
-      readonly: null,
-      start,
-      end,
-    };
+  let node = {
+    type: deserializeAccessorPropertyType(pos + 72),
+    decorators: null,
+    key: null,
+    typeAnnotation: null,
+    value: null,
+    computed: deserializeBool(pos + 73),
+    static: deserializeBool(pos + 74),
+    override: deserializeBool(pos + 75),
+    definite: deserializeBool(pos + 76),
+    accessibility: deserializeOptionTSAccessibility(pos + 77),
+    declare: null,
+    optional: null,
+    readonly: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = deserializeVecDecorator(pos + 8);
   node.key = deserializePropertyKey(pos + 32);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 48);
@@ -2277,33 +2221,29 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ImportExpression",
-      source: null,
-      options: null,
-      phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
-    };
+  let node = {
+    type: "ImportExpression",
+    source: null,
+    options: null,
+    phase: deserializeOptionImportPhase(pos + 40),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.source = deserializeExpression(pos + 8);
   node.options = deserializeOptionExpression(pos + 24);
   return node;
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "ImportDeclaration",
       specifiers: null,
       source: null,
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
       importKind: deserializeImportOrExportKind(pos + 89),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
   specifiers === null && (specifiers = []);
@@ -2339,16 +2279,14 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ImportSpecifier",
-      imported: null,
-      local: null,
-      importKind: deserializeImportOrExportKind(pos + 96),
-      start,
-      end,
-    };
+  let node = {
+    type: "ImportSpecifier",
+    imported: null,
+    local: null,
+    importKind: deserializeImportOrExportKind(pos + 96),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.imported = deserializeModuleExportName(pos + 8);
   node.local = deserializeBindingIdentifier(pos + 64);
   return node;
@@ -2405,17 +2343,15 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "ExportNamedDeclaration",
       declaration: null,
       specifiers: null,
       source: null,
       exportKind: deserializeImportOrExportKind(pos + 104),
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     withClause = deserializeOptionBoxWithClause(pos + 96);
   node.declaration = deserializeOptionDeclaration(pos + 8);
@@ -2439,16 +2375,14 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     withClause = deserializeOptionBoxWithClause(pos + 112);
   node.exported = deserializeOptionModuleExportName(pos + 8);
@@ -2458,16 +2392,14 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "ExportSpecifier",
-      local: null,
-      exported: null,
-      exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
-    };
+  let node = {
+    type: "ExportSpecifier",
+    local: null,
+    exported: null,
+    exportKind: deserializeImportOrExportKind(pos + 120),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.local = deserializeModuleExportName(pos + 8);
   node.exported = deserializeModuleExportName(pos + 64);
   return node;
@@ -2628,26 +2560,22 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     value = deserializeStr(pos + 8);
   deserializeBool(pos + 40) &&
@@ -2657,15 +2585,13 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     bigint = deserializeStr(pos + 8);
   node.value = BigInt(bigint);
@@ -2674,15 +2600,13 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     regex = deserializeRegExp(pos + 8),
     value = null;
@@ -3049,13 +2973,11 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -3088,14 +3010,12 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -3117,17 +3037,15 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSEnumDeclaration",
-      id: null,
-      body: null,
-      const: deserializeBool(pos + 80),
-      declare: deserializeBool(pos + 81),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSEnumDeclaration",
+    id: null,
+    body: null,
+    const: deserializeBool(pos + 80),
+    declare: deserializeBool(pos + 81),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.body = deserializeTSEnumBody(pos + 40);
   return node;
@@ -3348,15 +3266,13 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeOperator",
-      operator: deserializeTSTypeOperatorOperator(pos + 24),
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeOperator",
+    operator: deserializeTSTypeOperatorOperator(pos + 24),
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
@@ -3410,16 +3326,14 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSNamedTupleMember",
-      label: null,
-      elementType: null,
-      optional: deserializeBool(pos + 48),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSNamedTupleMember",
+    label: null,
+    elementType: null,
+    optional: deserializeBool(pos + 48),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.label = deserializeIdentifierName(pos + 8);
   node.elementType = deserializeTSTupleElement(pos + 32);
   return node;
@@ -3695,19 +3609,17 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeParameter",
-      name: null,
-      constraint: null,
-      default: null,
-      in: deserializeBool(pos + 72),
-      out: deserializeBool(pos + 73),
-      const: deserializeBool(pos + 74),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeParameter",
+    name: null,
+    constraint: null,
+    default: null,
+    in: deserializeBool(pos + 72),
+    out: deserializeBool(pos + 73),
+    const: deserializeBool(pos + 74),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.name = deserializeBindingIdentifier(pos + 8);
   node.constraint = deserializeOptionTSType(pos + 40);
   node.default = deserializeOptionTSType(pos + 56);
@@ -3726,17 +3638,15 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypeAliasDeclaration",
-      id: null,
-      typeParameters: null,
-      typeAnnotation: null,
-      declare: deserializeBool(pos + 68),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypeAliasDeclaration",
+    id: null,
+    typeParameters: null,
+    typeAnnotation: null,
+    declare: deserializeBool(pos + 68),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.typeAnnotation = deserializeTSType(pos + 48);
@@ -3797,18 +3707,16 @@ function deserializeTSClassImplements(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSInterfaceDeclaration",
-      id: null,
-      typeParameters: null,
-      extends: null,
-      body: null,
-      declare: deserializeBool(pos + 84),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSInterfaceDeclaration",
+    id: null,
+    typeParameters: null,
+    extends: null,
+    body: null,
+    declare: deserializeBool(pos + 84),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 40);
   node.extends = deserializeVecTSInterfaceHeritage(pos + 48);
@@ -3828,20 +3736,18 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSPropertySignature",
-      computed: deserializeBool(pos + 32),
-      optional: deserializeBool(pos + 33),
-      readonly: deserializeBool(pos + 34),
-      key: null,
-      typeAnnotation: null,
-      accessibility: null,
-      static: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSPropertySignature",
+    computed: deserializeBool(pos + 32),
+    optional: deserializeBool(pos + 33),
+    readonly: deserializeBool(pos + 34),
+    key: null,
+    typeAnnotation: null,
+    accessibility: null,
+    static: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.key = deserializePropertyKey(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   node.static = false;
@@ -3866,18 +3772,16 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSIndexSignature",
-      parameters: null,
-      typeAnnotation: null,
-      readonly: deserializeBool(pos + 40),
-      static: deserializeBool(pos + 41),
-      accessibility: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSIndexSignature",
+    parameters: null,
+    typeAnnotation: null,
+    readonly: deserializeBool(pos + 40),
+    static: deserializeBool(pos + 41),
+    accessibility: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
@@ -3915,9 +3819,7 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "TSMethodSignature",
       key: null,
       computed: deserializeBool(pos + 60),
@@ -3929,8 +3831,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     params = deserializeBoxFormalParameters(pos + 40),
     thisParam = deserializeOptionBoxTSThisParameter(pos + 32);
@@ -3960,17 +3862,15 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 8),
-      optional: null,
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "Identifier",
+    decorators: null,
+    name: deserializeStr(pos + 8),
+    optional: null,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.decorators = [];
   node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -3991,16 +3891,14 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSTypePredicate",
-      parameterName: null,
-      asserts: deserializeBool(pos + 32),
-      typeAnnotation: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSTypePredicate",
+    parameterName: null,
+    asserts: deserializeBool(pos + 32),
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
@@ -4120,18 +4018,16 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSModuleDeclaration",
-      id: null,
-      body: null,
-      kind: null,
-      declare: deserializeBool(pos + 76),
-      global: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSModuleDeclaration",
+    id: null,
+    body: null,
+    kind: null,
+    declare: deserializeBool(pos + 76),
+    global: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = {
     type: "Identifier",
     decorators: [],
@@ -4270,17 +4166,15 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSConstructorType",
-      abstract: deserializeBool(pos + 36),
-      typeParameters: null,
-      params: null,
-      returnType: null,
-      start,
-      end,
-    };
+  let node = {
+    type: "TSConstructorType",
+    abstract: deserializeBool(pos + 36),
+    typeParameters: null,
+    params: null,
+    returnType: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
   node.params = deserializeBoxFormalParameters(pos + 16);
   node.returnType = deserializeBoxTSTypeAnnotation(pos + 24);
@@ -4288,9 +4182,7 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
+  let node = {
       type: "TSMappedType",
       key: null,
       constraint: null,
@@ -4298,8 +4190,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
     },
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
@@ -4377,16 +4269,14 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSImportEqualsDeclaration",
-      id: null,
-      moduleReference: null,
-      importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSImportEqualsDeclaration",
+    id: null,
+    moduleReference: null,
+    importKind: deserializeImportOrExportKind(pos + 56),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.id = deserializeBindingIdentifier(pos + 8);
   node.moduleReference = deserializeTSModuleReference(pos + 40);
   return node;
@@ -4487,29 +4377,25 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSJSDocNullableType",
-      typeAnnotation: null,
-      postfix: deserializeBool(pos + 24),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSJSDocNullableType",
+    typeAnnotation: null,
+    postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "TSJSDocNonNullableType",
-      typeAnnotation: null,
-      postfix: deserializeBool(pos + 24),
-      start,
-      end,
-    };
+  let node = {
+    type: "TSJSDocNonNullableType",
+    typeAnnotation: null,
+    postfix: deserializeBool(pos + 24),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
   node.typeAnnotation = deserializeTSType(pos + 8);
   return node;
 }
@@ -4548,12 +4434,10 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4596,16 +4480,14 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4706,12 +4588,10 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4903,12 +4783,10 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -4923,23 +4801,19 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -165,17 +165,15 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -185,17 +183,15 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -205,17 +201,15 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -225,17 +219,15 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -254,14 +246,12 @@ function deserializeThisExpression(pos) {
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
@@ -371,14 +361,12 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
@@ -398,9 +386,7 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: deserializePropertyKind(pos + 40),
@@ -410,8 +396,8 @@ function deserializeObjectProperty(pos) {
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
       optional: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 8);
@@ -532,15 +518,13 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -550,16 +534,14 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TaggedTemplateExpression",
       tag: null,
       typeArguments: null,
       quasi: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.tag = deserializeExpression(pos + 8);
@@ -597,17 +579,15 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -618,17 +598,15 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -639,17 +617,15 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -660,17 +636,15 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "CallExpression",
       callee: null,
       typeArguments: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.callee = deserializeExpression(pos + 8);
@@ -681,16 +655,14 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "NewExpression",
       callee: null,
       typeArguments: null,
       arguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.callee = deserializeExpression(pos + 8);
@@ -701,15 +673,13 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.meta = deserializeIdentifierName(pos + 8);
@@ -719,14 +689,12 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -830,16 +798,14 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
@@ -848,16 +814,14 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -867,16 +831,14 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeExpression(pos + 8);
@@ -886,16 +848,14 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 8);
@@ -906,16 +866,14 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeExpression(pos + 8);
@@ -925,16 +883,14 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -945,16 +901,14 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -1014,17 +968,15 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       decorators: null,
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
@@ -1038,17 +990,15 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       decorators: null,
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
@@ -1062,9 +1012,7 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "RestElement",
       decorators: null,
@@ -1072,8 +1020,8 @@ function deserializeAssignmentTargetRest(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -1113,9 +1061,7 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       decorators: null,
@@ -1123,8 +1069,8 @@ function deserializeAssignmentTargetWithDefault(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -1203,9 +1149,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: null,
@@ -1215,8 +1159,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       shorthand: null,
       computed: deserializeBool(pos + 40),
       optional: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.kind = "init";
@@ -1230,14 +1174,12 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expressions = deserializeVecExpression(pos + 8);
@@ -1255,14 +1197,12 @@ function deserializeSuper(pos) {
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -1271,14 +1211,12 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeChainElement(pos + 8);
@@ -1394,15 +1332,13 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeStringLiteral(pos + 8);
@@ -1411,26 +1347,22 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecStatement(pos + 8);
@@ -1464,16 +1396,14 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
       declare: deserializeBool(pos + 33),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
@@ -1533,15 +1463,13 @@ function deserializeEmptyStatement(pos) {
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -1550,16 +1478,14 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -1570,15 +1496,13 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeStatement(pos + 8);
@@ -1588,15 +1512,13 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeExpression(pos + 8);
@@ -1606,17 +1528,15 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForStatement",
       init: null,
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.init = deserializeOptionForStatementInit(pos + 8);
@@ -1723,16 +1643,14 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1772,17 +1690,15 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ForOfStatement",
       await: deserializeBool(pos + 60),
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1793,14 +1709,12 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1809,14 +1723,12 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1825,14 +1737,12 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeOptionExpression(pos + 8);
@@ -1841,15 +1751,13 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 8);
@@ -1859,15 +1767,13 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.discriminant = deserializeExpression(pos + 8);
@@ -1877,15 +1783,13 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.test = deserializeOptionExpression(pos + 8);
@@ -1895,15 +1799,13 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeLabelIdentifier(pos + 8);
@@ -1913,14 +1815,12 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -1929,16 +1829,14 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.block = deserializeBoxBlockStatement(pos + 8);
@@ -1949,15 +1847,13 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.param = deserializeOptionCatchParameter(pos + 8);
@@ -2004,9 +1900,7 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
       decorators: null,
@@ -2014,8 +1908,8 @@ function deserializeAssignmentPattern(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -2027,17 +1921,15 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
       decorators: null,
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     properties = deserializeVecBindingProperty(pos + 8),
@@ -2051,9 +1943,7 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Property",
       kind: null,
@@ -2063,8 +1953,8 @@ function deserializeBindingProperty(pos) {
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
       optional: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.kind = "init";
@@ -2077,17 +1967,15 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
       decorators: null,
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     elements = deserializeVecOptionBindingPattern(pos + 8),
@@ -2101,9 +1989,7 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "RestElement",
       decorators: null,
@@ -2111,8 +1997,8 @@ function deserializeBindingRestElement(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -2123,9 +2009,7 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeFunctionType(pos + 84),
       id: null,
@@ -2137,8 +2021,8 @@ function deserializeFunction(pos) {
       returnType: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 56);
@@ -2307,14 +2191,12 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeVecDirective(pos + 8);
@@ -2326,8 +2208,6 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "ArrowFunctionExpression",
@@ -2339,8 +2219,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeBoxFunctionBody(pos + 32);
@@ -2358,15 +2238,13 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeOptionExpression(pos + 8);
@@ -2375,9 +2253,7 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeClassType(pos + 132),
       decorators: null,
@@ -2389,8 +2265,8 @@ function deserializeClass(pos) {
       body: null,
       abstract: deserializeBool(pos + 133),
       declare: deserializeBool(pos + 134),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2416,14 +2292,12 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecClassElement(pos + 8);
@@ -2449,9 +2323,7 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
@@ -2463,8 +2335,8 @@ function deserializeMethodDefinition(pos) {
       override: deserializeBool(pos + 60),
       optional: deserializeBool(pos + 61),
       accessibility: deserializeOptionTSAccessibility(pos + 62),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2486,9 +2358,7 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
@@ -2503,8 +2373,8 @@ function deserializePropertyDefinition(pos) {
       definite: deserializeBool(pos + 78),
       readonly: deserializeBool(pos + 79),
       accessibility: deserializeOptionTSAccessibility(pos + 80),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2542,26 +2412,22 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecStatement(pos + 8);
@@ -2581,9 +2447,7 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
@@ -2598,8 +2462,8 @@ function deserializeAccessorProperty(pos) {
       declare: null,
       optional: null,
       readonly: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2614,16 +2478,14 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.source = deserializeExpression(pos + 8);
@@ -2633,9 +2495,7 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportDeclaration",
       specifiers: null,
@@ -2643,8 +2503,8 @@ function deserializeImportDeclaration(pos) {
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
       importKind: deserializeImportOrExportKind(pos + 89),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
@@ -2682,16 +2542,14 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
       importKind: deserializeImportOrExportKind(pos + 96),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.imported = deserializeModuleExportName(pos + 8);
@@ -2701,14 +2559,12 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2717,14 +2573,12 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2737,15 +2591,13 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializeImportAttributeKey(pos + 8);
@@ -2766,9 +2618,7 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportNamedDeclaration",
       declaration: null,
@@ -2776,8 +2626,8 @@ function deserializeExportNamedDeclaration(pos) {
       source: null,
       exportKind: deserializeImportOrExportKind(pos + 104),
       attributes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     withClause = deserializeOptionBoxWithClause(pos + 96);
@@ -2790,15 +2640,13 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
       exportKind: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
@@ -2808,17 +2656,15 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     withClause = deserializeOptionBoxWithClause(pos + 112);
@@ -2830,16 +2676,14 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.local = deserializeModuleExportName(pos + 8);
@@ -2961,15 +2805,13 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeIdentifierName(pos + 8);
@@ -3014,28 +2856,24 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     value = deserializeStr(pos + 8);
@@ -3047,16 +2885,14 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     bigint = deserializeStr(pos + 8);
@@ -3067,16 +2903,14 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     regex = deserializeRegExp(pos + 8),
@@ -3113,16 +2947,14 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
@@ -3136,17 +2968,15 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXOpeningElement",
       name: null,
       typeArguments: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXElementName(pos + 8);
@@ -3158,14 +2988,12 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXElementName(pos + 8);
@@ -3174,16 +3002,14 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
@@ -3194,13 +3020,11 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXOpeningFragment",
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   parent = previousParent;
@@ -3248,15 +3072,13 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.namespace = deserializeJSXIdentifier(pos + 8);
@@ -3266,15 +3088,13 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
@@ -3311,14 +3131,12 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeJSXExpression(pos + 8);
@@ -3442,15 +3260,13 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXAttributeName(pos + 8);
@@ -3460,14 +3276,12 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 8);
@@ -3502,13 +3316,11 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
@@ -3531,14 +3343,12 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -3547,30 +3357,26 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
     parent,
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -3582,17 +3388,15 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumDeclaration",
       id: null,
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3602,14 +3406,12 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.members = deserializeVecTSEnumMember(pos + 8);
@@ -3618,16 +3420,14 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeTSEnumMemberName(pos + 8);
@@ -3653,14 +3453,12 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3669,14 +3467,12 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.literal = deserializeTSLiteral(pos + 8);
@@ -3785,17 +3581,15 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConditionalType",
       checkType: null,
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.checkType = deserializeTSType(pos + 8);
@@ -3807,14 +3601,12 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.types = deserializeVecTSType(pos + 8);
@@ -3823,14 +3615,12 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.types = deserializeVecTSType(pos + 8);
@@ -3856,15 +3646,13 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3886,14 +3674,12 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elementType = deserializeTSType(pos + 8);
@@ -3902,15 +3688,13 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.objectType = deserializeTSType(pos + 8);
@@ -3920,14 +3704,12 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
@@ -3936,16 +3718,14 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.label = deserializeIdentifierName(pos + 8);
@@ -3955,14 +3735,12 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3971,14 +3749,12 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4198,15 +3974,13 @@ function deserializeTSBigIntKeyword(pos) {
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeName = deserializeTSTypeName(pos + 8);
@@ -4229,15 +4003,13 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeTSTypeName(pos + 8);
@@ -4247,14 +4019,12 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.params = deserializeVecTSType(pos + 8);
@@ -4263,9 +4033,7 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameter",
       name: null,
@@ -4274,8 +4042,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeBindingIdentifier(pos + 8);
@@ -4286,14 +4054,12 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.params = deserializeVecTSTypeParameter(pos + 8);
@@ -4302,17 +4068,15 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAliasDeclaration",
       id: null,
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4336,15 +4100,13 @@ function deserializeTSAccessibility(pos) {
 }
 
 function deserializeTSClassImplements(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSClassImplements",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     expression = deserializeTSTypeName(pos + 8);
@@ -4389,9 +4151,7 @@ function deserializeTSClassImplements(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceDeclaration",
       id: null,
@@ -4399,8 +4159,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4412,14 +4172,12 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.body = deserializeVecTSSignature(pos + 8);
@@ -4428,9 +4186,7 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSPropertySignature",
       computed: deserializeBool(pos + 32),
@@ -4440,8 +4196,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 8);
@@ -4469,9 +4225,7 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSIndexSignature",
       parameters: null,
@@ -4479,8 +4233,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
@@ -4490,16 +4244,14 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4526,9 +4278,7 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSMethodSignature",
       key: null,
@@ -4541,8 +4291,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 40),
@@ -4559,16 +4309,14 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4579,17 +4327,15 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.decorators = [];
@@ -4600,15 +4346,13 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -4618,16 +4362,14 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
@@ -4767,9 +4509,7 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSModuleDeclaration",
       id: null,
@@ -4777,8 +4517,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = {
@@ -4799,14 +4539,12 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     body = deserializeVecDirective(pos + 8);
@@ -4817,14 +4555,12 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.members = deserializeVecTSSignature(pos + 8);
@@ -4833,14 +4569,12 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
@@ -4849,15 +4583,13 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
@@ -4882,17 +4614,15 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSImportType",
       source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.source = deserializeStringLiteral(pos + 8);
@@ -4915,15 +4645,13 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializeTSImportTypeQualifier(pos + 8);
@@ -4933,16 +4661,14 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4956,17 +4682,15 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSConstructorType",
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4977,9 +4701,7 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSMappedType",
       key: null,
@@ -4988,8 +4710,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     }),
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
@@ -5017,15 +4739,13 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -5035,15 +4755,13 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5053,15 +4771,13 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5071,15 +4787,13 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -5089,16 +4803,14 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -5123,14 +4835,12 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeStringLiteral(pos + 8);
@@ -5139,14 +4849,12 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5155,14 +4863,12 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5171,14 +4877,12 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5187,14 +4891,12 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeIdentifierName(pos + 8);
@@ -5203,15 +4905,13 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.expression = deserializeExpression(pos + 8);
@@ -5232,15 +4932,13 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -5249,15 +4947,13 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
+  let previousParent = parent,
     node = (parent = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
       parent,
     });
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -5300,12 +4996,10 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5348,16 +5042,14 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5458,12 +5150,10 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5655,12 +5345,10 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
@@ -5675,23 +5363,19 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -158,16 +158,16 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -176,16 +176,16 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -194,16 +194,16 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -212,16 +212,16 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -230,24 +230,23 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "ThisExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elements = deserializeVecArrayExpressionElement(pos + 8);
@@ -356,13 +355,13 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.properties = deserializeVecObjectPropertyKind(pos + 8);
@@ -381,8 +380,8 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: deserializePropertyKind(pos + 40),
@@ -392,8 +391,8 @@ function deserializeObjectProperty(pos) {
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 8);
@@ -513,14 +512,14 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -529,15 +528,15 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TaggedTemplateExpression",
       tag: null,
       typeArguments: null,
       quasi: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.tag = deserializeExpression(pos + 8);
@@ -574,16 +573,16 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -593,16 +592,16 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -612,16 +611,16 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MemberExpression",
       object: null,
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -631,16 +630,16 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "CallExpression",
       callee: null,
       typeArguments: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.callee = deserializeExpression(pos + 8);
@@ -650,15 +649,15 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "NewExpression",
       callee: null,
       typeArguments: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.callee = deserializeExpression(pos + 8);
@@ -668,14 +667,14 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.meta = deserializeIdentifierName(pos + 8);
@@ -684,13 +683,13 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -793,15 +792,15 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeSimpleAssignmentTarget(pos + 8);
@@ -809,15 +808,15 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -826,15 +825,15 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeExpression(pos + 8);
@@ -843,15 +842,15 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializePrivateIdentifier(pos + 8);
@@ -861,15 +860,15 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeExpression(pos + 8);
@@ -878,15 +877,15 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -896,15 +895,15 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeAssignmentTarget(pos + 8);
@@ -963,16 +962,16 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayPattern",
       decorators: null,
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 8),
@@ -985,16 +984,16 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectPattern",
       decorators: null,
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     properties = deserializeVecAssignmentTargetProperty(pos + 8),
@@ -1007,8 +1006,8 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "RestElement",
       decorators: null,
@@ -1016,8 +1015,8 @@ function deserializeAssignmentTargetRest(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -1056,8 +1055,8 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentPattern",
       decorators: null,
@@ -1065,8 +1064,8 @@ function deserializeAssignmentTargetWithDefault(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -1140,8 +1139,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: null,
@@ -1151,8 +1150,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       shorthand: null,
       computed: deserializeBool(pos + 40),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.kind = "init";
@@ -1165,13 +1164,13 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expressions = deserializeVecExpression(pos + 8);
@@ -1179,24 +1178,23 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Super",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -1204,13 +1202,13 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeChainElement(pos + 8);
@@ -1324,14 +1322,14 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeStringLiteral(pos + 8);
@@ -1339,25 +1337,24 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecStatement(pos + 8);
@@ -1390,15 +1387,15 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
       declare: deserializeBool(pos + 33),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.declarations = deserializeVecVariableDeclarator(pos + 8);
@@ -1447,25 +1444,24 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "EmptyStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExpressionStatement",
       expression: null,
       directive: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -1473,15 +1469,15 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -1491,14 +1487,14 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeStatement(pos + 8);
@@ -1507,14 +1503,14 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeExpression(pos + 8);
@@ -1523,16 +1519,16 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForStatement",
       init: null,
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.init = deserializeOptionForStatementInit(pos + 8);
@@ -1638,15 +1634,15 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1685,16 +1681,16 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ForOfStatement",
       await: deserializeBool(pos + 60),
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeForStatementLeft(pos + 8);
@@ -1704,13 +1700,13 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1718,13 +1714,13 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeOptionLabelIdentifier(pos + 8);
@@ -1732,13 +1728,13 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeOptionExpression(pos + 8);
@@ -1746,14 +1742,14 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 8);
@@ -1762,14 +1758,14 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.discriminant = deserializeExpression(pos + 8);
@@ -1778,14 +1774,14 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.test = deserializeOptionExpression(pos + 8);
@@ -1794,14 +1790,14 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeLabelIdentifier(pos + 8);
@@ -1810,13 +1806,13 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -1824,15 +1820,15 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.block = deserializeBoxBlockStatement(pos + 8);
@@ -1842,14 +1838,14 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.param = deserializeOptionCatchParameter(pos + 8);
@@ -1871,12 +1867,11 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "DebuggerStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -1897,8 +1892,8 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "AssignmentPattern",
       decorators: null,
@@ -1906,8 +1901,8 @@ function deserializeAssignmentPattern(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -1918,16 +1913,16 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ObjectPattern",
       decorators: null,
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     properties = deserializeVecBindingProperty(pos + 8),
@@ -1940,8 +1935,8 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Property",
       kind: null,
@@ -1951,8 +1946,8 @@ function deserializeBindingProperty(pos) {
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.kind = "init";
@@ -1964,16 +1959,16 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ArrayPattern",
       decorators: null,
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     elements = deserializeVecOptionBindingPattern(pos + 8),
@@ -1986,8 +1981,8 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "RestElement",
       decorators: null,
@@ -1995,8 +1990,8 @@ function deserializeBindingRestElement(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -2006,8 +2001,8 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeFunctionType(pos + 84),
       id: null,
@@ -2019,8 +2014,8 @@ function deserializeFunction(pos) {
       returnType: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 56);
@@ -2192,13 +2187,13 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeVecDirective(pos + 8);
@@ -2209,8 +2204,8 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+    start,
+    end,
     node = {
       type: "ArrowFunctionExpression",
       expression,
@@ -2221,8 +2216,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeBoxFunctionBody(pos + 32);
@@ -2236,14 +2231,14 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeOptionExpression(pos + 8);
@@ -2251,8 +2246,8 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeClassType(pos + 132),
       decorators: null,
@@ -2264,8 +2259,8 @@ function deserializeClass(pos) {
       body: null,
       abstract: deserializeBool(pos + 133),
       declare: deserializeBool(pos + 134),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2290,13 +2285,13 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecClassElement(pos + 8);
@@ -2321,8 +2316,8 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeMethodDefinitionType(pos + 56),
       decorators: null,
@@ -2334,8 +2329,8 @@ function deserializeMethodDefinition(pos) {
       override: deserializeBool(pos + 60),
       optional: deserializeBool(pos + 61),
       accessibility: deserializeOptionTSAccessibility(pos + 62),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2356,8 +2351,8 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializePropertyDefinitionType(pos + 72),
       decorators: null,
@@ -2372,8 +2367,8 @@ function deserializePropertyDefinition(pos) {
       definite: deserializeBool(pos + 78),
       readonly: deserializeBool(pos + 79),
       accessibility: deserializeOptionTSAccessibility(pos + 80),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2410,25 +2405,24 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecStatement(pos + 8);
@@ -2447,8 +2441,8 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: deserializeAccessorPropertyType(pos + 72),
       decorators: null,
@@ -2463,8 +2457,8 @@ function deserializeAccessorProperty(pos) {
       declare: null,
       optional: null,
       readonly: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = deserializeVecDecorator(pos + 8);
@@ -2478,15 +2472,15 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.source = deserializeExpression(pos + 8);
@@ -2495,8 +2489,8 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportDeclaration",
       specifiers: null,
@@ -2504,8 +2498,8 @@ function deserializeImportDeclaration(pos) {
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
       importKind: deserializeImportOrExportKind(pos + 89),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     specifiers = deserializeOptionVecImportDeclarationSpecifier(pos + 8);
@@ -2542,15 +2536,15 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
       importKind: deserializeImportOrExportKind(pos + 96),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.imported = deserializeModuleExportName(pos + 8);
@@ -2559,13 +2553,13 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2573,13 +2567,13 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeBindingIdentifier(pos + 8);
@@ -2591,14 +2585,14 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializeImportAttributeKey(pos + 8);
@@ -2618,8 +2612,8 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportNamedDeclaration",
       declaration: null,
@@ -2627,8 +2621,8 @@ function deserializeExportNamedDeclaration(pos) {
       source: null,
       exportKind: deserializeImportOrExportKind(pos + 104),
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     withClause = deserializeOptionBoxWithClause(pos + 96);
@@ -2640,14 +2634,14 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportDefaultDeclaration",
       declaration: null,
       exportKind: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 8);
@@ -2656,16 +2650,16 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportAllDeclaration",
       exported: null,
       source: null,
       attributes: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     withClause = deserializeOptionBoxWithClause(pos + 112);
@@ -2676,15 +2670,15 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.local = deserializeModuleExportName(pos + 8);
@@ -2805,14 +2799,14 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeIdentifierName(pos + 8);
@@ -2852,27 +2846,26 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     value = deserializeStr(pos + 8);
@@ -2883,15 +2876,15 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     bigint = deserializeStr(pos + 8);
@@ -2901,15 +2894,15 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     regex = deserializeRegExp(pos + 8),
@@ -2945,15 +2938,15 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     closingElement = deserializeOptionBoxJSXClosingElement(pos + 40),
@@ -2966,16 +2959,16 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXOpeningElement",
       name: null,
       typeArguments: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXElementName(pos + 8);
@@ -2986,13 +2979,13 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXElementName(pos + 8);
@@ -3000,15 +2993,15 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.openingFragment = deserializeJSXOpeningFragment(pos + 8);
@@ -3018,23 +3011,21 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXOpeningFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXClosingFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -3071,14 +3062,14 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.namespace = deserializeJSXIdentifier(pos + 8);
@@ -3087,14 +3078,14 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeJSXMemberExpressionObject(pos + 8);
@@ -3130,13 +3121,13 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeJSXExpression(pos + 8);
@@ -3239,12 +3230,11 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXEmptyExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -3261,14 +3251,14 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXAttributeName(pos + 8);
@@ -3277,13 +3267,13 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 8);
@@ -3317,13 +3307,12 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -3346,13 +3335,13 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -3360,29 +3349,28 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -3393,16 +3381,16 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumDeclaration",
       id: null,
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -3411,13 +3399,13 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.members = deserializeVecTSEnumMember(pos + 8);
@@ -3425,15 +3413,15 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeTSEnumMemberName(pos + 8);
@@ -3458,13 +3446,13 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3472,13 +3460,13 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.literal = deserializeTSLiteral(pos + 8);
@@ -3586,16 +3574,16 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConditionalType",
       checkType: null,
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.checkType = deserializeTSType(pos + 8);
@@ -3606,13 +3594,13 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.types = deserializeVecTSType(pos + 8);
@@ -3620,13 +3608,13 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.types = deserializeVecTSType(pos + 8);
@@ -3650,14 +3638,14 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3678,13 +3666,13 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elementType = deserializeTSType(pos + 8);
@@ -3692,14 +3680,14 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.objectType = deserializeTSType(pos + 8);
@@ -3708,13 +3696,13 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.elementTypes = deserializeVecTSTupleElement(pos + 8);
@@ -3722,15 +3710,15 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.label = deserializeIdentifierName(pos + 8);
@@ -3739,13 +3727,13 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3753,13 +3741,13 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -3852,168 +3840,154 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSAnyKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSStringKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBooleanKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNumberKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNeverKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSIntrinsicKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUnknownKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNullKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUndefinedKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSVoidKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSSymbolKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSThisType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSObjectKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBigIntKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeName = deserializeTSTypeName(pos + 8);
@@ -4035,14 +4009,14 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeTSTypeName(pos + 8);
@@ -4051,13 +4025,13 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.params = deserializeVecTSType(pos + 8);
@@ -4065,8 +4039,8 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameter",
       name: null,
@@ -4075,8 +4049,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeBindingIdentifier(pos + 8);
@@ -4086,13 +4060,13 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.params = deserializeVecTSTypeParameter(pos + 8);
@@ -4100,16 +4074,16 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAliasDeclaration",
       id: null,
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4132,14 +4106,14 @@ function deserializeTSAccessibility(pos) {
 }
 
 function deserializeTSClassImplements(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSClassImplements",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     expression = deserializeTSTypeName(pos + 8);
@@ -4179,8 +4153,8 @@ function deserializeTSClassImplements(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceDeclaration",
       id: null,
@@ -4188,8 +4162,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4200,13 +4174,13 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.body = deserializeVecTSSignature(pos + 8);
@@ -4214,8 +4188,8 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSPropertySignature",
       computed: deserializeBool(pos + 32),
@@ -4225,8 +4199,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 8);
@@ -4253,8 +4227,8 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSIndexSignature",
       parameters: null,
@@ -4262,8 +4236,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.parameters = deserializeVecTSIndexSignatureName(pos + 8);
@@ -4272,15 +4246,15 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4306,8 +4280,8 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSMethodSignature",
       key: null,
@@ -4320,8 +4294,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 40),
@@ -4337,15 +4311,15 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4355,16 +4329,16 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Identifier",
       decorators: null,
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.decorators = [];
@@ -4374,14 +4348,14 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4390,15 +4364,15 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.parameterName = deserializeTSTypePredicateName(pos + 8);
@@ -4526,8 +4500,8 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSModuleDeclaration",
       id: null,
@@ -4535,8 +4509,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     keywordStart,
@@ -4558,13 +4532,13 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     body = deserializeVecDirective(pos + 8);
@@ -4574,13 +4548,13 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.members = deserializeVecTSSignature(pos + 8);
@@ -4588,13 +4562,13 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameter = deserializeBoxTSTypeParameter(pos + 8);
@@ -4602,14 +4576,14 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.exprName = deserializeTSTypeQueryExprName(pos + 8);
@@ -4633,16 +4607,16 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSImportType",
       source: null,
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.source = deserializeStringLiteral(pos + 8);
@@ -4664,14 +4638,14 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializeTSImportTypeQualifier(pos + 8);
@@ -4680,15 +4654,15 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     params = deserializeBoxFormalParameters(pos + 24),
@@ -4701,16 +4675,16 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSConstructorType",
       abstract: deserializeBool(pos + 36),
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 8);
@@ -4720,8 +4694,8 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSMappedType",
       key: null,
@@ -4730,8 +4704,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     },
     optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
@@ -4758,14 +4732,14 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.quasis = deserializeVecTemplateElement(pos + 8);
@@ -4774,14 +4748,14 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4790,14 +4764,14 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4806,14 +4780,14 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4822,15 +4796,15 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeBindingIdentifier(pos + 8);
@@ -4854,13 +4828,13 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeStringLiteral(pos + 8);
@@ -4868,13 +4842,13 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4882,13 +4856,13 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4896,13 +4870,13 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4910,13 +4884,13 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeIdentifierName(pos + 8);
@@ -4924,14 +4898,14 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.expression = deserializeExpression(pos + 8);
@@ -4951,14 +4925,14 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4966,14 +4940,14 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     node = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.typeAnnotation = deserializeTSType(pos + 8);
@@ -4981,12 +4955,11 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSJSDocUnknownType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5018,12 +4991,11 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5070,16 +5042,15 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5191,12 +5162,11 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5389,12 +5359,11 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5410,24 +5379,22 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -166,8 +166,8 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -175,8 +175,8 @@ function deserializeIdentifierName(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -187,8 +187,8 @@ function deserializeIdentifierName(pos) {
 }
 
 function deserializeIdentifierReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -196,8 +196,8 @@ function deserializeIdentifierReference(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -208,8 +208,8 @@ function deserializeIdentifierReference(pos) {
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -217,8 +217,8 @@ function deserializeBindingIdentifier(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -229,8 +229,8 @@ function deserializeBindingIdentifier(pos) {
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -238,8 +238,8 @@ function deserializeLabelIdentifier(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -250,26 +250,25 @@ function deserializeLabelIdentifier(pos) {
 }
 
 function deserializeThisExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "ThisExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeArrayExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayExpression",
       elements: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -380,14 +379,14 @@ function deserializeElision(pos) {
 }
 
 function deserializeObjectExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectExpression",
       properties: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -408,8 +407,8 @@ function deserializeObjectPropertyKind(pos) {
 }
 
 function deserializeObjectProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -420,8 +419,8 @@ function deserializeObjectProperty(pos) {
       shorthand: deserializeBool(pos + 42),
       computed: deserializeBool(pos + 43),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -543,15 +542,15 @@ function deserializePropertyKind(pos) {
 }
 
 function deserializeTemplateLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TemplateLiteral",
       quasis: null,
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -562,16 +561,16 @@ function deserializeTemplateLiteral(pos) {
 }
 
 function deserializeTaggedTemplateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TaggedTemplateExpression",
       tag: null,
       typeArguments: null,
       quasi: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -611,8 +610,8 @@ function deserializeTemplateElementValue(pos) {
 }
 
 function deserializeComputedMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -620,8 +619,8 @@ function deserializeComputedMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 40),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -633,8 +632,8 @@ function deserializeComputedMemberExpression(pos) {
 }
 
 function deserializeStaticMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -642,8 +641,8 @@ function deserializeStaticMemberExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -655,8 +654,8 @@ function deserializeStaticMemberExpression(pos) {
 }
 
 function deserializePrivateFieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MemberExpression",
@@ -664,8 +663,8 @@ function deserializePrivateFieldExpression(pos) {
       property: null,
       optional: deserializeBool(pos + 48),
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -677,8 +676,8 @@ function deserializePrivateFieldExpression(pos) {
 }
 
 function deserializeCallExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "CallExpression",
@@ -686,8 +685,8 @@ function deserializeCallExpression(pos) {
       typeArguments: null,
       arguments: null,
       optional: deserializeBool(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -699,16 +698,16 @@ function deserializeCallExpression(pos) {
 }
 
 function deserializeNewExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "NewExpression",
       callee: null,
       typeArguments: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -720,15 +719,15 @@ function deserializeNewExpression(pos) {
 }
 
 function deserializeMetaProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "MetaProperty",
       meta: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -739,14 +738,14 @@ function deserializeMetaProperty(pos) {
 }
 
 function deserializeSpreadElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SpreadElement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -851,16 +850,16 @@ function deserializeArgument(pos) {
 }
 
 function deserializeUpdateExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "UpdateExpression",
       operator: deserializeUpdateOperator(pos + 24),
       prefix: deserializeBool(pos + 25),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -870,16 +869,16 @@ function deserializeUpdateExpression(pos) {
 }
 
 function deserializeUnaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 24),
       argument: null,
       prefix: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -890,16 +889,16 @@ function deserializeUnaryExpression(pos) {
 }
 
 function deserializeBinaryExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: deserializeBinaryOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -910,16 +909,16 @@ function deserializeBinaryExpression(pos) {
 }
 
 function deserializePrivateInExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BinaryExpression",
       left: null,
       operator: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -931,16 +930,16 @@ function deserializePrivateInExpression(pos) {
 }
 
 function deserializeLogicalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "LogicalExpression",
       left: null,
       operator: deserializeLogicalOperator(pos + 40),
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -951,16 +950,16 @@ function deserializeLogicalExpression(pos) {
 }
 
 function deserializeConditionalExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ConditionalExpression",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -972,16 +971,16 @@ function deserializeConditionalExpression(pos) {
 }
 
 function deserializeAssignmentExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentExpression",
       operator: deserializeAssignmentOperator(pos + 40),
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1042,8 +1041,8 @@ function deserializeSimpleAssignmentTarget(pos) {
 }
 
 function deserializeArrayAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
@@ -1051,8 +1050,8 @@ function deserializeArrayAssignmentTarget(pos) {
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1067,8 +1066,8 @@ function deserializeArrayAssignmentTarget(pos) {
 }
 
 function deserializeObjectAssignmentTarget(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
@@ -1076,8 +1075,8 @@ function deserializeObjectAssignmentTarget(pos) {
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -1092,8 +1091,8 @@ function deserializeObjectAssignmentTarget(pos) {
 }
 
 function deserializeAssignmentTargetRest(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
@@ -1102,8 +1101,8 @@ function deserializeAssignmentTargetRest(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1144,8 +1143,8 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeAssignmentTargetWithDefault(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
@@ -1154,8 +1153,8 @@ function deserializeAssignmentTargetWithDefault(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1240,8 +1239,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -1252,8 +1251,8 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
       shorthand: null,
       computed: deserializeBool(pos + 40),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1268,14 +1267,14 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeSequenceExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SequenceExpression",
       expressions: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1285,26 +1284,25 @@ function deserializeSequenceExpression(pos) {
 }
 
 function deserializeSuper(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Super",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeAwaitExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AwaitExpression",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1314,14 +1312,14 @@ function deserializeAwaitExpression(pos) {
 }
 
 function deserializeChainExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ChainExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1441,15 +1439,15 @@ function deserializeStatement(pos) {
 }
 
 function deserializeDirective(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: deserializeStr(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1459,27 +1457,26 @@ function deserializeDirective(pos) {
 }
 
 function deserializeHashbang(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Hashbang",
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeBlockStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1514,16 +1511,16 @@ function deserializeDeclaration(pos) {
 }
 
 function deserializeVariableDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "VariableDeclaration",
       kind: deserializeVariableDeclarationKind(pos + 32),
       declarations: null,
       declare: deserializeBool(pos + 33),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1579,27 +1576,26 @@ function deserializeVariableDeclarator(pos) {
 }
 
 function deserializeEmptyStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "EmptyStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeExpressionStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExpressionStatement",
       expression: null,
       directive: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1609,16 +1605,16 @@ function deserializeExpressionStatement(pos) {
 }
 
 function deserializeIfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "IfStatement",
       test: null,
       consequent: null,
       alternate: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1630,15 +1626,15 @@ function deserializeIfStatement(pos) {
 }
 
 function deserializeDoWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "DoWhileStatement",
       body: null,
       test: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1649,15 +1645,15 @@ function deserializeDoWhileStatement(pos) {
 }
 
 function deserializeWhileStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "WhileStatement",
       test: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1668,8 +1664,8 @@ function deserializeWhileStatement(pos) {
 }
 
 function deserializeForStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForStatement",
@@ -1677,8 +1673,8 @@ function deserializeForStatement(pos) {
       test: null,
       update: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1786,16 +1782,16 @@ function deserializeForStatementInit(pos) {
 }
 
 function deserializeForInStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForInStatement",
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1836,8 +1832,8 @@ function deserializeForStatementLeft(pos) {
 }
 
 function deserializeForOfStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ForOfStatement",
@@ -1845,8 +1841,8 @@ function deserializeForOfStatement(pos) {
       left: null,
       right: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1858,14 +1854,14 @@ function deserializeForOfStatement(pos) {
 }
 
 function deserializeContinueStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ContinueStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1875,14 +1871,14 @@ function deserializeContinueStatement(pos) {
 }
 
 function deserializeBreakStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BreakStatement",
       label: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1892,14 +1888,14 @@ function deserializeBreakStatement(pos) {
 }
 
 function deserializeReturnStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ReturnStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1909,15 +1905,15 @@ function deserializeReturnStatement(pos) {
 }
 
 function deserializeWithStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "WithStatement",
       object: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1928,15 +1924,15 @@ function deserializeWithStatement(pos) {
 }
 
 function deserializeSwitchStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SwitchStatement",
       discriminant: null,
       cases: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1947,15 +1943,15 @@ function deserializeSwitchStatement(pos) {
 }
 
 function deserializeSwitchCase(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "SwitchCase",
       test: null,
       consequent: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1966,15 +1962,15 @@ function deserializeSwitchCase(pos) {
 }
 
 function deserializeLabeledStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "LabeledStatement",
       label: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -1985,14 +1981,14 @@ function deserializeLabeledStatement(pos) {
 }
 
 function deserializeThrowStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ThrowStatement",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2002,16 +1998,16 @@ function deserializeThrowStatement(pos) {
 }
 
 function deserializeTryStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TryStatement",
       block: null,
       handler: null,
       finalizer: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2023,15 +2019,15 @@ function deserializeTryStatement(pos) {
 }
 
 function deserializeCatchClause(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "CatchClause",
       param: null,
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2058,12 +2054,11 @@ function deserializeCatchParameter(pos) {
 }
 
 function deserializeDebuggerStatement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "DebuggerStatement",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -2085,8 +2080,8 @@ function deserializeBindingPattern(pos) {
 }
 
 function deserializeAssignmentPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
@@ -2095,8 +2090,8 @@ function deserializeAssignmentPattern(pos) {
       right: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2109,8 +2104,8 @@ function deserializeAssignmentPattern(pos) {
 }
 
 function deserializeObjectPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
@@ -2118,8 +2113,8 @@ function deserializeObjectPattern(pos) {
       properties: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2134,8 +2129,8 @@ function deserializeObjectPattern(pos) {
 }
 
 function deserializeBindingProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Property",
@@ -2146,8 +2141,8 @@ function deserializeBindingProperty(pos) {
       shorthand: deserializeBool(pos + 40),
       computed: deserializeBool(pos + 41),
       optional: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2161,8 +2156,8 @@ function deserializeBindingProperty(pos) {
 }
 
 function deserializeArrayPattern(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
@@ -2170,8 +2165,8 @@ function deserializeArrayPattern(pos) {
       elements: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2186,8 +2181,8 @@ function deserializeArrayPattern(pos) {
 }
 
 function deserializeBindingRestElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
@@ -2196,8 +2191,8 @@ function deserializeBindingRestElement(pos) {
       optional: null,
       typeAnnotation: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2209,8 +2204,8 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeFunctionType(pos + 84),
@@ -2223,8 +2218,8 @@ function deserializeFunction(pos) {
       returnType: null,
       body: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2417,14 +2412,14 @@ function deserializeFormalParameter(pos) {
 }
 
 function deserializeFunctionBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "BlockStatement",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2437,8 +2432,8 @@ function deserializeFunctionBody(pos) {
 
 function deserializeArrowFunctionExpression(pos) {
   let expression = deserializeBool(pos + 44),
-    start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+    start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ArrowFunctionExpression",
@@ -2450,8 +2445,8 @@ function deserializeArrowFunctionExpression(pos) {
       body: null,
       id: null,
       generator: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2470,15 +2465,15 @@ function deserializeArrowFunctionExpression(pos) {
 }
 
 function deserializeYieldExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "YieldExpression",
       delegate: deserializeBool(pos + 24),
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2488,8 +2483,8 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeClassType(pos + 132),
@@ -2502,8 +2497,8 @@ function deserializeClass(pos) {
       body: null,
       abstract: deserializeBool(pos + 133),
       declare: deserializeBool(pos + 134),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2530,14 +2525,14 @@ function deserializeClassType(pos) {
 }
 
 function deserializeClassBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ClassBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2564,8 +2559,8 @@ function deserializeClassElement(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeMethodDefinitionType(pos + 56),
@@ -2578,8 +2573,8 @@ function deserializeMethodDefinition(pos) {
       override: deserializeBool(pos + 60),
       optional: deserializeBool(pos + 61),
       accessibility: deserializeOptionTSAccessibility(pos + 62),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2602,8 +2597,8 @@ function deserializeMethodDefinitionType(pos) {
 }
 
 function deserializePropertyDefinition(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializePropertyDefinitionType(pos + 72),
@@ -2619,8 +2614,8 @@ function deserializePropertyDefinition(pos) {
       definite: deserializeBool(pos + 78),
       readonly: deserializeBool(pos + 79),
       accessibility: deserializeOptionTSAccessibility(pos + 80),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2659,27 +2654,26 @@ function deserializeMethodDefinitionKind(pos) {
 }
 
 function deserializePrivateIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "PrivateIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStaticBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "StaticBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2700,8 +2694,8 @@ function deserializeAccessorPropertyType(pos) {
 }
 
 function deserializeAccessorProperty(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: deserializeAccessorPropertyType(pos + 72),
@@ -2717,8 +2711,8 @@ function deserializeAccessorProperty(pos) {
       declare: null,
       optional: null,
       readonly: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2734,16 +2728,16 @@ function deserializeAccessorProperty(pos) {
 }
 
 function deserializeImportExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportExpression",
       source: null,
       options: null,
       phase: deserializeOptionImportPhase(pos + 40),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2754,8 +2748,8 @@ function deserializeImportExpression(pos) {
 }
 
 function deserializeImportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportDeclaration",
@@ -2764,8 +2758,8 @@ function deserializeImportDeclaration(pos) {
       phase: deserializeOptionImportPhase(pos + 88),
       attributes: null,
       importKind: deserializeImportOrExportKind(pos + 89),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2804,16 +2798,16 @@ function deserializeImportDeclarationSpecifier(pos) {
 }
 
 function deserializeImportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportSpecifier",
       imported: null,
       local: null,
       importKind: deserializeImportOrExportKind(pos + 96),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2824,14 +2818,14 @@ function deserializeImportSpecifier(pos) {
 }
 
 function deserializeImportDefaultSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportDefaultSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2841,14 +2835,14 @@ function deserializeImportDefaultSpecifier(pos) {
 }
 
 function deserializeImportNamespaceSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportNamespaceSpecifier",
       local: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2862,15 +2856,15 @@ function deserializeWithClause(pos) {
 }
 
 function deserializeImportAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ImportAttribute",
       key: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2892,8 +2886,8 @@ function deserializeImportAttributeKey(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportNamedDeclaration",
@@ -2902,8 +2896,8 @@ function deserializeExportNamedDeclaration(pos) {
       source: null,
       exportKind: deserializeImportOrExportKind(pos + 104),
       attributes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2917,15 +2911,15 @@ function deserializeExportNamedDeclaration(pos) {
 }
 
 function deserializeExportDefaultDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
       exportKind: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -2936,8 +2930,8 @@ function deserializeExportDefaultDeclaration(pos) {
 }
 
 function deserializeExportAllDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportAllDeclaration",
@@ -2945,8 +2939,8 @@ function deserializeExportAllDeclaration(pos) {
       source: null,
       attributes: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -2959,16 +2953,16 @@ function deserializeExportAllDeclaration(pos) {
 }
 
 function deserializeExportSpecifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "ExportSpecifier",
       local: null,
       exported: null,
       exportKind: deserializeImportOrExportKind(pos + 120),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3091,15 +3085,15 @@ function deserializeModuleExportName(pos) {
 }
 
 function deserializeV8IntrinsicExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "V8IntrinsicExpression",
       name: null,
       arguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3147,29 +3141,28 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "Literal",
     value: deserializeF64(pos + 8),
     raw: deserializeOptionStr(pos + 16),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3182,16 +3175,16 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 24),
       bigint: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3203,16 +3196,16 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
       raw: deserializeOptionStr(pos + 40),
       regex: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3250,16 +3243,16 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXElement",
       openingElement: null,
       children: null,
       closingElement: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -3274,8 +3267,8 @@ function deserializeJSXElement(pos) {
 }
 
 function deserializeJSXOpeningElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXOpeningElement",
@@ -3283,8 +3276,8 @@ function deserializeJSXOpeningElement(pos) {
       typeArguments: null,
       attributes: null,
       selfClosing: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3297,14 +3290,14 @@ function deserializeJSXOpeningElement(pos) {
 }
 
 function deserializeJSXClosingElement(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXClosingElement",
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3314,16 +3307,16 @@ function deserializeJSXClosingElement(pos) {
 }
 
 function deserializeJSXFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXFragment",
       openingFragment: null,
       children: null,
       closingFragment: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3335,13 +3328,13 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXOpeningFragment",
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3350,12 +3343,11 @@ function deserializeJSXOpeningFragment(pos) {
 }
 
 function deserializeJSXClosingFragment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXClosingFragment",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3395,15 +3387,15 @@ function deserializeJSXElementName(pos) {
 }
 
 function deserializeJSXNamespacedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXNamespacedName",
       namespace: null,
       name: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3414,15 +3406,15 @@ function deserializeJSXNamespacedName(pos) {
 }
 
 function deserializeJSXMemberExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXMemberExpression",
       object: null,
       property: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3462,14 +3454,14 @@ function deserializeJSXMemberExpressionObject(pos) {
 }
 
 function deserializeJSXExpressionContainer(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXExpressionContainer",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3574,12 +3566,11 @@ function deserializeJSXExpression(pos) {
 }
 
 function deserializeJSXEmptyExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXEmptyExpression",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3597,15 +3588,15 @@ function deserializeJSXAttributeItem(pos) {
 }
 
 function deserializeJSXAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXAttribute",
       name: null,
       value: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3616,14 +3607,14 @@ function deserializeJSXAttribute(pos) {
 }
 
 function deserializeJSXSpreadAttribute(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXSpreadAttribute",
       argument: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3659,13 +3650,12 @@ function deserializeJSXAttributeValue(pos) {
 }
 
 function deserializeJSXIdentifier(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXIdentifier",
     name: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -3689,14 +3679,14 @@ function deserializeJSXChild(pos) {
 }
 
 function deserializeJSXSpreadChild(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "JSXSpreadChild",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3706,22 +3696,21 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "JSXText",
     value: deserializeStr(pos + 8),
     raw: deserializeOptionStr(pos + 24),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -3729,8 +3718,8 @@ function deserializeTSThisParameter(pos) {
       name: null,
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3743,8 +3732,8 @@ function deserializeTSThisParameter(pos) {
 }
 
 function deserializeTSEnumDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumDeclaration",
@@ -3752,8 +3741,8 @@ function deserializeTSEnumDeclaration(pos) {
       body: null,
       const: deserializeBool(pos + 80),
       declare: deserializeBool(pos + 81),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3764,14 +3753,14 @@ function deserializeTSEnumDeclaration(pos) {
 }
 
 function deserializeTSEnumBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumBody",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3781,16 +3770,16 @@ function deserializeTSEnumBody(pos) {
 }
 
 function deserializeTSEnumMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSEnumMember",
       id: null,
       initializer: null,
       computed: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3817,14 +3806,14 @@ function deserializeTSEnumMemberName(pos) {
 }
 
 function deserializeTSTypeAnnotation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAnnotation",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3834,14 +3823,14 @@ function deserializeTSTypeAnnotation(pos) {
 }
 
 function deserializeTSLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSLiteralType",
       literal: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3951,8 +3940,8 @@ function deserializeTSType(pos) {
 }
 
 function deserializeTSConditionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConditionalType",
@@ -3960,8 +3949,8 @@ function deserializeTSConditionalType(pos) {
       extendsType: null,
       trueType: null,
       falseType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3974,14 +3963,14 @@ function deserializeTSConditionalType(pos) {
 }
 
 function deserializeTSUnionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSUnionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -3991,14 +3980,14 @@ function deserializeTSUnionType(pos) {
 }
 
 function deserializeTSIntersectionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIntersectionType",
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4028,15 +4017,15 @@ function deserializeTSParenthesizedType(pos) {
 }
 
 function deserializeTSTypeOperator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeOperator",
       operator: deserializeTSTypeOperatorOperator(pos + 24),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4059,14 +4048,14 @@ function deserializeTSTypeOperatorOperator(pos) {
 }
 
 function deserializeTSArrayType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSArrayType",
       elementType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4076,15 +4065,15 @@ function deserializeTSArrayType(pos) {
 }
 
 function deserializeTSIndexedAccessType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIndexedAccessType",
       objectType: null,
       indexType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4095,14 +4084,14 @@ function deserializeTSIndexedAccessType(pos) {
 }
 
 function deserializeTSTupleType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTupleType",
       elementTypes: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4112,16 +4101,16 @@ function deserializeTSTupleType(pos) {
 }
 
 function deserializeTSNamedTupleMember(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNamedTupleMember",
       label: null,
       elementType: null,
       optional: deserializeBool(pos + 48),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4132,14 +4121,14 @@ function deserializeTSNamedTupleMember(pos) {
 }
 
 function deserializeTSOptionalType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSOptionalType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4149,14 +4138,14 @@ function deserializeTSOptionalType(pos) {
 }
 
 function deserializeTSRestType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSRestType",
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4251,183 +4240,169 @@ function deserializeTSTupleElement(pos) {
 }
 
 function deserializeTSAnyKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSAnyKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSStringKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSStringKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBooleanKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBooleanKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNumberKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNumberKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNeverKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNeverKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSIntrinsicKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSIntrinsicKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUnknownKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUnknownKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSNullKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSNullKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSUndefinedKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSUndefinedKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSVoidKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSVoidKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSSymbolKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSSymbolKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSThisType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSThisType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSObjectKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSObjectKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSBigIntKeyword(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSBigIntKeyword",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
 }
 
 function deserializeTSTypeReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeReference",
       typeName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4451,15 +4426,15 @@ function deserializeTSTypeName(pos) {
 }
 
 function deserializeTSQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4470,14 +4445,14 @@ function deserializeTSQualifiedName(pos) {
 }
 
 function deserializeTSTypeParameterInstantiation(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterInstantiation",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4487,8 +4462,8 @@ function deserializeTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeTSTypeParameter(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameter",
@@ -4498,8 +4473,8 @@ function deserializeTSTypeParameter(pos) {
       in: deserializeBool(pos + 72),
       out: deserializeBool(pos + 73),
       const: deserializeBool(pos + 74),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4511,14 +4486,14 @@ function deserializeTSTypeParameter(pos) {
 }
 
 function deserializeTSTypeParameterDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeParameterDeclaration",
       params: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4528,8 +4503,8 @@ function deserializeTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeTSTypeAliasDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAliasDeclaration",
@@ -4537,8 +4512,8 @@ function deserializeTSTypeAliasDeclaration(pos) {
       typeParameters: null,
       typeAnnotation: null,
       declare: deserializeBool(pos + 68),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4563,15 +4538,15 @@ function deserializeTSAccessibility(pos) {
 }
 
 function deserializeTSClassImplements(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSClassImplements",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4621,8 +4596,8 @@ function deserializeTSClassImplements(pos) {
 }
 
 function deserializeTSInterfaceDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceDeclaration",
@@ -4631,8 +4606,8 @@ function deserializeTSInterfaceDeclaration(pos) {
       extends: null,
       body: null,
       declare: deserializeBool(pos + 84),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4645,14 +4620,14 @@ function deserializeTSInterfaceDeclaration(pos) {
 }
 
 function deserializeTSInterfaceBody(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceBody",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4662,8 +4637,8 @@ function deserializeTSInterfaceBody(pos) {
 }
 
 function deserializeTSPropertySignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSPropertySignature",
@@ -4674,8 +4649,8 @@ function deserializeTSPropertySignature(pos) {
       typeAnnotation: null,
       accessibility: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4704,8 +4679,8 @@ function deserializeTSSignature(pos) {
 }
 
 function deserializeTSIndexSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSIndexSignature",
@@ -4714,8 +4689,8 @@ function deserializeTSIndexSignature(pos) {
       readonly: deserializeBool(pos + 40),
       static: deserializeBool(pos + 41),
       accessibility: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4726,16 +4701,16 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSCallSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4763,8 +4738,8 @@ function deserializeTSMethodSignatureKind(pos) {
 }
 
 function deserializeTSMethodSignature(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSMethodSignature",
@@ -4778,8 +4753,8 @@ function deserializeTSMethodSignature(pos) {
       accessibility: null,
       readonly: null,
       static: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -4797,16 +4772,16 @@ function deserializeTSMethodSignature(pos) {
 }
 
 function deserializeTSConstructSignatureDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConstructSignatureDeclaration",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4818,8 +4793,8 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
@@ -4827,8 +4802,8 @@ function deserializeTSIndexSignatureName(pos) {
       name: deserializeStr(pos + 8),
       optional: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4840,15 +4815,15 @@ function deserializeTSIndexSignatureName(pos) {
 }
 
 function deserializeTSInterfaceHeritage(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInterfaceHeritage",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -4859,16 +4834,16 @@ function deserializeTSInterfaceHeritage(pos) {
 }
 
 function deserializeTSTypePredicate(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypePredicate",
       parameterName: null,
       asserts: deserializeBool(pos + 32),
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5016,8 +4991,8 @@ function deserializeTSModuleDeclarationBody(pos) {
 }
 
 function deserializeTSGlobalDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSModuleDeclaration",
@@ -5026,8 +5001,8 @@ function deserializeTSGlobalDeclaration(pos) {
       kind: null,
       declare: deserializeBool(pos + 76),
       global: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5052,14 +5027,14 @@ function deserializeTSGlobalDeclaration(pos) {
 }
 
 function deserializeTSModuleBlock(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSModuleBlock",
       body: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5071,14 +5046,14 @@ function deserializeTSModuleBlock(pos) {
 }
 
 function deserializeTSTypeLiteral(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeLiteral",
       members: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5088,14 +5063,14 @@ function deserializeTSTypeLiteral(pos) {
 }
 
 function deserializeTSInferType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInferType",
       typeParameter: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5105,15 +5080,15 @@ function deserializeTSInferType(pos) {
 }
 
 function deserializeTSTypeQuery(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeQuery",
       exprName: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5139,8 +5114,8 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSImportType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSImportType",
@@ -5148,8 +5123,8 @@ function deserializeTSImportType(pos) {
       options: null,
       qualifier: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5173,15 +5148,15 @@ function deserializeTSImportTypeQualifier(pos) {
 }
 
 function deserializeTSImportTypeQualifiedName(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSQualifiedName",
       left: null,
       right: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5192,16 +5167,16 @@ function deserializeTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeTSFunctionType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSFunctionType",
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5216,8 +5191,8 @@ function deserializeTSFunctionType(pos) {
 }
 
 function deserializeTSConstructorType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSConstructorType",
@@ -5225,8 +5200,8 @@ function deserializeTSConstructorType(pos) {
       typeParameters: null,
       params: null,
       returnType: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5238,8 +5213,8 @@ function deserializeTSConstructorType(pos) {
 }
 
 function deserializeTSMappedType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSMappedType",
@@ -5249,8 +5224,8 @@ function deserializeTSMappedType(pos) {
       typeAnnotation: null,
       optional: null,
       readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     }),
@@ -5279,15 +5254,15 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeTSTemplateLiteralType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTemplateLiteralType",
       quasis: null,
       types: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5298,15 +5273,15 @@ function deserializeTSTemplateLiteralType(pos) {
 }
 
 function deserializeTSAsExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSAsExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5317,15 +5292,15 @@ function deserializeTSAsExpression(pos) {
 }
 
 function deserializeTSSatisfiesExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSSatisfiesExpression",
       expression: null,
       typeAnnotation: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5336,15 +5311,15 @@ function deserializeTSSatisfiesExpression(pos) {
 }
 
 function deserializeTSTypeAssertion(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSTypeAssertion",
       typeAnnotation: null,
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5355,16 +5330,16 @@ function deserializeTSTypeAssertion(pos) {
 }
 
 function deserializeTSImportEqualsDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSImportEqualsDeclaration",
       id: null,
       moduleReference: null,
       importKind: deserializeImportOrExportKind(pos + 56),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5390,14 +5365,14 @@ function deserializeTSModuleReference(pos) {
 }
 
 function deserializeTSExternalModuleReference(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSExternalModuleReference",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5407,14 +5382,14 @@ function deserializeTSExternalModuleReference(pos) {
 }
 
 function deserializeTSNonNullExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNonNullExpression",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5424,14 +5399,14 @@ function deserializeTSNonNullExpression(pos) {
 }
 
 function deserializeDecorator(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "Decorator",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5441,14 +5416,14 @@ function deserializeDecorator(pos) {
 }
 
 function deserializeTSExportAssignment(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSExportAssignment",
       expression: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5458,14 +5433,14 @@ function deserializeTSExportAssignment(pos) {
 }
 
 function deserializeTSNamespaceExportDeclaration(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSNamespaceExportDeclaration",
       id: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5475,15 +5450,15 @@ function deserializeTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeTSInstantiationExpression(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSInstantiationExpression",
       expression: null,
       typeArguments: null,
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5505,15 +5480,15 @@ function deserializeImportOrExportKind(pos) {
 }
 
 function deserializeJSDocNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSJSDocNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5523,15 +5498,15 @@ function deserializeJSDocNullableType(pos) {
 }
 
 function deserializeJSDocNonNullableType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
+  let start,
+    end,
     previousParent = parent,
     node = (parent = {
       type: "TSJSDocNonNullableType",
       typeAnnotation: null,
       postfix: deserializeBool(pos + 24),
-      start,
-      end,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
@@ -5541,12 +5516,11 @@ function deserializeJSDocNonNullableType(pos) {
 }
 
 function deserializeJSDocUnknownType(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     type: "TSJSDocUnknownType",
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
     parent,
   };
@@ -5579,12 +5553,11 @@ function deserializeComment(pos) {
 }
 
 function deserializeNameSpan(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     value: deserializeStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5631,16 +5604,15 @@ function deserializeImportImportName(pos) {
 }
 
 function deserializeExportEntry(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeOptionNameSpan(pos + 16),
     importName: deserializeExportImportName(pos + 40),
     exportName: deserializeExportExportName(pos + 72),
     localName: deserializeExportLocalName(pos + 104),
     isType: deserializeBool(pos + 136),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5752,12 +5724,11 @@ function deserializeExportLocalName(pos) {
 }
 
 function deserializeDynamicImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeSpan(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5950,12 +5921,11 @@ function deserializeErrorSeverity(pos) {
 }
 
 function deserializeErrorLabel(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     message: deserializeOptionStr(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
@@ -5971,24 +5941,22 @@ function deserializeEcmaScriptModule(pos) {
 }
 
 function deserializeStaticImport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     moduleRequest: deserializeNameSpan(pos + 8),
     entries: deserializeVecImportEntry(pos + 32),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }
 
 function deserializeStaticExport(pos) {
-  let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4);
+  let start, end;
   return {
     entries: deserializeVecExportEntry(pos + 8),
-    start,
-    end,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
     range: [start, end],
   };
 }


### PR DESCRIPTION
## Summary

- Use inline assignment pattern (`let x; { x: x = value }`) for `start` and `end` fields instead of declaring them in the preamble
- This allows minifiers to eliminate unused variables when RANGE is false
- Restores original file size for deserializers that don't use range fields

**Before (js.js with RANGE=false):**
```javascript
function deserializeIdentifierName(pos) {
  let start = deserializeU32(pos),
    end = deserializeU32(pos + 4);
  return { type: "Identifier", name: deserializeStr(pos + 8), start, end };
}
```

**After (js.js with RANGE=false):**
```javascript
function deserializeIdentifierName(pos) {
  return { type: "Identifier", name: deserializeStr(pos + 8), start: deserializeU32(pos), end: deserializeU32(pos + 4) };
}
```

Closes #14332

## Test plan

- [x] `just ast` regenerates deserializers correctly
- [x] `pnpm test --filter='@oxc-project/napi-parser'` passes (109 tests)
- [x] `cargo clippy -p oxc_ast_tools` passes

🤖 Generated with [Claude Code](https://claude.ai/code)