### PR TITLE
test(linter/plugins): fix regex used for skipping conformance tests

### DIFF
--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -95,7 +95,7 @@ export function it(code: string, fn: () => void): void {
 
     // Skip test cases which include `// eslint-disable` comments.
     // These are not handled by `RuleTester`.
-    if (code.match(/\/\/\s*eslint-disable((-next)?-line)?\s/)) {
+    if (code.match(/\/\/\s*eslint-disable((-next)?-line)?(\s|$)/)) {
       testResult.isSkipped = true;
     }
 


### PR DESCRIPTION
Fix the regex used for skipping test cases, introduced in #18309, as per review comment https://github.com/oxc-project/oxc/pull/18309#discussion_r2709800779.