### PR TITLE
perf(semantic): skip checking redeclarations for function expressions

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -625,6 +625,12 @@ pub fn is_function_part_of_if_statement(function: &Function, builder: &SemanticB
 // and the duplicate entries are only bound by FunctionDeclarations.
 // https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics
 pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) {
+    if !func.is_declaration() {
+        return;
+    }
+
+    // Function declarations always have an identifier, except for `export default function () {}`.
+    // Skip that case.
     let Some(id) = &func.id else { return };
 
     if is_function_part_of_if_statement(func, ctx) {


### PR DESCRIPTION
Function expressions can't have redeclarations, so exit `check_function_redeclaration` early for function expressions, rather than proceeding through more expensive checks which can't pass anyway.

Marginal improvement (0.1% - 0.2%) on most semantic benchmarks. Or perhaps it's just noise.