### PR TITLE
fix(ci): use correct release URL in Discord webhook

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -455,7 +455,7 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_OXC_RELEASES_CHANNEL }}
           embed-title: oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}
           embed-description: A new release is available! Check the changelog for details.
-          embed-url: ${{ steps.release.outputs.url }}
+          embed-url: https://github.com/${{ github.repository }}/releases/tag/apps_v${{ needs.check.outputs.oxlint_version }}
 
       - name: wait 3 minutes for smoke test
         run: sleep 180s


### PR DESCRIPTION
## Summary
- Fix Discord webhook using incorrect "untagged" release URL
- The `softprops/action-gh-release` outputs a temporary URL when creating draft releases
- Construct the URL manually using the known tag name instead

## Test plan
- [ ] Next release should show correct URL in Discord notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)