### PR TITLE
fix(linter): Update `typescript/no-restricted-types` rule to error on invalid config options.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
@@ -36,9 +36,9 @@ fn no_restricted_types_diagnostic(
 pub struct NoRestrictedTypes(Box<NoRestrictedTypesConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NoRestrictedTypesConfig {
     /// A mapping of type names to ban configurations.
-    #[serde(default)]
     types: FxHashMap<String, BanConfigValue>,
 }
 
@@ -150,9 +150,7 @@ declare_oxc_lint!(
 
 impl Rule for NoRestrictedTypes {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
The shape of the config option on this one is a bit rough, but it does get validated fine.