### PR TITLE
feat(span)!: use `ModuleKind::CommonJS` for `SourceType::cjs()`

### DIFF
--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -10,7 +10,12 @@ fn test_script_same(source_text: &str) {
 
 #[track_caller]
 fn test_script(source_text: &str, expected: &str) {
-    test_options_source_type(source_text, expected, SourceType::cjs(), &default_options());
+    test_options_source_type(
+        source_text,
+        expected,
+        SourceType::cjs().with_script(true),
+        &default_options(),
+    );
 }
 
 #[track_caller]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -120,7 +120,7 @@ fn remove_unused_class_declaration() {
 #[test]
 fn keep_in_script_mode() {
     let options = CompressOptions::smallest();
-    let source_type = SourceType::cjs();
+    let source_type = SourceType::cjs().with_script(true);
     test_same_options_source_type("var x = 1; x = 2;", source_type, &options);
     test_same_options_source_type("var x = 1; x = 2, foo(x)", source_type, &options);
 

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -415,7 +415,7 @@ fn remove_unused_assignment_expression() {
     );
 
     let options = CompressOptions::smallest();
-    let source_type = SourceType::cjs();
+    let source_type = SourceType::cjs().with_script(true);
     test_same_options_source_type("var x = 1; x = 2;", source_type, &options);
     test_same_options_source_type("var x = 1; x = 2, foo(x)", source_type, &options);
     test_options_source_type(

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -211,12 +211,10 @@ impl From<FileExtension> for SourceType {
 }
 
 impl SourceType {
-    /// Creates a [`SourceType`] representing a regular [`JavaScript`] file.
+    /// Creates a [`SourceType`] representing a [`JavaScript`] file using CommonJS
+    /// modules. This is akin to a file with an `.cjs` extension.
     ///
-    /// This file could be a vanilla script (no module system of any kind) or a
-    /// CommonJS file.
-    ///
-    /// The resulting source type is not a [`module`], nor does it support [`JSX`].
+    /// The resulting source type does not support [`JSX`].
     /// Use [`SourceType::jsx`] for [`JSX`] sources.
     ///
     /// ## Example
@@ -225,17 +223,16 @@ impl SourceType {
     ///
     /// let js = SourceType::cjs();
     /// assert!(js.is_javascript());
-    /// assert!(js.is_script()); // not a module
+    /// assert!(js.is_commonjs());
     /// assert!(!js.is_jsx());
     /// ```
     ///
     /// [`JavaScript`]: Language::JavaScript
-    /// [`module`]: ModuleKind::Module
     /// [`JSX`]: LanguageVariant::Jsx
     pub const fn cjs() -> Self {
         Self {
             language: Language::JavaScript,
-            module_kind: ModuleKind::Script,
+            module_kind: ModuleKind::CommonJS,
             variant: LanguageVariant::Standard,
         }
     }
@@ -554,12 +551,12 @@ impl SourceType {
     /// for TypeScript files, only `.tsx` files are treated as JSX.
     ///
     /// Note that this behavior deviates from [`SourceType::cjs`], which produces
-    /// [`scripts`].
+    /// [`commonjs`].
     ///
     /// ### Modules vs. Scripts.
     /// Oxc has partial support for Node's
     /// [CommonJS](https://nodejs.org/api/modules.html#enabling) detection
-    /// strategy. Any file with a `.c[tj]s` extension is treated as a [`script`].
+    /// strategy. Any file with a `.c[tj]s` extension is treated as a [`commonjs`].
     /// All other files are treated as [`modules`].
     ///
     /// # Errors
@@ -569,8 +566,7 @@ impl SourceType {
     ///     "mts", "cts", "tsx". See [`VALID_EXTENSIONS`] for the list of valid
     ///     extensions.
     ///
-    /// [`script`]: ModuleKind::Script
-    /// [`scripts`]: ModuleKind::Script
+    /// [`commonjs`]: ModuleKind::CommonJS
     /// [`modules`]: ModuleKind::Module
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, UnknownExtension> {
         let file_name = path

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -9,7 +9,7 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 mod options;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use napi::{Either, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
@@ -55,8 +55,6 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
 
     let source_type = if options.module == Some(true) {
         SourceType::mjs()
-    } else if Path::new(&filename).extension().is_some_and(|ext| ext == "js") {
-        SourceType::cjs()
     } else {
         SourceType::from_path(filename).unwrap_or_default()
     };

--- a/tasks/coverage/src/node_compat_table/mod.rs
+++ b/tasks/coverage/src/node_compat_table/mod.rs
@@ -86,7 +86,7 @@ impl NodeCompatCase {
     }
 
     pub fn source_type() -> SourceType {
-        SourceType::cjs()
+        SourceType::cjs().with_script(true)
     }
 }
 

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -178,7 +178,7 @@ impl Test262RuntimeCase {
         let source_text = self.base.code();
         let is_module = self.base.is_module();
         let is_only_strict = self.base.is_only_strict();
-        let source_type = SourceType::cjs().with_module(is_module);
+        let source_type = SourceType::cjs().with_script(!is_module).with_module(is_module);
         let allocator = Allocator::default();
         let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
 

--- a/tasks/coverage/src/test262/mod.rs
+++ b/tasks/coverage/src/test262/mod.rs
@@ -143,7 +143,7 @@ impl Case for Test262Case {
     // https://github.com/tc39/test262/blob/05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d/INTERPRETING.md#strict-mode
     fn run(&mut self) {
         let flags = &self.meta.flags;
-        let source_type = SourceType::cjs();
+        let source_type = SourceType::cjs().with_script(true);
 
         self.result = if flags.contains(&TestFlag::OnlyStrict) {
             self.always_strict = true;

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -148,7 +148,7 @@ pub fn run() -> Result<(), io::Error> {
 }
 
 fn minify_twice(file: &TestFile, options: Options) -> (String, u8) {
-    let source_type = SourceType::cjs();
+    let source_type = SourceType::cjs().with_script(true);
     let (code1, iterations) = minify(&file.source_text, source_type, options);
     let (code2, _) = minify(&code1, source_type, options);
     assert_eq_minified_code(&code1, &code2, &file.file_name);


### PR DESCRIPTION
Follow-up to #18089.

Maybe we should add `SourceType::script()` so that it's easier to create a SourceType with `ModuleType::Script`.
