### PR TITLE
fix(oxfmt): Apply `.editorconfig` root section with `oxfmtrc.overrides`

### DIFF
--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/__snapshots__/oxfmtrc_overrides.test.ts.snap
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/__snapshots__/oxfmtrc_overrides.test.ts.snap
@@ -47,6 +47,21 @@ Finished in <variable>ms on 7 files using 1 threads.
 --------------------"
 `;
 
+exports[`oxfmtrc overrides > editorconfig root section applies with oxfmtrc overrides 1`] = `
+"--------------------
+arguments: --check test.js
+working directory: oxfmtrc_overrides/fixtures/editorconfig_root_only
+exit code: 0
+--- STDOUT ---------
+Checking formatting...
+
+All matched files use the correct format.
+Finished in <variable>ms on 1 files using 1 threads.
+--- STDERR ---------
+
+--------------------"
+`;
+
 exports[`oxfmtrc overrides > multiple overrides - later overrides take precedence 1`] = `
 "--------------------
 arguments: --check .

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/.editorconfig
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_style = tab

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "overrides": [{ "files": ["*.js"], "options": { "semi": false } }]
+}

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/test.js
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/editorconfig_root_only/test.js
@@ -1,0 +1,3 @@
+if (true) {
+	console.log("hello")
+}

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/oxfmtrc_overrides.test.ts
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/oxfmtrc_overrides.test.ts
@@ -36,6 +36,21 @@ describe("oxfmtrc overrides", () => {
     expect(snapshot).toMatchSnapshot();
   });
 
+  // .editorconfig:
+  //   [*] indent_style=tab
+  // .oxfmtrc.json:
+  //   overrides: [{ files: ["*.js"], options: { semi: false } }]
+  //
+  // Expected:
+  // - test.js: useTabs=true (from editorconfig [*]), semi=false (from oxfmtrc overrides)
+  //
+  // This test verifies editorconfig [*] section is applied even when oxfmtrc overrides trigger slow path
+  it("editorconfig root section applies with oxfmtrc overrides", async () => {
+    const cwd = join(fixturesDir, "editorconfig_root_only");
+    const snapshot = await runAndSnapshot(cwd, [["--check", "test.js"]]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
   // .oxfmtrc.json:
   //   tabWidth: 2
   //   overrides: [{ files: ["src/*.js"], options: { tabWidth: 4 } }]


### PR DESCRIPTION
Fixed a bug found through self-review.