### PR TITLE
test(linter): Add a snapshot test for a complex config

### DIFF
--- a/apps/oxlint/fixtures/valid_complex_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/valid_complex_config/.oxlintrc.json
@@ -1,0 +1,48 @@
+{
+  "plugins": [
+    "eslint",
+    "import",
+    "react",
+    "typescript",
+    "unicorn",
+    "vue",
+    "jsdoc"
+  ],
+  "categories": {
+    "correctness": "off"
+  },
+  // This config is intended to be fully valid and cover a variety of different
+  // configuration options on various rules.
+  "rules": {
+    "eslint/no-cond-assign": ["error", "except-parens"],
+    "eslint/unicode-bom": ["error", "never"],
+    "eslint/no-bitwise": ["error", { "allow": [] }],
+    "eslint/no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true }],
+
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+    "import/no-absolute-path": ["error", { "esmodule": true, "commonjs": true, "amd": true }],
+    "import/no-unassigned-import": ["error", { "allow": [] }],
+    "import/no-duplicates": ["error", { "preferInline": true }],
+    "import/prefer-default-export": ["error", { "target": "single" }],
+
+    "react/jsx-fragments": ["error", "syntax"],
+    "react/prefer-es6-class": ["error", "always"],
+    "react/state-in-constructor": ["error", "always"],
+    "react/jsx-no-target-blank": ["error", { "allowReferrer": true }],
+
+    "typescript/consistent-indexed-object-style": ["error", "record"],
+    "typescript/consistent-type-definitions": ["error", "interface"],
+    "typescript/return-await": ["error", "in-try-catch"],
+    "typescript/no-explicit-any": ["error", { "fixToUnknown": false }],
+    "typescript/prefer-nullish-coalescing": ["error", { "ignorePrimitives": { "bigint": false } }],
+
+    "unicorn/switch-case-braces": ["error", "always"],
+    "unicorn/explicit-length-check": ["error", { "non-zero": "greater-than" }],
+    "unicorn/no-array-reverse": ["error", { "allowExpressionStatement": true }],
+
+    "vue/define-emits-declaration": ["error", "type-based"],
+    "vue/define-props-declaration": ["error", "runtime"],
+
+    "jsdoc/require-returns": ["error", { "exemptedBy": ["test"] }]
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1512,4 +1512,9 @@ export { redundant };
             .with_cwd("fixtures/invalid_config_type_difference".into())
             .test_and_snapshot(&[]);
     }
+
+    #[test]
+    fn test_valid_complex_config() {
+        Tester::new().with_cwd("fixtures/valid_complex_config".into()).test_and_snapshot(&[]);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__valid_complex_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__valid_complex_config_@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/valid_complex_config
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files with 22 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
Cherry-picked out of #18104 since I want to keep that PR focused on one thing.

This adds a snapshot test to ensure that this complex config is valid and doesn't result in any errors for the end-user. This is basically just protecting against us breaking the config validation system by accident, and covers a variety of different config shapes.