### PR TITLE
docs(linter): Update a handful of rules that were missing the "Why is this bad?" docs header.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
+++ b/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
@@ -74,7 +74,17 @@ enum IgnoreClassWithImplements {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce that class methods utilize this.
+    /// Enforce that class methods utilize `this`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// For class methods that do not use `this`, you should consider converting them
+    /// to `static` methods. This is not always possible or desirable, but it can
+    /// help clarify that the method does not rely on instance state.
+    ///
+    /// If you do convert the method into a `static` function,
+    /// instances of the class that call that particular method have to be converted
+    /// to a `static` call as well.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -26,7 +26,15 @@ pub struct PaddingAroundTestBlocks;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces a line of padding before and after 1 or more test/it statements
+    /// This rule enforces a line of padding before and after 1 or more
+    /// `test`/`it` statements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent formatting of code can make the code more difficult to read
+    /// and follow. This rule helps ensure that test blocks are visually
+    /// separated from the rest of the code, making them easier to identify while
+    /// looking through test files.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -133,8 +133,12 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// Enforce `it`, `test`, `describe`, and `bench` to have descriptions that begin with a
-    /// lowercase letter. This provides more readable test failures. This rule is not
-    /// enabled by default.
+    /// lowercase letter. This provides more readable test failures.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Lowercase messages for test failures generally result in more grammatically correct
+    /// failure messages when you have a test failure.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -24,7 +24,14 @@ pub struct RoleSupportsAriaProps;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`. Many ARIA attributes (states and properties) can only be used on elements with particular roles. Some elements have implicit roles, such as `<a href="#" />`, which will resolve to `role="link"`.
+    /// Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.
+    /// Many ARIA attributes (states and properties) can only be used on elements with particular roles.
+    /// Some elements have implicit roles, such as `<a href="#" />`, which will resolve to `role="link"`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using ARIA attributes that are inconsistent with the element's role can cause problems for assistive
+    /// technologies and their ability to understand or engage with the content of a page.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -39,8 +39,15 @@ pub struct CheckedRequiresOnchangeOrReadonly {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces onChange or readonly attribute for checked property of input elements.
-    /// It also warns when checked and defaultChecked properties are used together.
+    /// This rule enforces `onChange` or `readOnly` attribute for checked property of input elements.
+    /// It also warns when `checked` and `defaultChecked` properties are used together.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `checked` should generally always be used with one of `onChange` or `readOnly`.
+    ///
+    /// And using `checked` and `defaultChecked` together is likely an error as they are mutually
+    /// exclusive ways to control the checked state of an input element.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_emits_declaration.rs
@@ -56,6 +56,11 @@ declare_oxc_lint!(
     /// This rule enforces `defineEmits` typing style which you should use `type-based`, strict `type-literal` (introduced in Vue 3.3), or `runtime` declaration.
     /// This rule only works in setup script and `lang="ts"`.
     ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent code style can be confusing and make code harder to read
+    /// through.
+    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_declaration.rs
@@ -39,7 +39,12 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// This rule enforces `defineProps` typing style which you should use `type-based` or `runtime` declaration.
-    /// This rule only works in setup script and `lang="ts"`.
+    /// This rule only works in `<script setup>` with `lang="ts"`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent code style can be confusing and make code harder to
+    /// read through.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
Found this by adding a check for the presence of the "### Why is this bad?" header in the docs macro, but not committing that here for now as it feels a bit excessive. Just fixing all the cases it found.