### PR TITLE
fix(ci): add --workspace flag to 32-bit cross test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           tools: cross
       # `--lib --bins --tests` to skip doctests which are very slow to run via `cross`.
       # https://github.com/cross-rs/cross/issues/1703
-      - run: cross test --lib --bins --tests --all-features --exclude oxc_language_server --exclude oxc_linter --exclude oxlint --target armv7-unknown-linux-gnueabihf
+      - run: cross test --workspace --lib --bins --tests --all-features --exclude oxc_language_server --exclude oxc_linter --exclude oxlint --target armv7-unknown-linux-gnueabihf
 
   test-wasm32-wasip1-threads:
     name: Test wasm32-wasip1-threads


### PR DESCRIPTION
## Summary
- Add missing `--workspace` flag to the 32-bit CI test command
- The `--exclude` flag requires `--workspace` to function correctly in Cargo

Fixes https://github.com/oxc-project/oxc/actions/runs/21125647983/job/60746354306

## Test plan
- [ ] CI should pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)