### PR TITLE
refactor(linter): replace `ptr::eq` with `Address` equality checks

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::UnstableAddress;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -67,7 +68,7 @@ impl Rule for NoUselessSwitchCase {
         let default_case = default_cases[0];
 
         // Check if the `default` case is the last case
-        if !std::ptr::eq(default_case, cases.last().unwrap()) {
+        if default_case.unstable_address() != cases.last().unwrap().unstable_address() {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -60,7 +61,7 @@ impl Rule for PreferEventTarget {
                     return;
                 };
 
-                if !std::ptr::eq(ident, callee_ident.as_ref()) {
+                if ident.unstable_address() != callee_ident.address() {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -1,6 +1,6 @@
 use phf::{Map, phf_map};
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, GetAddress, UnstableAddress};
 use oxc_ast::{
     AstBuilder, AstKind,
     ast::{
@@ -353,10 +353,10 @@ impl PreferKeyboardEventKey {
 
         match second_arg {
             Argument::ArrowFunctionExpression(arrow) => {
-                matches!(callback, CallbackFunction::Arrow(cb) if std::ptr::eq(*cb, arrow.as_ref()))
+                matches!(callback, CallbackFunction::Arrow(cb) if cb.unstable_address() == arrow.address())
             }
             Argument::FunctionExpression(func) => {
-                matches!(callback, CallbackFunction::Regular(cb) if std::ptr::eq(*cb, func.as_ref()))
+                matches!(callback, CallbackFunction::Regular(cb) if cb.unstable_address() == func.address())
             }
             _ => false,
         }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{
     AstKind,
     ast::{Expression, MemberExpression},
@@ -90,7 +91,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the for statement is the same node as the call expression.
-                if !std::ptr::eq(call_expr2.as_ref(), call_expr) {
+                if call_expr2.address() != call_expr.unstable_address() {
                     return;
                 }
             }
@@ -100,7 +101,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the conditional expression is the same node as the call expression.
-                if !std::ptr::eq(call_expr2.as_ref(), call_expr) {
+                if call_expr2.address() != call_expr.unstable_address() {
                     return;
                 }
             }


### PR DESCRIPTION
`ptr::eq` is error-prone as it's easy to pass it a double-reference `&&T` when you mean to pass it a `&T` - and then it doesn't do what you expect it to. Use `Address`es instead for node comparison to avoid these pitfalls.