### PR TITLE
refactor(minifier): turn off `scope_tree_child_ids` for `SemanticBuilder`

### DIFF
--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -136,11 +136,7 @@ impl<'a> Minifier {
             .options
             .mangle
             .map(|options| {
-                let mut semantic = SemanticBuilder::new()
-                    .with_stats(stats)
-                    .with_scope_tree_child_ids(true)
-                    .build(program)
-                    .semantic;
+                let mut semantic = SemanticBuilder::new().with_stats(stats).build(program).semantic;
                 let class_private_mappings = Mangler::default()
                     .with_options(options)
                     .build_with_semantic(&mut semantic, program);


### PR DESCRIPTION
I didn't see any `scope_tree_child_ids` related API calls in the minifier, so turn it off.