### PR TITLE
docs(linter): Fix a mistake in the documentation for prefer-ts-expect-error

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     /// const multiLine: number = 'value';
     /// ```
     ///
-    /// Examples of **incorrect** code for this rule:
+    /// Examples of **correct** code for this rule:
     /// ```ts
     /// /**
     /// * Explaining comment


### PR DESCRIPTION
Suggested by https://github.com/oxc-project/oxc-project.github.io/pull/803