### PR TITLE
refactor(oxfmt): Update TS type and tailwind option docs

### DIFF
--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -30,68 +30,49 @@ export async function format(fileName: string, sourceText: string, options?: For
 
 // NOTE: Regarding the handwritten TypeScript types.
 //
-// Initially, I tried to use the `Oxfmtrc` struct to automatically generate types with `napi(object)`,
+// Initially, I tried to use the `FormatConfig` struct to automatically generate types with `napi(object)`,
 // but since `Oxfmtrc` has many fields defined as `enum`, the API usage would look like this:
+//
 // ```ts
 // oxfmt.format("file.ts", "const a=1;", {
 //   endOfLine: oxfmt.EndOfLine.Lf,
 //   // ...
 // });
 // ```
+//
 // Since it cannot be specified with string literals, the API usability is not good.
 //
-// Also, since `Oxfmtrc` is primarily a configuration file,
-// it includes fields like `ignorePatterns` that are unnecessary for the API.
-//
-// Therefore, I decided that if I were to create a dedicated struct for `napi(object)`,
-// it would be better to just handwrite the TypeScript types.
-//
-// There is a mechanism to generate JSON Schema, so it might be possible to generate type definitions from that in the future.
+// Therefore, I decided to just handwrite the TypeScript types.
+// There is already a mechanism to generate JSON Schema,
+// so it might be possible to generate type definitions from that.
+// TODO: in the future.
 
 /**
- * Configuration options for the Oxfmt.
- *
- * Most options are the same as Prettier's options.
- * See also <https://prettier.io/docs/options>
- *
- * In addition, some options are our own extensions.
+ * Configuration options for the `format()` API.
  */
-export type FormatOptions = {
-  /** Use tabs for indentation or spaces. (Default: `false`) */
-  useTabs?: boolean;
-  /** Number of spaces per indentation level. (Default: `2`) */
-  tabWidth?: number;
+export type FormatOptions = Pick<
+  Options,
+  | "useTabs"
+  | "tabWidth"
+  | "singleQuote"
+  | "jsxSingleQuote"
+  | "quoteProps"
+  | "trailingComma"
+  | "semi"
+  | "arrowParens"
+  | "bracketSpacing"
+  | "bracketSameLine"
+  | "objectWrap"
+  | "singleAttributePerLine"
+  | "embeddedLanguageFormatting"
+  | "proseWrap"
+  | "htmlWhitespaceSensitivity"
+  | "vueIndentScriptAndStyle"
+> & {
   /** Which end of line characters to apply. (Default: `"lf"`) */
   endOfLine?: "lf" | "crlf" | "cr";
   /** The line length that the printer will wrap on. (Default: `100`) */
   printWidth?: number;
-  /** Use single quotes instead of double quotes. (Default: `false`) */
-  singleQuote?: boolean;
-  /** Use single quotes instead of double quotes in JSX. (Default: `false`) */
-  jsxSingleQuote?: boolean;
-  /** Change when properties in objects are quoted. (Default: `"as-needed"`) */
-  quoteProps?: "as-needed" | "consistent" | "preserve";
-  /** Print trailing commas wherever possible. (Default: `"all"`) */
-  trailingComma?: "all" | "es5" | "none";
-  /** Print semicolons at the ends of statements. (Default: `true`) */
-  semi?: boolean;
-  /** Include parentheses around a sole arrow function parameter. (Default: `"always"`) */
-  arrowParens?: "always" | "avoid";
-  /** Print spaces between brackets in object literals. (Default: `true`) */
-  bracketSpacing?: boolean;
-  /**
-   * Put the `>` of a multi-line JSX element at the end of the last line
-   * instead of being alone on the next line. (Default: `false`)
-   */
-  bracketSameLine?: boolean;
-  /**
-   * How to wrap object literals when they could fit on one line or span multiple lines. (Default: `"preserve"`)
-   */
-  objectWrap?: "preserve" | "collapse";
-  /** Put each attribute on a new line in JSX. (Default: `false`) */
-  singleAttributePerLine?: boolean;
-  /** Control whether formats quoted code embedded in the file. (Default: `"auto"`) */
-  embeddedLanguageFormatting?: "auto" | "off";
   /** Whether to insert a final newline at the end of the file. (Default: `true`) */
   insertFinalNewline?: boolean;
   /** Experimental: Sort import statements. Disabled by default. */
@@ -103,8 +84,7 @@ export type FormatOptions = {
    * (Default: disabled)
    */
   experimentalTailwindcss?: TailwindcssOptions;
-} & Pick<Options, "proseWrap" | "htmlWhitespaceSensitivity" | "vueIndentScriptAndStyle"> &
-  Record<string, unknown>; // Also allow additional options for we don't have typed yet.
+} & Record<string, unknown>; // Also allow additional options for we don't have typed yet.
 
 /**
  * Configuration options for sort imports.
@@ -122,7 +102,7 @@ export type SortImportsOptions = {
   ignoreCase?: boolean;
   /** Add newlines between import groups. (Default: `true`) */
   newlinesBetween?: boolean;
-  /** Glob patterns to identify internal imports. */
+  /** Prefixes to identify internal imports. (Default: `["~/", "@/"]`) */
   internalPattern?: string[];
   /**
    * Groups configuration for organizing imports.
@@ -143,9 +123,15 @@ export type TailwindcssOptions = {
   config?: string;
   /** Path to Tailwind stylesheet (v4). e.g., `"./src/app.css"` */
   stylesheet?: string;
-  /** List of custom function names whose arguments should be sorted. e.g., `["clsx", "cva", "tw"]` */
+  /**
+   * List of custom function names whose arguments should be sorted.
+   * e.g., `["clsx", "cva", "tw"]` (Default: `[]`)
+   */
   functions?: string[];
-  /** List of additional HTML/JSX attributes to sort (beyond `class` and `className`). e.g., `["myClassProp", ":class"]` */
+  /**
+   * List of additional HTML/JSX attributes to sort (beyond `class` and `className`).
+   * e.g., `["myClassProp", ":class"]` (Default: `[]`)
+   */
   attributes?: string[];
   /** Preserve whitespace around classes. (Default: `false`) */
   preserveWhitespace?: boolean;

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -756,7 +756,7 @@ pub struct TailwindcssConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stylesheet: Option<String>,
 
-    /// List of custom function name prefixes that contain Tailwind CSS classes.
+    /// List of custom function names whose arguments should be sorted (exact match).
     ///
     /// NOTE: Regex patterns are not yet supported.
     ///
@@ -764,11 +764,11 @@ pub struct TailwindcssConfig {
     /// - Example: `["clsx", "cn", "cva", "tw"]`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub functions: Option<Vec<String>>,
-    /// List of attribute prefixes that contain Tailwind CSS classes.
+    /// List of additional attributes to sort beyond `class` and `className` (exact match).
     ///
     /// NOTE: Regex patterns are not yet supported.
     ///
-    /// - Default: `["class", "className"]`
+    /// - Default: `[]`
     /// - Example: `["myClassProp", ":class"]`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<Vec<String>>,

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -108,11 +108,11 @@ pub struct TailwindcssOptions {
     /// Default: `[]`
     pub functions: Vec<String>,
 
-    /// List of attributes that contain Tailwind CSS classes.
+    /// List of additional attributes to sort (beyond `class` and `className`).
     ///
     /// Example: `["myClassProp", ":class"]`
     ///
-    /// Default: `["class", "className"]`
+    /// Default: `[]`
     pub attributes: Vec<String>,
 
     /// Preserve whitespace around classes.

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -730,7 +730,7 @@
       "type": "object",
       "properties": {
         "attributes": {
-          "description": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
+          "description": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`",
           "type": [
             "array",
             "null"
@@ -738,7 +738,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`"
+          "markdownDescription": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`"
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
@@ -749,7 +749,7 @@
           "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
-          "description": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
+          "description": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
           "type": [
             "array",
             "null"
@@ -757,7 +757,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
+          "markdownDescription": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -734,7 +734,7 @@ expression: json
       "type": "object",
       "properties": {
         "attributes": {
-          "description": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`",
+          "description": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`",
           "type": [
             "array",
             "null"
@@ -742,7 +742,7 @@ expression: json
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of attribute prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[\"class\", \"className\"]`\n- Example: `[\"myClassProp\", \":class\"]`"
+          "markdownDescription": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`"
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
@@ -753,7 +753,7 @@ expression: json
           "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
-          "description": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
+          "description": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
           "type": [
             "array",
             "null"
@@ -761,7 +761,7 @@ expression: json
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of custom function name prefixes that contain Tailwind CSS classes.\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
+          "markdownDescription": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`"
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -337,11 +337,11 @@ For details, see each field's documentation.
 type: `string[]`
 
 
-List of attribute prefixes that contain Tailwind CSS classes.
+List of additional attributes to sort beyond `class` and `className` (exact match).
 
 NOTE: Regex patterns are not yet supported.
 
-- Default: `["class", "className"]`
+- Default: `[]`
 - Example: `["myClassProp", ":class"]`
 
 
@@ -362,7 +362,7 @@ NOTE: Paths are resolved relative to the Oxfmt configuration file.
 type: `string[]`
 
 
-List of custom function name prefixes that contain Tailwind CSS classes.
+List of custom function names whose arguments should be sorted (exact match).
 
 NOTE: Regex patterns are not yet supported.
 
@@ -826,11 +826,11 @@ For details, see each field's documentation.
 type: `string[]`
 
 
-List of attribute prefixes that contain Tailwind CSS classes.
+List of additional attributes to sort beyond `class` and `className` (exact match).
 
 NOTE: Regex patterns are not yet supported.
 
-- Default: `["class", "className"]`
+- Default: `[]`
 - Example: `["myClassProp", ":class"]`
 
 
@@ -851,7 +851,7 @@ NOTE: Paths are resolved relative to the Oxfmt configuration file.
 type: `string[]`
 
 
-List of custom function name prefixes that contain Tailwind CSS classes.
+List of custom function names whose arguments should be sorted (exact match).
 
 NOTE: Regex patterns are not yet supported.
 


### PR DESCRIPTION
- Use `Pick<Options, ...>` from Prettier to reuse fully compatible option types
- Fix misleading documentation for Tailwind `attributes` and `functions`:
  - Clarify they use exact match (not prefix)
  - Correct `attributes` default from `["class", "className"]` to `[]`
    - `class`/`className` are hardcoded, option is for additional
