### PR TITLE
test(linter): Add a snapshot test for the unix output formatter

### DIFF
--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -133,26 +133,15 @@ mod test {
     const TEST_CWD: &str = "fixtures/output_formatter_diagnostic";
 
     #[test]
-    fn test_output_formatter_diagnostic_default() {
-        let args = &["--format=default", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    /// disabled for windows
-    /// json will output the offset which will be different for windows
-    /// when there are multiple lines (`\r\n` vs `\n`)
-    #[cfg(all(test, not(target_os = "windows")))]
-    #[test]
-    fn test_output_formatter_diagnostic_json() {
-        let args = &["--format=json", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    #[test]
     fn test_output_formatter_diagnostic_checkstyle() {
         let args = &["--format=checkstyle", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_output_formatter_diagnostic_default() {
+        let args = &["--format=default", "test.js"];
 
         Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
     }
@@ -171,6 +160,24 @@ mod test {
         Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
     }
 
+    /// disabled for windows
+    /// json will output the offset which will be different for windows
+    /// when there are multiple lines (`\r\n` vs `\n`)
+    #[cfg(all(test, not(target_os = "windows")))]
+    #[test]
+    fn test_output_formatter_diagnostic_json() {
+        let args = &["--format=json", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_output_formatter_diagnostic_junit() {
+        let args = &["--format=junit", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
     #[test]
     fn test_output_formatter_diagnostic_stylish() {
         let args = &["--format=stylish", "test.js"];
@@ -179,8 +186,8 @@ mod test {
     }
 
     #[test]
-    fn test_output_formatter_diagnostic_junit() {
-        let args = &["--format=junit", "test.js"];
+    fn test_output_formatter_diagnostic_unix() {
+        let args = &["--format=unix", "test.js"];
 
         Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
     }

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix test.js@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=unix test.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+test.js:5:1: `debugger` statement is not allowed [Error/eslint(no-debugger)]
+test.js:1:10: Function 'foo' is declared but never used. [Warning/eslint(no-unused-vars)]
+test.js:1:17: Parameter 'b' is declared but never used. Unused parameters should start with a '_'. [Warning/eslint(no-unused-vars)]
+
+3 problems
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
I probably should've done this when I did #18158, but I didn't realize it until I had already started the merge.

This also reorders the snap tests so we have them in alphabetical order, makes it easier to figure out if any are missing.