### PR TITLE
refactor(ast)!: replace TSMappedType.type_parameter with dedicated key and constraint fields

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5441,23 +5441,18 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       range: [start, end],
       parent,
     }),
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name;
-  key.parent = parent;
-  let { constraint } = typeParameter;
-  constraint !== null && (constraint.parent = parent);
-  let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   parent = previousParent;
   return node;

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1570,8 +1570,8 @@ export interface TSConstructorType extends Span {
 
 export interface TSMappedType extends Span {
   type: "TSMappedType";
-  key: TSTypeParameter["name"];
-  constraint: TSTypeParameter["constraint"];
+  key: BindingIdentifier;
+  constraint: TSType;
   nameType: TSType | null;
   typeAnnotation: TSType | null;
   optional: TSMappedTypeModifierOperator | false;

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1477,13 +1477,13 @@ pub struct TSConstructorType<'a> {
 /// type Maybe<T> = {
 /// //        _____ constraint
 ///     [P in keyof T]?: T[P]
-/// //   ^ type_parameter
+/// //   ^ key
 /// }
 /// ```
 ///
 /// ```ts
 /// type ReadonlyDefinite<T> = {
-/// //           _ type parameter
+/// //           _ key
 ///    readonly [P in keyof T]-?: T[P]
 /// //                        ^^ `optional` modifier
 /// };
@@ -1495,15 +1495,13 @@ pub struct TSConstructorType<'a> {
 #[scope]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
-#[estree(
-    add_fields(key = TSMappedTypeKey, constraint = TSMappedTypeConstraint),
-    field_order(key, constraint, name_type, type_annotation, optional, readonly, span),
-)]
+#[estree(field_order(key, constraint, name_type, type_annotation, optional, readonly, span))]
 pub struct TSMappedType<'a> {
     pub span: Span,
     /// Key type parameter, e.g. `P` in `[P in keyof T]`.
-    #[estree(skip)]
-    pub type_parameter: Box<'a, TSTypeParameter<'a>>,
+    pub key: BindingIdentifier<'a>,
+    /// Constraint type, e.g. `keyof T` in `[P in keyof T]`.
+    pub constraint: TSType<'a>,
     pub name_type: Option<TSType<'a>>,
     pub type_annotation: Option<TSType<'a>>,
     /// Optional modifier on type annotation

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1493,15 +1493,16 @@ const _: () = {
     assert!(offset_of!(TSConstructorType, scope_id) == 32);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSMappedType>() == 56);
+    assert!(size_of::<TSMappedType>() == 96);
     assert!(align_of::<TSMappedType>() == 8);
     assert!(offset_of!(TSMappedType, span) == 0);
-    assert!(offset_of!(TSMappedType, type_parameter) == 8);
-    assert!(offset_of!(TSMappedType, name_type) == 16);
-    assert!(offset_of!(TSMappedType, type_annotation) == 32);
-    assert!(offset_of!(TSMappedType, optional) == 52);
-    assert!(offset_of!(TSMappedType, readonly) == 53);
-    assert!(offset_of!(TSMappedType, scope_id) == 48);
+    assert!(offset_of!(TSMappedType, key) == 8);
+    assert!(offset_of!(TSMappedType, constraint) == 40);
+    assert!(offset_of!(TSMappedType, name_type) == 56);
+    assert!(offset_of!(TSMappedType, type_annotation) == 72);
+    assert!(offset_of!(TSMappedType, optional) == 92);
+    assert!(offset_of!(TSMappedType, readonly) == 93);
+    assert!(offset_of!(TSMappedType, scope_id) == 88);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
@@ -3114,15 +3115,16 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSConstructorType, scope_id) == 20);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSMappedType>() == 36);
+    assert!(size_of::<TSMappedType>() == 60);
     assert!(align_of::<TSMappedType>() == 4);
     assert!(offset_of!(TSMappedType, span) == 0);
-    assert!(offset_of!(TSMappedType, type_parameter) == 8);
-    assert!(offset_of!(TSMappedType, name_type) == 12);
-    assert!(offset_of!(TSMappedType, type_annotation) == 20);
-    assert!(offset_of!(TSMappedType, optional) == 32);
-    assert!(offset_of!(TSMappedType, readonly) == 33);
-    assert!(offset_of!(TSMappedType, scope_id) == 28);
+    assert!(offset_of!(TSMappedType, key) == 8);
+    assert!(offset_of!(TSMappedType, constraint) == 28);
+    assert!(offset_of!(TSMappedType, name_type) == 36);
+    assert!(offset_of!(TSMappedType, type_annotation) == 44);
+    assert!(offset_of!(TSMappedType, optional) == 56);
+    assert!(offset_of!(TSMappedType, readonly) == 57);
+    assert!(offset_of!(TSMappedType, scope_id) == 52);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -10711,27 +10711,27 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
-    pub fn ts_type_mapped_type<T1>(
+    pub fn ts_type_mapped_type(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
-    ) -> TSType<'a>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> TSType<'a> {
         TSType::TSMappedType(self.alloc_ts_mapped_type(
             span,
-            type_parameter,
+            key,
+            constraint,
             name_type,
             type_annotation,
             optional,
@@ -10745,29 +10745,29 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
     #[inline]
-    pub fn ts_type_mapped_type_with_scope_id<T1>(
+    pub fn ts_type_mapped_type_with_scope_id(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
-    ) -> TSType<'a>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> TSType<'a> {
         TSType::TSMappedType(self.alloc_ts_mapped_type_with_scope_id(
             span,
-            type_parameter,
+            key,
+            constraint,
             name_type,
             type_annotation,
             optional,
@@ -14476,27 +14476,27 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
-    pub fn ts_mapped_type<T1>(
+    pub fn ts_mapped_type(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
-    ) -> TSMappedType<'a>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> TSMappedType<'a> {
         TSMappedType {
             span,
-            type_parameter: type_parameter.into_in(self.allocator),
+            key,
+            constraint,
             name_type,
             type_annotation,
             optional,
@@ -14512,28 +14512,28 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
-    pub fn alloc_ts_mapped_type<T1>(
+    pub fn alloc_ts_mapped_type(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
-    ) -> Box<'a, TSMappedType<'a>>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> Box<'a, TSMappedType<'a>> {
         Box::new_in(
             self.ts_mapped_type(
                 span,
-                type_parameter,
+                key,
+                constraint,
                 name_type,
                 type_annotation,
                 optional,
@@ -14550,29 +14550,29 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
     #[inline]
-    pub fn ts_mapped_type_with_scope_id<T1>(
+    pub fn ts_mapped_type_with_scope_id(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
-    ) -> TSMappedType<'a>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> TSMappedType<'a> {
         TSMappedType {
             span,
-            type_parameter: type_parameter.into_in(self.allocator),
+            key,
+            constraint,
             name_type,
             type_annotation,
             optional,
@@ -14588,30 +14588,30 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `type_parameter`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `key`: Key type parameter, e.g. `P` in `[P in keyof T]`.
+    /// * `constraint`: Constraint type, e.g. `keyof T` in `[P in keyof T]`.
     /// * `name_type`
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
     #[inline]
-    pub fn alloc_ts_mapped_type_with_scope_id<T1>(
+    pub fn alloc_ts_mapped_type_with_scope_id(
         self,
         span: Span,
-        type_parameter: T1,
+        key: BindingIdentifier<'a>,
+        constraint: TSType<'a>,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
-    ) -> Box<'a, TSMappedType<'a>>
-    where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> Box<'a, TSMappedType<'a>> {
         Box::new_in(
             self.ts_mapped_type_with_scope_id(
                 span,
-                type_parameter,
+                key,
+                constraint,
                 name_type,
                 type_annotation,
                 optional,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7600,7 +7600,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
             span: CloneIn::clone_in(&self.span, allocator),
-            type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            constraint: CloneIn::clone_in(&self.constraint, allocator),
             name_type: CloneIn::clone_in(&self.name_type, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
@@ -7612,7 +7613,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            type_parameter: CloneIn::clone_in_with_semantic_ids(&self.type_parameter, allocator),
+            key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
+            constraint: CloneIn::clone_in_with_semantic_ids(&self.constraint, allocator),
             name_type: CloneIn::clone_in_with_semantic_ids(&self.name_type, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
             optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2377,7 +2377,8 @@ impl ContentEq for TSConstructorType<'_> {
 
 impl ContentEq for TSMappedType<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+        ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.constraint, &other.constraint)
             && ContentEq::content_eq(&self.name_type, &other.name_type)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.optional, &other.optional)

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2718,11 +2718,12 @@ impl<'a> Dummy<'a> for TSConstructorType<'a> {
 impl<'a> Dummy<'a> for TSMappedType<'a> {
     /// Create a dummy [`TSMappedType`].
     ///
-    /// Has cost of making 1 allocation (80 bytes).
+    /// Has cost of making 1 allocation (8 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            type_parameter: Dummy::dummy(allocator),
+            key: Dummy::dummy(allocator),
+            constraint: Dummy::dummy(allocator),
             name_type: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
             optional: Dummy::dummy(allocator),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3028,8 +3028,8 @@ impl ESTree for TSMappedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("TSMappedType"));
-        state.serialize_field("key", &crate::serialize::ts::TSMappedTypeKey(self));
-        state.serialize_field("constraint", &crate::serialize::ts::TSMappedTypeConstraint(self));
+        state.serialize_field("key", &self.key);
+        state.serialize_field("constraint", &self.constraint);
         state.serialize_field("nameType", &self.name_type);
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("optional", &crate::serialize::ts::TSMappedTypeOptional(self));

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -304,46 +304,6 @@ impl ESTree for TSMappedTypeOptional<'_, '_> {
     }
 }
 
-/// Serializer for `key` field of `TSMappedType`.
-#[ast_meta]
-#[estree(
-    ts_type = "TSTypeParameter['name']",
-    raw_deser = "
-        const typeParameter = DESER[Box<TSTypeParameter>](POS_OFFSET.type_parameter),
-            key = typeParameter.name;
-        if (PARENT) key.parent = parent;
-        key
-    "
-)]
-pub struct TSMappedTypeKey<'a, 'b>(pub &'b TSMappedType<'a>);
-
-impl ESTree for TSMappedTypeKey<'_, '_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        self.0.type_parameter.name.serialize(serializer);
-    }
-}
-
-/// Serializer for `constraint` field of `TSMappedType`.
-///
-/// NOTE: Variable `typeParameter` in `raw_deser` is shared between `key` and `constraint` serializers.
-/// They will be concatenated in the generated code.
-#[ast_meta]
-#[estree(
-    ts_type = "TSTypeParameter['constraint']",
-    raw_deser = "
-        const { constraint } = typeParameter;
-        if (PARENT && constraint !== null) constraint.parent = parent;
-        constraint
-    "
-)]
-pub struct TSMappedTypeConstraint<'a, 'b>(pub &'b TSMappedType<'a>);
-
-impl ESTree for TSMappedTypeConstraint<'_, '_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        self.0.type_parameter.constraint.serialize(serializer);
-    }
-}
-
 /// Serializer for `expression` field of `TSClassImplements`.
 ///
 /// Our AST represents `X.Y` in `class C implements X.Y {}` as a `TSQualifiedName`.

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -149,7 +149,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ("CommentNewlines", StructDetails { field_order: None }),
         ("JSXText", StructDetails { field_order: None }),
         ("ExportAllDeclaration", StructDetails { field_order: None }),
-        ("TSMappedType", StructDetails { field_order: Some(&[0, 1, 2, 3, 5, 6, 4]) }),
+        ("TSMappedType", StructDetails { field_order: Some(&[0, 1, 2, 3, 4, 6, 7, 5]) }),
         ("TSStringKeyword", StructDetails { field_order: None }),
         ("TSNamedTupleMember", StructDetails { field_order: None }),
         ("TSTypeLiteral", StructDetails { field_order: None }),

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4049,7 +4049,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type_parameter(&it.type_parameter);
+        visitor.visit_binding_identifier(&it.key);
+        visitor.visit_ts_type(&it.constraint);
         if let Some(name_type) = &it.name_type {
             visitor.visit_ts_type(name_type);
         }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4264,7 +4264,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_parameter(&mut it.type_parameter);
+        visitor.visit_binding_identifier(&mut it.key);
+        visitor.visit_ts_type(&mut it.constraint);
         if let Some(name_type) = &mut it.name_type {
             visitor.visit_ts_type(name_type);
         }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3167,15 +3167,9 @@ impl Gen for TSMappedType<'_> {
             None => {}
         }
         p.print_ascii_byte(b'[');
-        self.type_parameter.name.print(p, ctx);
-        if let Some(constraint) = &self.type_parameter.constraint {
-            p.print_str(" in ");
-            constraint.print(p, ctx);
-        }
-        if let Some(default) = &self.type_parameter.default {
-            p.print_str(" = ");
-            default.print(p, ctx);
-        }
+        self.key.print(p, ctx);
+        p.print_str(" in ");
+        self.constraint.print(p, ctx);
         if let Some(name_type) = &self.name_type {
             p.print_str(" as ");
             name_type.print(p, ctx);

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -8798,7 +8798,18 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
 
 impl<'a> AstNode<'a, TSMappedType<'a>> {
     #[inline]
-    pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
+    pub fn key(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+        let following_span = Some(self.inner.constraint.span());
+        self.allocator.alloc(AstNode {
+            inner: &self.inner.key,
+            allocator: self.allocator,
+            parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
+            following_span,
+        })
+    }
+
+    #[inline]
+    pub fn constraint(&self) -> &AstNode<'a, TSType<'a>> {
         let following_span = self
             .inner
             .name_type
@@ -8807,7 +8818,7 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
             .or_else(|| self.inner.type_annotation.as_ref().map(GetSpan::span))
             .or(self.following_span);
         self.allocator.alloc(AstNode {
-            inner: self.inner.type_parameter.as_ref(),
+            inner: &self.inner.constraint,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
             following_span,

--- a/crates/oxc_formatter/src/print/mapped_type.rs
+++ b/crates/oxc_formatter/src/print/mapped_type.rs
@@ -12,22 +12,22 @@ use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        if f.comments().is_suppressed(self.type_parameter.span.start) {
+        if f.comments().is_suppressed(self.key.span.start) {
             return write!(f, FormatSuppressedNode(self.span));
         }
 
-        let type_parameter = self.type_parameter();
+        let key = self.key();
+        let constraint = self.constraint();
         let name_type = self.name_type();
         let should_expand = has_line_break_before_property_name(self, f.source_text());
 
         let format_inner = format_with(|f| {
             if should_expand {
-                let comments =
-                    if f.comments().has_leading_own_line_comment(self.type_parameter.span.start) {
-                        f.context().comments().comments_before(self.type_parameter.span.start)
-                    } else {
-                        f.context().comments().comments_before_character(self.span.start, b'[')
-                    };
+                let comments = if f.comments().has_leading_own_line_comment(self.key.span.start) {
+                    f.context().comments().comments_before(self.key.span.start)
+                } else {
+                    f.context().comments().comments_before_character(self.span.start, b'[')
+                };
                 write!(f, FormatLeadingComments::Comments(comments));
             }
 
@@ -42,17 +42,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
 
             let format_inner_inner = format_with(|f| {
                 write!(f, "[");
-                write!(f, type_parameter.name());
-                if let Some(constraint) = &type_parameter.constraint() {
-                    write!(f, [space(), "in", space(), constraint]);
-                }
-                if let Some(default) = &type_parameter.default() {
-                    write!(f, [space(), "=", space(), default]);
-                }
+                write!(f, key);
+                write!(f, [space(), "in", space(), constraint]);
                 if let Some(name_type) = &name_type {
                     write!(f, [space(), "as", space(), name_type]);
                 }
-                type_parameter.format_trailing_comments(f);
+                key.format_trailing_comments(f);
                 write!(f, "]");
                 if let Some(optional) = self.optional() {
                     write!(
@@ -100,5 +95,5 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
 ///     in B]: T}
 /// Because the break is _after_ the `A`.
 fn has_line_break_before_property_name(node: &TSMappedType, f: SourceText) -> bool {
-    f.contains_newline_between(node.span.start, node.type_parameter.span.start)
+    f.contains_newline_between(node.span.start, node.key.span.start)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
@@ -64,6 +64,7 @@ impl NoUnusedVars {
             | AstKind::TSEnumMember(_)
             | AstKind::TSImportEqualsDeclaration(_)
             | AstKind::TSInterfaceDeclaration(_)
+            | AstKind::TSMappedType(_)
             | AstKind::TSModuleDeclaration(_)
             | AstKind::TSTypeAliasDeclaration(_)
             | AstKind::TSTypeParameter(_) => self.is_ignored_var(declared_binding),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -338,6 +338,8 @@ impl NoUnusedVars {
                 }
                 ctx.diagnostic(diagnostic::declared(symbol, &self.vars_ignore_pattern, false));
             }
+            // Mapped type keys are always used within the type definition
+            AstKind::TSMappedType(_) => {}
             AstKind::CatchParameter(catch) => {
                 // NOTE: these are safe suggestions as deleting unused catch
                 // bindings wont have any side effects.

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -600,22 +600,12 @@ impl<'a> ParserImpl<'a> {
         }
 
         self.expect(Kind::LBrack);
-        let type_parameter_span = self.start_span();
         if !self.cur_kind().is_identifier_name() {
             return self.unexpected();
         }
-        let name = self.parse_binding_identifier();
+        let key = self.parse_binding_identifier();
         self.expect(Kind::In);
         let constraint = self.parse_ts_type();
-        let type_parameter = self.alloc(self.ast.ts_type_parameter(
-            self.end_span(type_parameter_span),
-            name,
-            Some(constraint),
-            None,
-            false,
-            false,
-            false,
-        ));
 
         let name_type = if self.eat(Kind::As) { Some(self.parse_ts_type()) } else { None };
         self.expect(Kind::RBrack);
@@ -644,7 +634,8 @@ impl<'a> ParserImpl<'a> {
 
         self.ast.ts_type_mapped_type(
             self.end_span(span),
-            type_parameter,
+            key,
+            constraint,
             name_type,
             type_annotation,
             optional,

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -700,3 +700,16 @@ impl<'a> Binder<'a> for TSTypeParameter<'a> {
         self.name.symbol_id.set(Some(symbol_id));
     }
 }
+
+impl<'a> Binder<'a> for TSMappedType<'a> {
+    fn bind(&self, builder: &mut SemanticBuilder) {
+        let symbol_id = builder.declare_symbol_on_scope(
+            self.key.span,
+            &self.key.name,
+            builder.current_scope_id,
+            SymbolFlags::TypeParameter,
+            SymbolFlags::TypeParameterExcludes,
+        );
+        self.key.symbol_id.set(Some(symbol_id));
+    }
+}

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2351,6 +2351,24 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
+        let kind = AstKind::TSMappedType(self.alloc(it));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        it.bind(self);
+        self.visit_span(&it.span);
+        self.visit_binding_identifier(&it.key);
+        self.visit_ts_type(&it.constraint);
+        if let Some(name_type) = &it.name_type {
+            self.visit_ts_type(name_type);
+        }
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type(type_annotation);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
     fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
         let kind = AstKind::IdentifierReference(self.alloc(ident));
         self.enter_node(kind);

--- a/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
+++ b/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
@@ -101,6 +101,7 @@ impl ConformanceTest for SymbolDeclarationTest {
             // =========================== TYPESCRIPT ===========================
             AstKind::TSImportEqualsDeclaration(import) => check_binding(symbol_id, &import.id),
             AstKind::TSTypeParameter(decl) => check_binding(symbol_id, &decl.name),
+            AstKind::TSMappedType(decl) => check_binding(symbol_id, &decl.key),
             AstKind::TSModuleDeclaration(decl) => match &decl.id {
                 TSModuleDeclarationName::Identifier(id) => check_binding(symbol_id, id),
                 TSModuleDeclarationName::StringLiteral(_) => {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -24,19 +24,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
-                "node": "TSTypeParameter(k)",
+                "node": "TSMappedType",
                 "references": [
                   {
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "k",
-                    "node_id": 15
+                    "node_id": 14
                   },
                   {
                     "flags": "ReferenceFlags(Type)",
                     "id": 3,
                     "name": "k",
-                    "node_id": 20
+                    "node_id": 19
                   }
                 ]
               }
@@ -63,7 +63,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
-            "node_id": 18
+            "node_id": 17
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
-                "node": "TSTypeParameter(k)",
+                "node": "TSMappedType",
                 "references": [
                   {
                     "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "k",
-                    "node_id": 18
+                    "node_id": 17
                   }
                 ]
               }
@@ -57,7 +57,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 16
+            "node_id": 15
           }
         ]
       },

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -299,28 +299,29 @@ pub(crate) enum AncestorType {
     TSConstructorTypeTypeParameters = 275,
     TSConstructorTypeParams = 276,
     TSConstructorTypeReturnType = 277,
-    TSMappedTypeTypeParameter = 278,
-    TSMappedTypeNameType = 279,
-    TSMappedTypeTypeAnnotation = 280,
-    TSTemplateLiteralTypeQuasis = 281,
-    TSTemplateLiteralTypeTypes = 282,
-    TSAsExpressionExpression = 283,
-    TSAsExpressionTypeAnnotation = 284,
-    TSSatisfiesExpressionExpression = 285,
-    TSSatisfiesExpressionTypeAnnotation = 286,
-    TSTypeAssertionTypeAnnotation = 287,
-    TSTypeAssertionExpression = 288,
-    TSImportEqualsDeclarationId = 289,
-    TSImportEqualsDeclarationModuleReference = 290,
-    TSExternalModuleReferenceExpression = 291,
-    TSNonNullExpressionExpression = 292,
-    DecoratorExpression = 293,
-    TSExportAssignmentExpression = 294,
-    TSNamespaceExportDeclarationId = 295,
-    TSInstantiationExpressionExpression = 296,
-    TSInstantiationExpressionTypeArguments = 297,
-    JSDocNullableTypeTypeAnnotation = 298,
-    JSDocNonNullableTypeTypeAnnotation = 299,
+    TSMappedTypeKey = 278,
+    TSMappedTypeConstraint = 279,
+    TSMappedTypeNameType = 280,
+    TSMappedTypeTypeAnnotation = 281,
+    TSTemplateLiteralTypeQuasis = 282,
+    TSTemplateLiteralTypeTypes = 283,
+    TSAsExpressionExpression = 284,
+    TSAsExpressionTypeAnnotation = 285,
+    TSSatisfiesExpressionExpression = 286,
+    TSSatisfiesExpressionTypeAnnotation = 287,
+    TSTypeAssertionTypeAnnotation = 288,
+    TSTypeAssertionExpression = 289,
+    TSImportEqualsDeclarationId = 290,
+    TSImportEqualsDeclarationModuleReference = 291,
+    TSExternalModuleReferenceExpression = 292,
+    TSNonNullExpressionExpression = 293,
+    DecoratorExpression = 294,
+    TSExportAssignmentExpression = 295,
+    TSNamespaceExportDeclarationId = 296,
+    TSInstantiationExpressionExpression = 297,
+    TSInstantiationExpressionTypeArguments = 298,
+    JSDocNullableTypeTypeAnnotation = 299,
+    JSDocNonNullableTypeTypeAnnotation = 300,
 }
 
 /// Ancestor type used in AST traversal.
@@ -857,8 +858,9 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSConstructorTypeParams as u16,
     TSConstructorTypeReturnType(TSConstructorTypeWithoutReturnType<'a, 't>) =
         AncestorType::TSConstructorTypeReturnType as u16,
-    TSMappedTypeTypeParameter(TSMappedTypeWithoutTypeParameter<'a, 't>) =
-        AncestorType::TSMappedTypeTypeParameter as u16,
+    TSMappedTypeKey(TSMappedTypeWithoutKey<'a, 't>) = AncestorType::TSMappedTypeKey as u16,
+    TSMappedTypeConstraint(TSMappedTypeWithoutConstraint<'a, 't>) =
+        AncestorType::TSMappedTypeConstraint as u16,
     TSMappedTypeNameType(TSMappedTypeWithoutNameType<'a, 't>) =
         AncestorType::TSMappedTypeNameType as u16,
     TSMappedTypeTypeAnnotation(TSMappedTypeWithoutTypeAnnotation<'a, 't>) =
@@ -1815,7 +1817,8 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_mapped_type(self) -> bool {
         matches!(
             self,
-            Self::TSMappedTypeTypeParameter(_)
+            Self::TSMappedTypeKey(_)
+                | Self::TSMappedTypeConstraint(_)
                 | Self::TSMappedTypeNameType(_)
                 | Self::TSMappedTypeTypeAnnotation(_)
         )
@@ -2175,6 +2178,7 @@ impl<'a, 't> Ancestor<'a, 't> {
                 | Self::TSTypeParameterConstraint(_)
                 | Self::TSTypeParameterDefault(_)
                 | Self::TSTypeAliasDeclarationTypeAnnotation(_)
+                | Self::TSMappedTypeConstraint(_)
                 | Self::TSMappedTypeNameType(_)
                 | Self::TSMappedTypeTypeAnnotation(_)
                 | Self::TSTemplateLiteralTypeTypes(_)
@@ -2526,7 +2530,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSConstructorTypeTypeParameters(a) => a.address(),
             Self::TSConstructorTypeParams(a) => a.address(),
             Self::TSConstructorTypeReturnType(a) => a.address(),
-            Self::TSMappedTypeTypeParameter(a) => a.address(),
+            Self::TSMappedTypeKey(a) => a.address(),
+            Self::TSMappedTypeConstraint(a) => a.address(),
             Self::TSMappedTypeNameType(a) => a.address(),
             Self::TSMappedTypeTypeAnnotation(a) => a.address(),
             Self::TSTemplateLiteralTypeQuasis(a) => a.address(),
@@ -15266,8 +15271,8 @@ impl<'a, 't> GetAddress for TSConstructorTypeWithoutReturnType<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_MAPPED_TYPE_SPAN: usize = offset_of!(TSMappedType, span);
-pub(crate) const OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER: usize =
-    offset_of!(TSMappedType, type_parameter);
+pub(crate) const OFFSET_TS_MAPPED_TYPE_KEY: usize = offset_of!(TSMappedType, key);
+pub(crate) const OFFSET_TS_MAPPED_TYPE_CONSTRAINT: usize = offset_of!(TSMappedType, constraint);
 pub(crate) const OFFSET_TS_MAPPED_TYPE_NAME_TYPE: usize = offset_of!(TSMappedType, name_type);
 pub(crate) const OFFSET_TS_MAPPED_TYPE_TYPE_ANNOTATION: usize =
     offset_of!(TSMappedType, type_annotation);
@@ -15277,15 +15282,22 @@ pub(crate) const OFFSET_TS_MAPPED_TYPE_SCOPE_ID: usize = offset_of!(TSMappedType
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSMappedTypeWithoutTypeParameter<'a, 't>(
+pub struct TSMappedTypeWithoutKey<'a, 't>(
     pub(crate) *const TSMappedType<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSMappedTypeWithoutTypeParameter<'a, 't> {
+impl<'a, 't> TSMappedTypeWithoutKey<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn constraint(self) -> &'t TSType<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_CONSTRAINT) as *const TSType<'a>)
+        }
     }
 
     #[inline]
@@ -15329,7 +15341,75 @@ impl<'a, 't> TSMappedTypeWithoutTypeParameter<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSMappedTypeWithoutTypeParameter<'a, 't> {
+impl<'a, 't> GetAddress for TSMappedTypeWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        unsafe { Address::from_ptr(self.0) }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSMappedTypeWithoutConstraint<'a, 't>(
+    pub(crate) *const TSMappedType<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSMappedTypeWithoutConstraint<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn key(self) -> &'t BindingIdentifier<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_KEY) as *const BindingIdentifier<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn name_type(self) -> &'t Option<TSType<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_NAME_TYPE)
+                as *const Option<TSType<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn type_annotation(self) -> &'t Option<TSType<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_TYPE_ANNOTATION)
+                as *const Option<TSType<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn optional(self) -> &'t Option<TSMappedTypeModifierOperator> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_OPTIONAL)
+                as *const Option<TSMappedTypeModifierOperator>)
+        }
+    }
+
+    #[inline]
+    pub fn readonly(self) -> &'t Option<TSMappedTypeModifierOperator> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_READONLY)
+                as *const Option<TSMappedTypeModifierOperator>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSMappedTypeWithoutConstraint<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         unsafe { Address::from_ptr(self.0) }
@@ -15350,10 +15430,16 @@ impl<'a, 't> TSMappedTypeWithoutNameType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameter(self) -> &'t Box<'a, TSTypeParameter<'a>> {
+    pub fn key(self) -> &'t BindingIdentifier<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER)
-                as *const Box<'a, TSTypeParameter<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_KEY) as *const BindingIdentifier<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn constraint(self) -> &'t TSType<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_CONSTRAINT) as *const TSType<'a>)
         }
     }
 
@@ -15411,10 +15497,16 @@ impl<'a, 't> TSMappedTypeWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameter(self) -> &'t Box<'a, TSTypeParameter<'a>> {
+    pub fn key(self) -> &'t BindingIdentifier<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER)
-                as *const Box<'a, TSTypeParameter<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_KEY) as *const BindingIdentifier<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn constraint(self) -> &'t TSType<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_CONSTRAINT) as *const TSType<'a>)
         }
     }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5383,13 +5383,17 @@ unsafe fn walk_ts_mapped_type<'a, State, Tr: Traverse<'a, State>>(
         .get()
         .unwrap();
     ctx.set_current_scope_id(current_scope_id);
-    let pop_token = ctx.push_stack(Ancestor::TSMappedTypeTypeParameter(
-        ancestor::TSMappedTypeWithoutTypeParameter(node, PhantomData),
-    ));
-    walk_ts_type_parameter(
+    let pop_token = ctx
+        .push_stack(Ancestor::TSMappedTypeKey(ancestor::TSMappedTypeWithoutKey(node, PhantomData)));
+    walk_binding_identifier(
         traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER)
-            as *mut Box<TSTypeParameter>)) as *mut _,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_KEY) as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSMappedTypeConstraint);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_CONSTRAINT) as *mut TSType,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_NAME_TYPE)

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -3982,19 +3982,16 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
     },
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name,
-    { constraint } = typeParameter,
-    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -4652,22 +4652,17 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       parent,
     }),
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name;
-  key.parent = parent;
-  let { constraint } = typeParameter;
-  constraint !== null && (constraint.parent = parent);
-  let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   parent = previousParent;
   return node;

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -4391,20 +4391,17 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       range: [start, end],
     },
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name,
-    { constraint } = typeParameter,
-    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -4884,23 +4884,18 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       range: [start, end],
       parent,
     }),
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name;
-  key.parent = parent;
-  let { constraint } = typeParameter;
-  constraint !== null && (constraint.parent = parent);
-  let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   parent = previousParent;
   return node;

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -4297,19 +4297,16 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
     },
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name,
-    { constraint } = typeParameter,
-    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -4987,22 +4987,17 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       parent,
     }),
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name;
-  key.parent = parent;
-  let { constraint } = typeParameter;
-  constraint !== null && (constraint.parent = parent);
-  let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   parent = previousParent;
   return node;

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -4729,20 +4729,17 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       range: [start, end],
     },
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name,
-    { constraint } = typeParameter,
-    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -5248,23 +5248,18 @@ function deserializeTSMappedType(pos) {
       nameType: null,
       typeAnnotation: null,
       optional: null,
-      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 53),
+      readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 93),
       start,
       end,
       range: [start, end],
       parent,
     }),
-    typeParameter = deserializeBoxTSTypeParameter(pos + 8),
-    key = typeParameter.name;
-  key.parent = parent;
-  let { constraint } = typeParameter;
-  constraint !== null && (constraint.parent = parent);
-  let optional = deserializeOptionTSMappedTypeModifierOperator(pos + 52);
+    optional = deserializeOptionTSMappedTypeModifierOperator(pos + 92);
   optional === null && (optional = false);
-  node.key = key;
-  node.constraint = constraint;
-  node.nameType = deserializeOptionTSType(pos + 16);
-  node.typeAnnotation = deserializeOptionTSType(pos + 32);
+  node.key = deserializeBindingIdentifier(pos + 8);
+  node.constraint = deserializeTSType(pos + 40);
+  node.nameType = deserializeOptionTSType(pos + 56);
+  node.typeAnnotation = deserializeOptionTSType(pos + 72);
   node.optional = optional;
   parent = previousParent;
   return node;

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -10935,24 +10935,34 @@ export class TSMappedType {
     return constructU32(internal.pos + 4, internal.ast);
   }
 
+  get key() {
+    const internal = this.#internal;
+    return new BindingIdentifier(internal.pos + 8, internal.ast);
+  }
+
+  get constraint() {
+    const internal = this.#internal;
+    return constructTSType(internal.pos + 40, internal.ast);
+  }
+
   get nameType() {
     const internal = this.#internal;
-    return constructOptionTSType(internal.pos + 16, internal.ast);
+    return constructOptionTSType(internal.pos + 56, internal.ast);
   }
 
   get typeAnnotation() {
     const internal = this.#internal;
-    return constructOptionTSType(internal.pos + 32, internal.ast);
+    return constructOptionTSType(internal.pos + 72, internal.ast);
   }
 
   get optional() {
     const internal = this.#internal;
-    return constructOptionTSMappedTypeModifierOperator(internal.pos + 52, internal.ast);
+    return constructOptionTSMappedTypeModifierOperator(internal.pos + 92, internal.ast);
   }
 
   get readonly() {
     const internal = this.#internal;
-    return constructOptionTSMappedTypeModifierOperator(internal.pos + 53, internal.ast);
+    return constructOptionTSMappedTypeModifierOperator(internal.pos + 93, internal.ast);
   }
 
   toJSON() {
@@ -10960,6 +10970,8 @@ export class TSMappedType {
       type: "TSMappedType",
       start: this.start,
       end: this.end,
+      key: this.key,
+      constraint: this.constraint,
       nameType: this.nameType,
       typeAnnotation: this.typeAnnotation,
       optional: this.optional,

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -4476,8 +4476,10 @@ function walkTSMappedType(pos, ast, visitors) {
     if (enter !== null) enter(node);
   }
 
-  walkOptionTSType(pos + 16, ast, visitors);
-  walkOptionTSType(pos + 32, ast, visitors);
+  walkBindingIdentifier(pos + 8, ast, visitors);
+  walkTSType(pos + 40, ast, visitors);
+  walkOptionTSType(pos + 56, ast, visitors);
+  walkOptionTSType(pos + 72, ast, visitors);
 
   if (exit !== null) exit(node);
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1563,8 +1563,8 @@ export interface TSConstructorType extends Span {
 
 export interface TSMappedType extends Span {
   type: "TSMappedType";
-  key: TSTypeParameter["name"];
-  constraint: TSTypeParameter["constraint"];
+  key: BindingIdentifier;
+  constraint: TSType;
   nameType: TSType | null;
   typeAnnotation: TSType | null;
   optional: TSMappedTypeModifierOperator | false;


### PR DESCRIPTION
## Summary

- Replace `type_parameter: Box<'a, TSTypeParameter<'a>>` with two dedicated fields:
  - `key: BindingIdentifier<'a>` - the parameter name (e.g., `P` in `[P in keyof T]`)
  - `constraint: TSType<'a>` - the constraint type (e.g., `keyof T`)
- Improves type safety by preventing invalid AST states - `TSTypeParameter` contains `const`, `in`, `out`, and `default` fields that are syntactically invalid in mapped types
- Matches TSESTree structure more closely

Closes #15101

## Test plan

- [x] All parser, codegen, semantic, and linter tests pass
- [x] Conformance tests show no regressions
- [x] Semantic snapshots updated to reflect the new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)