### PR TITLE
chore(ci): remove `oxc_language_server/Cargo.toml` from oxlint release workflow

### DIFF
--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -22,7 +22,6 @@ versioned_files = [
   "crates/oxc_linter/Cargo.toml",
   "editors/vscode/package.json",
   "npm/oxlint/package.json",
-  "crates/oxc_language_server/Cargo.toml",
 ]
 
 [[releases]]


### PR DESCRIPTION
This crate is only consumed by the apps and does not need a version dump.