### PR TITLE
fix(transformer): use `require` not `import` in CommonJS files

### DIFF
--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -159,10 +159,10 @@ impl<'a> ModuleImportsStore<'a> {
 
     /// Insert `import` / `require` statements at top of program.
     fn insert_into_program(&self, transform_ctx: &TransformCtx<'a>, ctx: &mut TraverseCtx<'a>) {
-        if transform_ctx.source_type.is_script() {
-            self.insert_require_statements(transform_ctx, ctx);
-        } else {
+        if transform_ctx.source_type.is_module() {
             self.insert_import_statements(transform_ctx, ctx);
+        } else {
+            self.insert_require_statements(transform_ctx, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -460,15 +460,15 @@ impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
                     }
                 };
 
-                if ctx.source_type.is_script() {
-                    Bindings::AutomaticScript(AutomaticScriptBindings::new(
+                if ctx.source_type.is_module() {
+                    Bindings::AutomaticModule(AutomaticModuleBindings::new(
                         ctx,
                         jsx_runtime_importer,
                         source_len,
                         is_development,
                     ))
                 } else {
-                    Bindings::AutomaticModule(AutomaticModuleBindings::new(
+                    Bindings::AutomaticScript(AutomaticScriptBindings::new(
                         ctx,
                         jsx_runtime_importer,
                         source_len,
@@ -509,10 +509,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for JsxImpl<'a, '_> {
 }
 
 impl<'a> JsxImpl<'a, '_> {
-    fn is_script(&self) -> bool {
-        self.ctx.source_type.is_script()
-    }
-
     fn insert_filename_var_statement(&self, ctx: &TraverseCtx<'a>) {
         let Some(declarator) = self.jsx_source.get_filename_var_declarator(ctx) else { return };
 
@@ -520,7 +516,7 @@ impl<'a> JsxImpl<'a, '_> {
         // This is the same behavior as Babel.
         // If in classic mode, then there are no import statements, so it doesn't matter either way.
         // TODO(improve-on-babel): Simplify this once we don't need to follow Babel exactly.
-        if self.bindings.is_classic() || !self.is_script() {
+        if self.bindings.is_classic() || self.ctx.source_type.is_module() {
             // Insert before imports - add to `top_level_statements` immediately
             let stmt = Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
                 SPAN,

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: fc58af40
 
 semantic_babel Summary:
 AST Parsed     : 2227/2227 (100.00%)
-Positive Passed: 1938/2227 (87.02%)
+Positive Passed: 1939/2227 (87.07%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -24,11 +24,6 @@ rebuilt        : SymbolId(2): Span { start: 65, end: 66 }
 Symbol flags mismatch for "_default":
 after transform: SymbolId(3): SymbolFlags(Class)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-commonjs/top-level-using/input.js
-Symbol flags mismatch for "_usingCtx2":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(Import)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/input.ts
 Bindings mismatch:


### PR DESCRIPTION
Transformer was deciding whether to insert an `import` statement or `require()` call depending on `source_type.is_script()`. That returns `false` for CommonJS, which was resulting in `import` statements being inserted in CommonJS files. Fix it by checking `source_type.is_module()` instead.