### PR TITLE
perf(semantic): move check for function declaration out of `is_function_part_of_if_statement`

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -6,7 +6,7 @@ use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
 use oxc_span::GetSpan;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, symbol::SymbolFlags};
 
-use crate::{SemanticBuilder, checker::is_function_part_of_if_statement};
+use crate::{SemanticBuilder, checker::is_function_decl_part_of_if_statement};
 
 pub trait Binder<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>);
@@ -144,7 +144,8 @@ impl<'a> Binder<'a> for Function<'a> {
         if let Some(ident) = &self.id {
             let excludes = if builder.source_type.is_typescript() {
                 SymbolFlags::FunctionExcludes
-            } else if is_function_part_of_if_statement(self, builder) {
+            } else if self.is_declaration() && is_function_decl_part_of_if_statement(self, builder)
+            {
                 SymbolFlags::empty()
             } else {
                 // `var x; function x() {}` is valid in non-strict mode, but `TypeScript`

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -602,10 +602,11 @@ pub fn check_variable_declarator_redeclaration(
 }
 
 /// Check for Annex B `if (foo) function a() {} else function b() {}`
-pub fn is_function_part_of_if_statement(function: &Function, builder: &SemanticBuilder) -> bool {
-    if !function.is_declaration() {
-        return false;
-    }
+pub fn is_function_decl_part_of_if_statement(
+    function: &Function,
+    builder: &SemanticBuilder,
+) -> bool {
+    debug_assert!(function.is_declaration());
 
     // Function declarations cannot be `consequent` or `alternate` of an `IfStatement` in strict mode.
     // This check is redundant - parent kind lookup below will always return `false` in strict mode.
@@ -633,7 +634,7 @@ pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) 
     // Skip that case.
     let Some(id) = &func.id else { return };
 
-    if is_function_part_of_if_statement(func, ctx) {
+    if is_function_decl_part_of_if_statement(func, ctx) {
         return;
     }
 

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -7,7 +7,7 @@ mod typescript;
 use javascript as js;
 use typescript as ts;
 
-pub use javascript::is_function_part_of_if_statement;
+pub use javascript::is_function_decl_part_of_if_statement;
 
 /// Perform syntax error checking for the given AST node.
 ///


### PR DESCRIPTION
Small optimization. After #18291, one of the callers of `is_function_part_of_if_statement` has already done the check for whether the `Function` is a declaration. So move that repeated check out of `is_function_part_of_if_statement`.

As that function now only applies to function declarations, rename it to `is_function_decl_part_of_if_statement`.