### PR TITLE
feat(mangler)!: enable `top_level` by default for modules and commonjs

### DIFF
--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -43,7 +43,7 @@ fn main() -> std::io::Result<()> {
     let source_type = SourceType::from_path(path).unwrap();
 
     let options = MangleOptions {
-        top_level: !source_type.is_script(),
+        top_level: None,
         keep_names: MangleOptionsKeepNames { function: keep_names, class: keep_names },
         debug,
     };

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -23,8 +23,8 @@ function foo(e) {
 }
 
 import { x } from 's'; export { x }
-import { x } from "s";
-export { x };
+import { x as e } from "s";
+export { e as x };
 
 Object.defineProperty(exports, '__esModule', { value: true })
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -97,7 +97,7 @@ export interface MangleOptions {
   /**
    * Pass `true` to mangle names declared in the top level scope.
    *
-   * @default false
+   * @default true for modules and commonjs, otherwise false
    */
   toplevel?: boolean
   /**

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -202,7 +202,7 @@ impl From<&CompressOptionsKeepNames> for oxc_minifier::CompressOptionsKeepNames 
 pub struct MangleOptions {
     /// Pass `true` to mangle names declared in the top level scope.
     ///
-    /// @default false
+    /// @default true for modules and commonjs, otherwise false
     pub toplevel: Option<bool>,
 
     /// Preserve `name` property for functions and classes.
@@ -218,7 +218,7 @@ impl From<&MangleOptions> for oxc_minifier::MangleOptions {
     fn from(o: &MangleOptions) -> Self {
         let default = oxc_minifier::MangleOptions::default();
         Self {
-            top_level: o.toplevel.unwrap_or(default.top_level),
+            top_level: o.toplevel,
             keep_names: match &o.keep_names {
                 Some(Either::A(false)) => oxc_minifier::MangleOptionsKeepNames::all_false(),
                 Some(Either::A(true)) => oxc_minifier::MangleOptionsKeepNames::all_true(),

--- a/napi/minify/test/terser.test.ts
+++ b/napi/minify/test/terser.test.ts
@@ -25,7 +25,7 @@ import { run_code } from "./sandbox";
 function run(input: string, expected: string[], prepend_code?: string) {
   const consoleMock = vi.spyOn(console, "log").mockImplementation(() => undefined);
   try {
-    const minified = minifySync("test.cjs", input).code;
+    const minified = minifySync("test.cjs", input, { mangle: { toplevel: false } }).code;
     expect(minified).not.toBeFalsy();
     // Use `consoleMock` instead of the returned output.
     const _ = run_code(minified, prepend_code);

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -337,7 +337,7 @@ impl Oxc {
         };
         let mangle = if options.run.mangle {
             options.mangle.map(|o| MangleOptions {
-                top_level: o.top_level,
+                top_level: Some(o.top_level),
                 keep_names: MangleOptionsKeepNames { function: o.keep_names, class: o.keep_names },
                 debug: false,
             })

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -87,7 +87,7 @@ fn bench_mangler(criterion: &mut Criterion) {
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .with_options(MangleOptions {
-                            top_level: false,
+                            top_level: None,
                             keep_names: MangleOptionsKeepNames::all_true(),
                             debug: false,
                         })

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           3989 |           1675 ||         152600 |          28244
+checker.ts                 | 2.92 MB        ||           3995 |           1675 ||         152600 |          28244
 
-cal.com.tsx                | 1.06 MB        ||          21107 |            474 ||          37138 |           4586
+cal.com.tsx                | 1.06 MB        ||          21119 |            474 ||          37138 |           4586
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             52 |              0 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             54 |              0 ||             30 |              6
 
 pdf.mjs                    | 567.30 kB      ||           4679 |            572 ||          47462 |           7734
 
 antd.js                    | 6.69 MB        ||          10703 |           2517 ||         331644 |          69358
 
-binder.ts                  | 193.08 kB      ||            416 |            123 ||           7075 |            824
+binder.ts                  | 193.08 kB      ||            420 |            123 ||           7075 |            824
 


### PR DESCRIPTION
I think we can enable `top_level` by default.

refs #18233