### PR TITLE
docs(linter/plugins): remove outdated comments

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -141,7 +141,6 @@ const PARSER_OPTIONS = Object.freeze({
   get sourceType(): ModuleKind {
     // TODO: Would be better to get `sourceType` without deserializing whole AST,
     // in case it's used in `create` to return an empty visitor if wrong type.
-    // TODO: ESLint also has `commonjs` option.
     if (ast === null) initAst();
     debugAssertIsNonNull(ast);
 
@@ -157,7 +156,6 @@ const LANGUAGE_OPTIONS = {
   get sourceType(): ModuleKind {
     // TODO: Would be better to get `sourceType` without deserializing whole AST,
     // in case it's used in `create` to return an empty visitor if wrong type.
-    // TODO: ESLint also has `commonjs` option.
     if (ast === null) initAst();
     debugAssertIsNonNull(ast);
 


### PR DESCRIPTION
Remove 2 outdated comments. #18089 introduced `commonjs` source type.