### PR TITLE
perf(parser): add specialized token reading methods to reduce branch misprediction

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -189,6 +189,118 @@ impl<'a> ParserImpl<'a> {
         self.advance(kind);
     }
 
+    // ===== Specialized expect methods using optimized lexer paths =====
+
+    /// Expect `}` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_rcurly(&mut self) {
+        if !self.at(Kind::RCurly) {
+            self.handle_expect_failure(Kind::RCurly);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_rcurly();
+    }
+
+    /// Expect `)` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_rparen(&mut self) {
+        if !self.at(Kind::RParen) {
+            self.handle_expect_failure(Kind::RParen);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_rparen();
+    }
+
+    /// Expect `]` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_rbrack(&mut self) {
+        if !self.at(Kind::RBrack) {
+            self.handle_expect_failure(Kind::RBrack);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_rbrack();
+    }
+
+    /// Expect `>` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_rangle(&mut self) {
+        if !self.at(Kind::RAngle) {
+            self.handle_expect_failure(Kind::RAngle);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_rangle();
+    }
+
+    /// Expect `:` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_colon(&mut self) {
+        if !self.at(Kind::Colon) {
+            self.handle_expect_failure(Kind::Colon);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_colon();
+    }
+
+    /// Expect `(` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_lparen(&mut self) {
+        if !self.at(Kind::LParen) {
+            self.handle_expect_failure(Kind::LParen);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_lparen();
+    }
+
+    /// Expect `{` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_lcurly(&mut self) {
+        if !self.at(Kind::LCurly) {
+            self.handle_expect_failure(Kind::LCurly);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_lcurly();
+    }
+
+    /// Expect `[` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_lbrack(&mut self) {
+        if !self.at(Kind::LBrack) {
+            self.handle_expect_failure(Kind::LBrack);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_lbrack();
+    }
+
+    /// Expect `<` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_langle(&mut self) {
+        if !self.at(Kind::LAngle) {
+            self.handle_expect_failure(Kind::LAngle);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_langle();
+    }
+
+    /// Expect `=` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_eq(&mut self) {
+        if !self.at(Kind::Eq) {
+            self.handle_expect_failure(Kind::Eq);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_eq();
+    }
+
+    /// Expect `;` using optimized lexer path.
+    #[inline]
+    pub(crate) fn expect_semicolon(&mut self) {
+        if !self.at(Kind::Semicolon) {
+            self.handle_expect_failure(Kind::Semicolon);
+        }
+        self.prev_token_end = self.token.end();
+        self.token = self.lexer.next_token_expecting_semicolon();
+    }
+
     #[inline]
     pub(crate) fn expect_closing(&mut self, kind: Kind, opening_span: Span) {
         if !self.at(kind) {

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -43,7 +43,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_object_binding_pattern(&mut self) -> BindingPattern<'a> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (list, rest) = self.parse_delimited_list_with_rest(
             Kind::RCurly,
             opening_span,
@@ -58,7 +58,7 @@ impl<'a> ParserImpl<'a> {
             return self.fatal_error(error);
         }
 
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         self.ast.binding_pattern_object_pattern(
             self.end_span(span),
             list,
@@ -70,7 +70,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_array_binding_pattern(&mut self) -> BindingPattern<'a> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LBrack);
+        self.expect_lbrack();
         let (list, rest) = self.parse_delimited_list_with_rest(
             Kind::RBrack,
             opening_span,
@@ -78,7 +78,7 @@ impl<'a> ParserImpl<'a> {
             Self::parse_rest_element,
             diagnostics::binding_rest_element_last,
         );
-        self.expect(Kind::RBrack);
+        self.expect_rbrack();
         self.ast.binding_pattern_array_pattern(
             self.end_span(span),
             list,
@@ -183,7 +183,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             // let { a: b } = c
             //       ^ IdentifierReference
-            self.expect(Kind::Colon);
+            self.expect_colon();
             self.parse_binding_pattern_with_initializer()
         };
 

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -31,7 +31,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_function_body(&mut self) -> Box<'a, FunctionBody<'a>> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
 
         let (directives, statements) = self.context_add(Context::Return, |p| {
             p.parse_directives_and_statements(/* is_top_level */ false)
@@ -48,7 +48,7 @@ impl<'a> ParserImpl<'a> {
     ) -> (Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>) {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LParen);
+        self.expect_lparen();
         let this_param = if self.is_ts && self.at(Kind::This) {
             let param = self.parse_ts_this_parameter();
             self.bump(Kind::Comma);
@@ -57,7 +57,7 @@ impl<'a> ParserImpl<'a> {
             None
         };
         let (list, rest) = self.parse_formal_parameters_list(func_kind, opening_span);
-        self.expect(Kind::RParen);
+        self.expect_rparen();
 
         let formal_parameters =
             self.ast.alloc_formal_parameters(self.end_span(span), params_kind, list, rest);

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -34,7 +34,7 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         phase: Option<ImportPhase>,
     ) -> Expression<'a> {
-        self.expect(Kind::LParen);
+        self.expect_lparen();
         if self.eat(Kind::RParen) {
             let error = diagnostics::import_requires_a_specifier(self.end_span(span));
             return self.fatal_error(error);
@@ -333,13 +333,13 @@ impl<'a> ParserImpl<'a> {
         import_kind: ImportOrExportKind,
     ) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (list, _) = self.context_remove(self.ctx, |p| {
             p.parse_delimited_list(Kind::RCurly, Kind::Comma, opening_span, |parser| {
                 parser.parse_import_specifier(import_kind)
             })
         });
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         list
     }
 
@@ -355,7 +355,7 @@ impl<'a> ParserImpl<'a> {
 
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (with_entries, _) = self.context_remove(self.ctx, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -364,7 +364,7 @@ impl<'a> ParserImpl<'a> {
                 Self::parse_import_attribute,
             )
         });
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
 
         let mut keys = FxHashMap::default();
         for e in &with_entries {
@@ -384,7 +384,7 @@ impl<'a> ParserImpl<'a> {
             Kind::Str => ImportAttributeKey::StringLiteral(self.parse_literal_string()),
             _ => ImportAttributeKey::Identifier(self.parse_identifier_name()),
         };
-        self.expect(Kind::Colon);
+        self.expect_colon();
         if !self.at(Kind::Str) {
             return self.fatal_error(diagnostics::import_attribute_value_must_be_string_literal(
                 self.cur_token().span(),
@@ -399,7 +399,7 @@ impl<'a> ParserImpl<'a> {
         start_span: u32,
         stmt_ctx: StatementContext,
     ) -> Box<'a, TSExportAssignment<'a>> {
-        self.expect(Kind::Eq);
+        self.expect_eq();
         let expression = self.parse_assignment_expression_or_higher();
         self.asi();
         if stmt_ctx.is_top_level() {
@@ -551,13 +551,13 @@ impl<'a> ParserImpl<'a> {
     ) -> Box<'a, ExportNamedDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (mut specifiers, _) = self.context_remove(self.ctx, |p| {
             p.parse_delimited_list(Kind::RCurly, Kind::Comma, opening_span, |parser| {
                 parser.parse_export_specifier(export_kind)
             })
         });
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         let (source, with_clause) = if self.eat(Kind::From) && self.cur_kind().is_literal() {
             let source = self.parse_literal_string();
             (Some(source), self.parse_import_attributes())

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -19,7 +19,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_object_expression(&mut self) -> Box<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (object_expression_properties, comma_span) = self.context_add(Context::In, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -31,7 +31,7 @@ impl<'a> ParserImpl<'a> {
         if let Some(comma_span) = comma_span {
             self.state.trailing_commas.insert(span, self.end_span(comma_span));
         }
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         self.ast.alloc_object_expression(self.end_span(span), object_expression_properties)
     }
 
@@ -149,7 +149,7 @@ impl<'a> ParserImpl<'a> {
         key: PropertyKey<'a>,
         computed: bool,
     ) -> Box<'a, ObjectProperty<'a>> {
-        self.expect(Kind::Colon);
+        self.expect_colon();
         let value = self.parse_assignment_expression_or_higher();
         self.ast.alloc_object_property(
             self.end_span(span),
@@ -189,7 +189,7 @@ impl<'a> ParserImpl<'a> {
 
         let expression = self.context_add(Context::In, Self::parse_assignment_expression_or_higher);
 
-        self.expect(Kind::RBrack);
+        self.expect_rbrack();
         expression
     }
 

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -336,7 +336,7 @@ impl<'a> ParserImpl<'a> {
         };
 
         let parenthesis_opening_span = self.cur_token().span();
-        self.expect(Kind::LParen);
+        self.expect_lparen();
 
         // for (;..
         if self.at(Kind::Semicolon) {
@@ -556,7 +556,7 @@ impl<'a> ParserImpl<'a> {
         init: Option<ForStatementInit<'a>>,
         r#await: bool,
     ) -> Statement<'a> {
-        self.expect(Kind::Semicolon);
+        self.expect_semicolon();
         if let Some(ForStatementInit::VariableDeclaration(decl)) = &init {
             for d in &decl.declarations {
                 self.check_missing_initializer(d);
@@ -567,7 +567,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             Some(self.context_add(Context::In, ParserImpl::parse_expr))
         };
-        self.expect(Kind::Semicolon);
+        self.expect_semicolon();
         let update = if self.at(Kind::RParen) {
             None
         } else {
@@ -693,7 +693,7 @@ impl<'a> ParserImpl<'a> {
                     .fatal_error(diagnostics::expect_switch_clause(self.cur_token().span()));
             }
         };
-        self.expect(Kind::Colon);
+        self.expect_colon();
         let mut consequent = self.ast.vec();
         loop {
             let kind = self.cur_kind();
@@ -759,7 +759,7 @@ impl<'a> ParserImpl<'a> {
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {
             let (pattern, type_annotation) = self.parse_binding_pattern_with_type_annotation();
-            self.expect(Kind::RParen);
+            self.expect_rparen();
             Some((pattern, type_annotation))
         } else {
             None

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -38,12 +38,12 @@ impl<'a> ParserImpl<'a> {
     /// </>
     fn parse_jsx_closing_fragment(&mut self, in_jsx_child: bool) -> JSXClosingFragment {
         let span = self.start_span();
-        self.expect(Kind::LAngle);
+        self.expect_langle();
         self.expect(Kind::Slash);
         if in_jsx_child {
             self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle);
+            self.expect_rangle();
         }
         self.ast.jsx_closing_fragment(self.end_span(span))
     }
@@ -91,7 +91,7 @@ impl<'a> ParserImpl<'a> {
         if !self_closing || in_jsx_child {
             self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle);
+            self.expect_rangle();
         }
         let elem = self.ast.alloc_jsx_opening_element(
             self.end_span(span),
@@ -104,13 +104,13 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_jsx_closing_element(&mut self, in_jsx_child: bool) -> Box<'a, JSXClosingElement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LAngle);
+        self.expect_langle();
         self.expect(Kind::Slash);
         let name = self.parse_jsx_element_name();
         if in_jsx_child {
             self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle);
+            self.expect_rangle();
         }
         self.ast.alloc_jsx_closing_element(self.end_span(span), name)
     }
@@ -286,7 +286,7 @@ impl<'a> ParserImpl<'a> {
             if in_jsx_child {
                 self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly);
+                self.expect_rcurly();
             }
             let span = self.end_span(span_start);
 
@@ -305,7 +305,7 @@ impl<'a> ParserImpl<'a> {
             if in_jsx_child {
                 self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly);
+                self.expect_rcurly();
             }
             expr
         };
@@ -365,7 +365,7 @@ impl<'a> ParserImpl<'a> {
         self.bump_any(); // bump `{`
         self.expect(Kind::Dot3);
         let argument = self.parse_expr();
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument)
     }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -45,14 +45,14 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_enum_body(&mut self) -> TSEnumBody<'a> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (members, _) = self.parse_delimited_list(
             Kind::RCurly,
             Kind::Comma,
             opening_span,
             Self::parse_ts_enum_member,
         );
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         self.ast.ts_enum_body(self.end_span(span), members)
     }
 
@@ -130,7 +130,7 @@ impl<'a> ParserImpl<'a> {
 
         let id = self.parse_binding_identifier();
         let params = self.parse_ts_type_parameters();
-        self.expect(Kind::Eq);
+        self.expect_eq();
 
         let intrinsic_token = self.cur_token();
         let ty = if self.at(Kind::Intrinsic) {
@@ -344,10 +344,10 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_ts_module_block(&mut self) -> Box<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let (directives, statements) =
             self.parse_directives_and_statements(/* is_top_level */ false);
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
         self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
     }
 
@@ -546,9 +546,9 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_type_assertion(&mut self) -> Expression<'a> {
         let span = self.start_span();
-        self.expect(Kind::LAngle);
+        self.expect_langle();
         let type_annotation = self.parse_ts_type();
-        self.expect(Kind::RAngle);
+        self.expect_rangle();
         let lhs_span = self.start_span();
         let expression = self.parse_simple_unary_expression(lhs_span);
         self.ast.expression_ts_type_assertion(self.end_span(span), type_annotation, expression)
@@ -560,13 +560,13 @@ impl<'a> ParserImpl<'a> {
         identifier: BindingIdentifier<'a>,
         span: u32,
     ) -> Declaration<'a> {
-        self.expect(Kind::Eq);
+        self.expect_eq();
 
         let reference_span = self.start_span();
         let module_reference = if self.eat(Kind::Require) {
-            self.expect(Kind::LParen);
+            self.expect_lparen();
             let expression = self.parse_literal_string();
-            self.expect(Kind::RParen);
+            self.expect_rparen();
             self.ast.ts_module_reference_external_module_reference(
                 self.end_span(reference_span),
                 expression,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -158,14 +158,14 @@ impl<'a> ParserImpl<'a> {
         }
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LAngle);
+        self.expect_langle();
         let (params, _) = self.parse_delimited_list(
             Kind::RAngle,
             Kind::Comma,
             opening_span,
             Self::parse_ts_type_parameter,
         );
-        self.expect(Kind::RAngle);
+        self.expect_rangle();
         let span = self.end_span(span);
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_parameter_list(span));
@@ -327,14 +327,14 @@ impl<'a> ParserImpl<'a> {
                     self.bump_any();
                     if self.is_start_of_type(/* in_start_of_parameter */ false) {
                         let index_type = self.parse_ts_type();
-                        self.expect(Kind::RBrack);
+                        self.expect_rbrack();
                         ty = self.ast.ts_type_indexed_access_type(
                             self.end_span(span),
                             ty,
                             index_type,
                         );
                     } else {
-                        self.expect(Kind::RBrack);
+                        self.expect_rbrack();
                         ty = self.ast.ts_type_array_type(self.end_span(span), ty);
                     }
                 }
@@ -589,7 +589,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_mapped_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        self.expect(Kind::LCurly);
+        self.expect_lcurly();
         let mut readonly = None;
         if self.eat(Kind::Readonly) {
             readonly = Some(TSMappedTypeModifierOperator::True);
@@ -599,7 +599,7 @@ impl<'a> ParserImpl<'a> {
             readonly = Some(TSMappedTypeModifierOperator::Minus);
         }
 
-        self.expect(Kind::LBrack);
+        self.expect_lbrack();
         let type_parameter_span = self.start_span();
         if !self.cur_kind().is_identifier_name() {
             return self.unexpected();
@@ -618,7 +618,7 @@ impl<'a> ParserImpl<'a> {
         ));
 
         let name_type = if self.eat(Kind::As) { Some(self.parse_ts_type()) } else { None };
-        self.expect(Kind::RBrack);
+        self.expect_rbrack();
 
         let optional = match self.cur_kind() {
             Kind::Question => {
@@ -640,7 +640,7 @@ impl<'a> ParserImpl<'a> {
 
         let type_annotation = self.eat(Kind::Colon).then(|| self.parse_ts_type());
         self.bump(Kind::Semicolon);
-        self.expect(Kind::RCurly);
+        self.expect_rcurly();
 
         self.ast.ts_type_mapped_type(
             self.end_span(span),
@@ -815,14 +815,14 @@ impl<'a> ParserImpl<'a> {
         if self.at(Kind::LAngle) {
             let span = self.start_span();
             let opening_span = self.cur_token().span();
-            self.expect(Kind::LAngle);
+            self.expect_langle();
             let (params, _) = self.parse_delimited_list(
                 Kind::RAngle,
                 Kind::Comma,
                 opening_span,
                 Self::parse_ts_type,
             );
-            self.expect(Kind::RAngle);
+            self.expect_rangle();
             let span = self.end_span(span);
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
@@ -838,14 +838,14 @@ impl<'a> ParserImpl<'a> {
         if !self.cur_token().is_on_new_line() && self.re_lex_ts_l_angle() {
             let span = self.start_span();
             let opening_span = self.cur_token().span();
-            self.expect(Kind::LAngle);
+            self.expect_langle();
             let (params, _) = self.parse_delimited_list(
                 Kind::RAngle,
                 Kind::Comma,
                 opening_span,
                 Self::parse_ts_type,
             );
-            self.expect(Kind::RAngle);
+            self.expect_rangle();
             let span = self.end_span(span);
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
@@ -863,7 +863,7 @@ impl<'a> ParserImpl<'a> {
             return self.unexpected();
         }
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LAngle);
+        self.expect_langle();
         let (params, _) =
             self.parse_delimited_list(Kind::RAngle, Kind::Comma, opening_span, Self::parse_ts_type);
         // `a < b> = c`` is valid but `a < b >= c` is BinaryExpression
@@ -871,7 +871,7 @@ impl<'a> ParserImpl<'a> {
             return self.unexpected();
         }
         self.re_lex_ts_r_angle();
-        self.expect(Kind::RAngle);
+        self.expect_rangle();
         if !self.can_follow_type_arguments_in_expr() {
             return self.unexpected();
         }
@@ -897,7 +897,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_tuple_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LBrack);
+        self.expect_lbrack();
 
         let mut seen_rest_span: Option<Span> = None;
         let mut seen_optional_span: Option<Span> = None;
@@ -956,7 +956,7 @@ impl<'a> ParserImpl<'a> {
 
                 tuple
             });
-        self.expect(Kind::RBrack);
+        self.expect_rbrack();
         self.ast.ts_type_tuple_type(self.end_span(span), elements)
     }
 
@@ -970,7 +970,7 @@ impl<'a> ParserImpl<'a> {
             let member_span_start = self.start_span();
             let label = self.parse_identifier_name();
             let optional = self.eat(Kind::Question);
-            self.expect(Kind::Colon);
+            self.expect_colon();
             let type_span_start = self.start_span();
             let rest_after_tuple_member_name = self.eat(Kind::Dot3);
             let ty = self.parse_ts_type();
@@ -1030,7 +1030,7 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `(`
         let ty = self.parse_ts_type();
-        self.expect(Kind::RParen);
+        self.expect_rparen();
         if self.options.preserve_parens {
             self.ast.ts_type_parenthesized_type(self.end_span(span), ty)
         } else {
@@ -1066,7 +1066,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_ts_import_type(&mut self) -> Box<'a, TSImportType<'a>> {
         let span = self.start_span();
         self.expect(Kind::Import);
-        self.expect(Kind::LParen);
+        self.expect_lparen();
 
         let source = if self.at(Kind::Str) {
             self.parse_literal_string()
@@ -1084,7 +1084,7 @@ impl<'a> ParserImpl<'a> {
 
         let options =
             if self.eat(Kind::Comma) { Some(self.parse_object_expression()) } else { None };
-        self.expect(Kind::RParen);
+        self.expect_rparen();
         let qualifier =
             if self.eat(Kind::Dot) { Some(self.parse_ts_import_type_qualifier()) } else { None };
         let type_arguments = self.parse_type_arguments_of_type_reference();
@@ -1295,7 +1295,7 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers<'a>,
     ) -> Box<'a, TSIndexSignature<'a>> {
         let opening_span = self.cur_token().span();
-        self.expect(Kind::LBrack);
+        self.expect_lbrack();
         let (params, comma_span) = self.parse_delimited_list(
             Kind::RBrack,
             Kind::Comma,
@@ -1308,7 +1308,7 @@ impl<'a> ParserImpl<'a> {
                 self.end_span(comma_span),
             ));
         }
-        self.expect(Kind::RBrack);
+        self.expect_rbrack();
         if params.len() != 1 {
             self.error(diagnostics::index_signature_one_parameter(self.end_span(span)));
         }


### PR DESCRIPTION
## Summary

- Add specialized `next_token_expecting_*` methods to the lexer that create separate indirect branch sites with skewed token distributions
- Add corresponding `expect_*` methods to the parser cursor
- The CPU branch predictor can learn these patterns more effectively since each call site has a 95%+ probability of the expected token

### Tokens covered
- Closing brackets: `}`, `)`, `]`, `>`
- Opening brackets: `{`, `(`, `[`, `<`
- Other: `:`, `=`, `;`

### Implementation
The specialized methods:
1. Skip whitespace optimized for single spaces (most common case)
2. Check for expected single-byte tokens directly
3. Fall back to regular token reading only when unexpected (cold path)

Related: https://github.com/oxc-project/backlog/issues/192

## Test plan

- [x] `cargo test -p oxc_parser` passes
- [ ] Benchmark results pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)