### PR TITLE
chore(linter): Improve strictness of apps/oxlint tsconfig.

### DIFF
--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -8,7 +8,8 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strictFunctionTypes": true
   },
   "exclude": ["node_modules", "fixtures", "test/fixtures/*/files", "conformance/submodules"]
 }


### PR DESCRIPTION
This reveals a type error in the JS Plugin types.

Noticed while looking into #18154, this helps explain why external rule configs would have type errors that JS Plugins do not have.

This results in `Found 84 errors in 48 files.`, nearly all of them being from `create` and `createOnce` on a `defineRule`. `strict` triggers another 30 or so errors on top of that, so not bothering with it for now.

This is basically just a demo for what we need to do as part of actually fixing the type signature for the VisitorObject.