### PR TITLE
fix(parser): reparse all statements with await identifier in unambiguous mode

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -66,6 +66,10 @@ impl<'a> ParserImpl<'a> {
         if !kind.is_identifier_reference(false, false) {
             return self.unexpected();
         }
+        // Track await identifier for potential reparsing in unambiguous mode
+        if kind == Kind::Await && !self.ctx.has_await() {
+            self.state.encountered_await_identifier = true;
+        }
         self.check_identifier(kind, self.ctx);
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.ast.identifier_reference(span, name)

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -20,13 +20,17 @@ pub struct ParserState<'a> {
 
     /// Statements that may need reparsing when `sourceType` is `unambiguous`.
     ///
-    /// In unambiguous mode, we initially parse top-level `await / ...` as
-    /// `await / 0 / u` (identifier divided by something). But if ESM syntax
-    /// is detected later, we need to reparse these as `await /0/u` (await
-    /// expression with regex).
+    /// In unambiguous mode, we initially parse top-level `await ...` as
+    /// `await(...)` (identifier/function call). But if ESM syntax is detected
+    /// later, we need to reparse these as await expressions.
     ///
     /// Each entry contains: (statement_index, checkpoint_before_statement)
     pub potential_await_reparse: Vec<(usize, ParserCheckpoint<'a>)>,
+
+    /// Flag to track if an `await` identifier was encountered during statement parsing.
+    /// Used to determine if a statement needs to be stored for potential reparsing
+    /// in unambiguous mode.
+    pub encountered_await_identifier: bool,
 }
 
 impl ParserState<'_> {
@@ -36,6 +40,7 @@ impl ParserState<'_> {
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),
+            encountered_await_identifier: false,
         }
     }
 }

--- a/tasks/coverage/misc/pass/unambiguous-await-call.js
+++ b/tasks/coverage/misc/pass/unambiguous-await-call.js
@@ -1,0 +1,2 @@
+// In unambiguous mode with ESM syntax, `await (...)` should parse as await expression
+await (async function () { })(); export {}

--- a/tasks/coverage/misc/pass/unambiguous-await-in-declaration.js
+++ b/tasks/coverage/misc/pass/unambiguous-await-in-declaration.js
@@ -1,0 +1,2 @@
+// In unambiguous mode with ESM syntax, await in declarations should parse as await expression
+const x = await (async function () { })(); export {}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 59/59 (100.00%)
-Positive Passed: 59/59 (100.00%)
+AST Parsed     : 61/61 (100.00%)
+Positive Passed: 61/61 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 59/59 (100.00%)
-Positive Passed: 59/59 (100.00%)
+AST Parsed     : 61/61 (100.00%)
+Positive Passed: 61/61 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 59/59 (100.00%)
-Positive Passed: 59/59 (100.00%)
+AST Parsed     : 61/61 (100.00%)
+Positive Passed: 61/61 (100.00%)
 Negative Passed: 130/130 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -19688,109 +19688,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·            ╰── `as` expected
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:4:1]
+  × Parenthesized expressions may not have a trailing comma.
+   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:4:9]
  3 │ // reparse call as invalid await should error
  4 │ await (1,);
-   · ─────
+   ·         ─
  5 │ await <number, string>(1);
    ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:5:1]
- 4 │ await (1,);
- 5 │ await <number, string>(1);
-   · ─────
- 6 │ 
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:8:1]
- 7 │ // reparse tagged template as invalid await should error
- 8 │ await <number, string> ``;
-   · ─────
- 9 │ 
-   ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:11:17]
- 10 │ // reparse class extends clause should fail
- 11 │ class C extends await<string> {
-    ·                 ─────
- 12 │ }
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:15:3]
- 14 │ // await in class decorators should fail
- 15 │ @(await)
-    ·   ─────
- 16 │ class C1 {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:18:2]
- 17 │ 
- 18 │ @await(x)
-    ·  ─────
- 19 │ class C2 {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:21:2]
- 20 │ 
- 21 │ @await
-    ·  ─────
- 22 │ class C3 {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:26:6]
- 25 │ class C4 {
- 26 │     @await
-    ·      ─────
- 27 │     ["foo"]() {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:30:6]
- 29 │ class C5 {
- 30 │     @await(1)
-    ·      ─────
- 31 │     ["foo"]() {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:34:7]
- 33 │ class C6 {
- 34 │     @(await)
-    ·       ─────
- 35 │     ["foo"]() {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:40:14]
- 39 │ class C7 {
- 40 │     method1(@await [x]) {}
-    ·              ─────
- 41 │     method2(@await(1) [x]) {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:41:14]
- 40 │     method1(@await [x]) {}
- 41 │     method2(@await(1) [x]) {}
-    ·              ─────
- 42 │     method3(@(await) [x]) {}
-    ╰────
-
-  × The keyword 'await' is reserved
-    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts:42:15]
- 41 │     method2(@await(1) [x]) {}
- 42 │     method3(@(await) [x]) {}
-    ·               ─────
- 43 │ }
-    ╰────
+  help: Remove the trailing comma here
 
   × Identifier expected. 'await' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.10.ts:2:19]
@@ -19820,11 +19725,25 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·        ─────
    ╰────
 
+  × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.12.ts:5:8]
+ 4 │ // await disallowed in import=namespace when in a module
+ 5 │ import await = foo.await;
+   ·        ─────
+   ╰────
+
   × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.12.ts:5:8]
  4 │ // await disallowed in import=namespace when in a module
  5 │ import await = foo.await;
    ·        ─────
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.2.ts:4:5]
+ 3 │ // reparse variable name as await should fail
+ 4 │ var await = 1;
+   ·     ─────
    ╰────
 
   × The keyword 'await' is reserved
@@ -19834,10 +19753,24 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·     ─────
    ╰────
 
+  × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.3.ts:4:6]
+ 3 │ // reparse binding pattern as await should fail
+ 4 │ var {await} = {await:1};
+   ·      ─────
+   ╰────
+
   × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.3.ts:4:6]
  3 │ // reparse binding pattern as await should fail
  4 │ var {await} = {await:1};
+   ·      ─────
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.4.ts:4:6]
+ 3 │ // reparse binding pattern as await should fail
+ 4 │ var [await] = [1];
    ·      ─────
    ╰────
 
@@ -24105,6 +24038,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  2 │     *constructor() {}
    ·      ───────────
  3 │ }
+   ╰────
+
+  × Cannot use `await` as an identifier in an async context
+   ╭─[typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts:3:7]
+ 2 │ export default 13
+ 3 │ const await = 1
+   ·       ─────
+ 4 │ const yield = 2
    ╰────
 
   × Cannot use `await` as an identifier in an async context

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 59/59 (100.00%)
-Positive Passed: 40/59 (67.80%)
+AST Parsed     : 61/61 (100.00%)
+Positive Passed: 42/61 (68.85%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,5 +1,5 @@
 transformer_misc Summary:
-AST Parsed     : 59/59 (100.00%)
-Positive Passed: 58/59 (98.31%)
+AST Parsed     : 61/61 (100.00%)
+Positive Passed: 60/61 (98.36%)
 Mismatch: tasks/coverage/misc/pass/babel-16776-s.js
 


### PR DESCRIPTION
## Summary

- Fix parsing of `await (...)` and other cases where `await` followed by certain tokens was parsed as an identifier instead of an await expression in unambiguous mode
- Commit 92e27b4 only handled `await /regex/` but missed other cases

## Changes

- Add `encountered_await_identifier` flag to `ParserState` to track when await is parsed as identifier
- Set flag in `parse_identifier_reference` when parsing "await" as identifier in non-await context
- Modify statement parsing to track checkpoints only for statements that actually used await as identifier
- Once ESM detected, enable await context for remaining statements

## Test plan

- Added test cases in `tasks/coverage/misc/pass/`:
  - `unambiguous-await-call.js` - Tests `await (async function () { })();`
  - `unambiguous-await-in-declaration.js` - Tests `const x = await (async function () { })();`
- All parser tests pass
- All conformance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)