### PR TITLE
chore(linter): Add message to diagnostics optimizations debug assert

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -329,7 +329,7 @@ impl Linter {
                     assert_eq!(
                         optimized_diagnostics.len(),
                         unoptimized_diagnostics.len(),
-                        "Running with and without optimizations produced different diagnostic counts: {} vs {}",
+                        "Running with and without optimizations produced different diagnostic counts: {} vs {}.\nThis can be caused by a mismatch between the rule definition and generated RuleRunner impl. Try `cargo run -p oxc_linter_codegen` to regenerate.",
                         optimized_diagnostics.len(),
                         unoptimized_diagnostics.len()
                     );


### PR DESCRIPTION
Changing `run()` into `run_once()` during implementation will cause this assert to be triggered, but the message is not pointing to a clear direction.
It took me a while to debug this for https://github.com/oxc-project/oxc/pull/17688.

rebase: fix commit message typo