### PR TITLE
test(linter): Add a snapshot for the GitLab report format.

### DIFF
--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -165,6 +165,13 @@ mod test {
     }
 
     #[test]
+    fn test_output_formatter_diagnostic_gitlab() {
+        let args = &["--format=gitlab", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_output_formatter_diagnostic_stylish() {
         let args = &["--format=stylish", "test.js"];
 

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab test.js@oxlint.snap
@@ -1,0 +1,50 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=gitlab test.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+[
+  {
+    "description": "`debugger` statement is not allowed",
+    "check_name": "eslint(no-debugger)",
+    "fingerprint": "9333a3278325994",
+    "severity": "critical",
+    "location": {
+      "path": "test.js",
+      "lines": {
+        "begin": 5,
+        "end": 5
+      }
+    }
+  },
+  {
+    "description": "Function 'foo' is declared but never used.",
+    "check_name": "eslint(no-unused-vars)",
+    "fingerprint": "b1e9b343a9c1e457",
+    "severity": "major",
+    "location": {
+      "path": "test.js",
+      "lines": {
+        "begin": 1,
+        "end": 1
+      }
+    }
+  },
+  {
+    "description": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.",
+    "check_name": "eslint(no-unused-vars)",
+    "fingerprint": "53ecf7c08335f91",
+    "severity": "major",
+    "location": {
+      "path": "test.js",
+      "lines": {
+        "begin": 1,
+        "end": 1
+      }
+    }
+  }
+]----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
While investigating #17999, realized we did not have a snapshot test for this.