### PR TITLE
fix(linter/unicorn): fix `prefer-array-some` autofix for `.filter().length` pattern

### DIFF
--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_some.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_some.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
    ╭─[prefer_array_some.tsx:1:9]
@@ -34,14 +35,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ array.filter(fn).length > 0
    ·       ──────
    ╰────
-  help: Replace `filter` with `some`.
+  help: Replace `.filter(…).length` with `.some(…)`
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over non-zero length check from `.filter(…)`.
    ╭─[prefer_array_some.tsx:1:7]
  1 │ array.filter(fn).length !== 0
    ·       ──────
    ╰────
-  help: Replace `filter` with `some`.
+  help: Replace `.filter(…).length` with `.some(…)`
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
    ╭─[prefer_array_some.tsx:1:5]


### PR DESCRIPTION
## Summary

- Fix autofix for `unicorn/prefer-array-some` rule when handling `.filter(fn).length > 0` pattern

The autofix was incorrectly transforming:
```javascript
array.filter(fn).length > 0
// into broken code:
array.some(fn).length > 0
```

This is broken because `.some()` returns a boolean, not an array. Accessing `.length` on a boolean yields `undefined`.

The fix now correctly removes the `.length > 0` comparison:
```javascript
array.filter(fn).length > 0
// becomes:
array.some(fn)
```

Closes #18150

## Test plan

- Updated existing unit tests to expect correct output
- `cargo test -p oxc_linter -- prefer_array_some` passes