### PR TITLE
fix(semantic): do not rely on spans for node comparison in `Function::bind`

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -3,7 +3,6 @@
 use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
-use oxc_span::GetSpan;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, symbol::SymbolFlags};
 
 use crate::{SemanticBuilder, checker::is_function_decl_part_of_if_statement};
@@ -173,7 +172,7 @@ impl<'a> Binder<'a> for Function<'a> {
             //
             // { set [function() {}](val) {} }
             //        ^^^^^^^^^^^^^
-            if prop.key.span() == self.span {
+            if prop.key.address() == self.unstable_address() {
                 return;
             }
             let flags = builder.scoping.scope_flags_mut(builder.current_scope_id);


### PR DESCRIPTION
Binder for `Function` was using spans to check for node equality. 

This is fine when the AST has come directly from the parser as spans are guaranteed to be unique, but it is not reliable when the AST has gone through transformation. If the code has been generated, it might have zeroed spans (`SPAN`), in which case span equality does not guarantee uniqueness.

e.g. if this code is generated:

```js
const obj = {
  [function f() {}]: function g() {},
};
```

`f` and `g` both have the same span (0, 0).

Switch to using `Address` for comparison, which doesn't have this problem.