### PR TITLE
docs(linter): Add "Examples" headers to rules missing them

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -26,8 +26,6 @@ pub struct DefaultCaseConfig {
     ///
     /// Examples of **incorrect** code for this rule with the `{ "commentPattern": "^skip\\sdefault" }` option:
     /// ```js
-    /// /* default-case: ["error", { "commentPattern": "^skip\sdefault" }] */
-    ///
     /// switch (a) {
     ///   case 1:
     ///     break;
@@ -37,8 +35,6 @@ pub struct DefaultCaseConfig {
     ///
     /// Examples of **correct** code for this rule with the `{ "commentPattern": "^skip\\sdefault" }` option:
     /// ```js
-    /// /* default-case: ["error", { "commentPattern": "^skip\\sdefault" }] */
-    ///
     /// switch (a) {
     ///   case 1:
     ///     break;
@@ -72,16 +68,16 @@ declare_oxc_lint!(
     /// no default case. The comment may be in any desired case, such as `// No Default`.
     ///
     /// Example configuration:
-    ///   ```json
-    ///   {
-    ///       "default-case": ["error", { "commentPattern": "^skip\\sdefault" }]
-    ///   }
-    ///   ```
+    /// ```json
+    /// {
+    ///     "default-case": ["error", { "commentPattern": "^skip\\sdefault" }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// /* default-case: ["error"] */
-    ///
     /// switch (foo) {
     ///   case 1:
     ///     break;
@@ -90,8 +86,6 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    /// /* default-case: ["error"] */
-    ///
     /// switch (a) {
     ///   case 1:
     ///     break;

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
     /// `event`, but using this variable has been considered as a bad practice for a long time. Restricting
     /// this will make sure this variable isn't used in browser code.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// If we have options:
     ///

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     ///
     /// Nesting `describe()` blocks too deeply can make the test suite hard to read and understand.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// The following patterns are considered warnings (with the default option of
     /// `{ "max": 5 } `):

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     /// - being called after other Jest functions like hooks, `describe`, `test`, or `it`
     ///
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// All of these are invalid case:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// tests. Before committing changes we may want to check that all tests are
     /// running.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// ```js
     /// describe.skip('foo', () => {});

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -76,7 +76,7 @@ declare_oxc_lint!(
     /// good as its review and as such keeping it short, sweet, and readable is
     /// important to allow for thorough reviews.
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -36,22 +36,22 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
+    /// Anchor elements without content can be confusing for users relying
+    /// on screen readers to understand.
     ///
-    /// ### Example
+    /// ### Examples
     ///
-    /// #### good
-    ///
-    /// ```
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
     /// <a>Anchor Content!</a>
-    ///  <a><TextWrapper /></a>
-    ///  <a dangerouslySetInnerHTML={{ __html: 'foo' }} />
-    ///  <a title='foo' />
-    ///  <a aria-label='foo' />
+    /// <a><TextWrapper /></a>
+    /// <a dangerouslySetInnerHTML={{ __html: 'foo' }} />
+    /// <a title='foo' />
+    /// <a aria-label='foo' />
     /// ```
     ///
-    /// #### bad
-    ///
-    /// ```
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
     /// <a />
     /// <a><TextWrapper aria-hidden /></a>
     /// ```

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
     /// * <https://github.com/thepassle/eslint-plugin-barrel-files>
     /// * <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7>
     ///
-    /// ### Example
+    /// ### Examples
     ///
     /// Invalid:
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -66,11 +66,32 @@ impl NoThisAlias {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow aliasing `this`
+    /// Disallow aliasing of `this`.
     ///
     /// ### Why is this bad?
     ///
-    /// Assigning a variable to `this` instead of properly using arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
+    /// Assigning a variable to `this` instead of properly using
+    /// arrow lambdas may be a symptom of pre-ES2015 practices or not managing scope well.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    ///
+    /// ```js
+    /// const self = this;
+    ///
+    /// setTimeout(function () {
+    ///   self.doWork();
+    /// });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// ```js
+    /// setTimeout(() => {
+    ///   this.doWork();
+    /// });
+    /// ```
     NoThisAlias,
     typescript,
     correctness,

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -36,6 +36,61 @@ declare_oxc_lint!(
     /// Files with no executable or exportable content are typically unintentional
     /// or left over from refactoring. They clutter the codebase and may confuse
     /// tooling or developers by appearing to serve a purpose when they do not.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    ///
+    /// ```js
+    ///
+    /// ```
+    ///
+    /// ```js
+    /// // Comment
+    /// ```
+    ///
+    /// ```js
+    /// /* Comment */
+    /// ```
+    ///
+    /// ```js
+    /// 'use strict';
+    /// ```
+    ///
+    /// ```js
+    /// ;
+    /// ```
+    ///
+    /// ```js
+    /// {
+    /// }
+    /// ```
+    ///
+    /// ```js
+    /// #!/usr/bin/env node
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// ```js
+    /// const x = 0;
+    /// ```
+    ///
+    /// ```js
+    /// 'use strict';
+    /// const x = 0;
+    /// ```
+    ///
+    /// ```js
+    /// ;;
+    /// const x = 0;
+    /// ```
+    ///
+    /// ```js
+    /// {
+    ///   const x = 0;
+    /// }
+    /// ```
     NoEmptyFile,
     unicorn,
     correctness,

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -1412,7 +1412,7 @@ References:
 * <https://github.com/thepassle/eslint-plugin-barrel-files>
 * <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7>
 
-### Example
+### Examples
 
 Invalid:
 


### PR DESCRIPTION
This adds "Examples" headers to various rules that were missing them, for consistency. Also miscellaneous cleanup.