### PR TITLE
chore(coverage): skip Babel tests using `disallowAmbiguousJSXLike` option

### DIFF
--- a/crates/oxc_transformer/src/options/babel/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/mod.rs
@@ -182,6 +182,10 @@ impl BabelOptions {
         self.plugins.syntax_typescript.is_some_and(|o| o.dts)
     }
 
+    pub fn has_disallow_ambiguous_jsx_like(&self) -> bool {
+        self.plugins.syntax_typescript.is_some_and(|o| o.disallow_ambiguous_jsx_like)
+    }
+
     pub fn is_module(&self) -> bool {
         self.source_type.as_ref().is_some_and(|s| s.as_str() == "module")
     }

--- a/crates/oxc_transformer/src/options/babel/plugins.rs
+++ b/crates/oxc_transformer/src/options/babel/plugins.rs
@@ -12,6 +12,8 @@ use super::PluginPresetEntries;
 pub struct SyntaxTypeScriptOptions {
     #[serde(default)]
     pub dts: bool,
+    #[serde(default, rename = "disallowAmbiguousJSXLike")]
+    pub disallow_ambiguous_jsx_like: bool,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -1,5 +1,5 @@
 commit: fc58af40
 
 codegen_babel Summary:
-AST Parsed     : 2230/2230 (100.00%)
-Positive Passed: 2230/2230 (100.00%)
+AST Parsed     : 2229/2229 (100.00%)
+Positive Passed: 2229/2229 (100.00%)

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 formatter_babel Summary:
-AST Parsed     : 2230/2230 (100.00%)
-Positive Passed: 2224/2230 (99.73%)
+AST Parsed     : 2229/2229 (100.00%)
+Positive Passed: 2223/2229 (99.73%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/async-arrow-function/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-method/input.js

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,9 +1,9 @@
 commit: fc58af40
 
 parser_babel Summary:
-AST Parsed     : 2224/2230 (99.73%)
-Positive Passed: 2207/2230 (98.97%)
-Negative Passed: 1651/1697 (97.29%)
+AST Parsed     : 2223/2229 (99.73%)
+Positive Passed: 2206/2229 (98.97%)
+Negative Passed: 1651/1695 (97.40%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
@@ -47,10 +47,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/namespace-function/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments-invalid/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/disallow-jsx-ambiguity/type-assertion/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/disallow-jsx-ambiguity/type-parameter/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/input.ts
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 semantic_babel Summary:
-AST Parsed     : 2230/2230 (100.00%)
-Positive Passed: 1939/2230 (86.95%)
+AST Parsed     : 2229/2229 (100.00%)
+Positive Passed: 1938/2229 (86.94%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 transformer_babel Summary:
-AST Parsed     : 2230/2230 (100.00%)
-Positive Passed: 2227/2230 (99.87%)
+AST Parsed     : 2229/2229 (100.00%)
+Positive Passed: 2226/2229 (99.87%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowYieldOutsideFunction-true-2/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/ambiguous-script/input.js

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -194,6 +194,7 @@ impl Case for BabelCase {
         has_not_supported_plugins
             || self.options.allow_await_outside_function
             || self.options.allow_undeclared_exports
+            || self.options.has_disallow_ambiguous_jsx_like()
     }
 
     fn run(&mut self) {


### PR DESCRIPTION
## Summary

- Add support for parsing Babel's `disallowAmbiguousJSXLike` TypeScript plugin option
- Skip tests that use this option since it's Babel-specific and not supported by TypeScript (the reference implementation)

This skips the `typescript/disallow-jsx-ambiguity/*` tests which test Babel-specific JSX ambiguity handling.

## Test plan

- `cargo coverage -- parser` passes
- Tests using `disallowAmbiguousJSXLike` are now skipped in conformance snapshots

🤖 Generated with [Claude Code](https://claude.ai/code)