### PR TITLE
test(linter/plugins): improve internal types

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -11,29 +11,18 @@ import { ESLINT_RULES_TESTS_DIR_PATH } from "./run.ts";
 import { FILTER_ONLY_CODE } from "./filter.ts";
 
 import type { Rule } from "#oxlint";
+import type { LanguageOptionsInternal } from "../../src-js/package/rule_tester.ts";
+export type { LanguageOptionsInternal };
 
 type DescribeFn = RuleTester.DescribeFn;
 type ItFn = RuleTester.ItFn;
 type TestCases = RuleTester.TestCases;
 type ValidTestCase = RuleTester.ValidTestCase;
 type InvalidTestCase = RuleTester.InvalidTestCase;
-type LanguageOptions = RuleTester.LanguageOptions;
 type Globals = RuleTester.Globals;
 export type TestCase = ValidTestCase | InvalidTestCase;
 
 const { isArray } = Array;
-
-/**
- * Language options config, with `parser` and `ecmaVersion` properties.
- * This is a copy of `RuleTester`'s internal type of the same name.
- */
-interface LanguageOptionsInternal extends LanguageOptions {
-  ecmaVersion?: number | "latest";
-  parser?: {
-    parse?: (code: string, options?: Record<string, unknown>) => unknown;
-    parseForESLint?: (code: string, options?: Record<string, unknown>) => unknown;
-  };
-}
 
 // Get `@typescript-eslint/parser` module.
 // Load the instance which would be loaded by files in ESLint's `tests/lib/rules` directory.

--- a/apps/oxlint/conformance/tester.ts
+++ b/apps/oxlint/conformance/tester.ts
@@ -15,25 +15,18 @@ import { builtinRules } from "./submodules/eslint/lib/unsupported-api.js";
 
 import type { Rule } from "#oxlint";
 import type { RuleTester as OxlintRuleTesterTypes } from "#oxlint";
+import type { LanguageOptionsInternal } from "./src/rule_tester.ts";
 
 type ValidTestCase = OxlintRuleTesterTypes.ValidTestCase;
 type InvalidTestCase = OxlintRuleTesterTypes.InvalidTestCase;
 
-type ExtraCaseProps = {
+interface TestCaseExtension {
   code?: string;
-  languageOptions?: {
-    ecmaVersion?: number | "latest";
-    parserOptions?: {
-      ecmaFeatures?: {
-        globalReturn?: boolean;
-        impliedStrict?: boolean;
-      };
-    };
-  };
-};
+  languageOptions?: LanguageOptionsInternal;
+}
 
-type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & ExtraCaseProps;
-type InvalidTestCaseWithoutCode = Omit<InvalidTestCase, "code"> & ExtraCaseProps;
+type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & TestCaseExtension;
+type InvalidTestCaseWithoutCode = Omit<InvalidTestCase, "code"> & TestCaseExtension;
 type TestCaseWithoutCode = ValidTestCaseWithoutCode | InvalidTestCaseWithoutCode;
 
 // Reset `describe` + `it` to simple pass-through functions.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -124,17 +124,18 @@ interface LanguageOptions {
 }
 
 /**
- * Language options config, with `parser` and `ecmaVersion` properties.
+ * Language options config, with `parser` and `ecmaVersion` properties, and extended `parserOptions`.
  * These properties should not be present in `languageOptions` config,
  * but could be if test cases are ported from ESLint.
  * For internal use only.
  */
-interface LanguageOptionsInternal extends LanguageOptions {
+export interface LanguageOptionsInternal extends LanguageOptions {
   ecmaVersion?: number | "latest";
   parser?: {
     parse?: (code: string, options?: Record<string, unknown>) => unknown;
     parseForESLint?: (code: string, options?: Record<string, unknown>) => unknown;
   };
+  parserOptions?: ParserOptionsInternal;
 }
 
 /**
@@ -183,6 +184,16 @@ interface ParserOptions {
    * `true` to ignore non-fatal parsing errors.
    */
   ignoreNonFatalErrors?: boolean;
+}
+
+/**
+ * Parser options config, with extended `ecmaFeatures`.
+ * These properties should not be present in `languageOptions` config,
+ * but could be if test cases are ported from ESLint.
+ * For internal use only.
+ */
+interface ParserOptionsInternal extends ParserOptions {
+  ecmaFeatures?: EcmaFeaturesInternal;
 }
 
 /**
@@ -1253,9 +1264,7 @@ function setEcmaVersionAndFeatures(test: TestCase) {
   setEcmaVersion(version);
 
   // Set `globalReturn` and `impliedStrict` in scope analyzer options
-  const ecmaFeatures = languageOptions?.parserOptions?.ecmaFeatures as
-    | EcmaFeaturesInternal
-    | undefined;
+  const ecmaFeatures = languageOptions?.parserOptions?.ecmaFeatures;
   ecmaFeaturesOverride.globalReturn = ecmaFeatures?.globalReturn ?? null;
   ecmaFeaturesOverride.impliedStrict = ecmaFeatures?.impliedStrict ?? null;
 }


### PR DESCRIPTION
Pure refactor.

1. Add a `ParserOptionsInternal` type which bridges between `LanguageOptionsInternal` and `EcmaFeaturesInternal`.
2. Reuse `LanguageOptionsInternal` type in conformance tests, rather than redefining the same type again.