### PR TITLE
feat(parser): add syntax errors for constructor declarations

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -554,6 +554,17 @@ pub fn constructor_generator(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn declare_constructor(span: Span) -> OxcDiagnostic {
+    ts_error("1031", "'declare' modifier cannot appear on a constructor declaration.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn constructor_return_type(span: Span) -> OxcDiagnostic {
+    ts_error("1093", "Type annotation cannot appear on a constructor declaration.").with_label(span)
+}
+
+#[cold]
 pub fn field_constructor(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Classes can't have a field named 'constructor'").with_label(span)
 }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -472,6 +472,10 @@ impl<'a> ParserImpl<'a> {
         modifiers: &Modifiers<'a>,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
+        if let Some(modifier) = modifiers.iter().find(|m| m.kind == ModifierKind::Declare) {
+            self.error(diagnostics::declare_constructor(modifier.span));
+        }
+
         let value = self.parse_method(
             modifiers.contains(ModifierKind::Async),
             false,
@@ -775,6 +779,11 @@ impl<'a> ParserImpl<'a> {
         if let Some(type_sig) = &method.value.type_parameters {
             // class Foo { constructor<T>(param: T ) {} }
             self.error(diagnostics::ts_constructor_type_parameter(type_sig.span));
+        }
+        if method.value.body.is_some()
+            && let Some(return_type) = &method.value.return_type
+        {
+            self.error(diagnostics::constructor_return_type(return_type.span));
         }
     }
 }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: f5ccf434
 parser_typescript Summary:
 AST Parsed     : 9844/9845 (99.99%)
 Positive Passed: 9836/9845 (99.91%)
-Negative Passed: 1498/2549 (58.77%)
+Negative Passed: 1500/2549 (58.85%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -1746,11 +1746,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration2.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration2.ts
 
@@ -21409,6 +21405,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │ }
    ╰────
 
+  × TS(1093): Type annotation cannot appear on a constructor declaration.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts:2:16]
+ 1 │ class C {
+ 2 │   constructor(): number { }
+   ·                ────────
+ 3 │ }
+   ╰────
+
   × TS(1098): Type parameter list cannot be empty.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts:2:14]
  1 │ class C {
@@ -21431,6 +21435,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  1 │ class C {
  2 │   export constructor() { }
    ·   ──────
+ 3 │ }
+   ╰────
+
+  × TS(1031): 'declare' modifier cannot appear on a constructor declaration.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration4.ts:2:3]
+ 1 │ class C {
+ 2 │   declare constructor() { }
+   ·   ───────
  3 │ }
    ╰────
 


### PR DESCRIPTION
## Summary

- Add TS1031 error for `declare` modifier on constructor: `declare constructor() {}`
- Add TS1093 error for return type annotation on constructor: `constructor(): number {}`

## Test plan

- Parser conformance tests updated
- Negative Passed: 1498 → 1500 (+2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)