### PR TITLE
chore(linter): Bump the peer dependency for oxlint-tsgolint to >=0.11.1

### DIFF
--- a/npm/oxlint/scripts/generate-packages.js
+++ b/npm/oxlint/scripts/generate-packages.js
@@ -90,7 +90,7 @@ function writeManifest() {
   // Do not automatically install 'oxlint-tsgolint'.
   // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta
   manifestData.peerDependencies = {
-    "oxlint-tsgolint": ">=0.10.0",
+    "oxlint-tsgolint": ">=0.11.1",
   };
   manifestData.peerDependenciesMeta = {
     "oxlint-tsgolint": {


### PR DESCRIPTION
To ensure that the prefer-optional-chain rule is available, otherwise you can end up with errors if you try to use it.

Technically, only 0.11.0 is necessary, but eh.