### PR TITLE
chore(prettier): ignore top-level-await tests due to Prettier bug

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 741/760 (97.50%)
+js compatibility: 737/754 (97.75%)
 
 # Failed
 
@@ -20,6 +20,4 @@ js compatibility: 741/760 (97.50%)
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
 | js/ternaries/parenthesis/await-expression.js | 💥 | 33.33% |
-| js/top-level-await/test.js | 💥 | 0.00% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/top-level-await/test.jsx | 💥 | 0.00% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,11 +1,10 @@
-ts compatibility: 585/605 (96.69%)
+ts compatibility: 583/600 (97.17%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
-| jsx/top-level-await/test.jsx | 💥 | 0.00% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 82.22% |
@@ -18,8 +17,6 @@ ts compatibility: 585/605 (96.69%)
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
-| typescript/top-level-await/test.ts | 💥 | 0.00% |
-| typescript/top-level-await/test.tsx | 💥 | 0.00% |
 | typescript/union/comments/18106.ts | 💥 | 92.68% |
 | typescript/union/comments/18379.ts | 💥 | 87.27% |
 | typescript/union/comments/18389.ts | 💥 | 51.28% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -106,4 +106,8 @@ pub const IGNORE_TESTS: &[&str] = &[
     "cursor",
     // Invalid
     "js/call/invalid",
+    // Prettier bug: https://github.com/prettier/prettier/issues/18707
+    "js/top-level-await",
+    "jsx/top-level-await",
+    "typescript/top-level-await",
 ];


### PR DESCRIPTION
## Summary

- Ignore top-level-await conformance tests due to Prettier bug

Prettier incorrectly parses `await(1)` as a top-level await expression in `.js` files even without ESM syntax, formatting it as `await 1`.

Babel, TypeScript, and Oxc all use content-based detection for unambiguous source types and correctly keep it as `await(1)`.

See https://github.com/prettier/prettier/issues/18707

🤖 Generated with [Claude Code](https://claude.ai/code)