### PR TITLE
feat(linter/plugins): support `commonjs` source type in `RuleTester`

### DIFF
--- a/apps/oxlint/conformance/snapshot.md
+++ b/apps/oxlint/conformance/snapshot.md
@@ -18,8 +18,8 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests | 33090 | 100.0% |
-| Passing     | 32699 |  98.8% |
-| Failing     |   284 |   0.9% |
+| Passing     | 32703 |  98.8% |
+| Failing     |   280 |   0.8% |
 | Skipped     |   107 |   0.3% |
 
 ## Fully Passing Rules
@@ -317,7 +317,7 @@
 - `prefer-regex-literals` - 249 / 251 (99.2%)
 - `radix` - 53 / 54 (98.1%)
 - `semi` - 307 / 308 (99.7%)
-- `strict` - 106 / 126 (84.1%)
+- `strict` - 110 / 126 (87.3%)
 - `unicode-bom` - 4 / 7 (57.1%)
 
 ## Rules with Failures Detail
@@ -14073,8 +14073,8 @@ AssertionError [ERR_ASSERTION]: Should have 2 errors but had 1: [
 
 ### `strict`
 
-Pass: 106 / 126 (84.1%)
-Fail: 20 / 126 (15.9%)
+Pass: 110 / 126 (87.3%)
+Fail: 16 / 126 (12.7%)
 Skip: 0 / 126 (0.0%)
 
 #### strict > valid
@@ -14352,107 +14352,6 @@ AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
 ]
 
 1 !== 0
-
-    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### strict > valid
-
-```js
-'use strict'; module.exports = function identity (value) { return value; }
-```
-
-```json
-{
-  "languageOptions": {
-    "sourceType": "commonjs"
-  }
-}
-```
-
-AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
-  {
-    ruleId: 'rule-to-test/strict',
-    message: "Use the function form of 'use strict'.",
-    messageId: 'function',
-    severity: 1,
-    nodeType: 'Literal',
-    line: 1,
-    column: 0,
-    endLine: 1,
-    endColumn: 13,
-    suggestions: null
-  },
-  {
-    ruleId: 'rule-to-test/strict',
-    message: "Use the function form of 'use strict'.",
-    messageId: 'function',
-    severity: 1,
-    nodeType: 'FunctionExpression',
-    line: 1,
-    column: 31,
-    endLine: 1,
-    endColumn: 74,
-    suggestions: null
-  }
-]
-
-2 !== 0
-
-    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### strict > valid
-
-```js
-'use strict'; module.exports = function identity (value) { return value; }
-```
-
-```json
-{
-  "options": [
-    "safe"
-  ],
-  "languageOptions": {
-    "sourceType": "commonjs"
-  }
-}
-```
-
-AssertionError [ERR_ASSERTION]: Should have no errors but had 2: [
-  {
-    ruleId: 'rule-to-test/strict',
-    message: "Use the function form of 'use strict'.",
-    messageId: 'function',
-    severity: 1,
-    nodeType: 'Literal',
-    line: 1,
-    column: 0,
-    endLine: 1,
-    endColumn: 13,
-    suggestions: null
-  },
-  {
-    ruleId: 'rule-to-test/strict',
-    message: "Use the function form of 'use strict'.",
-    messageId: 'function',
-    severity: 1,
-    nodeType: 'FunctionExpression',
-    line: 1,
-    column: 31,
-    endLine: 1,
-    endColumn: 74,
-    suggestions: null
-  }
-]
-
-2 !== 0
 
     at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
     at assertValidTestCasePasses (apps/oxlint/dist/index.js)
@@ -14932,75 +14831,6 @@ AssertionError [ERR_ASSERTION]: messageId 'unnecessaryInClasses' does not match 
 
 + 'unnecessaryInClasses'
 - 'implied'
-
-    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### strict > invalid
-
-```js
-module.exports = function identity (value) { return value; }
-```
-
-```json
-{
-  "output": null,
-  "options": [
-    "safe"
-  ],
-  "languageOptions": {
-    "sourceType": "commonjs"
-  },
-  "errors": [
-    {
-      "messageId": "global",
-      "line": 1
-    }
-  ]
-}
-```
-
-AssertionError [ERR_ASSERTION]: messageId 'function' does not match expected messageId 'global'
-+ actual - expected
-
-+ 'function'
-- 'global'
-
-    at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)
-    at runInvalidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### strict > invalid
-
-```js
-module.exports = function identity (value) { return value; }
-```
-
-```json
-{
-  "output": null,
-  "languageOptions": {
-    "sourceType": "commonjs"
-  },
-  "errors": [
-    {
-      "messageId": "global",
-      "line": 1
-    }
-  ]
-}
-```
-
-AssertionError [ERR_ASSERTION]: messageId 'function' does not match expected messageId 'global'
-+ actual - expected
-
-+ 'function'
-- 'global'
 
     at assertInvalidTestCaseMessageIsCorrect (apps/oxlint/dist/index.js)
     at assertInvalidTestCasePasses (apps/oxlint/dist/index.js)

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -101,8 +101,7 @@ class RuleTesterShim extends RuleTester {
 
 function modifyTestCase(test: TestCase): void {
   // Enable ESLint compat mode.
-  // This makes `RuleTester` adjust column indexes in diagnostics to match ESLint's behavior,
-  // and enables `sourceType: "commonjs"`.
+  // This makes `RuleTester` adjust column indexes in diagnostics to match ESLint's behavior.
   test.eslintCompat = true;
 
   // Ignore parsing errors. ESLint's test cases include invalid code.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -140,10 +140,9 @@ interface LanguageOptionsInternal extends LanguageOptions {
 /**
  * Source type.
  *
- * - `'unambiguous'` is not supported in ESLint compatibility mode.
- * - `'commonjs'` is only supported in ESLint compatibility mode.
+ * `'unambiguous'` is not supported in ESLint compatibility mode.
  */
-type SourceType = "script" | "module" | "unambiguous" | "commonjs";
+type SourceType = "script" | "module" | "commonjs" | "unambiguous";
 
 /**
  * Value of a property in `globals` object.
@@ -1037,28 +1036,14 @@ function getParseOptions(test: TestCase): ParseOptions {
   if (languageOptions.parser != null) throw new Error("Custom parsers are not supported");
 
   // Handle `languageOptions.sourceType`
-  let { sourceType } = languageOptions;
+  const { sourceType } = languageOptions;
   if (sourceType != null) {
-    if (test.eslintCompat === true) {
-      // ESLint compatibility mode.
-      // `unambiguous` is disallowed. Treat `commonjs` as `script`.
-      if (sourceType === "commonjs") {
-        sourceType = "script";
-      } else if (sourceType === "unambiguous") {
-        throw new Error(
-          "'unambiguous' source type is not supported in ESLint compatibility mode.\n" +
-            "Disable ESLint compatibility mode by setting `eslintCompat` to `false` in the config / test case.",
-        );
-      }
-    } else {
-      // Not ESLint compatibility mode.
-      // `commonjs` is disallowed.
-      if (sourceType === "commonjs") {
-        throw new Error(
-          "'commonjs' source type is only supported in ESLint compatibility mode.\n" +
-            "Enable ESLint compatibility mode by setting `eslintCompat` to `true` in the config / test case.",
-        );
-      }
+    // `unambiguous` is disallowed in ESLint compatibility mode
+    if (test.eslintCompat === true && sourceType === "unambiguous") {
+      throw new Error(
+        "'unambiguous' source type is not supported in ESLint compatibility mode.\n" +
+          "Disable ESLint compatibility mode by setting `eslintCompat` to `false` in the config / test case.",
+      );
     }
 
     parseOptions.sourceType = sourceType;

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1198,138 +1198,71 @@ describe("RuleTester", () => {
       });
 
       describe("commonjs", () => {
-        describe("with `eslintCompat` option", () => {
-          it("set globally", () => {
-            RuleTester.setDefaultConfig({
-              languageOptions: { sourceType: "commonjs" },
-              eslintCompat: true,
-            });
-
-            const tester = new RuleTester();
-            tester.run("no-foo", simpleRule, {
-              valid: ["with (obj) {}", "import x from 'foo';"],
-              invalid: [],
-            });
-
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                null,
-                [Error: Parsing failed],
-              ]
-            `);
+        it("set globally", () => {
+          RuleTester.setDefaultConfig({
+            languageOptions: { sourceType: "commonjs" },
           });
 
-          it("set in `RuleTester` options", () => {
-            const tester = new RuleTester({
-              languageOptions: { sourceType: "commonjs" },
-              eslintCompat: true,
-            });
-            tester.run("no-foo", simpleRule, {
-              valid: ["with (obj) {}", "import x from 'foo';"],
-              invalid: [],
-            });
-
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                null,
-                [Error: Parsing failed],
-              ]
-            `);
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: ["with (obj) {}", "return 123;", "import x from 'foo';"],
+            invalid: [],
           });
 
-          it("set in individual test cases", () => {
-            const tester = new RuleTester();
-            tester.run("no-foo", simpleRule, {
-              valid: [
-                {
-                  code: "with (obj) {}",
-                  languageOptions: { sourceType: "commonjs" },
-                  eslintCompat: true,
-                },
-                {
-                  code: "import x from 'foo';",
-                  languageOptions: { sourceType: "commonjs" },
-                  eslintCompat: true,
-                },
-              ],
-              invalid: [],
-            });
-
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                null,
-                [Error: Parsing failed],
-              ]
-            `);
-          });
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
         });
 
-        describe("without `eslintCompat` option", () => {
-          it("set globally", () => {
-            RuleTester.setDefaultConfig({
-              languageOptions: { sourceType: "commonjs" },
-            });
-
-            const tester = new RuleTester();
-            tester.run("no-foo", simpleRule, {
-              valid: ["with (obj) {}", "import x from 'foo';"],
-              invalid: [],
-            });
-
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-              ]
-            `);
+        it("set in `RuleTester` options", () => {
+          const tester = new RuleTester({
+            languageOptions: { sourceType: "commonjs" },
+          });
+          tester.run("no-foo", simpleRule, {
+            valid: ["with (obj) {}", "return 123;", "import x from 'foo';"],
+            invalid: [],
           });
 
-          it("set in `RuleTester` options", () => {
-            const tester = new RuleTester({
-              languageOptions: { sourceType: "commonjs" },
-            });
-            tester.run("no-foo", simpleRule, {
-              valid: ["with (obj) {}", "import x from 'foo';"],
-              invalid: [],
-            });
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
+        });
 
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-              ]
-            `);
+        it("set in individual test cases", () => {
+          const tester = new RuleTester();
+          tester.run("no-foo", simpleRule, {
+            valid: [
+              {
+                code: "with (obj) {}",
+                languageOptions: { sourceType: "commonjs" },
+              },
+              {
+                code: "return 123;",
+                languageOptions: { sourceType: "commonjs" },
+              },
+              {
+                code: "import x from 'foo';",
+                languageOptions: { sourceType: "commonjs" },
+              },
+            ],
+            invalid: [],
           });
 
-          it("set in individual test cases", () => {
-            const tester = new RuleTester();
-            tester.run("no-foo", simpleRule, {
-              valid: [
-                {
-                  code: "with (obj) {}",
-                  languageOptions: { sourceType: "commonjs" },
-                },
-                {
-                  code: "import x from 'foo';",
-                  languageOptions: { sourceType: "commonjs" },
-                },
-              ],
-              invalid: [],
-            });
-
-            expect(runCases()).toMatchInlineSnapshot(`
-              [
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-                [Error: 'commonjs' source type is only supported in ESLint compatibility mode.
-              Enable ESLint compatibility mode by setting \`eslintCompat\` to \`true\` in the config / test case.],
-              ]
-            `);
-          });
+          expect(runCases()).toMatchInlineSnapshot(`
+            [
+              null,
+              null,
+              [Error: Parsing failed],
+            ]
+          `);
         });
       });
 


### PR DESCRIPTION
`commonjs` source type was previously supported in `RuleTester` only with `eslintCompat` option enabled (and it was then treated as `script`).

#18089 added support in Oxc parser for `commonjs`. Accept it in `RuleTester` (either with or without ESLint compatibility mode) and parse properly as CommonJS.