### PR TITLE
docs(linter): "no-unused-vars" extend ignored files section for svelte and astro files

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -78,11 +78,11 @@ declare_oxc_lint!(
     /// functions, etc.
     ///
     /// #### Ignored Files
-    /// This rule ignores `.d.ts` files and `.vue` files entirely. Variables,
+    /// This rule ignores `.d.ts`, `.astro`, `.svelte` and `.vue` files entirely. Variables,
     /// classes, interfaces, and types declared in `.d.ts` files are generally
     /// used by other files, which are not checked by Oxlint. Since Oxlint does
-    /// not support parsing Vue templates, this rule cannot tell if a variable
-    /// is used or unused in a Vue file.
+    /// not support parsing template syntax, this rule cannot tell if a variable
+    /// is used or unused in a Vue / Svelte / Astro file.
     ///
     /// #### Exported
     ///

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -72,11 +72,11 @@ Enums and namespaces are treated the same as variables, classes,
 functions, etc.
 
 #### Ignored Files
-This rule ignores `.d.ts` files and `.vue` files entirely. Variables,
+This rule ignores `.d.ts`, `.astro`, `.svelte` and `.vue` files entirely. Variables,
 classes, interfaces, and types declared in `.d.ts` files are generally
 used by other files, which are not checked by Oxlint. Since Oxlint does
-not support parsing Vue templates, this rule cannot tell if a variable
-is used or unused in a Vue file.
+not support parsing template syntax, this rule cannot tell if a variable
+is used or unused in a Vue / Svelte / Astro file.
 
 #### Exported
 


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/17991