### PR TITLE
test(linter): Add HTML comment tests for astro and svelte as well.

### DIFF
--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -178,6 +178,20 @@ mod test {
     }
 
     #[test]
+    fn test_script_inside_code_comment() {
+        let source_text = r"
+        <!-- <script>a</script> -->
+        <!-- <script> -->
+        <script>b</script>
+        ";
+
+        let sources = parse_astro(source_text);
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_text, "b");
+        assert_eq!(sources[0].start, 79);
+    }
+
+    #[test]
     fn test_parse_astro_with_inline_script_self_closing() {
         let source_text = r#"
         <h1>Welcome, world!</h1>

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -98,6 +98,19 @@ mod test {
     }
 
     #[test]
+    fn test_script_inside_code_comment() {
+        let source_text = r"
+        <!-- <script>a</script> -->
+        <!-- <script> -->
+        <script>b</script>
+        ";
+
+        let result = parse_svelte(source_text);
+        assert_eq!(result.source_text, "b");
+        assert_eq!(result.start, 79);
+    }
+
+    #[test]
     fn test_parse_svelte_ts_with_generic() {
         let source_text = r#"
         <script lang="ts" generics="T extends Record<string, unknown>">


### PR DESCRIPTION
This was fixed a while ago, in #15202, but it wasn't being tested before except for Vue files. So I've ported the test over to the other two as well.