### PR TITLE
fix(vscode): Update package.json to restrict a few more config options.

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -313,7 +313,9 @@
       "restrictedConfigurations": [
         "oxc.path.server",
         "oxc.path.oxlint",
-        "oxc.path.oxfmt"
+        "oxc.path.oxfmt",
+        "oxc.path.tsgolint",
+        "oxc.path.node"
       ]
     }
   },


### PR DESCRIPTION
As an aside, the extension's description for this configuration says "The Extension will always use the Language Server shipped with the Extension.", is that still true / should we revise the way the extension works for untrusted workspaces? (we could possibly just say "it doesn't work in untrusted workspaces", basically)