### PR TITLE
chore(prettier_conformance): ignore fbt tests

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 741/761 (97.37%)
+js compatibility: 741/760 (97.50%)
 
 # Failed
 
@@ -21,6 +21,5 @@ js compatibility: 741/761 (97.37%)
 | js/strings/template-literals.js | 💥💥 | 98.01% |
 | js/ternaries/parenthesis/await-expression.js | 💥 | 33.33% |
 | js/top-level-await/test.js | 💥 | 0.00% |
-| jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/top-level-await/test.jsx | 💥 | 0.00% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,10 +1,9 @@
-ts compatibility: 581/606 (95.87%)
+ts compatibility: 581/605 (96.03%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| jsx/fbt/test.js | 💥 | 84.06% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | jsx/top-level-await/test.jsx | 💥 | 0.00% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -16,6 +16,8 @@ pub const IGNORE_TESTS: &[&str] = &[
     "js/async-do-expressions/",
     "js/do/",
     "jsx/do/",
+    // Facebook Translation (fbt) is not supported
+    "jsx/fbt/",
     // Experimental syntax: `export X from "mod"`
     "js/export-default/export-default-from/",
     "js/export-default/escaped/default-escaped.js",


### PR DESCRIPTION
## Summary

- Ignore fbt (Facebook Translation) tests in prettier conformance since it's a non-standard JSX syntax we don't need to support

Closes #18071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)