### PR TITLE
fix(linter/jsx-a11y): change `no-autofocus` autofix to suggestion

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
     NoAutofocus,
     jsx_a11y,
     correctness,
-    fix,
+    suggestion,
     config = NoAutofocus,
 );
 
@@ -81,7 +81,7 @@ impl Rule for NoAutofocus {
             if HTML_TAG.contains(element_type.as_ref())
                 && let JSXAttributeItem::Attribute(attr) = autofocus
             {
-                ctx.diagnostic_with_fix(no_autofocus_diagnostic(attr.span), |fixer| {
+                ctx.diagnostic_with_suggestion(no_autofocus_diagnostic(attr.span), |fixer| {
                     fixer.delete(&attr.span)
                 });
             }
@@ -89,7 +89,7 @@ impl Rule for NoAutofocus {
         }
 
         if let JSXAttributeItem::Attribute(attr) = autofocus {
-            ctx.diagnostic_with_fix(no_autofocus_diagnostic(attr.span), |fixer| {
+            ctx.diagnostic_with_suggestion(no_autofocus_diagnostic(attr.span), |fixer| {
                 fixer.delete(&attr.span)
             });
         }


### PR DESCRIPTION
## Summary

- Change `jsx-a11y/no-autofocus` autofix from automatic `fix` to manual `suggestion`

The autofix was automatically removing `autoFocus` attributes from JSX elements during `--fix`. This is dangerous because:

1. **Silently changes application behavior** - removes auto-focus functionality without warning
2. **Causes test failures** - tests verifying focus behavior start failing
3. **Degrades user experience** - form inputs lose their intended auto-focus behavior
4. **Inconsistent with ESLint** - the ESLint `jsx-a11y/no-autofocus` rule does NOT have an autofix

Now users must explicitly opt-in with `--fix-suggestions` to apply this transformation.

Closes #18151

## Test plan

- `cargo test -p oxc_linter -- no_autofocus` passes
- The fix behavior is now gated behind `--fix-suggestions` flag