### PR TITLE
feat(napi/parser, napi/transform): accept `sourceType: "commonjs"`

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -91,7 +91,7 @@ export interface ParserOptions {
   /** Treat the source text as `js`, `jsx`, `ts`, `tsx` or `dts`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts'
   /** Treat the source text as `script` or `module` code. */
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
+  sourceType?: 'script' | 'module' | 'commonjs' | 'unambiguous' | undefined
   /** Ignore non-fatal parsing errors */
   ignoreNonFatalErrors?: boolean
 }

--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -32,7 +32,7 @@ pub struct ParserOptions {
     pub lang: Option<String>,
 
     /// Treat the source text as `script` or `module` code.
-    #[napi(ts_type = "'script' | 'module' | 'unambiguous' | undefined")]
+    #[napi(ts_type = "'script' | 'module' | 'commonjs' | 'unambiguous' | undefined")]
     pub source_type: Option<String>,
 
     /// Ignore non-fatal parsing errors

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -66,7 +66,7 @@ pub fn get_source_type(
     source_type: Option<&str>,
 ) -> SourceType {
     // When `lang` is specified, use unambiguous module kind to match the behavior of
-    // SourceType::from_path for .js/.jsx/.ts/.tsx extensions.
+    // `SourceType::from_path` for .js/.jsx/.ts/.tsx extensions.
     let ty = match lang {
         Some("js") => SourceType::unambiguous(),
         Some("jsx") => SourceType::unambiguous().with_jsx(true),
@@ -78,6 +78,7 @@ pub fn get_source_type(
     match source_type {
         Some("script") => ty.with_script(true),
         Some("module") => ty.with_module(true),
+        Some("commonjs") => ty.with_commonjs(true),
         Some("unambiguous") => ty.with_unambiguous(true),
         _ => ty,
     }

--- a/napi/parser/src-js/index.d.ts
+++ b/napi/parser/src-js/index.d.ts
@@ -152,7 +152,7 @@ export interface ParserOptions {
   /** Treat the source text as `js`, `jsx`, `ts`, `tsx` or `dts`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts'
   /** Treat the source text as `script` or `module` code. */
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
+  sourceType?: 'script' | 'module' | 'commonjs' | 'unambiguous' | undefined
   /**
    * Return an AST which includes TypeScript-related properties, or excludes them.
    *

--- a/napi/parser/src/types.rs
+++ b/napi/parser/src/types.rs
@@ -12,7 +12,7 @@ pub struct ParserOptions {
     pub lang: Option<String>,
 
     /// Treat the source text as `script` or `module` code.
-    #[napi(ts_type = "'script' | 'module' | 'unambiguous' | undefined")]
+    #[napi(ts_type = "'script' | 'module' | 'commonjs' | 'unambiguous' | undefined")]
     pub source_type: Option<String>,
 
     /// Return an AST which includes TypeScript-related properties, or excludes them.

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -46,20 +46,34 @@ describe("parse", () => {
   });
 
   describe("sets lang and sourceType", () => {
-    const code = "await(1)";
     const langs: ParserOptions["lang"][] = ["js", "ts", "jsx", "tsx"];
+
     test.each(langs)("%s", (lang) => {
+      const code = "await(1)";
       const ret = parseSync("test.cjs", code, { lang, sourceType: "script" });
       expect(ret.errors.length).toBe(0);
+      expect(ret.program.sourceType).toBe("script");
       // Parsed as `await(1)`
       expect((ret.program.body[0] as ExpressionStatement).expression.type).toBe("CallExpression");
     });
+
     test.each(langs)("%s", (lang) => {
+      const code = "await(1)";
       const ret = parseSync("test.cjs", code, { lang, sourceType: "module" });
       expect(ret.errors.length).toBe(0);
+      expect(ret.program.sourceType).toBe("module");
       // Parsed as `await 1`
       expect((ret.program.body[0] as ExpressionStatement).expression.type).toBe("AwaitExpression");
     });
+
+    test.each(langs)("%s", (lang) => {
+      const code = "return 123;";
+      const ret = parseSync("test.cjs", code, { lang, sourceType: "commonjs" });
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.sourceType).toBe("commonjs");
+      expect(ret.program.body[0].type).toBe("ReturnStatement");
+    });
+
     test("sets lang as dts", () => {
       const code = "declare const foo";
       const ret = parseSync("test", code, { lang: "dts" });

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -460,7 +460,7 @@ export interface TransformOptions {
   /** Treat the source text as `js`, `jsx`, `ts`, `tsx`, or `dts`. */
   lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts'
   /** Treat the source text as `script` or `module` code. */
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
+  sourceType?: 'script' | 'module' | 'commonjs' | 'unambiguous' | undefined
   /**
    * The current working directory. Used to resolve relative paths in other
    * options.

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -91,7 +91,7 @@ pub struct TransformOptions {
     pub lang: Option<String>,
 
     /// Treat the source text as `script` or `module` code.
-    #[napi(ts_type = "'script' | 'module' | 'unambiguous' | undefined")]
+    #[napi(ts_type = "'script' | 'module' | 'commonjs' | 'unambiguous' | undefined")]
     pub source_type: Option<String>,
 
     /// The current working directory. Used to resolve relative paths in other


### PR DESCRIPTION
#18089 added support in parser for `commonjs` source type.

Extend this support to the NAPI packages - accept `sourceType: 'commonjs'` in options for `oxc-parser` and `oxc-transform`.