### PR TITLE
fix(parser): respect optional `TSNamedTupleMember`  for ts error 1266 &1257

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -928,10 +928,11 @@ impl<'a> ParserImpl<'a> {
                     seen_rest_span = Some(tuple.span());
                 }
 
-                if !matches!(
-                    tuple,
-                    TSTupleElement::TSOptionalType(_) | TSTupleElement::TSRestType(_)
-                ) && let Some(seen_optional_span) = seen_optional_span
+                if !match &tuple {
+                    TSTupleElement::TSOptionalType(_) | TSTupleElement::TSRestType(_) => true,
+                    TSTupleElement::TSNamedTupleMember(named) => named.optional,
+                    _ => false,
+                } && let Some(seen_optional_span) = seen_optional_span
                 {
                     me.error(diagnostics::required_element_cannot_follow_optional_element(
                         tuple.span(),
@@ -939,7 +940,11 @@ impl<'a> ParserImpl<'a> {
                     ));
                 }
 
-                if matches!(tuple, TSTupleElement::TSOptionalType(_)) {
+                if match &tuple {
+                    TSTupleElement::TSOptionalType(_) => true,
+                    TSTupleElement::TSNamedTupleMember(named) => named.optional,
+                    _ => false,
+                } {
                     if let Some(seen_rest_span) = seen_rest_span {
                         me.error(diagnostics::optional_element_cannot_follow_rest_element(
                             tuple.span(),

--- a/tasks/coverage/misc/pass/ts-tuple-named-optional-member-twice.ts
+++ b/tasks/coverage/misc/pass/ts-tuple-named-optional-member-twice.ts
@@ -1,0 +1,1 @@
+let x: [A?: string, B?: number];

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 61/61 (100.00%)
-Positive Passed: 61/61 (100.00%)
+AST Parsed     : 62/62 (100.00%)
+Positive Passed: 62/62 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 61/61 (100.00%)
-Positive Passed: 61/61 (100.00%)
+AST Parsed     : 62/62 (100.00%)
+Positive Passed: 62/62 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: fc58af40
 parser_babel Summary:
 AST Parsed     : 2224/2230 (99.73%)
 Positive Passed: 2207/2230 (98.97%)
-Negative Passed: 1650/1697 (97.23%)
+Negative Passed: 1651/1697 (97.29%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
@@ -95,8 +95,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-computed-properties/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-spread-element/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-required-after-labeled-optional/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
 
@@ -14377,6 +14375,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ───┬───  ───┬──
    ·            │        ╰── Required element here
    ·            ╰── Optional element seen here
+   ╰────
+
+  × TS(1257): A required element cannot follow an optional element.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-required-after-labeled-optional/input.ts:1:11]
+ 1 │ type T = [x?: A, y: B];
+   ·           ──┬──  ──┬─
+   ·             │      ╰── Required element here
+   ·             ╰── Optional element seen here
    ╰────
 
   × TS(1273): 'public' modifier cannot be used on a type parameter.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 61/61 (100.00%)
-Positive Passed: 61/61 (100.00%)
+AST Parsed     : 62/62 (100.00%)
+Positive Passed: 62/62 (100.00%)
 Negative Passed: 130/130 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 61/61 (100.00%)
-Positive Passed: 42/61 (68.85%)
+AST Parsed     : 62/62 (100.00%)
+Positive Passed: 43/62 (69.35%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,5 +1,5 @@
 transformer_misc Summary:
-AST Parsed     : 61/61 (100.00%)
-Positive Passed: 60/61 (98.36%)
+AST Parsed     : 62/62 (100.00%)
+Positive Passed: 61/62 (98.39%)
 Mismatch: tasks/coverage/misc/pass/babel-16776-s.js
 


### PR DESCRIPTION
> This PR fixes TypeScript parser errors 1266 and 1257 by properly handling the `optional` field of `TSNamedTupleMember` when validating tuple element ordering constraints.

Introduced in #18146 and #18145 