### PR TITLE
fix(linter/plugins): set scope analyse settings based on source type

### DIFF
--- a/apps/oxlint/conformance/snapshot.md
+++ b/apps/oxlint/conformance/snapshot.md
@@ -18,8 +18,8 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests | 33090 | 100.0% |
-| Passing     | 32717 |  98.9% |
-| Failing     |   266 |   0.8% |
+| Passing     | 32719 |  98.9% |
+| Failing     |   264 |   0.8% |
 | Skipped     |   107 |   0.3% |
 
 ## Fully Passing Rules
@@ -291,7 +291,7 @@
 - `no-extra-parens` - 1068 / 1072 (99.6%)
 - `no-fallthrough` - 86 / 87 (98.9%)
 - `no-global-assign` - 15 / 18 (83.3%)
-- `no-implicit-globals` - 155 / 245 (63.3%)
+- `no-implicit-globals` - 157 / 245 (64.1%)
 - `no-invalid-this` - 520 / 562 (92.5%)
 - `no-irregular-whitespace` - 279 / 280 (99.6%)
 - `no-lone-blocks` - 49 / 50 (98.0%)
@@ -1132,8 +1132,8 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 ### `no-implicit-globals`
 
-Pass: 155 / 245 (63.3%)
-Fail: 90 / 245 (36.7%)
+Pass: 157 / 245 (64.1%)
+Fail: 88 / 245 (35.9%)
 Skip: 0 / 245 (0.0%)
 
 #### no-implicit-globals > valid
@@ -1191,80 +1191,6 @@ function foo() {}
         "globalReturn": true
       }
     }
-  }
-}
-```
-
-AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
-  {
-    ruleId: 'rule-to-test/no-implicit-globals',
-    message: 'Unexpected function declaration in the global scope, wrap in an IIFE for a local variable, assign as global property for a global variable.',
-    messageId: 'globalNonLexicalBinding',
-    severity: 1,
-    nodeType: 'FunctionDeclaration',
-    line: 1,
-    column: 0,
-    endLine: 1,
-    endColumn: 17,
-    suggestions: null
-  }
-]
-
-1 !== 0
-
-    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### no-implicit-globals > valid
-
-```js
-var foo = 1;
-```
-
-```json
-{
-  "languageOptions": {
-    "sourceType": "commonjs"
-  }
-}
-```
-
-AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
-  {
-    ruleId: 'rule-to-test/no-implicit-globals',
-    message: "Unexpected 'var' declaration in the global scope, wrap in an IIFE for a local variable, assign as global property for a global variable.",
-    messageId: 'globalNonLexicalBinding',
-    severity: 1,
-    nodeType: 'Identifier',
-    line: 1,
-    column: 4,
-    endLine: 1,
-    endColumn: 11,
-    suggestions: null
-  }
-]
-
-1 !== 0
-
-    at assertErrorCountIsCorrect (apps/oxlint/dist/index.js)
-    at assertValidTestCasePasses (apps/oxlint/dist/index.js)
-    at runValidTestCase (apps/oxlint/dist/index.js)
-    at apps/oxlint/dist/index.js
-
-
-#### no-implicit-globals > valid
-
-```js
-function foo() {}
-```
-
-```json
-{
-  "languageOptions": {
-    "sourceType": "commonjs"
   }
 }
 ```

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -117,7 +117,10 @@ function initTsScopeManager() {
   if (ast === null) initAst();
   debugAssertIsNonNull(ast);
 
-  analyzeOptions.sourceType = ast.sourceType;
+  const { sourceType } = ast;
+  analyzeOptions.sourceType = sourceType;
+  analyzeOptions.globalReturn = sourceType === "commonjs";
+  analyzeOptions.impliedStrict = sourceType === "module";
 
   // @ts-expect-error - TODO: Our types don't quite align yet
   tsScopeManager = analyze(ast, analyzeOptions);

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
@@ -54,7 +54,7 @@
   | isStrict: false
   | variables: [arguments, innerFunction]
   | through: [Object]
-  | upper type: global
+  | upper type: function
     ,-[files/index.cjs:5:1]
   4 |     
   5 | ,-> function topLevelFunction() {


### PR DESCRIPTION
Set `globalReturn` and `impliedStrict` options passed to TS-ESLint scope manager, dependent on source type. In particular, set `globalReturn: true` for CommonJS files. This adds an extra function scope above the global scope.