### PR TITLE
docs(linter): Fix formatting for empty-brace-spaces rule example.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -29,12 +29,15 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
+    /// <!-- prettier-ignore-start -->
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// const a = {  };
     /// class A {
     /// }
     /// ```
+    ///
+    /// <!-- prettier-ignore-end -->
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript


### PR DESCRIPTION
Add ignore comments to prevent oxfmt/prettier reformatting the example code here.

Pointed out by https://github.com/oxc-project/oxc-project.github.io/pull/801