### PR TITLE
refactor(semantic): move code into `if` block

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -137,13 +137,13 @@ impl<'a> Binder<'a> for Function<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         let is_declaration = self.is_declaration();
 
-        let includes = if self.declare {
-            SymbolFlags::Function | SymbolFlags::Ambient
-        } else {
-            SymbolFlags::Function
-        };
-
         if let Some(ident) = &self.id {
+            let includes = if self.declare {
+                SymbolFlags::Function | SymbolFlags::Ambient
+            } else {
+                SymbolFlags::Function
+            };
+
             let excludes = if builder.source_type.is_typescript() {
                 SymbolFlags::FunctionExcludes
             } else if is_declaration && is_function_decl_part_of_if_statement(self, builder) {


### PR DESCRIPTION
Pure refactor. Move calculating `includes` into the `if` block, since it's only used in that block.