### PR TITLE
fix(coverage): skip module-block tests in babel conformance

### DIFF
--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -1,5 +1,5 @@
 commit: fc58af40
 
 codegen_babel Summary:
-AST Parsed     : 2232/2232 (100.00%)
-Positive Passed: 2232/2232 (100.00%)
+AST Parsed     : 2230/2230 (100.00%)
+Positive Passed: 2230/2230 (100.00%)

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 formatter_babel Summary:
-AST Parsed     : 2232/2232 (100.00%)
-Positive Passed: 2226/2232 (99.73%)
+AST Parsed     : 2230/2230 (100.00%)
+Positive Passed: 2224/2230 (99.73%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/async-arrow-function/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-method/input.js

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -1,5 +1,5 @@
 commit: fc58af40
 
 minifier_babel Summary:
-AST Parsed     : 1793/1793 (100.00%)
-Positive Passed: 1793/1793 (100.00%)
+AST Parsed     : 1791/1791 (100.00%)
+Positive Passed: 1791/1791 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 parser_babel Summary:
-AST Parsed     : 2224/2232 (99.64%)
-Positive Passed: 2207/2232 (98.88%)
+AST Parsed     : 2224/2230 (99.73%)
+Positive Passed: 2207/2230 (98.97%)
 Negative Passed: 1648/1697 (97.11%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/private-in/invalid-private-followed-by-in-2/input.js
 
@@ -234,16 +234,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022
    ╰────
   help: Either remove this `await` or add the `async` keyword to the enclosing function
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/valid-module-block-top-level-using-binding/input.js
-
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/valid-module-block-top-level-using-binding/input.js:1:17]
- 1 │ const m = module {
-   ·                 ▲
- 2 │   await using foo = bar();
-   ╰────
-  help: Try inserting a semicolon here
-
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-await-using-binding-escaped-of-of/input.mjs
 
   × Keywords cannot contain escape characters
@@ -275,16 +265,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026
    ·     │                  ╰── `)` expected
    ·     ╰── Opened here
    ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-module-block-top-level-using-binding/input.js
-
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-module-block-top-level-using-binding/input.js:1:7]
- 1 │ module {
-   ·       ▲
- 2 │   using foo = bar();
-   ╰────
-  help: Try inserting a semicolon here
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-modifier-names/input.ts
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 semantic_babel Summary:
-AST Parsed     : 2232/2232 (100.00%)
-Positive Passed: 1939/2232 (86.87%)
+AST Parsed     : 2230/2230 (100.00%)
+Positive Passed: 1939/2230 (86.95%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -145,9 +145,6 @@ Unresolved references mismatch:
 after transform: ["arguments", "require"]
 rebuilt        : ["arguments", "of", "require"]
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/valid-module-block-top-level-using-binding/input.js
-Expected a semicolon or an implicit semicolon after a statement, but found none
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/valid-using-binding-basic/input.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "basic"]
@@ -199,9 +196,6 @@ Expected `)` but found `of`
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-using-binding-escaped-of-of/input.js
 Keywords cannot contain escape characters
 Expected `)` but found `of`
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-module-block-top-level-using-binding/input.js
-Expected a semicolon or an implicit semicolon after a statement, but found none
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.ts
 Scope children mismatch:

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 transformer_babel Summary:
-AST Parsed     : 2232/2232 (100.00%)
-Positive Passed: 2229/2232 (99.87%)
+AST Parsed     : 2230/2230 (100.00%)
+Positive Passed: 2227/2230 (99.87%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowYieldOutsideFunction-true-2/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/ambiguous-script/input.js

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -45,6 +45,8 @@ impl<T: Case> Suite<T> for BabelSuite<T> {
             "annex-b/disabled",
             // Call expressions as assignment targets in non-strict mode - oxc intentionally does not support
             "annex-b/enabled/valid-assignment-target-type",
+            // Module blocks are stage 1
+            "module-block",
         ]
         .iter()
         .any(|p| path.to_string_lossy().replace('\\', "/").contains(p));


### PR DESCRIPTION
## Summary
- Skip module-block tests in babel conformance suite
- Module blocks are a stage 1 proposal and not supported by oxc

## Test plan
- [x] `cargo coverage -- parser` runs successfully
- [x] All affected snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)