### PR TITLE
refactor(formatter,oxfmt): Move tag-to-parser logic from `oxc_formatter` to `oxfmt`

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -31,7 +31,7 @@ export declare const enum Severity {
  *
  * Since it internally uses `await prettier.format()` in JS side, `formatSync()` cannot be provided.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, tagName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, parserName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -55,4 +55,4 @@ export interface FormatResult {
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, tagName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindcssClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, parserName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindcssClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -22,10 +22,10 @@ export async function initExternalFormatter(numThreads: number): Promise<string[
 
 export async function formatEmbeddedCode(
   options: Options,
-  tagName: string,
+  parserName: string,
   code: string,
 ): Promise<string> {
-  return pool!.run({ options, code, tagName } satisfies FormatEmbeddedCodeParam, {
+  return pool!.run({ options, code, parserName } satisfies FormatEmbeddedCodeParam, {
     name: "formatEmbeddedCode",
   });
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -22,7 +22,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     sourceText,
     options ?? {},
     resolvePlugins,
-    (options, tagName, code) => formatEmbeddedCode({ options, tagName, code }),
+    (options, parserName, code) => formatEmbeddedCode({ options, parserName, code }),
     (options, parserName, fileName, code) => formatFile({ options, parserName, fileName, code }),
     (filepath, options, classes) => sortTailwindClasses({ filepath, classes, options }),
   );

--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -30,23 +30,9 @@ export async function resolvePlugins(): Promise<string[]> {
 
 // ---
 
-const TAG_TO_PARSER: Record<string, string> = {
-  // CSS
-  css: "css",
-  styled: "css",
-  // GraphQL
-  gql: "graphql",
-  graphql: "graphql",
-  // HTML
-  html: "html",
-  // Markdown
-  md: "markdown",
-  markdown: "markdown",
-};
-
 export type FormatEmbeddedCodeParam = {
   code: string;
-  tagName: string;
+  parserName: string;
   options: Options;
 };
 
@@ -59,15 +45,9 @@ export type FormatEmbeddedCodeParam = {
  */
 export async function formatEmbeddedCode({
   code,
-  tagName,
+  parserName,
   options,
 }: FormatEmbeddedCodeParam): Promise<string> {
-  // TODO: This should be resolved in Rust side
-  const parserName = TAG_TO_PARSER[tagName];
-
-  // Unknown tag, return original code
-  if (!parserName) return code;
-
   const prettier = await loadPrettier();
 
   // SAFETY: `options` is created in Rust side, so it's safe to mutate here

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -38,7 +38,7 @@ pub async fn run_cli(
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
     #[napi(
-        ts_arg_type = "(options: Record<string, any>, tagName: string, code: string) => Promise<string>"
+        ts_arg_type = "(options: Record<string, any>, parserName: string, code: string) => Promise<string>"
     )]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(
@@ -134,7 +134,7 @@ pub async fn format(
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
     #[napi(
-        ts_arg_type = "(options: Record<string, any>, tagName: string, code: string) => Promise<string>"
+        ts_arg_type = "(options: Record<string, any>, parserName: string, code: string) => Promise<string>"
     )]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -9,9 +9,6 @@ pub type EmbeddedFormatterCallback =
 /// Takes classes and returns the sorted versions.
 pub type TailwindCallback = Arc<dyn Fn(Vec<String>) -> Vec<String> + Send + Sync>;
 
-/// See <apps/oxfmt/src-js/embedded.ts> for supported tags.
-const SUPPORTED_TAGS: &[&str] = &["css", "styled", "gql", "graphql", "html", "md", "markdown"];
-
 /// External callbacks for JS-side functionality.
 ///
 /// This struct holds all callbacks that delegate to external (typically JS) implementations:
@@ -41,11 +38,6 @@ impl ExternalCallbacks {
     pub fn with_tailwind(mut self, callback: Option<TailwindCallback>) -> Self {
         self.tailwind = callback;
         self
-    }
-
-    /// Check if the given tag name is supported for embedded formatting.
-    pub fn is_supported_tag(tag_name: &str) -> bool {
-        SUPPORTED_TAGS.contains(&tag_name)
     }
 
     /// Format embedded code with the given tag name.

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -7,7 +7,7 @@ use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    ExternalCallbacks, IndentWidth,
+    IndentWidth,
     ast_nodes::{AstNode, AstNodeIterator, AstNodes},
     format_args,
     formatter::{
@@ -802,12 +802,13 @@ fn format_embedded_template<'a>(
 }
 
 /// Try to format a tagged template with the embedded formatter if supported.
-/// Returns `Some(result)` if formatting was attempted, `None` if not applicable.
+/// Returns `true` if formatting was performed, `false` if not applicable.
 fn try_format_embedded_template<'a>(
     tagged: &AstNode<'a, TaggedTemplateExpression<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let quasi = &tagged.quasi;
+    // TODO: Support expressions in the template
     if !quasi.is_no_substitution_template() {
         return false;
     }
@@ -816,12 +817,6 @@ fn try_format_embedded_template<'a>(
         return false;
     };
 
-    // Check if the tag is supported by the embedded formatter
-    if !ExternalCallbacks::is_supported_tag(tag_name) {
-        return false;
-    }
-
-    // Get the external callbacks from the context
     let template_content = quasi.quasis[0].value.raw.as_str();
 
     format_embedded_template(f, tag_name, template_content)
@@ -867,6 +862,7 @@ fn try_format_css_template<'a>(
     template_literal: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
+    // TODO: Support expressions in the template
     if !template_literal.is_no_substitution_template() {
         return false;
     }


### PR DESCRIPTION
Previously, both `oxc_formatter` (SUPPORTED_TAGS) and `oxfmt` JS (TAG_TO_PARSER) had knowledge about supported embedded language tags.

This created duplication and unclear responsibility boundaries.

- Remove `SUPPORTED_TAGS` and `is_supported_tag()` from `oxc_formatter`
- Add `tag_to_prettier_parser()` in `oxfmt` Rust side as single source of truth
- Change JS callback signature from `tagName` to `parserName`
- Simplify JS `formatEmbeddedCode()` to just call Prettier with given parser

