### PR TITLE
refactor(formatter,oxfmt): Use language as an identifier for `format_embedded()`

### DIFF
--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -144,11 +144,11 @@ impl ExternalFormatter {
         let embedded_callback: Option<EmbeddedFormatterCallback> = if needs_embedded {
             let format_embedded = Arc::clone(&self.format_embedded);
             let options_for_embedded = options.clone();
-            Some(Arc::new(move |tag_name: &str, code: &str| {
-                let Some(parser_name) = tag_to_prettier_parser(tag_name) else {
+            Some(Arc::new(move |language: &str, code: &str| {
+                let Some(parser_name) = language_to_prettier_parser(language) else {
                     // NOTE: Do not return `Ok(original)` here.
                     // We need to keep unsupported content as-is.
-                    return Err(format!("Unsupported tag: {tag_name}"));
+                    return Err(format!("Unsupported language: {language}"));
                 };
                 (format_embedded)(&options_for_embedded, parser_name, code)
             }))
@@ -198,15 +198,15 @@ impl ExternalFormatter {
 
 // ---
 
-/// Mapping from template tag names to Prettier parser names.
+/// Mapping from `oxc_formatter` language identifiers to Prettier `parser` names.
 /// This is the single source of truth for supported embedded languages.
-fn tag_to_prettier_parser(tag_name: &str) -> Option<&'static str> {
-    match tag_name {
-        // TODO: This should be `scss` to support quasis
-        "css" | "styled" => Some("css"),
-        "gql" | "graphql" => Some("graphql"),
-        "html" => Some("html"),
-        "md" | "markdown" => Some("markdown"),
+fn language_to_prettier_parser(language: &str) -> Option<&'static str> {
+    match language {
+        // TODO: "tagged-css" should use `scss` parser to support quasis
+        "tagged-css" | "styled-jsx" => Some("css"),
+        "tagged-graphql" => Some("graphql"),
+        "tagged-html" => Some("html"),
+        "tagged-markdown" => Some("markdown"),
         _ => None,
     }
 }

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -774,11 +774,11 @@ fn get_tag_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
 
 fn format_embedded_template<'a>(
     f: &mut Formatter<'_, 'a>,
-    tag_name: &str,
+    language: &str,
     template_content: &str,
 ) -> bool {
     let Some(Ok(formatted)) =
-        f.context().external_callbacks().format_embedded(tag_name, template_content)
+        f.context().external_callbacks().format_embedded(language, template_content)
     else {
         return false;
     };
@@ -813,13 +813,17 @@ fn try_format_embedded_template<'a>(
         return false;
     }
 
-    let Some(tag_name) = get_tag_name(&tagged.tag) else {
-        return false;
+    let language = match get_tag_name(&tagged.tag) {
+        Some("css" | "styled") => "tagged-css",
+        Some("gql" | "graphql") => "tagged-graphql",
+        Some("html") => "tagged-html",
+        Some("md" | "markdown") => "tagged-markdown",
+        _ => return false,
     };
 
     let template_content = quasi.quasis[0].value.raw.as_str();
 
-    format_embedded_template(f, tag_name, template_content)
+    format_embedded_template(f, language, template_content)
 }
 
 /// Check if the template literal is inside a `css` prop or `<style jsx>` element.
@@ -874,5 +878,5 @@ fn try_format_css_template<'a>(
     let quasi = template_literal.quasis();
     let template_content = quasi[0].value.raw.as_str();
 
-    format_embedded_template(f, "css", template_content)
+    format_embedded_template(f, "styled-jsx", template_content)
 }


### PR DESCRIPTION
Prepare for next PR, which supports `angular-(template|styles)`

`oxc_formatter` should not know about Prettier; it should only inform `oxfmt` about what it finds.