### PR TITLE
docs(linter): Cleanup docs for various rules for consistency.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// /* eslint eqeqeq: "error" */
+    /// /* eqeqeq: "error" */
     ///
     /// if (x == 42) {}
     /// if ("" == text) {}
@@ -75,7 +75,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    /// /* eslint eqeqeq: "error" */
+    /// /* eqeqeq: "error" */
     ///
     /// if (x === 42) {}
     /// if ("" === text) {}
@@ -86,7 +86,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule with the `"smart"` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "smart"] */
+    /// /* eqeqeq: ["error", "smart"] */
     ///
     /// if (x == 42) {}
     /// if ("" == text) {}
@@ -94,7 +94,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule with the `"smart"` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "smart"] */
+    /// /* eqeqeq: ["error", "smart"] */
     ///
     /// if (typeof foo == "undefined") {}
     /// if (foo == null) {}
@@ -105,14 +105,14 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule with the `{ "null": "ignore" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "ignore" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "ignore" }] */
     /// if (x == 42) {}
     /// if ("" == text) {}
     /// ```
     ///
     /// Examples of **correct** code for this rule with the `{ "null": "ignore" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "ignore" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "ignore" }] */
     /// if (foo == null) {}
     /// if (foo != null) {}
     /// ```
@@ -121,7 +121,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule with the `{ "null": "always" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "always" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "always" }] */
     ///
     /// if (foo == null) {}
     /// if (foo != null) {}
@@ -129,7 +129,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule with the `{ "null": "always" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "always" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "always" }] */
     ///
     /// if (foo === null) {}
     /// if (foo !== null) {}
@@ -139,7 +139,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule with the `{ "null": "never" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "never" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "never" }] */
     ///
     /// if (x == 42) {}
     /// if ("" == text) {}
@@ -149,7 +149,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule with the `{ "null": "never" }` option:
     /// ```js
-    /// /* eslint eqeqeq: ["error", "always", { "null": "never" }] */
+    /// /* eqeqeq: ["error", "always", { "null": "never" }] */
     ///
     /// if (x === 42) {}
     /// if ("" === text) {}

--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -98,7 +98,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
+    /// /* id-length: "error" */     // default is minimum 2-chars ({ "min": 2 })
     ///
     /// const x = 5;
     /// obj.e = document.body;
@@ -127,7 +127,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    /// /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
+    /// /* id-length: "error" */     // default is minimum 2-chars ({ "min": 2 })
     ///
     /// const num = 5;
     /// function _f() { return 42; }

--- a/crates/oxc_linter/src/rules/eslint/init_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/init_declarations.rs
@@ -57,9 +57,9 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// In JavaScript, variables can be assigned during declaration, or at any point afterwards using an assignment statement.
-    /// For example, in the following code, foo is initialized during declaration, while bar is initialized later.
+    /// For example, in the following code, `foo` is initialized during declaration, while `bar` is initialized later.
     ///
-    /// ### Examples
+    /// ```js
     /// var foo = 1;
     /// var bar;
     /// if (foo) {
@@ -67,19 +67,22 @@ declare_oxc_lint!(
     /// } else {
     ///     bar = 2;
     /// }
+    /// ```
     ///
-    /// Examples of incorrect code for the default "always" option:
+    /// ### Examples
+    ///
+    /// Examples of incorrect code for the default `"always"` option:
     /// ```js
-    /// /*eslint init-declarations: ["error", "always"]*/
+    /// /* init-declarations: ["error", "always"] */
     /// function foo() {
     ///     var bar;
     ///     let baz;
     /// }
     /// ```
     ///
-    /// Examples of incorrect code for the "never" option:
+    /// Examples of incorrect code for the `"never"` option:
     /// ```js
-    /// /*eslint init-declarations: ["error", "never"]*/
+    /// /* init-declarations: ["error", "never"] */
     /// function foo() {
     ///     var bar = 1;
     ///     let baz = 2;
@@ -87,9 +90,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of correct code for the default "always" option:
+    /// Examples of correct code for the default `"always"` option:
     /// ```js
-    /// /*eslint init-declarations: ["error", "always"]*/
+    /// /* init-declarations: ["error", "always"] */
     ///
     /// function foo() {
     ///     var bar = 1;
@@ -98,9 +101,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of correct code for the "never" option:
+    /// Examples of correct code for the `"never"` option:
     /// ```js
-    /// /*eslint init-declarations: ["error", "never"]*/
+    /// /* init-declarations: ["error", "never"] */
     ///
     /// function foo() {
     ///     var bar;
@@ -109,9 +112,9 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of correct code for the "never", { "ignoreForLoopInit": true } options:
+    /// Examples of correct code for the `"never", { "ignoreForLoopInit": true }` options:
     /// ```js
-    /// /*eslint init-declarations: ["error", "never", { "ignoreForLoopInit": true }]*/
+    /// /* init-declarations: ["error", "never", { "ignoreForLoopInit": true }] */
     /// for (var i = 0; i < 1; i++) {}
     /// ```
     InitDeclarations,

--- a/crates/oxc_linter/src/rules/eslint/new_cap.rs
+++ b/crates/oxc_linter/src/rules/eslint/new_cap.rs
@@ -170,7 +170,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "newIsCap": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": true }]*/
+    /// /* new-cap: ["error", { "newIsCap": true }] */
     ///
     /// var friend = new person();
     /// ```
@@ -178,7 +178,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "newIsCap": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": true }]*/
+    /// /* new-cap: ["error", { "newIsCap": true }] */
     ///
     /// var friend = new Person();
     /// ```
@@ -186,7 +186,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "newIsCap": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": false }]*/
+    /// /* new-cap: ["error", { "newIsCap": false }] */
     ///
     /// var friend = new person();
     /// ```
@@ -194,7 +194,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "capIsNew": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": true }]*/
+    /// /* new-cap: ["error", { "capIsNew": true }] */
     ///
     /// var colleague = Person();
     /// ```
@@ -202,7 +202,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "capIsNew": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": true }]*/
+    /// /* new-cap: ["error", { "capIsNew": true }] */
     ///
     /// var colleague = new Person();
     /// ```
@@ -210,7 +210,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "capIsNew": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": false }]*/
+    /// /* new-cap: ["error", { "capIsNew": false }] */
     ///
     /// var colleague = Person();
     /// ```
@@ -218,7 +218,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptions": ["events"] }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptions": ["events"] }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptions": ["events"] }] */
     ///
     /// var events = require('events');
     ///
@@ -228,7 +228,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "^person\\.." }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }] */
     ///
     /// var friend = new person.acquaintance();
     ///
@@ -238,7 +238,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "\\.bar$" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }] */
     ///
     /// var friend = new person.bar();
     /// ```
@@ -246,7 +246,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptions": ["Person"] }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptions": ["Person"] }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptions": ["Person"] }] */
     ///
     /// function foo(arg) {
     ///     return Person(arg);
@@ -256,7 +256,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^person\\.." }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }] */
     ///
     /// var friend = person.Acquaintance();
     /// var bestFriend = person.Friend();
@@ -265,7 +265,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "\\.Bar$" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "\\.Bar$" }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "\\.Bar$" }] */
     ///
     /// foo.Bar();
     /// ```
@@ -273,7 +273,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^Foo" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }] */
     ///
     /// var x = Foo(42);
     ///
@@ -287,7 +287,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "properties": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": true }]*/
+    /// /* new-cap: ["error", { "properties": true }] */
     ///
     /// var friend = new person.acquaintance();
     /// ```
@@ -295,7 +295,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "properties": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": true }]*/
+    /// /* new-cap: ["error", { "properties": true }] */
     ///
     /// var friend = new person.Acquaintance();
     /// ```
@@ -303,7 +303,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "properties": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": false }]*/
+    /// /* new-cap: ["error", { "properties": false }] */
     ///
     /// var friend = new person.acquaintance();
     /// ```
@@ -311,7 +311,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "newIsCap": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": true }]*/
+    /// /* new-cap: ["error", { "newIsCap": true }] */
     ///
     /// var friend = new person();
     /// ```
@@ -319,7 +319,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "newIsCap": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": true }]*/
+    /// /* new-cap: ["error", { "newIsCap": true }] */
     ///
     /// var friend = new Person();
     /// ```
@@ -327,7 +327,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "newIsCap": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCap": false }]*/
+    /// /* new-cap: ["error", { "newIsCap": false }] */
     ///
     /// var friend = new person();
     /// ```
@@ -335,7 +335,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "capIsNew": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": true }]*/
+    /// /* new-cap: ["error", { "capIsNew": true }] */
     ///
     /// var colleague = Person();
     /// ```
@@ -343,7 +343,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "capIsNew": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": true }]*/
+    /// /* new-cap: ["error", { "capIsNew": true }] */
     ///
     /// var colleague = new Person();
     /// ```
@@ -351,7 +351,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "capIsNew": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNew": false }]*/
+    /// /* new-cap: ["error", { "capIsNew": false }] */
     ///
     /// var colleague = Person();
     /// ```
@@ -359,7 +359,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptions": ["events"] }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptions": ["events"] }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptions": ["events"] }] */
     ///
     /// var events = require('events');
     ///
@@ -369,7 +369,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "^person\\.." }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }] */
     ///
     /// var friend = new person.acquaintance();
     ///
@@ -379,7 +379,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "\\.bar$" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }]*/
+    /// /* new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }] */
     ///
     /// var friend = new person.bar();
     /// ```
@@ -389,7 +389,7 @@ declare_oxc_lint!(
     /// ::: correct
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptions": ["Person"] }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptions": ["Person"] }] */
     ///
     /// function foo(arg) {
     ///     return Person(arg);
@@ -399,7 +399,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^person\\.." }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }] */
     ///
     /// var friend = person.Acquaintance();
     /// var bestFriend = person.Friend();
@@ -408,7 +408,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "\\.Bar$" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "\\.Bar$" }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "\\.Bar$" }] */
     ///
     /// foo.Bar();
     /// ```
@@ -416,7 +416,7 @@ declare_oxc_lint!(
     /// Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^Foo" }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }]*/
+    /// /* new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }] */
     ///
     /// var x = Foo(42);
     ///
@@ -428,7 +428,7 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule with the default `{ "properties": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": true }]*/
+    /// /* new-cap: ["error", { "properties": true }] */
     ///
     /// var friend = new person.acquaintance();
     /// ```
@@ -437,7 +437,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the default `{ "properties": true }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": true }]*/
+    /// /* new-cap: ["error", { "properties": true }] */
     ///
     /// var friend = new person.Acquaintance();
     /// ```
@@ -445,7 +445,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule with the `{ "properties": false }` option:
     ///
     /// ```js
-    /// /*eslint new-cap: ["error", { "properties": false }]*/
+    /// /* new-cap: ["error", { "properties": false }] */
     ///
     /// var friend = new person.acquaintance();
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -31,8 +31,6 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// /*eslint no-proto: "error"*/
-    ///
     /// var a = obj.__proto__;
     ///
     /// var a = obj["__proto__"];

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -29,10 +29,8 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
-    /// Examples of **incorrect** code for this rule
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// /*eslint no-script-url: "error"*/
-    ///
     /// location.href = "javascript:void(0)";
     ///
     /// location.href = `javascript:void(0)`;

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -96,8 +96,8 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     ///
     /// ```javascript
-    /// /*eslint no-unused-vars: "error"*/
-    /// /*global some_unused_var*/
+    /// /* no-unused-vars: "error" */
+    /// /* if you have `some_unused_var` defined as a global in .oxlintrc.json */
     ///
     /// // It checks variables you have defined as global
     /// some_unused_var = 42;
@@ -142,7 +142,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    /// /*eslint no-unused-vars: "error"*/
+    /// /* no-unused-vars: "error" */
     ///
     /// var x = 10;
     /// alert(x);

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -41,7 +41,7 @@ pub struct NoAbsolutePath {
     /// If set to `true`, dependency paths for AMD-style define and require calls will be resolved:
     ///
     /// ```js
-    /// /* eslint import/no-absolute-path: ['error', { commonjs: false, amd: true }] */
+    /// /* import/no-absolute-path: ["error", { "commonjs": false, "amd": true }] */
     /// define(['/foo'], function (foo) { /*...*/ }) // reported
     /// require(['/foo'], function (foo) { /*...*/ }) // reported
     ///

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -94,21 +94,21 @@ declare_oxc_lint!(
     /// export default class MyClass {};
     /// export default function foo() {};
     /// export default foo(bar);
-    /// /* eslint import/no-anonymous-default-export: ['error', {"allowLiteral": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowLiteral": true }] */
     /// export default 123;
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowArray": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowArray": true }] */
     /// export default []
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowArrowFunction": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowArrowFunction": true }] */
     /// export default () => {};
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowAnonymousClass": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowAnonymousClass": true }] */
     /// export default class {};
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowAnonymousFunction": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowAnonymousFunction": true }] */
     /// export default function() {};
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowObject": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowObject": true }] */
     /// export default {};
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowNew": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowNew": true }] */
     /// export default new Foo();
-    /// /* eslint import/no-anonymous-default-export: ['error, {"allowCallExpression": true}] */
+    /// /* import/no-anonymous-default-export: ["error", { "allowCallExpression": true }] */
     /// export default foo(bar);
     /// ```
     ///

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -95,7 +95,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// ```javascript
-    /// /*eslint jest/consistent-test-it: ["error", {"fn": "test"}]*/
+    /// /* jest/consistent-test-it: ["error", {"fn": "test"}] */
     /// test('foo'); // valid
     /// test.only('foo'); // valid
     ///
@@ -104,7 +104,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ```javascript
-    /// /*eslint jest/consistent-test-it: ["error", {"fn": "it"}]*/
+    /// /* jest/consistent-test-it: ["error", {"fn": "it"}] */
     /// it('foo'); // valid
     /// it.only('foo'); // valid
     /// test('foo'); // invalid
@@ -112,7 +112,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ```javascript
-    /// /*eslint jest/consistent-test-it: ["error", {"fn": "it", "withinDescribe": "test"}]*/
+    /// /* jest/consistent-test-it: ["error", {"fn": "it", "withinDescribe": "test"}] */
     /// it('foo'); // valid
     /// describe('foo', function () {
     ///     test('bar'); // valid

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -85,7 +85,7 @@ pub struct AlwaysReturnConfig {
     /// `["globalThis"]`.
     ///
     /// ```javascript
-    /// /* eslint promise/always-return: ["error", { ignoreAssignmentVariable: ["globalThis"] }] */
+    /// /* promise/always-return: ["error", { ignoreAssignmentVariable: ["globalThis"] }] */
     ///
     /// // OK
     /// promise.then((x) => {

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -90,8 +90,8 @@ standard, Oxlint does not support this feature.
 Examples of **incorrect** code for this rule:
 
 ```javascript
-/*eslint no-unused-vars: "error"*/
-/*global some_unused_var*/
+/* no-unused-vars: "error" */
+/* if you have `some_unused_var` defined as a global in .oxlintrc.json */
 
 // It checks variables you have defined as global
 some_unused_var = 42;
@@ -136,7 +136,7 @@ enum Color {
 
 Examples of **correct** code for this rule:
 ```js
-/*eslint no-unused-vars: "error"*/
+/* no-unused-vars: "error" */
 
 var x = 10;
 alert(x);


### PR DESCRIPTION
Remove implied eslint directive comments, which are not supported, by removing the mention of eslint at the start of the comment. And then misc fixes alongside those.