### PR TITLE
test(linter/plugins): fix types in tester script

### DIFF
--- a/apps/oxlint/conformance/tester.ts
+++ b/apps/oxlint/conformance/tester.ts
@@ -22,6 +22,7 @@ type InvalidTestCase = OxlintRuleTesterTypes.InvalidTestCase;
 type ExtraCaseProps = {
   code?: string;
   languageOptions?: {
+    ecmaVersion?: number | "latest";
     parserOptions?: {
       ecmaFeatures?: {
         globalReturn?: boolean;


### PR DESCRIPTION
Add `ecmaVersion` field to `languageOptions` type in tester script.