### PR TITLE
chore(linter): Fix nonsense with docs formatting on releases.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/await_thenable.rs
+++ b/crates/oxc_linter/src/rules/typescript/await_thenable.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```ts
+    /// ```
     /// await 12;
     /// await (() => {});
     ///
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```ts
+    /// ```
     /// await Promise.resolve('value');
     /// await Promise.reject(new Error());
     ///


### PR DESCRIPTION
Unfortunately this needs to be done to prevent the prettier ts formatter from doing dumb things where this code gets duplicated every time we run a release.

e.g. https://github.com/oxc-project/oxc-project.github.io/pull/779/changes/3431436a3a5f85715d5daba129cdb99591b079d3 and https://github.com/oxc-project/oxc-project.github.io/pull/804/changes/13ec92b469575536fe2be0b4b081061f8242b356