### PR TITLE
fix(ci): Add `--workspace` back to `codecov` command.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 ck = "check --all-features --all-targets --locked"
 lint = "clippy --all-targets --all-features"
 # Skip `tasks/website` due to linker errors with `oxlint`
-codecov = "llvm-cov --ignore-filename-regex tasks --exclude website"
+codecov = "llvm-cov --workspace --ignore-filename-regex tasks --exclude website"
 coverage = "run -p oxc_coverage --profile coverage --"
 benchmark = "bench -p oxc_benchmark"
 minsize = "run -p oxc_minsize --profile coverage --"


### PR DESCRIPTION
Apparently it's necessary if you want to use `--exclude`.

Regression from #18187. e.g. see https://github.com/oxc-project/oxc/actions/runs/21128701270/job/60754891058