### PR TITLE
fix(linter): Move typescript/prefer-optional-chain to nursery for now.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
@@ -58,6 +58,10 @@ declare_oxc_lint!(
     /// Enforce using concise optional chain expressions instead of chained logical AND
     /// operators, negated logical OR operators, or empty objects.
     ///
+    /// Note that this rule is in the nursery category while we ensure it is working
+    /// correctly in as many edge-case scenarios as possible. The logic for this is
+    /// complex and the autofix may cause logic changes in some edge-cases.
+    ///
     /// ### Why is this bad?
     ///
     /// TypeScript 3.7 introduced optional chaining (`?.`) which provides a more concise
@@ -89,7 +93,7 @@ declare_oxc_lint!(
     /// ```
     PreferOptionalChain(tsgolint),
     typescript,
-    style,
+    nursery, // move to style after we've confirmed this works correctly on as many edge-cases as possible.
     fix,
     config = PreferOptionalChainConfig,
 );


### PR DESCRIPTION
The rule is quite complex, so we want to make sure we get it right before we move it to wider usage. You can still use it, but it may have some edge-cases where it behaves incorrectly still.

e.g. https://github.com/oxc-project/oxc/issues/18110, https://github.com/oxc-project/oxc/issues/17968, https://github.com/oxc-project/oxc/issues/18106