### PR TITLE
perf(allocator): increase initial chunk size from 512B to 16KB

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -487,10 +487,8 @@ const MALLOC_OVERHEAD: usize = 16;
 // nearest suitable size boundary.
 const OVERHEAD: usize = (MALLOC_OVERHEAD + FOOTER_SIZE + (CHUNK_ALIGN - 1)) & !(CHUNK_ALIGN - 1);
 
-// Choose a relatively small default initial chunk size, since we double chunk
-// sizes as we grow bump arenas to amortize costs of hitting the global
-// allocator.
-const FIRST_ALLOCATION_GOAL: usize = 1 << 9;
+// 16KB covers the majority of real-world JS/TS files and reduces malloc calls by ~30%.
+const FIRST_ALLOCATION_GOAL: usize = 1 << 14;
 
 // The actual size of the first allocation is going to be a bit smaller
 // than the goal. We need to make room for the footer, and we also need
@@ -575,7 +573,7 @@ impl Bump {
 
         let chunk_footer = unsafe {
             Self::new_chunk(
-                Bump::new_chunk_memory_details(None, layout).ok_or(AllocErr)?,
+                Bump::new_chunk_memory_details(Some(capacity), layout).ok_or(AllocErr)?,
                 layout,
                 EMPTY_CHUNK.get(),
             )

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,11 +4,11 @@ checker.ts                 | 2.92 MB        ||           4128 |           1669 |
 
 cal.com.tsx                | 1.06 MB        ||          21098 |            474 ||          37138 |           4586
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             65 |              3 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             58 |              3 ||             30 |              6
 
 pdf.mjs                    | 567.30 kB      ||           4691 |            569 ||          47464 |           7730
 
-antd.js                    | 6.69 MB        ||          10732 |           2514 ||         331644 |          69358
+antd.js                    | 6.69 MB        ||          10728 |           2514 ||         331644 |          69358
 
-binder.ts                  | 193.08 kB      ||            431 |            119 ||           7075 |            824
+binder.ts                  | 193.08 kB      ||            430 |            119 ||           7075 |            824
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -4,7 +4,7 @@ checker.ts                 | 2.92 MB        ||           2166 |           1015 |
 
 cal.com.tsx                | 1.06 MB        ||          14986 |            208 ||              0 |              0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             23 |              0 ||              0 |              0
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              0 ||              0 |              0
 
 pdf.mjs                    | 567.30 kB      ||           1756 |            284 ||              0 |              0
 


### PR DESCRIPTION
## Summary

- Increase `FIRST_ALLOCATION_GOAL` from 512 bytes to 16 KB to reduce malloc calls
- Fix `Bump::with_capacity()` to respect exact capacity requested (otherwise `with_capacity(1024)` would allocate 16KB)

## Malloc Reduction

Tested against 310K real-world JS/TS files:

| Dataset | Files | Before (avg mallocs) | After | Reduction |
|---------|-------|---------------------|-------|-----------|
| oxlint-ecosystem-ci | 256K | 10.99 | 7.72 | **30%** |
| monitor-oxc npm | 53K | 11.56 | 8.51 | **26%** |

Memory overhead increases by ~37% in allocated capacity, but actual memory *used* remains the same since AST size does not change.

## Parser Benchmark (vs main)

| File | Size | Change |
|------|------|--------|
| RadixUIAdoptionSection.jsx | 2.5 KB | **-5.14%** ✅ |
| cal.com.tsx | 1 MB | **-4.85%** ✅ |
| react.development.js | 84 KB | -0.19% |
| binder.ts | 193 KB | -0.53% |
| checker.ts | 2.9 MB | -0.03% |

Smaller/medium files show ~5% speedup from fewer malloc calls.

🤖 Generated with [Claude Code](https://claude.ai/code)