### PR TITLE
refactor(formatter): `ArrowChain` avoid double-references

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -394,15 +394,15 @@ struct ArrowChain<'a, 'b> {
 
 impl<'a, 'b> ArrowChain<'a, 'b> {
     /// Returns an iterator over all arrow functions in this chain
-    fn arrows(&self) -> impl Iterator<Item = &&'b AstNode<'a, ArrowFunctionExpression<'a>>> {
+    fn arrows(&self) -> impl Iterator<Item = &'b AstNode<'a, ArrowFunctionExpression<'a>>> {
         use std::iter::once;
-        once(&self.head).chain(self.middle.iter()).chain(once(&self.tail))
+        once(self.head).chain(self.middle.iter().copied()).chain(once(self.tail))
     }
 }
 
 impl<'a> Format<'a> for ArrowChain<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let ArrowChain { tail, expand_signatures, .. } = self;
+        let ArrowChain { tail, expand_signatures, .. } = *self;
 
         let tail_body = tail.body();
         let is_grouped_call_arg_layout = self.options.call_argument_layout.is_some();
@@ -550,7 +550,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                 }
             });
 
-            group(&join_signatures).should_expand(*expand_signatures).fmt(f);
+            group(&join_signatures).should_expand(expand_signatures).fmt(f);
         });
 
         let format_tail_body_inner = format_with(|f| {


### PR DESCRIPTION
Refactor.

`ArrowChain::arrows` was returning an iterator of `&&AstNode<ArrowFunctionExpression>>`s (double references). Instead make it return an iterator of `&AstNode<ArrowFunctionExpression>>`s.

I came across this while replacing usage of `std::ptr::eq` in linter (#18249), and initially thought that the `ptr::eq` call here was buggy, because it was comparing double-references (`&&AstNode` not `&AstNode`):

https://github.com/oxc-project/oxc/blob/f79e770a82aee2dc3e64f7935fd7169bc1991ff9/crates/oxc_formatter/src/print/arrow_function_expression.rs#L545-L549

I was wrong about that - it's fine to compare `&&AstNode`s in this case because they're all stable references. But still IMO it's preferable not to be using double-references where it's avoidable. It's (to me, at least) confusing, and can be less performant due to an extra pointer-fetch on each access, if compiler doesn't manage to optimize that out.

This PR does subtly change behavior of the `ptr::eq` check. It will now pass if an earlier `AstNode` and the last `AstNode` are the same node (e.g. `head == tail`). But I assume that's impossible here.