### PR TITLE
test(linter): Skip the gitlab format test on big-endian systems due to hashing diff.

### DIFF
--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -153,6 +153,7 @@ mod test {
         Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
     }
 
+    #[cfg(not(target_endian = "big"))] // Apparently the fingerprint hash is different on big-endian systems.
     #[test]
     fn test_output_formatter_diagnostic_gitlab() {
         let args = &["--format=gitlab", "test.js"];


### PR DESCRIPTION
Apparently the `fingerprint` hash value we generate for the gitlab report format is different on big-endian systems, cool. So let's just skip the test on those for now.

See https://github.com/oxc-project/oxc/actions/runs/21104172323/job/60692802025 for ref