### PR TITLE
refactor(language_server): clarify pointer equality check

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -221,7 +221,7 @@ impl LanguageServer for Backend {
             let known_files = self.file_system.read().await.keys();
             let mut new_diagnostics = Vec::new();
 
-            for (index, worker) in needed_configurations.values().enumerate() {
+            for (index, worker) in needed_configurations.values().copied().enumerate() {
                 // get the configuration from the response and start the worker
                 let configuration = configurations.get(index).unwrap_or(&serde_json::Value::Null);
                 worker.start_worker(configuration.clone()).await;
@@ -231,7 +231,7 @@ impl LanguageServer for Backend {
                 for uri in &known_files {
                     // Check if this worker is the most specific one for this URI
                     let responsible_worker = Self::find_worker_for_uri(workers, uri);
-                    if responsible_worker.is_none_or(|w| !std::ptr::eq(w, *worker)) {
+                    if responsible_worker.is_none_or(|w| !std::ptr::eq(w, worker)) {
                         continue;
                     }
                     let content = self.file_system.read().await.get(uri);


### PR DESCRIPTION
Pure refactor.

`std::ptr::eq` is somewhat error-prone because it's really easy to compare double-references `&&T` when you mean to compare `&T`s, and the two do completely different things.

https://play.rust-lang.org/?gist=105d126c39ae9071804aa81a830e1ce1

Make this code using `ptr::eq` a bit clearer by removing the dereference in the argument to `ptr::eq`. In IDE you now get a hint on hover of what the type of `worker` is, and that's the type which is being compared.

This change does not alter the behavior - there's no bug here to fix - but hopefully makes it less likely for a bug to arise in future refactoring/changes.

I came across this while removing usages of `ptr::eq` in the linter (#18297).