### PR TITLE
chore(linter): Update Vitest tests to match the rulegen-generated rules better.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -96,46 +96,46 @@ fn test() {
         r#"it("foo", function () {})"#,
         "it('foo', () => {}); function myTest() { if ('bar') {} }",
         r#"function myFunc(str: string) {
-			    return str;
-			  }
-			  describe("myTest", () => {
-			     it("convert shortened equal filter", () => {
-			      expect(
-			      myFunc("5")
-			      ).toEqual("5");
-			     });
-			    });"#,
+                return str;
+              }
+              describe("myTest", () => {
+                 it("convert shortened equal filter", () => {
+                  expect(
+                  myFunc("5")
+                  ).toEqual("5");
+                 });
+                });"#,
         r#"describe("shows error", () => {
-			     if (1 === 2) {
-			      myFunc();
-			     }
-			     expect(true).toBe(false);
-			    });"#,
+                 if (1 === 2) {
+                  myFunc();
+                 }
+                 expect(true).toBe(false);
+                });"#,
     ];
 
     let fail = vec![
         r#"describe("shows error", () => {
-			    if(true) {
-			     test("shows error", () => {
-			      expect(true).toBe(true);
-			     })
-			    }
-			   })"#,
+                if(true) {
+                 test("shows error", () => {
+                  expect(true).toBe(true);
+                 })
+                }
+               })"#,
         r#"
-			   describe("shows error", () => {
-			    if(true) {
-			     it("shows error", () => {
-			      expect(true).toBe(true);
-			      })
-			     }
-			   })"#,
+               describe("shows error", () => {
+                if(true) {
+                 it("shows error", () => {
+                  expect(true).toBe(true);
+                  })
+                 }
+               })"#,
         r#"describe("errors", () => {
-			    if (Math.random() > 0) {
-			     test("test2", () => {
-			     expect(true).toBeTruthy();
-			    });
-			    }
-			   });"#,
+                if (Math.random() > 0) {
+                 test("test2", () => {
+                 expect(true).toBeTruthy();
+                });
+                }
+               });"#,
     ];
 
     Tester::new(NoConditionalTests::NAME, NoConditionalTests::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -69,16 +69,13 @@ impl Rule for NoImportNodeTest {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![(r#"import { test } from "vitest""#, None)];
+    let pass = vec![r#"import { test } from "vitest""#];
 
-    let fail = vec![
-        (r#"import { test } from "node:test""#, None),
-        ("import * as foo from 'node:test'", None),
-    ];
+    let fail = vec![r#"import { test } from "node:test""#, "import * as foo from 'node:test'"];
 
     let fix = vec![
-        (r#"import { test } from "node:test""#, r#"import { test } from "vitest""#, None),
-        (r#"import * as foo from "node:test""#, r#"import * as foo from "vitest""#, None),
+        (r#"import { test } from "node:test""#, r#"import { test } from "vitest""#),
+        ("import * as foo from 'node:test'", r#"import * as foo from "vitest""#),
     ];
 
     Tester::new(NoImportNodeTest::NAME, NoImportNodeTest::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
@@ -222,6 +222,7 @@ fn test() {
             "expect(fn).resolves.toHaveBeenCalledOnce(/*comment,*//*comment,*/);",
         ),
     ];
+
     Tester::new(PreferCalledOnce::NAME, PreferCalledOnce::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_vitest_plugin(true)

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_times.rs
@@ -160,21 +160,17 @@ fn test() {
     ];
 
     let fix = vec![
-        ("expect(fn).toBeCalledOnce();", "expect(fn).toBeCalledTimes(1);", None),
-        ("expect(fn).toHaveBeenCalledOnce();", "expect(fn).toHaveBeenCalledTimes(1);", None),
-        ("expect(fn).not.toBeCalledOnce();", "expect(fn).not.toBeCalledTimes(1);", None),
-        (
-            "expect(fn).not.toHaveBeenCalledOnce();",
-            "expect(fn).not.toHaveBeenCalledTimes(1);",
-            None,
-        ),
-        ("expect(fn).resolves.toBeCalledOnce();", "expect(fn).resolves.toBeCalledTimes(1);", None),
+        ("expect(fn).toBeCalledOnce();", "expect(fn).toBeCalledTimes(1);"),
+        ("expect(fn).toHaveBeenCalledOnce();", "expect(fn).toHaveBeenCalledTimes(1);"),
+        ("expect(fn).not.toBeCalledOnce();", "expect(fn).not.toBeCalledTimes(1);"),
+        ("expect(fn).not.toHaveBeenCalledOnce();", "expect(fn).not.toHaveBeenCalledTimes(1);"),
+        ("expect(fn).resolves.toBeCalledOnce();", "expect(fn).resolves.toBeCalledTimes(1);"),
         (
             "expect(fn).resolves.toHaveBeenCalledOnce();",
             "expect(fn).resolves.toHaveBeenCalledTimes(1);",
-            None,
         ),
     ];
+
     Tester::new(PreferCalledTimes::NAME, PreferCalledTimes::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
@@ -84,25 +84,20 @@ fn test() {
     ];
 
     let fix = vec![
-        ("expect(true).toBe(false);", "expect(true).toBeFalsy();", None),
-        ("expect(wasSuccessful).toEqual(false);", "expect(wasSuccessful).toBeFalsy();", None),
+        ("expect(true).toBe(false);", "expect(true).toBeFalsy();"),
+        ("expect(wasSuccessful).toEqual(false);", "expect(wasSuccessful).toBeFalsy();"),
         (
             "expect(fs.existsSync('/path/to/file')).toStrictEqual(false);",
             "expect(fs.existsSync('/path/to/file')).toBeFalsy();",
-            None,
         ),
-        (r#"expect("a string").not.toBe(false);"#, r#"expect("a string").not.toBeFalsy();"#, None),
-        (
-            r#"expect("a string").not.toEqual(false);"#,
-            r#"expect("a string").not.toBeFalsy();"#,
-            None,
-        ),
+        (r#"expect("a string").not.toBe(false);"#, r#"expect("a string").not.toBeFalsy();"#),
+        (r#"expect("a string").not.toEqual(false);"#, r#"expect("a string").not.toBeFalsy();"#),
         (
             r#"expectTypeOf("a string").not.toEqual(false);"#,
             r#"expectTypeOf("a string").not.toBeFalsy();"#,
-            None,
         ),
     ];
+
     Tester::new(PreferToBeFalsy::NAME, PreferToBeFalsy::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_vitest_plugin(true)

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
@@ -198,48 +198,26 @@ fn test() {
     ];
 
     let fix = vec![
-        (
-            "expectTypeOf(({} instanceof Object)).toBeTruthy();",
-            "expectTypeOf(({})).toBeObject();",
-            None,
-        ),
-        (
-            "expectTypeOf({} instanceof Object).toBeTruthy();",
-            "expectTypeOf({}).toBeObject();",
-            None,
-        ),
+        ("expectTypeOf(({} instanceof Object)).toBeTruthy();", "expectTypeOf(({})).toBeObject();"),
+        ("expectTypeOf({} instanceof Object).toBeTruthy();", "expectTypeOf({}).toBeObject();"),
         (
             "expectTypeOf({} instanceof Object).not.toBeTruthy();",
             "expectTypeOf({}).not.toBeObject();",
-            None,
         ),
-        (
-            "expectTypeOf({} instanceof Object).toBeFalsy();",
-            "expectTypeOf({}).not.toBeObject();",
-            None,
-        ),
-        (
-            "expectTypeOf({} instanceof Object).not.toBeFalsy();",
-            "expectTypeOf({}).toBeObject();",
-            None,
-        ),
-        ("expectTypeOf({}).toBeInstanceOf(Object);", "expectTypeOf({}).toBeObject();", None),
-        (
-            "expectTypeOf({}).not.toBeInstanceOf(Object);",
-            "expectTypeOf({}).not.toBeObject();",
-            None,
-        ),
+        ("expectTypeOf({} instanceof Object).toBeFalsy();", "expectTypeOf({}).not.toBeObject();"),
+        ("expectTypeOf({} instanceof Object).not.toBeFalsy();", "expectTypeOf({}).toBeObject();"),
+        ("expectTypeOf({}).toBeInstanceOf(Object);", "expectTypeOf({}).toBeObject();"),
+        ("expectTypeOf({}).not.toBeInstanceOf(Object);", "expectTypeOf({}).not.toBeObject();"),
         (
             "expectTypeOf(requestValues()).resolves.toBeInstanceOf(Object);",
             "expectTypeOf(requestValues()).resolves.toBeObject();",
-            None,
         ),
         (
             "expectTypeOf(queryApi()).resolves.not.toBeInstanceOf(Object);",
             "expectTypeOf(queryApi()).resolves.not.toBeObject();",
-            None,
         ),
     ];
+
     Tester::new(PreferToBeObject::NAME, PreferToBeObject::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
@@ -147,26 +147,21 @@ fn test() {
     ];
 
     let fix = vec![
-        ("expect(false).toBe(true);", "expect(false).toBeTruthy();", None),
-        ("expectTypeOf(false).toBe(true);", "expectTypeOf(false).toBeTruthy();", None),
-        ("expect(wasSuccessful).toEqual(true);", "expect(wasSuccessful).toBeTruthy();", None),
+        ("expect(false).toBe(true);", "expect(false).toBeTruthy();"),
+        ("expectTypeOf(false).toBe(true);", "expectTypeOf(false).toBeTruthy();"),
+        ("expect(wasSuccessful).toEqual(true);", "expect(wasSuccessful).toBeTruthy();"),
         (
             "expect(fs.existsSync('/path/to/file')).toStrictEqual(true);",
             "expect(fs.existsSync('/path/to/file')).toBeTruthy();",
-            None,
         ),
-        (r#"expect("a string").not.toBe(true);"#, r#"expect("a string").not.toBeTruthy();"#, None),
-        (
-            r#"expect("a string").not.toEqual(true);"#,
-            r#"expect("a string").not.toBeTruthy();"#,
-            None,
-        ),
+        (r#"expect("a string").not.toBe(true);"#, r#"expect("a string").not.toBeTruthy();"#),
+        (r#"expect("a string").not.toEqual(true);"#, r#"expect("a string").not.toBeTruthy();"#),
         (
             r#"expectTypeOf("a string").not.toStrictEqual(true);"#,
             r#"expectTypeOf("a string").not.toBeTruthy();"#,
-            None,
         ),
     ];
+
     Tester::new(PreferToBeTruthy::NAME, PreferToBeTruthy::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_vitest_plugin(true)

--- a/crates/oxc_linter/src/rules/vitest/warn_todo.rs
+++ b/crates/oxc_linter/src/rules/vitest/warn_todo.rs
@@ -120,26 +120,26 @@ fn test() {
     }
 
     let pass = vec![
-        (vitest_context!("describe('foo', function () {})"), None),
-        (vitest_context!("it('foo', function () {})"), None),
-        (vitest_context!("it.concurrent('foo', function () {})"), None),
-        (vitest_context!("test('foo', function () {})"), None),
-        (vitest_context!("test.concurrent('foo', function () {})"), None),
-        (vitest_context!("describe.only('foo', function () {})"), None),
-        (vitest_context!("it.only('foo', function () {})"), None),
-        (vitest_context!("it.each()('foo', function () {})"), None),
+        (vitest_context!(r#"describe("foo", function () {})"#)),
+        (vitest_context!(r#"it("foo", function () {})"#)),
+        (vitest_context!(r#"it.concurrent("foo", function () {})"#)),
+        (vitest_context!(r#"test("foo", function () {})"#)),
+        (vitest_context!(r#"test.concurrent("foo", function () {})"#)),
+        (vitest_context!(r#"describe.only("foo", function () {})"#)),
+        (vitest_context!(r#"it.only("foo", function () {})"#)),
+        (vitest_context!(r#"it.each()("foo", function () {})"#)),
     ];
 
     let fail = vec![
-        (vitest_context!("describe.todo('foo', function () {})"), None),
-        (vitest_context!("it.todo('foo', function () {})"), None),
-        (vitest_context!("test.todo('foo', function () {})"), None),
-        (vitest_context!("describe.todo.each([])('foo', function () {})"), None),
-        (vitest_context!("it.todo.each([])('foo', function () {})"), None),
-        (vitest_context!("test.todo.each([])('foo', function () {})"), None),
-        (vitest_context!("describe.only.todo('foo', function () {})"), None),
-        (vitest_context!("it.only.todo('foo', function () {})"), None),
-        (vitest_context!("test.only.todo('foo', function () {})"), None),
+        (vitest_context!(r#"describe.todo("foo", function () {})"#)),
+        (vitest_context!(r#"it.todo("foo", function () {})"#)),
+        (vitest_context!(r#"test.todo("foo", function () {})"#)),
+        (vitest_context!(r#"describe.todo.each([])("foo", function () {})"#)),
+        (vitest_context!(r#"it.todo.each([])("foo", function () {})"#)),
+        (vitest_context!(r#"test.todo.each([])("foo", function () {})"#)),
+        (vitest_context!(r#"describe.only.todo("foo", function () {})"#)),
+        (vitest_context!(r#"it.only.todo("foo", function () {})"#)),
+        (vitest_context!(r#"test.only.todo("foo", function () {})"#)),
     ];
 
     Tester::new(WarnTodo::NAME, WarnTodo::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/vitest_no_conditional_tests.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_conditional_tests.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-vitest(no-conditional-tests): Avoid having conditionals in tests
-   ╭─[no_conditional_tests.tsx:2:8]
+   ╭─[no_conditional_tests.tsx:2:17]
  1 │     describe("shows error", () => {
  2 │ ╭─▶                 if(true) {
  3 │ │                    test("shows error", () => {
@@ -14,7 +14,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the surrounding if statement.
 
   ⚠ eslint-plugin-vitest(no-conditional-tests): Avoid having conditionals in tests
-   ╭─[no_conditional_tests.tsx:3:8]
+   ╭─[no_conditional_tests.tsx:3:17]
  2 │                    describe("shows error", () => {
  3 │ ╭─▶                 if(true) {
  4 │ │                    it("shows error", () => {
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the surrounding if statement.
 
   ⚠ eslint-plugin-vitest(no-conditional-tests): Avoid having conditionals in tests
-   ╭─[no_conditional_tests.tsx:2:8]
+   ╭─[no_conditional_tests.tsx:2:17]
  1 │     describe("errors", () => {
  2 │ ╭─▶                 if (Math.random() > 0) {
  3 │ │                    test("test2", () => {

--- a/crates/oxc_linter/src/snapshots/vitest_warn_todo.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_warn_todo.snap
@@ -4,7 +4,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:10]
  2 │ 
- 3 │ describe.todo('foo', function () {})
+ 3 │ describe.todo("foo", function () {})
    ·          ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:4]
  2 │ 
- 3 │ it.todo('foo', function () {})
+ 3 │ it.todo("foo", function () {})
    ·    ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -20,7 +20,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:6]
  2 │ 
- 3 │ test.todo('foo', function () {})
+ 3 │ test.todo("foo", function () {})
    ·      ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:10]
  2 │ 
- 3 │ describe.todo.each([])('foo', function () {})
+ 3 │ describe.todo.each([])("foo", function () {})
    ·          ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -36,7 +36,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:4]
  2 │ 
- 3 │ it.todo.each([])('foo', function () {})
+ 3 │ it.todo.each([])("foo", function () {})
    ·    ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:6]
  2 │ 
- 3 │ test.todo.each([])('foo', function () {})
+ 3 │ test.todo.each([])("foo", function () {})
    ·      ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -52,7 +52,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:15]
  2 │ 
- 3 │ describe.only.todo('foo', function () {})
+ 3 │ describe.only.todo("foo", function () {})
    ·               ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -60,7 +60,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:9]
  2 │ 
- 3 │ it.only.todo('foo', function () {})
+ 3 │ it.only.todo("foo", function () {})
    ·         ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.
@@ -68,7 +68,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-vitest(warn-todo): The use of `.todo` is not recommended.
    ╭─[warn_todo.tsx:3:11]
  2 │ 
- 3 │ test.only.todo('foo', function () {})
+ 3 │ test.only.todo("foo", function () {})
    ·           ────
    ╰────
   help: Write an actual test and remove the `.todo` modifier before pushing/merging your changes.


### PR DESCRIPTION
Basically just formatting fixes.