### PR TITLE
refactor(minifier): merge `PeepholeOptimizations` state into `MinifierState`

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -31,7 +31,7 @@ impl<'a> Compressor<'a> {
         options: CompressOptions,
     ) -> u8 {
         let max_iterations = options.max_iterations;
-        let state = MinifierState::new(program.source_type, options);
+        let state = MinifierState::new(program.source_type, options, /* dce */ false);
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
         let normalize_options = NormalizeOptions {
             convert_while_to_fors: true,
@@ -39,7 +39,7 @@ impl<'a> Compressor<'a> {
             remove_unnecessary_use_strict: true,
         };
         Normalize::new(normalize_options).build(program, &mut ctx);
-        PeepholeOptimizations::new(max_iterations).run_in_loop(program, &mut ctx)
+        Self::run_in_loop(max_iterations, program, &mut ctx)
     }
 
     pub fn dead_code_elimination(self, program: &mut Program<'a>, options: CompressOptions) -> u8 {
@@ -55,7 +55,7 @@ impl<'a> Compressor<'a> {
         options: CompressOptions,
     ) -> u8 {
         let max_iterations = options.max_iterations;
-        let state = MinifierState::new(program.source_type, options);
+        let state = MinifierState::new(program.source_type, options, /* dce */ true);
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
         let normalize_options = NormalizeOptions {
             convert_while_to_fors: false,
@@ -63,6 +63,31 @@ impl<'a> Compressor<'a> {
             remove_unnecessary_use_strict: false,
         };
         Normalize::new(normalize_options).build(program, &mut ctx);
-        PeepholeOptimizations::new_dce(max_iterations).run_in_loop(program, &mut ctx)
+        Self::run_in_loop(max_iterations, program, &mut ctx)
+    }
+
+    /// Fixed-point iteration loop for peephole optimizations.
+    fn run_in_loop(
+        max_iterations: Option<u8>,
+        program: &mut Program<'a>,
+        ctx: &mut ReusableTraverseCtx<'a, MinifierState<'a>>,
+    ) -> u8 {
+        let mut iteration = 0u8;
+        loop {
+            PeepholeOptimizations.run_once(program, ctx);
+            if !ctx.state().changed {
+                break;
+            }
+            if let Some(max) = max_iterations {
+                if iteration >= max {
+                    break;
+                }
+            } else if iteration > 10 {
+                debug_assert!(false, "Ran loop more than 10 times.");
+                break;
+            }
+            iteration += 1;
+        }
+        iteration
     }
 }

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -12,6 +12,9 @@ pub struct MinifierState<'a> {
 
     pub options: CompressOptions,
 
+    /// When true, only run dead code elimination passes (subset of full peephole optimizations).
+    pub dce: bool,
+
     /// The return value of function declarations that are pure
     pub pure_functions: FxHashMap<SymbolId, Option<ConstantValue<'a>>>,
 
@@ -24,10 +27,11 @@ pub struct MinifierState<'a> {
 }
 
 impl MinifierState<'_> {
-    pub fn new(source_type: SourceType, options: CompressOptions) -> Self {
+    pub fn new(source_type: SourceType, options: CompressOptions, dce: bool) -> Self {
         Self {
             source_type,
             options,
+            dce,
             pure_functions: FxHashMap::default(),
             symbol_values: SymbolValues::default(),
             class_symbols_stack: ClassSymbolsStack::new(),

--- a/crates/oxc_traverse/src/context/reusable.rs
+++ b/crates/oxc_traverse/src/context/reusable.rs
@@ -39,6 +39,16 @@ impl<'a, State> ReusableTraverseCtx<'a, State> {
         (self.0.state, self.0.scoping.into_scoping())
     }
 
+    /// Get a reference to the user state.
+    pub fn state(&self) -> &State {
+        &self.0.state
+    }
+
+    /// Get a mutable reference to the user state.
+    pub fn state_mut(&mut self) -> &mut State {
+        &mut self.0.state
+    }
+
     /// Unwrap [`TraverseCtx`] in a [`ReusableTraverseCtx`].
     ///
     /// Only for use in tests. Allows circumventing the safety invariants of [`TraverseAncestry`].


### PR DESCRIPTION
## Summary

- Move `dce` flag from `PeepholeOptimizations` to `MinifierState`
- Eliminate duplicate `changed` flag (was in both structs, now single source of truth)
- Move iteration loop from `PeepholeOptimizations::run_in_loop` to `Compressor::run_in_loop`
- Make `PeepholeOptimizations` a stateless unit struct
- Add `state()` and `state_mut()` public getters to `ReusableTraverseCtx`

This simplifies the minifier's state management and prepares for future refactoring work.

## Test plan

- [x] All 466 minifier unit tests pass
- [x] Conformance tests pass (99.99% test262, 100% babel)

🤖 Generated with [Claude Code](https://claude.ai/code)