### PR TITLE
docs(napi/parser): correct typo in README

### DIFF
--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -85,13 +85,13 @@ export interface EcmaScriptModule {
    * Dynamic imports `import('foo')` are ignored since they can be used in non-ESM files.
    */
   hasModuleSyntax: boolean;
-  /** Import statements. */
+  /** Import statements */
   staticImports: Array<StaticImport>;
-  /** Export statements. */
+  /** Export statements */
   staticExports: Array<StaticExport>;
-  /** Dynamic import expressions. */
+  /** Dynamic import expressions */
   dynamicImports: Array<DynamicImport>;
-  /** Span positions` of `import.meta` */
+  /** Span positions of `import.meta` */
   importMetas: Array<Span>;
 }
 ```


### PR DESCRIPTION
An extraneous `` ` `` had crept in to a comment. Remove it. Also remove unnecessary full stops from short comments.