### PR TITLE
fix(oxfmt): increase Tailwind CSS test timeout for Windows CI

### DIFF
--- a/apps/oxfmt/test/tailwindcss/tailwindcss.test.ts
+++ b/apps/oxfmt/test/tailwindcss/tailwindcss.test.ts
@@ -2,7 +2,9 @@ import { format } from "../../dist/index.js";
 import { describe, expect, test } from "vitest";
 
 describe("Tailwind CSS Sorting", () => {
-  test("should sort Tailwind classes when experimentalTailwindcss is enabled", async () => {
+  // First test triggers Tailwind CSS initialization which is slow on Windows CI
+  // https://github.com/oxc-project/oxc/issues/18072
+  test("should sort Tailwind classes when experimentalTailwindcss is enabled", { timeout: 30_000 }, async () => {
     // Unsorted: p-4 comes before flex
     const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
 

--- a/apps/oxfmt/test/tailwindcss/tailwindcss.test.ts
+++ b/apps/oxfmt/test/tailwindcss/tailwindcss.test.ts
@@ -4,20 +4,24 @@ import { describe, expect, test } from "vitest";
 describe("Tailwind CSS Sorting", () => {
   // First test triggers Tailwind CSS initialization which is slow on Windows CI
   // https://github.com/oxc-project/oxc/issues/18072
-  test("should sort Tailwind classes when experimentalTailwindcss is enabled", { timeout: 30_000 }, async () => {
-    // Unsorted: p-4 comes before flex
-    const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
+  test(
+    "should sort Tailwind classes when experimentalTailwindcss is enabled",
+    { timeout: 30_000 },
+    async () => {
+      // Unsorted: p-4 comes before flex
+      const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
 
-    const result = await format("test.tsx", input, {
-      experimentalTailwindcss: {},
-    });
+      const result = await format("test.tsx", input, {
+        experimentalTailwindcss: {},
+      });
 
-    // After sorting, flex should come before p-4 (display before spacing)
-    // The exact order of bg-red-500 and text-white may vary by Tailwind version
-    expect(result.code).toContain('className="flex');
-    expect(result.code).not.toContain('className="p-4 flex'); // p-4 should not be before flex
-    expect(result.errors).toStrictEqual([]);
-  });
+      // After sorting, flex should come before p-4 (display before spacing)
+      // The exact order of bg-red-500 and text-white may vary by Tailwind version
+      expect(result.code).toContain('className="flex');
+      expect(result.code).not.toContain('className="p-4 flex'); // p-4 should not be before flex
+      expect(result.errors).toStrictEqual([]);
+    },
+  );
 
   test("should NOT sort Tailwind classes when experimentalTailwindcss is disabled (default)", async () => {
     const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;


### PR DESCRIPTION
## Summary
- Increase timeout for the first Tailwind CSS test from default 10s to 30s
- Add comment referencing the issue explaining why the timeout is needed

The first test triggers Tailwind CSS initialization which takes 10+ seconds on Windows CI due to cold startup costs (Prettier config resolution, Tailwind dynamic import, design system init).

Closes #18072

## Test plan
- [x] CI should pass on Windows now that timeout is increased

🤖 Generated with [Claude Code](https://claude.com/claude-code)