### PR TITLE
test(linter): Add more output snaps for output formatters

### DIFF
--- a/apps/oxlint/fixtures/output_formatter_diagnostic/disable-directive.js
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/disable-directive.js
@@ -1,0 +1,18 @@
+// This file is for testing formatters against invalid disable directives.
+
+// this one should be fine:
+// oxlint-disable-next-line eslint/no-debugger
+debugger;
+
+// These three should result in diagnostics as they are all unused:
+
+// eslint-disable-next-line no-debugger
+const foo = 3;
+
+// oxlint-disable-next-line no-debugger
+const bar = 3;
+
+// oxlint-disable-next-line eslint/no-debugger
+const baz = 3;
+
+console.log(foo, bar, baz);

--- a/apps/oxlint/fixtures/output_formatter_diagnostic/ok.js
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/ok.js
@@ -1,0 +1,1 @@
+// This file intentionally has no lint warnings

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -133,63 +133,79 @@ mod test {
     const TEST_CWD: &str = "fixtures/output_formatter_diagnostic";
 
     #[test]
-    fn test_output_formatter_diagnostic_checkstyle() {
-        let args = &["--format=checkstyle", "test.js"];
+    fn test_output_formatter_diagnostic_formats() {
+        let mut formats: Vec<&str> =
+            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
 
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+        // disabled for windows
+        // json will output the offset which will be different for windows
+        // when there are multiple lines (`\r\n` vs `\n`)
+        if cfg!(not(target_os = "windows")) {
+            formats.push("json");
+        }
+
+        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        if cfg!(not(target_endian = "big")) {
+            formats.push("gitlab");
+        }
+
+        for fmt in &formats {
+            let args_vec = [format!("--format={fmt}"), "test.js".to_string()];
+            let args_ref: Vec<&str> = args_vec.iter().map(std::string::String::as_str).collect();
+            Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(&args_ref);
+        }
     }
 
     #[test]
-    fn test_output_formatter_diagnostic_default() {
-        let args = &["--format=default", "test.js"];
+    fn test_output_formatter_diagnostic_formats_success() {
+        let mut formats: Vec<&str> =
+            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
 
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+        // disabled for windows
+        // json will output the offset which will be different for windows
+        // when there are multiple lines (`\r\n` vs `\n`)
+        if cfg!(not(target_os = "windows")) {
+            formats.push("json");
+        }
+
+        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        if cfg!(not(target_endian = "big")) {
+            formats.push("gitlab");
+        }
+
+        for fmt in &formats {
+            let args_vec = [format!("--format={fmt}"), "ok.js".to_string()];
+            let args_ref: Vec<&str> = args_vec.iter().map(std::string::String::as_str).collect();
+            Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(&args_ref);
+        }
     }
 
+    // Test that each of the formatters can output the disable directive violations.
     #[test]
-    fn test_output_formatter_diagnostic_github() {
-        let args = &["--format=github", "test.js"];
+    fn test_output_formatter_diagnostic_formats_with_disable_directive() {
+        let mut formats: Vec<&str> =
+            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
 
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
+        // disabled for windows
+        // json will output the offset which will be different for windows
+        // when there are multiple lines (`\r\n` vs `\n`)
+        if cfg!(not(target_os = "windows")) {
+            formats.push("json");
+        }
 
-    #[cfg(not(target_endian = "big"))] // Apparently the fingerprint hash is different on big-endian systems.
-    #[test]
-    fn test_output_formatter_diagnostic_gitlab() {
-        let args = &["--format=gitlab", "test.js"];
+        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        if cfg!(not(target_endian = "big")) {
+            formats.push("gitlab");
+        }
 
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    /// disabled for windows
-    /// json will output the offset which will be different for windows
-    /// when there are multiple lines (`\r\n` vs `\n`)
-    #[cfg(all(test, not(target_os = "windows")))]
-    #[test]
-    fn test_output_formatter_diagnostic_json() {
-        let args = &["--format=json", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    #[test]
-    fn test_output_formatter_diagnostic_junit() {
-        let args = &["--format=junit", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    #[test]
-    fn test_output_formatter_diagnostic_stylish() {
-        let args = &["--format=stylish", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
-    }
-
-    #[test]
-    fn test_output_formatter_diagnostic_unix() {
-        let args = &["--format=unix", "test.js"];
-
-        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+        for fmt in &formats {
+            let args_vec = [
+                format!("--format={fmt}"),
+                "--report-unused-disable-directives".to_string(),
+                "disable-directive.js".to_string(),
+            ];
+            let args_ref: Vec<&str> = args_vec.iter().map(std::string::String::as_str).collect();
+            Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(&args_ref);
+        }
     }
 }

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,11 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=checkstyle --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="disable-directive.js"><error line="9" column="3" severity="warning" message="Unused eslint-disable directive (no problems were reported)." source="" /><error line="12" column="3" severity="warning" message="Unused eslint-disable directive (no problems were reported)." source="" /><error line="15" column="3" severity="warning" message="Unused eslint-disable directive (no problems were reported)." source="" /></file></checkstyle>
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle ok.js@oxlint.snap
@@ -1,0 +1,11 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=checkstyle ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"></checkstyle>
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,37 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=default --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+
+  ! Unused eslint-disable directive (no problems were reported).
+    ,-[disable-directive.js:9:3]
+  8 | 
+  9 | // eslint-disable-next-line no-debugger
+    :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 10 | const foo = 3;
+    `----
+
+  ! Unused eslint-disable directive (no problems were reported).
+    ,-[disable-directive.js:12:3]
+ 11 | 
+ 12 | // oxlint-disable-next-line no-debugger
+    :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 13 | const bar = 3;
+    `----
+
+  ! Unused eslint-disable directive (no problems were reported).
+    ,-[disable-directive.js:15:3]
+ 14 | 
+ 15 | // oxlint-disable-next-line eslint/no-debugger
+    :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 16 | const baz = 3;
+    `----
+
+Found 3 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default ok.js@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=default ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,13 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=github --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+::warning file=disable-directive.js,line=9,endLine=9,col=3,endColumn=40,title=oxlint::Unused eslint-disable directive (no problems were reported).
+::warning file=disable-directive.js,line=12,endLine=12,col=3,endColumn=40,title=oxlint::Unused eslint-disable directive (no problems were reported).
+::warning file=disable-directive.js,line=15,endLine=15,col=3,endColumn=47,title=oxlint::Unused eslint-disable directive (no problems were reported).
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=github ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,50 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=gitlab --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+[
+  {
+    "description": "Unused eslint-disable directive (no problems were reported).",
+    "check_name": "",
+    "fingerprint": "6460b46f54ac436d",
+    "severity": "major",
+    "location": {
+      "path": "disable-directive.js",
+      "lines": {
+        "begin": 9,
+        "end": 9
+      }
+    }
+  },
+  {
+    "description": "Unused eslint-disable directive (no problems were reported).",
+    "check_name": "",
+    "fingerprint": "74c434632ebc59be",
+    "severity": "major",
+    "location": {
+      "path": "disable-directive.js",
+      "lines": {
+        "begin": 12,
+        "end": 12
+      }
+    }
+  },
+  {
+    "description": "Unused eslint-disable directive (no problems were reported).",
+    "check_name": "",
+    "fingerprint": "9854c19736e51e0c",
+    "severity": "major",
+    "location": {
+      "path": "disable-directive.js",
+      "lines": {
+        "begin": 15,
+        "end": 15
+      }
+    }
+  }
+]----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=gitlab ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+[]----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,18 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=json --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+{ "diagnostics": [{"message": "Unused eslint-disable directive (no problems were reported).","severity": "warning","causes": [],"filename": "disable-directive.js","labels": [{"span": {"offset": 233,"length": 37,"line": 9,"column": 3}}],"related": []},
+{"message": "Unused eslint-disable directive (no problems were reported).","severity": "warning","causes": [],"filename": "disable-directive.js","labels": [{"span": {"offset": 289,"length": 37,"line": 12,"column": 3}}],"related": []},
+{"message": "Unused eslint-disable directive (no problems were reported).","severity": "warning","causes": [],"filename": "disable-directive.js","labels": [{"span": {"offset": 345,"length": 44,"line": 15,"column": 3}}],"related": []}],
+              "number_of_files": 1,
+              "number_of_rules": 2,
+              "threads_count": 1,
+              "start_time": <variable>
+            }
+            ----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json ok.js@oxlint.snap
@@ -1,0 +1,16 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=json ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+{ "diagnostics": [],
+              "number_of_files": 1,
+              "number_of_rules": 2,
+              "threads_count": 1,
+              "start_time": <variable>
+            }
+            ----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,24 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=junit --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Oxlint" tests="3" failures="3" errors="0">
+    <testsuite name="disable-directive.js" tests="3" disabled="0" errors="0" failures="3">
+        <testcase name="">
+            <failure message="Unused eslint-disable directive (no problems were reported).">line 9, column 3, Unused eslint-disable directive (no problems were reported).</failure>
+        </testcase>
+        <testcase name="">
+            <failure message="Unused eslint-disable directive (no problems were reported).">line 12, column 3, Unused eslint-disable directive (no problems were reported).</failure>
+        </testcase>
+        <testcase name="">
+            <failure message="Unused eslint-disable directive (no problems were reported).">line 15, column 3, Unused eslint-disable directive (no problems were reported).</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit ok.js@oxlint.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=junit ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Oxlint" tests="0" failures="0" errors="0">
+
+</testsuites>
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,17 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=stylish --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+
+[4mdisable-directive.js[0m
+  [2m9:3 [0m  [33mwarning[0m  Unused eslint-disable directive (no problems were reported).  [2m[0m
+  [2m12:3[0m  [33mwarning[0m  Unused eslint-disable directive (no problems were reported).  [2m[0m
+  [2m15:3[0m  [33mwarning[0m  Unused eslint-disable directive (no problems were reported).  [2m[0m
+
+[33m✖ 3 problems (0 errors, 3 warnings)[0m
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=stylish ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=unix --report-unused-disable-directives disable-directive.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+disable-directive.js:9:3: Unused eslint-disable directive (no problems were reported). [Warning]
+disable-directive.js:12:3: Unused eslint-disable directive (no problems were reported). [Warning]
+disable-directive.js:15:3: Unused eslint-disable directive (no problems were reported). [Warning]
+
+3 problems
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=unix ok.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
Refactor the snapshots tests to be simpler, and then add a variety of test cases (default case of a few violations, then no violations, then disable-directive violations). Basically just trying to cover our bases on making sure we have snaps for each of these formatters.