### PR TITLE
perf(allocator): add #[cold] annotations to error handling functions

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -512,6 +512,7 @@ fn layout_from_size_align(size: usize, align: usize) -> Result<Layout, AllocErr>
     Layout::from_size_align(size, align).map_err(|_| AllocErr)
 }
 
+#[cold]
 #[inline(never)]
 fn allocation_size_overflow<T>() -> T {
     panic!("requested allocation size overflowed")

--- a/crates/oxc_allocator/src/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/bumpalo_alloc.rs
@@ -45,10 +45,14 @@ use core::usize;
 
 pub use core::alloc::{Layout, LayoutErr};
 
+#[cold]
+#[inline(never)]
 fn new_layout_err() -> LayoutErr {
     Layout::from_size_align(1, 3).unwrap_err()
 }
 
+#[cold]
+#[inline(never)]
 pub fn handle_alloc_error(layout: Layout) -> ! {
     panic!("encountered allocation error: {:?}", layout)
 }

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -856,6 +856,8 @@ fn alloc_guard(alloc_size: usize) -> Result<(), AllocError> {
 // One central function responsible for reporting capacity overflows. This'll
 // ensure that the code generation related to these panics is minimal as there's
 // only one location which panics rather than a bunch throughout the module.
+#[cold]
+#[inline(never)]
 fn capacity_overflow() -> ! {
     panic!("capacity overflow")
 }


### PR DESCRIPTION
## Summary

- Add `#[cold]` and `#[inline(never)]` annotations to error/panic functions in oxc_allocator
- Improves branch prediction and code layout for hot allocation paths

### Functions annotated

| File | Function | Change |
|------|----------|--------|
| `bump.rs` | `allocation_size_overflow` | Added `#[cold]` |
| `bumpalo_alloc.rs` | `new_layout_err` | Added `#[cold]` + `#[inline(never)]` |
| `bumpalo_alloc.rs` | `handle_alloc_error` | Added `#[cold]` + `#[inline(never)]` |
| `vec2/raw_vec.rs` | `capacity_overflow` | Added `#[cold]` + `#[inline(never)]` |

### Impact

The `#[cold]` attribute tells the compiler to:
1. Assume branches leading to these functions are unlikely
2. Move cold code away from hot paths (improves i-cache locality)
3. Avoid inlining cold functions into hot callers

## Test plan

- [x] `cargo test -p oxc_allocator` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)