### PR TITLE
fix(vscode): Update version info formatting.

### DIFF
--- a/editors/vscode/client/StatusBarItemHandler.ts
+++ b/editors/vscode/client/StatusBarItemHandler.ts
@@ -63,7 +63,7 @@ export default class StatusBarItemHandler {
 
     const text = sections
       .map(([tool, section]) => {
-        const version = section.version ? ` v${section.version}` : "unknown version";
+        const version = section.version ? `v${section.version}` : "unknown version";
         const statusText = section.isEnabled ? `enabled (${version})` : "disabled";
         return `**${tool} is ${statusText}**\n\n${section.content}`;
       })


### PR DESCRIPTION
The extra space bothered me :P

<img width="228" height="305" alt="Screenshot 2026-01-19 at 5 23 01 PM" src="https://github.com/user-attachments/assets/0af79495-e830-4747-ae3c-1a41d73ea07f" />
