### PR TITLE
fix(semantic): no error in `check_function_redeclaration` for CommonJS files

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -651,7 +651,7 @@ pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) 
     let current_scope_flags = ctx.current_scope_flags();
     if prev.flags.intersects(SymbolFlags::FunctionScopedVariable | SymbolFlags::Function)
         && (current_scope_flags.is_function()
-            || (ctx.source_type.is_script() && current_scope_flags.is_top()))
+            || (!ctx.source_type.is_module() && current_scope_flags.is_top()))
     {
         // https://tc39.github.io/ecma262/#sec-scripts-static-semantics-lexicallydeclarednames
         // `function a() {}; function a() {}` and `var a; function a() {}` are


### PR DESCRIPTION
I can't get my head around exactly what `check_function_redeclaration` is checking, so I'm not 100% sure about this change. But certainly this PR will make sure that behavior for CommonJS files is the same as it was before the introduction of `commonjs` source type.

Before `commonjs` source type existed:

* Module: `source_type.is_script() == false`
* Script: `source_type.is_script() == true`
* CommonJS: `source_type.is_script() == true`

After introduction of `commonjs` source type:

* Module: `source_type.is_script() == false`
* Script: `source_type.is_script() == true`
* CommonJS: `source_type.is_script() == false` **(CHANGED)**

After this PR:

* Module: `!source_type.is_module() == false`
* Script: `!source_type.is_module() == true`
* CommonJS: `!source_type.is_module() == true` **(CHANGED BACK)**
