### PR TITLE
docs(AGENTS.md): add test suite search paths for AI assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,15 @@ Git submodules managed via `just submodules`:
 
 Run all conformance tests with `cargo coverage` or `just conformance`.
 
+### Searching Test Suites
+
+These test suites are pre-cloned and ready to search:
+
+- **Test262** (`tasks/coverage/test262/`) - ECMAScript spec compliance
+- **Babel** (`tasks/coverage/babel/`) - Parsing and transformation edge cases
+- **TypeScript** (`tasks/coverage/typescript/`) - TypeScript syntax and semantics
+- **Prettier** (`tasks/prettier_conformance/prettier/`) - Formatting expectations
+
 ### Snapshot Testing
 
 - Uses `insta` crate for snapshot testing


### PR DESCRIPTION
## Summary
- Add a "Searching Test Suites" section documenting the pre-cloned test suite paths
- Helps AI assistants know where to search for test cases (test262, babel, typescript, prettier)

## Test plan
- Documentation only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)