### PR TITLE
perf(mangler): remove `frequencies` items if they are unused

### DIFF
--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -18,7 +18,7 @@ function foo(e) {
 
 var x; function foo(a) { ({ x } = y) }
 var x;
-function foo(t) {
+function foo(a) {
 	({x} = y);
 }
 


### PR DESCRIPTION
Remove the `frequencies` item that has no symbol_id, which means the slot doesn't have a symbol that needs to be renamed. This can prevent the construction of a never-used name.