### PR TITLE
docs(mangler): fix `top_level` option in example

### DIFF
--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -43,7 +43,7 @@ fn main() -> std::io::Result<()> {
     let source_type = SourceType::from_path(path).unwrap();
 
     let options = MangleOptions {
-        top_level: source_type.is_module(),
+        top_level: !source_type.is_script(),
         keep_names: MangleOptionsKeepNames { function: keep_names, class: keep_names },
         debug,
     };


### PR DESCRIPTION
Presumably it's safe to mangle top-level symbols in CommonJS files. Alter the mangler example to do that.

Previously, we had no way to distinguish between script and CommonJS file types. After #18089 introduced a `commonjs` source type, we now do.