### PR TITLE
refactor(oxfmt): Move tailwind option mapping to Rust

### DIFF
--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -3,7 +3,6 @@
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { hasOxfmtrcFile, createBlankOxfmtrcFile, saveOxfmtrcFile, exitWithError } from "./shared";
-import { TAILWIND_OPTION_MAPPING } from "../../libs/prettier";
 import { Options } from "prettier";
 
 /**
@@ -162,6 +161,15 @@ async function resolvePrettierIgnore(cwd: string) {
 }
 
 // ---
+
+const TAILWIND_OPTION_MAPPING: Record<string, string> = {
+  config: "tailwindConfig",
+  stylesheet: "tailwindStylesheet",
+  functions: "tailwindFunctions",
+  attributes: "tailwindAttributes",
+  preserveWhitespace: "tailwindPreserveWhitespace",
+  preserveDuplicates: "tailwindPreserveDuplicates",
+};
 
 /**
  * Migrate prettier-plugin-tailwindcss options to Oxfmt's experimentalTailwindcss format.


### PR DESCRIPTION
Follow up on #17648

Move the `experimentalTailwindcss` to `tailwindXxx` option mapping logic from JS to Rust side (`populate_prettier_config`).

Now, consolidate all Prettier option processing in one place (`populate_prettier_config`).
This may also slightly improve performance by reducing JS runtime overhead a bit.
