### PR TITLE
fix(vscode): Update notification for client restart to specify tool.

### DIFF
--- a/editors/vscode/client/tools/formatter.ts
+++ b/editors/vscode/client/tools/formatter.ts
@@ -319,19 +319,19 @@ export default class FormatterTool implements ToolInterface {
 
   async restartClient(): Promise<void> {
     if (this.client === undefined) {
-      window.showErrorMessage("oxc client not found");
+      window.showErrorMessage("oxfmt client not found");
       return;
     }
 
     try {
       if (this.client.isRunning()) {
         await this.client.restart();
-        window.showInformationMessage("oxc server restarted.");
+        window.showInformationMessage("oxfmt server restarted.");
       } else {
         await this.client.start();
       }
     } catch (err) {
-      this.client.error("Restarting client failed", err, "force");
+      this.client.error("Restarting oxfmt client failed", err, "force");
     }
   }
 

--- a/editors/vscode/client/tools/linter.ts
+++ b/editors/vscode/client/tools/linter.ts
@@ -253,19 +253,19 @@ export default class LinterTool implements ToolInterface {
 
   async restartClient(): Promise<void> {
     if (this.client === undefined) {
-      window.showErrorMessage("oxc client not found");
+      window.showErrorMessage("oxlint client not found");
       return;
     }
 
     try {
       if (this.client.isRunning()) {
         await this.client.restart();
-        window.showInformationMessage("oxc server restarted.");
+        window.showInformationMessage("oxlint server restarted.");
       } else {
         await this.client.start();
       }
     } catch (err) {
-      this.client.error("Restarting client failed", err, "force");
+      this.client.error("Restarting oxlint client failed", err, "force");
     }
   }
 


### PR DESCRIPTION
Since they're distinct servers now, we can specify oxfmt or oxlint when relevant.

Currently we just get "oxc server":

<img width="566" height="89" alt="Screenshot 2026-01-19 at 5 17 31 PM" src="https://github.com/user-attachments/assets/57e67fe9-56d0-421f-899f-c3fd1c3ee23b" />
