### PR TITLE
perf(formatter): reduce AstNode size by 8 bytes using following_span_start

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -815,42 +815,49 @@ impl<'a> AstNode<'a, Program<'a>> {
 
     #[inline]
     pub fn hashbang(&self) -> Option<&AstNode<'a, Hashbang<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .directives
             .first()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.body.first().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.body.first().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.hashbang.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_span = self.inner.body.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .body
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Program(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -859,7 +866,8 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -873,21 +881,21 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::NullLiteral(s) => AstNodes::NullLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::NumericLiteral(s) => {
                 AstNodes::NumericLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::BigIntLiteral(s) => {
@@ -895,7 +903,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::RegExpLiteral(s) => {
@@ -903,7 +911,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::StringLiteral(s) => {
@@ -911,7 +919,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TemplateLiteral(s) => {
@@ -919,7 +927,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::Identifier(s) => {
@@ -927,27 +935,27 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::MetaProperty(s) => AstNodes::MetaProperty(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::Super(s) => AstNodes::Super(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::ArrayExpression(s) => {
                 AstNodes::ArrayExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ArrowFunctionExpression(s) => {
@@ -955,7 +963,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::AssignmentExpression(s) => {
@@ -963,7 +971,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::AwaitExpression(s) => {
@@ -971,7 +979,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::BinaryExpression(s) => {
@@ -979,7 +987,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::CallExpression(s) => {
@@ -987,7 +995,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ChainExpression(s) => {
@@ -995,21 +1003,21 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ClassExpression(s) => AstNodes::Class(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::ConditionalExpression(s) => {
                 AstNodes::ConditionalExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::FunctionExpression(s) => {
@@ -1017,7 +1025,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ImportExpression(s) => {
@@ -1025,7 +1033,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::LogicalExpression(s) => {
@@ -1033,7 +1041,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::NewExpression(s) => {
@@ -1041,7 +1049,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ObjectExpression(s) => {
@@ -1049,7 +1057,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ParenthesizedExpression(s) => {
@@ -1057,7 +1065,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::SequenceExpression(s) => {
@@ -1065,7 +1073,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TaggedTemplateExpression(s) => {
@@ -1073,7 +1081,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::ThisExpression(s) => {
@@ -1081,7 +1089,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::UnaryExpression(s) => {
@@ -1089,7 +1097,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::UpdateExpression(s) => {
@@ -1097,7 +1105,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::YieldExpression(s) => {
@@ -1105,7 +1113,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::PrivateInExpression(s) => {
@@ -1113,27 +1121,27 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::JSXElement(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::JSXFragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Expression::TSAsExpression(s) => {
                 AstNodes::TSAsExpression(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TSSatisfiesExpression(s) => {
@@ -1141,7 +1149,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TSTypeAssertion(s) => {
@@ -1149,7 +1157,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TSNonNullExpression(s) => {
@@ -1157,7 +1165,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::TSInstantiationExpression(s) => {
@@ -1165,7 +1173,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Expression::V8IntrinsicExpression(s) => {
@@ -1173,7 +1181,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_member_expression!(Expression) => {
@@ -1183,7 +1191,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -1203,7 +1211,8 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1218,7 +1227,8 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1233,7 +1243,8 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1248,7 +1259,8 @@ impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1258,19 +1270,20 @@ impl<'a> AstNode<'a, ThisExpression> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ArrayExpression<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1279,7 +1292,8 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1293,7 +1307,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ArrayExpressionElement::Elision(s) => {
@@ -1301,7 +1315,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_expression!(ArrayExpressionElement) => {
@@ -1311,7 +1325,7 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -1326,19 +1340,20 @@ impl<'a> AstNode<'a, Elision> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ObjectExpression<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1347,7 +1362,8 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1361,7 +1377,7 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ObjectPropertyKind::SpreadProperty(s) => {
@@ -1369,7 +1385,7 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -1385,23 +1401,23 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = Some(self.inner.value.span());
+        let following_span_start = self.inner.value.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1425,7 +1441,8 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1439,7 +1456,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             PropertyKey::PrivateIdentifier(s) => {
@@ -1447,7 +1464,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_expression!(PropertyKey) => {
@@ -1457,7 +1474,7 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -1469,24 +1486,29 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
 impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
-        let following_span =
-            self.inner.expressions.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .expressions
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TemplateLiteral(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TemplateLiteral(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1495,49 +1517,51 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     #[inline]
     pub fn tag(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_arguments
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.quasi.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.quasi.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.tag,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = Some(self.inner.quasi.span());
+        let following_span_start = self.inner.quasi.span().start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn quasi(&self) -> &AstNode<'a, TemplateLiteral<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasi,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TaggedTemplateExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1546,7 +1570,8 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1571,7 +1596,8 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1585,7 +1611,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             MemberExpression::StaticMemberExpression(s) => {
@@ -1593,7 +1619,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             MemberExpression::PrivateFieldExpression(s) => {
@@ -1601,7 +1627,7 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -1612,23 +1638,23 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
 impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.expression.span());
+        let following_span_start = self.inner.expression.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ComputedMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ComputedMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1642,30 +1668,31 @@ impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.property.span());
+        let following_span_start = self.inner.property.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1679,30 +1706,31 @@ impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.field.span());
+        let following_span_start = self.inner.field.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateFieldExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn field(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.field,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateFieldExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1716,50 +1744,57 @@ impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, CallExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_arguments
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.arguments.first().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.arguments.first().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span =
-            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .arguments
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CallExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1778,50 +1813,57 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, NewExpression<'a>> {
     #[inline]
     pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_arguments
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.arguments.first().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.arguments.first().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span =
-            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .arguments
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::NewExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1835,30 +1877,31 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, MetaProperty<'a>> {
     #[inline]
     pub fn meta(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = Some(self.inner.property.span());
+        let following_span_start = self.inner.property.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.meta,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MetaProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MetaProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1867,19 +1910,20 @@ impl<'a> AstNode<'a, MetaProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, SpreadElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SpreadElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1888,7 +1932,8 @@ impl<'a> AstNode<'a, SpreadElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1901,7 +1946,7 @@ impl<'a> AstNode<'a, Argument<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             it @ match_expression!(Argument) => {
                 return self
@@ -1910,7 +1955,7 @@ impl<'a> AstNode<'a, Argument<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -1932,12 +1977,12 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, SimpleAssignmentTarget<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::UpdateExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1946,7 +1991,8 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -1958,12 +2004,12 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::UnaryExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1972,19 +2018,20 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, BinaryExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BinaryExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -1995,12 +2042,12 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BinaryExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2009,30 +2056,31 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateInExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PrivateInExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2041,19 +2089,20 @@ impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, LogicalExpression<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LogicalExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2064,12 +2113,12 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LogicalExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2078,41 +2127,42 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.consequent.span());
+        let following_span_start = self.inner.consequent.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.alternate.span());
+        let following_span_start = self.inner.alternate.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn alternate(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.alternate,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ConditionalExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2121,7 +2171,8 @@ impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2133,23 +2184,23 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
 
     #[inline]
     pub fn left(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2158,7 +2209,8 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2175,7 +2227,7 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
                         inner: it.to_simple_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2186,7 +2238,7 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
                         inner: it.to_assignment_target_pattern(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2204,7 +2256,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             SimpleAssignmentTarget::TSAsExpression(s) => {
@@ -2212,7 +2264,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             SimpleAssignmentTarget::TSSatisfiesExpression(s) => {
@@ -2220,7 +2272,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             SimpleAssignmentTarget::TSNonNullExpression(s) => {
@@ -2228,7 +2280,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             SimpleAssignmentTarget::TSTypeAssertion(s) => {
@@ -2236,7 +2288,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_member_expression!(SimpleAssignmentTarget) => {
@@ -2246,7 +2298,7 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2265,7 +2317,7 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             AssignmentTargetPattern::ObjectAssignmentTarget(s) => {
@@ -2273,7 +2325,7 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -2284,24 +2336,30 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
 impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
-        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .rest
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayAssignmentTarget(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ArrayAssignmentTarget(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -2311,32 +2369,39 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
-        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .rest
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectAssignmentTarget(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ObjectAssignmentTarget(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -2346,19 +2411,20 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     #[inline]
     pub fn target(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.target,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentTargetRest(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2367,7 +2433,8 @@ impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2381,7 +2448,7 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
@@ -2391,7 +2458,7 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         inner: it.to_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2403,27 +2470,27 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
-        let following_span = Some(self.inner.init.span());
+        let following_span_start = self.inner.init.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetWithDefault(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn init(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.init,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetWithDefault(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2432,7 +2499,8 @@ impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2446,7 +2514,7 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             AssignmentTargetProperty::AssignmentTargetPropertyProperty(s) => {
@@ -2454,7 +2522,7 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -2465,20 +2533,26 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
 impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, IdentifierReference<'a>> {
-        let following_span = self.inner.init.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .init
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| {
                 AstNode {
@@ -2487,7 +2561,7 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }
             }))
             .as_ref()
@@ -2498,34 +2572,35 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = Some(self.inner.binding.span());
+        let following_span_start = self.inner.binding.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn binding(&self) -> &AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::AssignmentTargetPropertyProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2539,19 +2614,20 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, SequenceExpression<'a>> {
     #[inline]
     pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SequenceExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2560,7 +2636,8 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2570,19 +2647,20 @@ impl<'a> AstNode<'a, Super> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, AwaitExpression<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AwaitExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2591,19 +2669,20 @@ impl<'a> AstNode<'a, AwaitExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ChainExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, ChainElement<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ChainExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2612,7 +2691,8 @@ impl<'a> AstNode<'a, ChainExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2626,7 +2706,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ChainElement::TSNonNullExpression(s) => {
@@ -2634,7 +2714,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_member_expression!(ChainElement) => {
@@ -2644,7 +2724,7 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                         inner: it.to_member_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2656,12 +2736,12 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
 impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ParenthesizedExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2670,7 +2750,8 @@ impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2684,7 +2765,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::BreakStatement(s) => {
@@ -2692,7 +2773,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ContinueStatement(s) => {
@@ -2700,7 +2781,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::DebuggerStatement(s) => {
@@ -2708,7 +2789,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::DoWhileStatement(s) => {
@@ -2716,7 +2797,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::EmptyStatement(s) => {
@@ -2724,7 +2805,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ExpressionStatement(s) => {
@@ -2732,7 +2813,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ForInStatement(s) => {
@@ -2740,7 +2821,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ForOfStatement(s) => {
@@ -2748,27 +2829,27 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ForStatement(s) => AstNodes::ForStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Statement::IfStatement(s) => AstNodes::IfStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Statement::LabeledStatement(s) => {
                 AstNodes::LabeledStatement(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ReturnStatement(s) => {
@@ -2776,7 +2857,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::SwitchStatement(s) => {
@@ -2784,7 +2865,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::ThrowStatement(s) => {
@@ -2792,28 +2873,28 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::TryStatement(s) => AstNodes::TryStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Statement::WhileStatement(s) => {
                 AstNodes::WhileStatement(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Statement::WithStatement(s) => AstNodes::WithStatement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             it @ match_declaration!(Statement) => {
                 return self
@@ -2822,7 +2903,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                         inner: it.to_declaration(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2833,7 +2914,7 @@ impl<'a> AstNode<'a, Statement<'a>> {
                         inner: it.to_module_declaration(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -2845,12 +2926,12 @@ impl<'a> AstNode<'a, Statement<'a>> {
 impl<'a> AstNode<'a, Directive<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Directive(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2864,7 +2945,8 @@ impl<'a> AstNode<'a, Directive<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2879,19 +2961,20 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, BlockStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BlockStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -2900,7 +2983,8 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -2914,7 +2998,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::FunctionDeclaration(s) => {
@@ -2922,21 +3006,21 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::ClassDeclaration(s) => AstNodes::Class(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             Declaration::TSTypeAliasDeclaration(s) => {
                 AstNodes::TSTypeAliasDeclaration(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::TSInterfaceDeclaration(s) => {
@@ -2944,7 +3028,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::TSEnumDeclaration(s) => {
@@ -2952,7 +3036,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::TSModuleDeclaration(s) => {
@@ -2960,7 +3044,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::TSGlobalDeclaration(s) => {
@@ -2968,7 +3052,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             Declaration::TSImportEqualsDeclaration(s) => {
@@ -2976,7 +3060,7 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -2992,12 +3076,12 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
 
     #[inline]
     pub fn declarations(&self) -> &AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.declarations,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::VariableDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3011,7 +3095,8 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3023,43 +3108,50 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
 
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_annotation
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.init.as_ref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.init.as_ref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::VariableDeclarator(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.inner.init.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .init
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::VariableDeclarator(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::VariableDeclarator(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3074,7 +3166,8 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3084,19 +3177,20 @@ impl<'a> AstNode<'a, EmptyStatement> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExpressionStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3105,42 +3199,43 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, IfStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.consequent.span());
+        let following_span_start = self.inner.consequent.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = self.inner.alternate.as_ref().map(GetSpan::span);
+        let following_span_start = self.inner.alternate.as_ref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn alternate(&self) -> Option<&AstNode<'a, Statement<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.alternate.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::IfStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3150,30 +3245,31 @@ impl<'a> AstNode<'a, IfStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = Some(self.inner.test.span());
+        let following_span_start = self.inner.test.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::DoWhileStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::DoWhileStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3182,30 +3278,31 @@ impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, WhileStatement<'a>> {
     #[inline]
     pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WhileStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WhileStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3214,65 +3311,72 @@ impl<'a> AstNode<'a, WhileStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ForStatement<'a>> {
     #[inline]
     pub fn init(&self) -> Option<&AstNode<'a, ForStatementInit<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .test
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.update.as_ref().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.update.as_ref().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span =
-            self.inner.update.as_ref().map(GetSpan::span).or_else(|| Some(self.inner.body.span()));
+        let following_span_start = self
+            .inner
+            .update
+            .as_ref()
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn update(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator
             .alloc(self.inner.update.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3281,7 +3385,8 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3295,7 +3400,7 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_expression!(ForStatementInit) => {
@@ -3305,7 +3410,7 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -3317,34 +3422,34 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
 impl<'a> AstNode<'a, ForInStatement<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForInStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3353,7 +3458,8 @@ impl<'a> AstNode<'a, ForInStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3367,7 +3473,7 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_assignment_target!(ForStatementLeft) => {
@@ -3377,7 +3483,7 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                         inner: it.to_assignment_target(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -3394,34 +3500,34 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
 
     #[inline]
     pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ForOfStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3430,20 +3536,21 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ContinueStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ContinueStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3453,20 +3560,21 @@ impl<'a> AstNode<'a, ContinueStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, BreakStatement<'a>> {
     #[inline]
     pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::BreakStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3476,20 +3584,21 @@ impl<'a> AstNode<'a, BreakStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ReturnStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ReturnStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3499,30 +3608,31 @@ impl<'a> AstNode<'a, ReturnStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, WithStatement<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3531,30 +3641,31 @@ impl<'a> AstNode<'a, WithStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, SwitchStatement<'a>> {
     #[inline]
     pub fn discriminant(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.inner.cases.first().map(GetSpan::span);
+        let following_span_start = self.inner.cases.first().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.discriminant,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn cases(&self) -> &AstNode<'a, Vec<'a, SwitchCase<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.cases,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3563,33 +3674,39 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, SwitchCase<'a>> {
     #[inline]
     pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span =
-            self.inner.consequent.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .consequent
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::SwitchCase(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn consequent(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::SwitchCase(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3598,30 +3715,31 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, LabeledStatement<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, LabelIdentifier<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LabeledStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::LabeledStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3630,19 +3748,20 @@ impl<'a> AstNode<'a, LabeledStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ThrowStatement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ThrowStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3651,49 +3770,51 @@ impl<'a> AstNode<'a, ThrowStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TryStatement<'a>> {
     #[inline]
     pub fn block(&self) -> &AstNode<'a, BlockStatement<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .handler
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.finalizer.as_deref().map(GetSpan::span));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.finalizer.as_deref().map(|n| n.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.block.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn handler(&self) -> Option<&AstNode<'a, CatchClause<'a>>> {
-        let following_span = self.inner.finalizer.as_deref().map(GetSpan::span);
+        let following_span_start = self.inner.finalizer.as_deref().map_or(0, |n| n.span().start);
         self.allocator
             .alloc(self.inner.handler.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn finalizer(&self) -> Option<&AstNode<'a, BlockStatement<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.finalizer.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TryStatement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3703,32 +3824,33 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, CatchClause<'a>> {
     #[inline]
     pub fn param(&self) -> Option<&AstNode<'a, CatchParameter<'a>>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator
             .alloc(self.inner.param.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::CatchClause(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, BlockStatement<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CatchClause(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3737,32 +3859,38 @@ impl<'a> AstNode<'a, CatchClause<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, CatchParameter<'a>> {
     #[inline]
     pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span =
-            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_annotation
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::CatchParameter(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::CatchParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3772,7 +3900,8 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3782,7 +3911,8 @@ impl<'a> AstNode<'a, DebuggerStatement> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3796,7 +3926,7 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             BindingPattern::ObjectPattern(s) => {
@@ -3804,7 +3934,7 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             BindingPattern::ArrayPattern(s) => {
@@ -3812,7 +3942,7 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             BindingPattern::AssignmentPattern(s) => {
@@ -3820,7 +3950,7 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -3831,23 +3961,23 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
 impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentPattern(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AssignmentPattern(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3856,31 +3986,38 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ObjectPattern<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
-        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .rest
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ObjectPattern(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ObjectPattern(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3890,30 +4027,31 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, BindingProperty<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = Some(self.inner.value.span());
+        let following_span_start = self.inner.value.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3932,31 +4070,38 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ArrayPattern<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
-        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .rest
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrayPattern(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ArrayPattern(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -3966,19 +4111,20 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, BindingRestElement<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::BindingRestElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -3987,7 +4133,8 @@ impl<'a> AstNode<'a, BindingRestElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -3999,19 +4146,20 @@ impl<'a> AstNode<'a, Function<'a>> {
 
     #[inline]
     pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_parameters
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.this_param.as_deref().map(GetSpan::span))
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.this_param.as_deref().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4033,74 +4181,82 @@ impl<'a> AstNode<'a, Function<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .this_param
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .return_type
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.body.as_deref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.body.as_deref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.inner.body.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .body
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> Option<&AstNode<'a, FunctionBody<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Function(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4120,7 +4276,8 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4132,24 +4289,30 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
 
     #[inline]
     pub fn items(&self) -> &AstNode<'a, Vec<'a, FormalParameter<'a>>> {
-        let following_span = self.inner.rest.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .rest
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.items,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameters(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, FormalParameterRest<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::FormalParameters(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4159,62 +4322,69 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, FormalParameter<'a>> {
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_span = Some(self.inner.pattern.span());
+        let following_span_start = self.inner.pattern.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_annotation
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.initializer.as_deref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.initializer.as_deref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span =
-            self.inner.initializer.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .initializer
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn initializer(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.initializer.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::FormalParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4244,32 +4414,38 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, FormalParameterRest<'a>> {
     #[inline]
     pub fn rest(&self) -> &AstNode<'a, BindingRestElement<'a>> {
-        let following_span =
-            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_annotation
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.rest,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FormalParameterRest(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::FormalParameterRest(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4279,31 +4455,37 @@ impl<'a> AstNode<'a, FormalParameterRest<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, FunctionBody<'a>> {
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_span =
-            self.inner.statements.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .statements
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FunctionBody(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn statements(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.statements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::FunctionBody(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4312,7 +4494,8 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4329,56 +4512,57 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .return_type
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, FunctionBody<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ArrowFunctionExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4397,7 +4581,8 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4409,13 +4594,13 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
 
     #[inline]
     pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::YieldExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4425,7 +4610,8 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4437,121 +4623,126 @@ impl<'a> AstNode<'a, Class<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .id
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.type_parameters.as_deref().map(GetSpan::span))
-            .or_else(|| self.inner.super_class.as_ref().map(GetSpan::span))
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
-            .or_else(|| self.inner.implements.first().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.type_parameters.as_deref().map(|n| n.span().start))
+            .or_else(|| self.inner.super_class.as_ref().map(|n| n.span().start))
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(|n| n.span().start))
+            .or_else(|| self.inner.implements.first().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_parameters
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.super_class.as_ref().map(GetSpan::span))
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
-            .or_else(|| self.inner.implements.first().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.super_class.as_ref().map(|n| n.span().start))
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(|n| n.span().start))
+            .or_else(|| self.inner.implements.first().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .super_class
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.super_type_arguments.as_deref().map(GetSpan::span))
-            .or_else(|| self.inner.implements.first().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.super_type_arguments.as_deref().map(|n| n.span().start))
+            .or_else(|| self.inner.implements.first().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn super_class(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .super_type_arguments
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.implements.first().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.implements.first().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.super_class.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn super_type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .implements
             .first()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.super_type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn implements(&self) -> &AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.implements,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, ClassBody<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Class(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4570,19 +4761,20 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ClassBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, ClassElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ClassBody(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4591,7 +4783,8 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4604,14 +4797,14 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             ClassElement::MethodDefinition(s) => {
                 AstNodes::MethodDefinition(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ClassElement::PropertyDefinition(s) => {
@@ -4619,7 +4812,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ClassElement::AccessorProperty(s) => {
@@ -4627,7 +4820,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ClassElement::TSIndexSignature(s) => {
@@ -4635,7 +4828,7 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -4651,34 +4844,34 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_span = Some(self.inner.key.span());
+        let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = Some(self.inner.value.span());
+        let following_span_start = self.inner.value.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, Function<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.value.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::MethodDefinition(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4717,7 +4910,8 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4729,54 +4923,61 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_span = Some(self.inner.key.span());
+        let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_annotation
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.value.as_ref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.value.as_ref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .value
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::PropertyDefinition(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -4826,7 +5027,8 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4841,19 +5043,20 @@ impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, StaticBlock<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::StaticBlock(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -4862,7 +5065,8 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -4876,7 +5080,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleDeclaration::ExportAllDeclaration(s) => {
@@ -4884,7 +5088,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleDeclaration::ExportDefaultDeclaration(s) => {
@@ -4892,7 +5096,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleDeclaration::ExportNamedDeclaration(s) => {
@@ -4900,7 +5104,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleDeclaration::TSExportAssignment(s) => {
@@ -4908,7 +5112,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleDeclaration::TSNamespaceExportDeclaration(s) => {
@@ -4916,7 +5120,7 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -4932,54 +5136,61 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
 
     #[inline]
     pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
-        let following_span = Some(self.inner.key.span());
+        let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_annotation
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.value.as_ref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.value.as_ref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .value
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::AccessorProperty(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5014,31 +5225,38 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ImportExpression<'a>> {
     #[inline]
     pub fn source(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.inner.options.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .options
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn options(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportExpression(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5053,32 +5271,33 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     #[inline]
     pub fn specifiers(&self) -> Option<&AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
-        let following_span = Some(self.inner.source.span());
+        let following_span_start = self.inner.source.span().start;
         self.allocator
             .alloc(self.inner.specifiers.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
+        let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5089,13 +5308,13 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ImportDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5110,7 +5329,8 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5124,7 +5344,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
@@ -5132,7 +5352,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
@@ -5140,7 +5360,7 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -5151,23 +5371,23 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
 impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     #[inline]
     pub fn imported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_span = Some(self.inner.local.span());
+        let following_span_start = self.inner.local.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.imported,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5181,19 +5401,20 @@ impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportDefaultSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5202,19 +5423,20 @@ impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportNamespaceSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5223,7 +5445,8 @@ impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5235,12 +5458,12 @@ impl<'a> AstNode<'a, WithClause<'a>> {
 
     #[inline]
     pub fn with_entries(&self) -> &AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.with_entries,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::WithClause(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5249,30 +5472,31 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ImportAttribute<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, ImportAttributeKey<'a>> {
-        let following_span = Some(self.inner.value.span());
+        let following_span_start = self.inner.value.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportAttribute(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn value(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ImportAttribute(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5281,7 +5505,8 @@ impl<'a> AstNode<'a, ImportAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5295,7 +5520,7 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ImportAttributeKey::StringLiteral(s) => {
@@ -5303,7 +5528,7 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -5314,50 +5539,52 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
 impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     #[inline]
     pub fn declaration(&self) -> Option<&AstNode<'a, Declaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .specifiers
             .first()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.source.as_ref().map(GetSpan::span))
-            .or_else(|| self.inner.with_clause.as_deref().map(GetSpan::span));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.source.as_ref().map(|n| n.span().start))
+            .or_else(|| self.inner.with_clause.as_deref().map(|n| n.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.declaration.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn specifiers(&self) -> &AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .source
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.with_clause.as_deref().map(GetSpan::span));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.with_clause.as_deref().map(|n| n.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.specifiers,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn source(&self) -> Option<&AstNode<'a, StringLiteral<'a>>> {
-        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
+        let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
         self.allocator
             .alloc(self.inner.source.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5369,14 +5596,14 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::ExportNamedDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5386,19 +5613,20 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     #[inline]
     pub fn declaration(&self) -> &AstNode<'a, ExportDefaultDeclarationKind<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.declaration,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportDefaultDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5407,44 +5635,45 @@ impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     #[inline]
     pub fn exported(&self) -> Option<&AstNode<'a, ModuleExportName<'a>>> {
-        let following_span = Some(self.inner.source.span());
+        let following_span_start = self.inner.source.span().start;
         self.allocator
             .alloc(self.inner.exported.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self.inner.with_clause.as_deref().map(GetSpan::span);
+        let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::ExportAllDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5459,30 +5688,31 @@ impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     #[inline]
     pub fn local(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_span = Some(self.inner.exported.span());
+        let following_span_start = self.inner.exported.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.exported,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::ExportSpecifier(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5496,7 +5726,8 @@ impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5510,7 +5741,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ExportDefaultDeclarationKind::ClassDeclaration(s) => {
@@ -5518,7 +5749,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(s) => {
@@ -5526,7 +5757,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_expression!(ExportDefaultDeclarationKind) => {
@@ -5536,7 +5767,7 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -5555,7 +5786,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleExportName::IdentifierReference(s) => {
@@ -5563,7 +5794,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             ModuleExportName::StringLiteral(s) => {
@@ -5571,7 +5802,7 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -5582,24 +5813,29 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
 impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span =
-            self.inner.arguments.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .arguments
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::V8IntrinsicExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::V8IntrinsicExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5608,7 +5844,8 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5623,7 +5860,8 @@ impl<'a> AstNode<'a, BooleanLiteral> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5633,7 +5871,8 @@ impl<'a> AstNode<'a, NullLiteral> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5658,7 +5897,8 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5683,7 +5923,8 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5708,7 +5949,8 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5728,49 +5970,56 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXElement<'a>> {
     #[inline]
     pub fn opening_element(&self) -> &AstNode<'a, JSXOpeningElement<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .children
             .first()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.closing_element.as_deref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.closing_element.as_deref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.opening_element.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
-        let following_span =
-            self.inner.closing_element.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .closing_element
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn closing_element(&self) -> Option<&AstNode<'a, JSXClosingElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.closing_element.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXElement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -5780,50 +6029,57 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_arguments
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.attributes.first().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.attributes.first().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span =
-            self.inner.attributes.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .attributes
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn attributes(&self) -> &AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.attributes,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXOpeningElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5832,19 +6088,20 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXClosingElement(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5853,46 +6110,48 @@ impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXFragment<'a>> {
     #[inline]
     pub fn opening_fragment(&self) -> &AstNode<'a, JSXOpeningFragment> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .children
             .first()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.closing_fragment.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.closing_fragment.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.opening_fragment,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
-        let following_span = Some(self.inner.closing_fragment.span());
+        let following_span_start = self.inner.closing_fragment.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn closing_fragment(&self) -> &AstNode<'a, JSXClosingFragment> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.closing_fragment,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXFragment(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -5901,7 +6160,8 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5911,7 +6171,8 @@ impl<'a> AstNode<'a, JSXOpeningFragment> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5921,7 +6182,8 @@ impl<'a> AstNode<'a, JSXClosingFragment> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -5935,7 +6197,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXElementName::IdentifierReference(s) => {
@@ -5943,7 +6205,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXElementName::NamespacedName(s) => {
@@ -5951,7 +6213,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXElementName::MemberExpression(s) => {
@@ -5959,7 +6221,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXElementName::ThisExpression(s) => {
@@ -5967,7 +6229,7 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -5978,23 +6240,23 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
 impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     #[inline]
     pub fn namespace(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_span = Some(self.inner.name.span());
+        let following_span_start = self.inner.name.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.namespace,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXNamespacedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXNamespacedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6003,30 +6265,31 @@ impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     #[inline]
     pub fn object(&self) -> &AstNode<'a, JSXMemberExpressionObject<'a>> {
-        let following_span = Some(self.inner.property.span());
+        let following_span_start = self.inner.property.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn property(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXMemberExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6035,7 +6298,8 @@ impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6049,7 +6313,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXMemberExpressionObject::MemberExpression(s) => {
@@ -6057,7 +6321,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXMemberExpressionObject::ThisExpression(s) => {
@@ -6065,7 +6329,7 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6076,12 +6340,12 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
 impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, JSXExpression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXExpressionContainer(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6090,7 +6354,8 @@ impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6104,7 +6369,7 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_expression!(JSXExpression) => {
@@ -6114,7 +6379,7 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                         inner: it.to_expression(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -6129,7 +6394,8 @@ impl<'a> AstNode<'a, JSXEmptyExpression> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6143,7 +6409,7 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXAttributeItem::SpreadAttribute(s) => {
@@ -6151,7 +6417,7 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6162,24 +6428,30 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
 impl<'a> AstNode<'a, JSXAttribute<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, JSXAttributeName<'a>> {
-        let following_span = self.inner.value.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .value
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXAttribute(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn value(&self) -> Option<&AstNode<'a, JSXAttributeValue<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::JSXAttribute(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -6189,19 +6461,20 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     #[inline]
     pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXSpreadAttribute(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6210,7 +6483,8 @@ impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6224,7 +6498,7 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXAttributeName::NamespacedName(s) => {
@@ -6232,7 +6506,7 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6250,7 +6524,7 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXAttributeValue::ExpressionContainer(s) => {
@@ -6258,21 +6532,21 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXAttributeValue::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             JSXAttributeValue::Fragment(s) => {
                 AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6291,7 +6565,8 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6304,33 +6579,33 @@ impl<'a> AstNode<'a, JSXChild<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             JSXChild::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             JSXChild::Fragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             JSXChild::ExpressionContainer(s) => {
                 AstNodes::JSXExpressionContainer(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             JSXChild::Spread(s) => AstNodes::JSXSpreadChild(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
         };
         self.allocator.alloc(node)
@@ -6340,12 +6615,12 @@ impl<'a> AstNode<'a, JSXChild<'a>> {
 impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSXSpreadChild(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6354,7 +6629,8 @@ impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6374,7 +6650,8 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6386,13 +6663,13 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSThisParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -6402,30 +6679,31 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, TSEnumBody<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6444,19 +6722,20 @@ impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSEnumBody<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumBody(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6465,32 +6744,38 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSEnumMember<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSEnumMemberName<'a>> {
-        let following_span =
-            self.inner.initializer.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .initializer
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSEnumMember(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn initializer(&self) -> Option<&AstNode<'a, Expression<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.initializer.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSEnumMember(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -6500,7 +6785,8 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6514,21 +6800,21 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSEnumMemberName::String(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSEnumMemberName::ComputedString(s) => {
                 AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSEnumMemberName::ComputedTemplateString(s) => {
@@ -6536,7 +6822,7 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6547,12 +6833,12 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
 impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAnnotation(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6561,19 +6847,20 @@ impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSLiteralType<'a>> {
     #[inline]
     pub fn literal(&self) -> &AstNode<'a, TSLiteral<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.literal,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSLiteralType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6582,7 +6869,8 @@ impl<'a> AstNode<'a, TSLiteralType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -6596,7 +6884,7 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSLiteral::NumericLiteral(s) => {
@@ -6604,27 +6892,27 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSLiteral::BigIntLiteral(s) => AstNodes::BigIntLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSLiteral::StringLiteral(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSLiteral::TemplateLiteral(s) => {
                 AstNodes::TemplateLiteral(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSLiteral::UnaryExpression(s) => {
@@ -6632,7 +6920,7 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6649,14 +6937,14 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSBigIntKeyword(s) => {
                 AstNodes::TSBigIntKeyword(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSBooleanKeyword(s) => {
@@ -6664,7 +6952,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSIntrinsicKeyword(s) => {
@@ -6672,27 +6960,27 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSNeverKeyword(s) => AstNodes::TSNeverKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSNullKeyword(s) => AstNodes::TSNullKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSNumberKeyword(s) => {
                 AstNodes::TSNumberKeyword(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSObjectKeyword(s) => {
@@ -6700,7 +6988,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSStringKeyword(s) => {
@@ -6708,7 +6996,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSSymbolKeyword(s) => {
@@ -6716,7 +7004,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSUndefinedKeyword(s) => {
@@ -6724,7 +7012,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSUnknownKeyword(s) => {
@@ -6732,27 +7020,27 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSVoidKeyword(s) => AstNodes::TSVoidKeyword(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSArrayType(s) => AstNodes::TSArrayType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSConditionalType(s) => {
                 AstNodes::TSConditionalType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSConstructorType(s) => {
@@ -6760,61 +7048,61 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSFunctionType(s) => AstNodes::TSFunctionType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSImportType(s) => AstNodes::TSImportType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSIndexedAccessType(s) => {
                 AstNodes::TSIndexedAccessType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSInferType(s) => AstNodes::TSInferType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSIntersectionType(s) => {
                 AstNodes::TSIntersectionType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSLiteralType(s) => AstNodes::TSLiteralType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSMappedType(s) => AstNodes::TSMappedType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSNamedTupleMember(s) => {
                 AstNodes::TSNamedTupleMember(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSTemplateLiteralType(s) => {
@@ -6822,33 +7110,33 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSThisType(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSTupleType(s) => AstNodes::TSTupleType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSTypeLiteral(s) => AstNodes::TSTypeLiteral(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSTypeOperatorType(s) => {
                 AstNodes::TSTypeOperator(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSTypePredicate(s) => {
@@ -6856,35 +7144,35 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSTypeQuery(s) => AstNodes::TSTypeQuery(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSTypeReference(s) => {
                 AstNodes::TSTypeReference(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::TSUnionType(s) => AstNodes::TSUnionType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             TSType::TSParenthesizedType(s) => {
                 AstNodes::TSParenthesizedType(self.allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::JSDocNullableType(s) => {
@@ -6892,7 +7180,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::JSDocNonNullableType(s) => {
@@ -6900,7 +7188,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSType::JSDocUnknownType(s) => {
@@ -6908,7 +7196,7 @@ impl<'a> AstNode<'a, TSType<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -6919,45 +7207,45 @@ impl<'a> AstNode<'a, TSType<'a>> {
 impl<'a> AstNode<'a, TSConditionalType<'a>> {
     #[inline]
     pub fn check_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = Some(self.inner.extends_type.span());
+        let following_span_start = self.inner.extends_type.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.check_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn extends_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = Some(self.inner.true_type.span());
+        let following_span_start = self.inner.true_type.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.extends_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn true_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = Some(self.inner.false_type.span());
+        let following_span_start = self.inner.false_type.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.true_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn false_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.false_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConditionalType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6966,19 +7254,20 @@ impl<'a> AstNode<'a, TSConditionalType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSUnionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSUnionType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -6987,19 +7276,20 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIntersectionType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7008,19 +7298,20 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSParenthesizedType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7029,7 +7320,8 @@ impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7041,12 +7333,12 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeOperator(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7055,19 +7347,20 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSArrayType<'a>> {
     #[inline]
     pub fn element_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSArrayType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7076,30 +7369,31 @@ impl<'a> AstNode<'a, TSArrayType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     #[inline]
     pub fn object_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = Some(self.inner.index_type.span());
+        let following_span_start = self.inner.index_type.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.object_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexedAccessType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn index_type(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.index_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexedAccessType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7108,19 +7402,20 @@ impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTupleType<'a>> {
     #[inline]
     pub fn element_types(&self) -> &AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTupleType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7129,30 +7424,31 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     #[inline]
     pub fn label(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = Some(self.inner.element_type.span());
+        let following_span_start = self.inner.element_type.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNamedTupleMember(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn element_type(&self) -> &AstNode<'a, TSTupleElement<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNamedTupleMember(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7166,19 +7462,20 @@ impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSOptionalType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSOptionalType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7187,19 +7484,20 @@ impl<'a> AstNode<'a, TSOptionalType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSRestType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSRestType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7208,7 +7506,8 @@ impl<'a> AstNode<'a, TSRestType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7222,14 +7521,14 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSTupleElement::TSRestType(s) => AstNodes::TSRestType(self.allocator.alloc(AstNode {
                 inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
             it @ match_ts_type!(TSTupleElement) => {
                 return self
@@ -7238,7 +7537,7 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
                         inner: it.to_ts_type(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -7253,7 +7552,8 @@ impl<'a> AstNode<'a, TSAnyKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7263,7 +7563,8 @@ impl<'a> AstNode<'a, TSStringKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7273,7 +7574,8 @@ impl<'a> AstNode<'a, TSBooleanKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7283,7 +7585,8 @@ impl<'a> AstNode<'a, TSNumberKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7293,7 +7596,8 @@ impl<'a> AstNode<'a, TSNeverKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7303,7 +7607,8 @@ impl<'a> AstNode<'a, TSIntrinsicKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7313,7 +7618,8 @@ impl<'a> AstNode<'a, TSUnknownKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7323,7 +7629,8 @@ impl<'a> AstNode<'a, TSNullKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7333,7 +7640,8 @@ impl<'a> AstNode<'a, TSUndefinedKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7343,7 +7651,8 @@ impl<'a> AstNode<'a, TSVoidKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7353,7 +7662,8 @@ impl<'a> AstNode<'a, TSSymbolKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7363,7 +7673,8 @@ impl<'a> AstNode<'a, TSThisType> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7373,7 +7684,8 @@ impl<'a> AstNode<'a, TSObjectKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7383,32 +7695,38 @@ impl<'a> AstNode<'a, TSBigIntKeyword> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeReference<'a>> {
     #[inline]
     pub fn type_name(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_span =
-            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_arguments
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeReference(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeReference(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -7418,7 +7736,8 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7432,7 +7751,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSTypeName::QualifiedName(s) => {
@@ -7440,7 +7759,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSTypeName::ThisExpression(s) => {
@@ -7448,7 +7767,7 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -7459,23 +7778,23 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
 impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSQualifiedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSQualifiedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7484,21 +7803,22 @@ impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSTypeParameterInstantiation(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7507,50 +7827,58 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     #[inline]
     pub fn name(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .constraint
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.default.as_ref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.default.as_ref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn constraint(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_span = self.inner.default.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .default
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.constraint.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn default(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.default.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeParameter(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -7575,21 +7903,22 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     #[inline]
     pub fn params(&self) -> &AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSTypeParameterDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7598,49 +7927,51 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_parameters
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.type_annotation.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.type_annotation.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = Some(self.inner.type_annotation.span());
+        let following_span_start = self.inner.type_annotation.span().start;
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAliasDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7654,32 +7985,38 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSClassImplements<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, TSTypeName<'a>> {
-        let following_span =
-            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_arguments
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSClassImplements(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSClassImplements(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -7689,62 +8026,69 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_parameters
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.extends.first().map(GetSpan::span))
-            .or_else(|| Some(self.inner.body.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.extends.first().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span =
-            self.inner.extends.first().map(GetSpan::span).or_else(|| Some(self.inner.body.span()));
+        let following_span_start = self
+            .inner
+            .extends
+            .first()
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.body.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent:
                     self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn extends(&self) -> &AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
-        let following_span = Some(self.inner.body.span());
+        let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.extends,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, TSInterfaceBody<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7758,19 +8102,20 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceBody(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7779,7 +8124,8 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7801,25 +8147,30 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
 
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span =
-            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_annotation
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSPropertySignature(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSPropertySignature(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -7829,7 +8180,8 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -7843,7 +8195,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSSignature::TSPropertySignature(s) => {
@@ -7851,7 +8203,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSSignature::TSCallSignatureDeclaration(s) => {
@@ -7859,7 +8211,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSSignature::TSConstructSignatureDeclaration(s) => {
@@ -7867,7 +8219,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSSignature::TSMethodSignature(s) => {
@@ -7875,7 +8227,7 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -7886,23 +8238,23 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
 impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     #[inline]
     pub fn parameters(&self) -> &AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
-        let following_span = Some(self.inner.type_annotation.span());
+        let following_span_start = self.inner.type_annotation.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameters,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignature(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignature(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -7921,19 +8273,21 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .this_param
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(
                 self.inner.type_parameters.as_ref().map(|inner| AstNode {
@@ -7942,7 +8296,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }),
             )
             .as_ref()
@@ -7950,7 +8304,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(
                 self.inner.this_param.as_ref().map(|inner| AstNode {
@@ -7959,7 +8313,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }),
             )
             .as_ref()
@@ -7967,21 +8321,26 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span =
-            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .return_type
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(
                 self.inner.return_type.as_ref().map(|inner| AstNode {
@@ -7990,7 +8349,7 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSCallSignatureDeclaration(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }),
             )
             .as_ref()
@@ -8001,25 +8360,27 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .type_parameters
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.this_param.as_deref().map(GetSpan::span))
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.this_param.as_deref().map(|n| n.span().start))
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8040,56 +8401,62 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .this_param
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span =
-            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .return_type
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMethodSignature(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8099,14 +8466,15 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| {
                 AstNode {
@@ -8115,7 +8483,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }
             }))
             .as_ref()
@@ -8123,21 +8491,26 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span =
-            self.inner.return_type.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .return_type
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| {
                 AstNode {
@@ -8146,7 +8519,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
                     parent: self
                         .allocator
                         .alloc(AstNodes::TSConstructSignatureDeclaration(transmute_self(self))),
-                    following_span,
+                    following_span_start,
                 }
             }))
             .as_ref()
@@ -8157,7 +8530,8 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8169,12 +8543,12 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSIndexSignatureName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8183,32 +8557,38 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span =
-            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_arguments
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInterfaceHeritage(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSInterfaceHeritage(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8218,20 +8598,26 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     #[inline]
     pub fn parameter_name(&self) -> &AstNode<'a, TSTypePredicateName<'a>> {
-        let following_span =
-            self.inner.type_annotation.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_annotation
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameter_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8242,13 +8628,13 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypePredicate(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8258,7 +8644,8 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8272,14 +8659,14 @@ impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSTypePredicateName::This(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
                 inner: s,
                 parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             })),
         };
         self.allocator.alloc(node)
@@ -8289,24 +8676,24 @@ impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
 impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, TSModuleDeclarationName<'a>> {
-        let following_span = self.inner.body.as_ref().map(GetSpan::span);
+        let following_span_start = self.inner.body.as_ref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> Option<&AstNode<'a, TSModuleDeclarationBody<'a>>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSModuleDeclaration(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8326,7 +8713,8 @@ impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8340,7 +8728,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSModuleDeclarationName::StringLiteral(s) => {
@@ -8348,7 +8736,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                     inner: s,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -8366,7 +8754,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSModuleDeclarationBody::TSModuleBlock(s) => {
@@ -8374,7 +8762,7 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -8390,12 +8778,12 @@ impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, TSModuleBlock<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSGlobalDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8409,30 +8797,37 @@ impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     #[inline]
     pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
-        let following_span = self.inner.body.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .body
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleBlock(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSModuleBlock(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8441,19 +8836,20 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     #[inline]
     pub fn members(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeLiteral(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8462,19 +8858,20 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSInferType<'a>> {
     #[inline]
     pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_parameter.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInferType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8483,32 +8880,38 @@ impl<'a> AstNode<'a, TSInferType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     #[inline]
     pub fn expr_name(&self) -> &AstNode<'a, TSTypeQueryExprName<'a>> {
-        let following_span =
-            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_arguments
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.expr_name,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeQuery(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSTypeQuery(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8518,7 +8921,8 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8532,7 +8936,7 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
@@ -8542,7 +8946,7 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                         inner: it.to_ts_type_name(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -8554,64 +8958,71 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
 impl<'a> AstNode<'a, TSImportType<'a>> {
     #[inline]
     pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .options
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.qualifier.as_ref().map(GetSpan::span))
-            .or_else(|| self.inner.type_arguments.as_deref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.qualifier.as_ref().map(|n| n.span().start))
+            .or_else(|| self.inner.type_arguments.as_deref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn options(&self) -> Option<&AstNode<'a, ObjectExpression<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .qualifier
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.type_arguments.as_deref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.type_arguments.as_deref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn qualifier(&self) -> Option<&AstNode<'a, TSImportTypeQualifier<'a>>> {
-        let following_span =
-            self.inner.type_arguments.as_deref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_arguments
+            .as_deref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.qualifier.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSImportType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8621,7 +9032,8 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8635,7 +9047,7 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             TSImportTypeQualifier::QualifiedName(s) => {
@@ -8643,7 +9055,7 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         };
@@ -8654,23 +9066,23 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
 impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
     #[inline]
     pub fn left(&self) -> &AstNode<'a, TSImportTypeQualifier<'a>> {
-        let following_span = Some(self.inner.right.span());
+        let following_span_start = self.inner.right.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportTypeQualifiedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportTypeQualifiedName(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8679,61 +9091,63 @@ impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSFunctionType<'a>> {
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .this_param
             .as_deref()
-            .map(GetSpan::span)
-            .or_else(|| Some(self.inner.params.span()));
+            .map(|n| n.span().start)
+            .or_else(|| Some(self.inner.params.span().start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span = Some(self.inner.return_type.span());
+        let following_span_start = self.inner.return_type.span().start;
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSFunctionType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8742,7 +9156,8 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -8754,36 +9169,36 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
 
     #[inline]
     pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
-        let following_span = Some(self.inner.params.span());
+        let following_span_start = self.inner.params.span().start;
         self.allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
-        let following_span = Some(self.inner.return_type.span());
+        let following_span_start = self.inner.return_type.span().start;
         self.allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSConstructorType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8792,62 +9207,69 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSMappedType<'a>> {
     #[inline]
     pub fn key(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = Some(self.inner.constraint.span());
+        let following_span_start = self.inner.constraint.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn constraint(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self
+        let following_span_start = self
             .inner
             .name_type
             .as_ref()
-            .map(GetSpan::span)
-            .or_else(|| self.inner.type_annotation.as_ref().map(GetSpan::span))
-            .or(self.following_span);
+            .map(|n| n.span().start)
+            .or_else(|| self.inner.type_annotation.as_ref().map(|n| n.span().start))
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.constraint,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn name_type(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_span =
-            self.inner.type_annotation.as_ref().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .type_annotation
+            .as_ref()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator
             .alloc(self.inner.name_type.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
     pub fn type_annotation(&self) -> Option<&AstNode<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
                 parent: self.allocator.alloc(AstNodes::TSMappedType(transmute_self(self))),
-                following_span,
+                following_span_start,
             }))
             .as_ref()
     }
@@ -8867,30 +9289,37 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     #[inline]
     pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
-        let following_span = self.inner.types.first().map(GetSpan::span).or(self.following_span);
+        let following_span_start = self
+            .inner
+            .types
+            .first()
+            .map(|n| n.span().start)
+            .or(Some(self.following_span_start))
+            .unwrap_or(0);
         self.allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTemplateLiteralType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTemplateLiteralType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8899,30 +9328,31 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSAsExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.type_annotation.span());
+        let following_span_start = self.inner.type_annotation.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSAsExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSAsExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8931,30 +9361,31 @@ impl<'a> AstNode<'a, TSAsExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.type_annotation.span());
+        let following_span_start = self.inner.type_annotation.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSSatisfiesExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSSatisfiesExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8963,30 +9394,31 @@ impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = Some(self.inner.expression.span());
+        let following_span_start = self.inner.expression.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAssertion(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSTypeAssertion(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -8995,30 +9427,31 @@ impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
-        let following_span = Some(self.inner.module_reference.span());
+        let following_span_start = self.inner.module_reference.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportEqualsDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn module_reference(&self) -> &AstNode<'a, TSModuleReference<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.module_reference,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSImportEqualsDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9032,7 +9465,8 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -9046,7 +9480,7 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
             it @ match_ts_type_name!(TSModuleReference) => {
@@ -9056,7 +9490,7 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                         inner: it.to_ts_type_name(),
                         parent,
                         allocator: self.allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .as_ast_nodes();
             }
@@ -9068,12 +9502,12 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
 impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSExternalModuleReference(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9082,19 +9516,20 @@ impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSNonNullExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9103,19 +9538,20 @@ impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, Decorator<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::Decorator(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9124,19 +9560,20 @@ impl<'a> AstNode<'a, Decorator<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSExportAssignment(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9145,21 +9582,22 @@ impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     #[inline]
     pub fn id(&self) -> &AstNode<'a, IdentifierName<'a>> {
-        let following_span = None;
+        let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
             parent: self
                 .allocator
                 .alloc(AstNodes::TSNamespaceExportDeclaration(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9168,30 +9606,31 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     #[inline]
     pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
-        let following_span = Some(self.inner.type_arguments.span());
+        let following_span_start = self.inner.type_arguments.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInstantiationExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
     #[inline]
     pub fn type_arguments(&self) -> &AstNode<'a, TSTypeParameterInstantiation<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: self.inner.type_arguments.as_ref(),
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::TSInstantiationExpression(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9200,19 +9639,20 @@ impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSDocNullableType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9226,19 +9666,20 @@ impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
 impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     #[inline]
     pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
             parent: self.allocator.alloc(AstNodes::JSDocNonNullableType(transmute_self(self))),
-            following_span,
+            following_span_start,
         })
     }
 
@@ -9252,7 +9693,8 @@ impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }
 
@@ -9262,6 +9704,7 @@ impl<'a> AstNode<'a, JSDocUnknownType> {
     }
 
     pub fn format_trailing_comments(&self, f: &mut Formatter<'_, 'a>) {
-        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span).fmt(f);
+        format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+            .fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -31,7 +31,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -41,7 +41,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -51,7 +51,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -61,7 +61,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -71,7 +71,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -81,7 +81,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -91,7 +91,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -101,7 +101,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -111,7 +111,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -121,7 +121,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -131,7 +131,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -141,7 +141,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -151,7 +151,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -161,7 +161,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -171,7 +171,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -181,7 +181,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -191,7 +191,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -201,7 +201,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -211,7 +211,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -221,7 +221,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -231,7 +231,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -241,7 +241,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -251,7 +251,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -261,7 +261,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -271,7 +271,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -281,7 +281,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -291,7 +291,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -301,7 +301,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -311,7 +311,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -321,7 +321,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -331,7 +331,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -341,7 +341,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -351,7 +351,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -361,7 +361,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -371,7 +371,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -381,7 +381,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -391,7 +391,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -401,7 +401,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -411,7 +411,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -421,7 +421,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -432,7 +432,7 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -560,7 +560,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -570,7 +570,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -581,7 +581,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -637,7 +637,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -647,7 +647,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -680,7 +680,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -690,7 +690,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -701,7 +701,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -780,7 +780,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -790,7 +790,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -800,7 +800,7 @@ impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -971,7 +971,7 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -982,7 +982,7 @@ impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1164,7 +1164,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1175,7 +1175,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1195,7 +1195,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1205,7 +1205,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1215,7 +1215,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1225,7 +1225,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1235,7 +1235,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1246,7 +1246,7 @@ impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1266,7 +1266,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1276,7 +1276,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1335,7 +1335,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1346,7 +1346,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1379,7 +1379,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1389,7 +1389,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1527,7 +1527,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1537,7 +1537,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1548,7 +1548,7 @@ impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1591,7 +1591,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1601,7 +1601,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1611,7 +1611,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1621,7 +1621,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1631,7 +1631,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1641,7 +1641,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1651,7 +1651,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1661,7 +1661,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1671,7 +1671,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1681,7 +1681,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1691,7 +1691,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1701,7 +1701,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1711,7 +1711,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1721,7 +1721,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1731,7 +1731,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1741,7 +1741,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1751,7 +1751,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1761,7 +1761,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1772,7 +1772,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1783,7 +1783,7 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1842,7 +1842,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1852,7 +1852,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1862,7 +1862,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1872,7 +1872,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1882,7 +1882,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1892,7 +1892,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1902,7 +1902,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1912,7 +1912,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -1922,7 +1922,7 @@ impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2046,7 +2046,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2057,7 +2057,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2090,7 +2090,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2101,7 +2101,7 @@ impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2290,7 +2290,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2300,7 +2300,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2310,7 +2310,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2320,7 +2320,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2610,7 +2610,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2620,7 +2620,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2630,7 +2630,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2640,7 +2640,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2650,7 +2650,7 @@ impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2722,7 +2722,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2732,7 +2732,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2742,7 +2742,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2752,7 +2752,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2762,7 +2762,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2772,7 +2772,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2841,7 +2841,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2851,7 +2851,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2861,7 +2861,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2946,7 +2946,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -2956,7 +2956,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3028,7 +3028,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3038,7 +3038,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3048,7 +3048,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3059,7 +3059,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3079,7 +3079,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3089,7 +3089,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3099,7 +3099,7 @@ impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3364,7 +3364,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3374,7 +3374,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3384,7 +3384,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3394,7 +3394,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3404,7 +3404,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3450,7 +3450,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3460,7 +3460,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3470,7 +3470,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3503,7 +3503,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3514,7 +3514,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3547,7 +3547,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3557,7 +3557,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3603,7 +3603,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3613,7 +3613,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3633,7 +3633,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3643,7 +3643,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3653,7 +3653,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3663,7 +3663,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3696,7 +3696,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3706,7 +3706,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3716,7 +3716,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3726,7 +3726,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3736,7 +3736,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3834,7 +3834,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3844,7 +3844,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3854,7 +3854,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3864,7 +3864,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3910,7 +3910,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3920,7 +3920,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3930,7 +3930,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3940,7 +3940,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3950,7 +3950,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3960,7 +3960,7 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3980,7 +3980,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -3990,7 +3990,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4000,7 +4000,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4010,7 +4010,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4020,7 +4020,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4030,7 +4030,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4040,7 +4040,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4050,7 +4050,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4060,7 +4060,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4070,7 +4070,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4080,7 +4080,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4090,7 +4090,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4100,7 +4100,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4110,7 +4110,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4120,7 +4120,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4130,7 +4130,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4140,7 +4140,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4150,7 +4150,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4160,7 +4160,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4170,7 +4170,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4180,7 +4180,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4190,7 +4190,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4200,7 +4200,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4210,7 +4210,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4220,7 +4220,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4230,7 +4230,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4240,7 +4240,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4250,7 +4250,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4260,7 +4260,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4270,7 +4270,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4280,7 +4280,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4290,7 +4290,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4300,7 +4300,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4310,7 +4310,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4320,7 +4320,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4330,7 +4330,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4340,7 +4340,7 @@ impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4542,7 +4542,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4552,7 +4552,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4563,7 +4563,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4778,7 +4778,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4788,7 +4788,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4798,7 +4798,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4935,7 +4935,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4945,7 +4945,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4955,7 +4955,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4965,7 +4965,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -4975,7 +4975,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5086,7 +5086,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5096,7 +5096,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5129,7 +5129,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5139,7 +5139,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5159,7 +5159,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5169,7 +5169,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5274,7 +5274,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5285,7 +5285,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5318,7 +5318,7 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5328,7 +5328,7 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5515,7 +5515,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }
@@ -5526,7 +5526,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                         inner,
                         parent,
                         allocator,
-                        following_span: self.following_span,
+                        following_span_start: self.following_span_start,
                     })
                     .fmt(f);
             }

--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -8,7 +8,7 @@ use std::cmp::min;
 
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::*;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 
 use super::{AstNode, AstNodes};
 
@@ -36,7 +36,7 @@ macro_rules! impl_ast_node_vec {
                         inner,
                         parent: self.parent,
                         allocator: self.allocator,
-                        following_span: inner_iter.next().map(GetSpan::span),
+                        following_span_start: inner_iter.next().map_or(0, |n| n.span().start),
                     }))
                     .as_ref()
             }
@@ -47,7 +47,7 @@ macro_rules! impl_ast_node_vec {
                         inner,
                         parent: self.parent,
                         allocator: self.allocator,
-                        following_span: None,
+                        following_span_start: 0,
                     }))
                     .as_ref()
             }
@@ -62,7 +62,7 @@ macro_rules! impl_ast_node_vec {
                         parent: self.parent,
                         inner,
                         allocator,
-                        following_span: self.inner.peek().copied().map(GetSpan::span),
+                        following_span_start: self.inner.peek().map_or(0, |n| n.span().start),
                     }))
                     .as_ref()
             }
@@ -96,12 +96,16 @@ macro_rules! impl_ast_node_vec_for_option {
             pub fn first(&self) -> Option<&'a AstNode<'a, $type>> {
                 let mut inner_iter = self.inner.iter();
                 self.allocator
-                    .alloc(inner_iter.next().map(|inner| AstNode {
-                        inner,
-                        parent: self.parent,
-                        allocator: self.allocator,
-                        following_span:
-                            inner_iter.next().and_then(|opt| opt.as_ref().map(GetSpan::span)),
+                    .alloc(inner_iter.next().map(|inner| {
+                        AstNode {
+                            inner,
+                            parent: self.parent,
+                            allocator: self.allocator,
+                            following_span_start: inner_iter
+                                .next()
+                                .and_then(|opt| opt.as_ref().map(|n| n.span().start))
+                                .unwrap_or(0),
+                        }
                     }))
                     .as_ref()
             }
@@ -112,7 +116,7 @@ macro_rules! impl_ast_node_vec_for_option {
                         inner,
                         parent: self.parent,
                         allocator: self.allocator,
-                        following_span: None,
+                        following_span_start: 0,
                     }))
                     .as_ref()
             }
@@ -128,11 +132,11 @@ macro_rules! impl_ast_node_vec_for_option {
                             parent: self.parent,
                             inner,
                             allocator,
-                            following_span: self
+                            following_span_start: self
                                 .inner
                                 .peek()
-                                .copied()
-                                .and_then(|opt| opt.as_ref().map(GetSpan::span)),
+                                .and_then(|opt| opt.as_ref().map(|n| n.span().start))
+                                .unwrap_or(0),
                         }
                     }))
                     .as_ref()
@@ -201,7 +205,7 @@ impl<'a> AstNode<'a, Vec<'a, Statement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_span: inner_iter.next().map(GetSpan::span),
+                following_span_start: inner_iter.next().map_or(0, |n| n.span().start),
             }))
             .as_ref()
     }
@@ -211,7 +215,7 @@ impl<'a> AstNode<'a, Vec<'a, Statement<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_span: None,
+                following_span_start: 0,
             }))
             .as_ref()
     }
@@ -225,39 +229,33 @@ impl<'a> Iterator for AstNodeIterator<'a, Statement<'a>> {
                 parent: self.parent,
                 inner,
                 allocator,
-                following_span: {
+                following_span_start: {
                     match self.inner.peek() {
                         // `@decorator export default class A {}`
-                        // Get the span of the decorator.
+                        // Get the span start of the decorator.
                         Some(Statement::ExportDefaultDeclaration(export)) => {
                             if let ExportDefaultDeclarationKind::ClassDeclaration(class) =
                                 &export.declaration
                                 && let Some(decorator) = class.decorators.first()
                             {
-                                Some(Span::new(
-                                    min(decorator.span.start, export.span.start),
-                                    export.span.end,
-                                ))
+                                min(decorator.span.start, export.span.start)
                             } else {
-                                Some(export.span)
+                                export.span.start
                             }
                         }
                         // `@decorator export class A {}`
-                        // Get the span of the decorator.
+                        // Get the span start of the decorator.
                         Some(Statement::ExportNamedDeclaration(export)) => {
                             if let Some(Declaration::ClassDeclaration(class)) = &export.declaration
                                 && let Some(decorator) = class.decorators.first()
                             {
-                                Some(Span::new(
-                                    min(decorator.span.start, export.span.start),
-                                    export.span.end,
-                                ))
+                                min(decorator.span.start, export.span.start)
                             } else {
-                                Some(export.span)
+                                export.span.start
                             }
                         }
-                        Some(next) => Some(next.span()),
-                        None => None,
+                        Some(next) => next.span().start,
+                        None => 0,
                     }
                 },
             }))
@@ -276,16 +274,16 @@ impl<'a> IntoIterator for &AstNode<'a, Vec<'a, Statement<'a>>> {
     }
 }
 
-fn get_following_span_for_directive_parent(parent: &AstNodes<'_>) -> Option<Span> {
+fn get_following_span_start_for_directive_parent(parent: &AstNodes<'_>) -> u32 {
     match parent {
-        AstNodes::Program(program) => program.body().first().map(GetSpan::span),
+        AstNodes::Program(program) => program.body().first().map_or(0, |n| n.span().start),
         AstNodes::FunctionBody(function_body) => {
-            function_body.statements().first().map(GetSpan::span)
+            function_body.statements().first().map_or(0, |n| n.span().start)
         }
         AstNodes::TSModuleBlock(ts_module_block) => {
-            ts_module_block.body().first().map(GetSpan::span)
+            ts_module_block.body().first().map_or(0, |n| n.span().start)
         }
-        _ => None,
+        _ => 0,
     }
 }
 
@@ -302,16 +300,14 @@ impl<'a> AstNode<'a, Vec<'a, Directive<'a>>> {
     pub fn first(&self) -> Option<&'a AstNode<'a, Directive<'a>>> {
         let mut inner_iter = self.inner.iter();
         self.allocator
-            .alloc(inner_iter.next().map(|inner| {
-                AstNode {
-                    inner,
-                    parent: self.parent,
-                    allocator: self.allocator,
-                    following_span: inner_iter
-                        .next()
-                        .map(GetSpan::span)
-                        .or_else(|| get_following_span_for_directive_parent(self.parent)),
-                }
+            .alloc(inner_iter.next().map(|inner| AstNode {
+                inner,
+                parent: self.parent,
+                allocator: self.allocator,
+                following_span_start: inner_iter.next().map_or_else(
+                    || get_following_span_start_for_directive_parent(self.parent),
+                    |n| n.span().start,
+                ),
             }))
             .as_ref()
     }
@@ -321,7 +317,7 @@ impl<'a> AstNode<'a, Vec<'a, Directive<'a>>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_span: get_following_span_for_directive_parent(self.parent),
+                following_span_start: get_following_span_start_for_directive_parent(self.parent),
             }))
             .as_ref()
     }
@@ -331,18 +327,14 @@ impl<'a> Iterator for AstNodeIterator<'a, Directive<'a>> {
     fn next(&mut self) -> Option<Self::Item> {
         let allocator = self.allocator;
         allocator
-            .alloc(self.inner.next().map(|inner| {
-                AstNode {
-                    parent: self.parent,
-                    inner,
-                    allocator,
-                    following_span: self
-                        .inner
-                        .peek()
-                        .copied()
-                        .map(GetSpan::span)
-                        .or_else(|| get_following_span_for_directive_parent(self.parent)),
-                }
+            .alloc(self.inner.next().map(|inner| AstNode {
+                parent: self.parent,
+                inner,
+                allocator,
+                following_span_start: self.inner.peek().map_or_else(
+                    || get_following_span_start_for_directive_parent(self.parent),
+                    |n| n.span().start,
+                ),
             }))
             .as_ref()
     }

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -14,7 +14,8 @@ pub struct AstNode<'a, T> {
     pub(super) inner: &'a T,
     pub parent: &'a AstNodes<'a>,
     pub(super) allocator: &'a Allocator,
-    pub(super) following_span: Option<Span>,
+    /// The start position of the following sibling node, or 0 if none.
+    pub(super) following_span_start: u32,
 }
 
 impl<T: fmt::Debug> fmt::Debug for AstNode<'_, T> {
@@ -22,7 +23,7 @@ impl<T: fmt::Debug> fmt::Debug for AstNode<'_, T> {
         f.debug_struct("AstNode")
             .field("inner", &self.inner)
             .field("parent", &self.parent.debug_name())
-            .field("following_span", &self.following_span)
+            .field("following_span_start", &self.following_span_start)
             .finish()
     }
 }
@@ -48,7 +49,7 @@ impl<'a, T> AstNode<'a, Option<T>> {
                 inner,
                 parent: self.parent,
                 allocator: self.allocator,
-                following_span: self.following_span,
+                following_span_start: self.following_span_start,
             }))
             .as_ref()
     }
@@ -110,7 +111,7 @@ impl<'a, T> AstNode<'a, T> {
 
 impl<'a> AstNode<'a, Program<'a>> {
     pub fn new(inner: &'a Program<'a>, parent: &'a AstNodes<'a>, allocator: &'a Allocator) -> Self {
-        AstNode { inner, parent, allocator, following_span: None }
+        AstNode { inner, parent, allocator, following_span_start: 0 }
     }
 }
 
@@ -170,7 +171,7 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
         }
 
         let arguments_ref = self.allocator.alloc(arguments);
-        let following_span = self.following_span;
+        let following_span_start = self.following_span_start;
 
         self.allocator.alloc(AstNode {
             inner: arguments_ref,
@@ -184,7 +185,7 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
                     >(self)
                 }
             })),
-            following_span,
+            following_span_start,
         })
     }
 }

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -163,16 +163,16 @@ impl<'a> Format<'a> for FormatLeadingComments<'a> {
 pub const fn format_trailing_comments<'a>(
     enclosing_span: Span,
     preceding_span: Span,
-    following_span: Option<Span>,
+    following_span_start: u32,
 ) -> FormatTrailingComments<'a> {
-    FormatTrailingComments::Node((enclosing_span, preceding_span, following_span))
+    FormatTrailingComments::Node((enclosing_span, preceding_span, following_span_start))
 }
 
 /// Formats the trailing comments of `node`
 #[derive(Debug, Clone, Copy)]
 pub enum FormatTrailingComments<'a> {
-    // (enclosing_span, preceding_span, following_span)
-    Node((Span, Span, Option<Span>)),
+    // (enclosing_span, preceding_span, following_span_start)
+    Node((Span, Span, u32)),
     Comments(&'a [Comment]),
 }
 
@@ -252,11 +252,11 @@ impl<'a> Format<'a> for FormatTrailingComments<'a> {
         }
 
         match self {
-            Self::Node((enclosing_span, preceding_span, following_span)) => {
+            Self::Node((enclosing_span, preceding_span, following_span_start)) => {
                 let comments = f.context().comments().get_trailing_comments(
                     *enclosing_span,
                     *preceding_span,
-                    *following_span,
+                    *following_span_start,
                 );
 
                 if comments.is_empty() {

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -265,60 +265,88 @@ fn generate_struct_impls(
 
             let should_not_have_following_node =
                 no_following_node_type_ids.contains(&struct_def.id);
-            let mut following_span = if should_not_have_following_node {
-                quote! {
-                    None
-                }
-            } else {
-                quote! {
-                    self.following_span
-                }
-            };
 
+            // Find the next field that can provide a following_span_start
             let mut next_field_index = index + 1;
+            let mut following_span_start = None;
+            let mut is_optional_chain = false;
+
             while let Some(next_field) = fields.get(next_field_index) {
                 let next_field_type_def = next_field.type_def(schema);
                 if let Some(next_following_node_tmp) =
-                    generate_next_following_node(next_field, next_field_type_def, schema)
+                    generate_next_following_node_start(next_field, next_field_type_def, schema)
                 {
-                    following_span = if next_field_type_def.is_option()
-                        || next_field_type_def.is_vec()
-                    {
+                    if next_field_type_def.is_option() || next_field_type_def.is_vec() {
                         let or_else_following_nodes = build_following_node_chain_until_non_option(
                             &fields[next_field_index + 1..],
                             should_not_have_following_node,
                             schema,
                         );
-                        quote! {
-                            #next_following_node_tmp #or_else_following_nodes
+                        // Check if we have an actual chain or a simple case
+                        if or_else_following_nodes.is_empty() {
+                            // Simple case - use map_or pattern directly (returns u32)
+                            following_span_start = Some(
+                                generate_simple_following_node_start(
+                                    next_field,
+                                    next_field_type_def,
+                                    schema,
+                                )
+                                .unwrap(),
+                            );
+                            // is_optional_chain stays false since we use map_or
+                        } else {
+                            is_optional_chain = true;
+                            following_span_start = Some(quote! {
+                                #next_following_node_tmp #or_else_following_nodes
+                            });
                         }
                     } else {
-                        next_following_node_tmp
-                    };
+                        // Non-optional field - we get a definite u32 value
+                        following_span_start = Some(next_following_node_tmp);
+                    }
                     break;
                 }
-
                 next_field_index += 1;
             }
 
+            // Generate the final following_span_start expression
+            let following_span_start_expr = match (following_span_start, is_optional_chain) {
+                (Some(expr), true) => {
+                    // Optional chain - need .unwrap_or(0)
+                    quote! { let following_span_start = #expr.unwrap_or(0); }
+                }
+                (Some(expr), false) => {
+                    // Direct u32 value (from non-optional field or map_or pattern)
+                    quote! { let following_span_start = #expr; }
+                }
+                (None, _) if should_not_have_following_node => {
+                    // No following node and type shouldn't have one
+                    quote! { let following_span_start = 0; }
+                }
+                (None, _) => {
+                    // No next field found, use parent's following_span_start
+                    quote! { let following_span_start = self.following_span_start; }
+                }
+            };
+
             if is_option {
                 quote! {
-                    let following_span = #following_span;
+                    #following_span_start_expr
                     self.allocator.alloc(self.inner.#field_name.as_ref().map(|inner| AstNode {
                         inner: #inner_access,
                         allocator: self.allocator,
                         parent: #parent_expr,
-                        following_span
+                        following_span_start
                     })).as_ref()
                 }
             } else {
                 quote! {
-                    let following_span = #following_span;
+                    #following_span_start_expr
                     self.allocator.alloc(AstNode {
                         inner: #field_access,
                         allocator: self.allocator,
                         parent: #parent_expr,
-                        following_span
+                        following_span_start
                     })
                 }
             }
@@ -363,7 +391,7 @@ fn generate_struct_impls(
                 format_trailing_comments(
                     self.parent.span(),
                     self.inner.span(),
-                    self.following_span,
+                    self.following_span_start,
                 )
                 .fmt(f);
             }
@@ -371,7 +399,8 @@ fn generate_struct_impls(
     }
 }
 
-fn generate_next_following_node(
+/// Generates code that returns `Option<u32>` for the start position of the following node.
+fn generate_next_following_node_start(
     next_field: &FieldDef,
     next_field_type_def: &TypeDef,
     schema: &Schema,
@@ -390,9 +419,12 @@ fn generate_next_following_node(
         return None;
     }
 
-    let following_span = match next_field_type_def {
+    // For non-optional fields, return plain u32 expression
+    // For optional/vec fields, return Option<u32> expression
+    let following_span_start = match next_field_type_def {
         TypeDef::Box(_) | TypeDef::Struct(_) | TypeDef::Enum(_) => {
-            quote! { Some(#next_field_accessor.span()) }
+            // Non-optional: returns plain u32
+            quote! { #next_field_accessor.span().start }
         }
         TypeDef::Option(option_def) => {
             let inner_type = option_def.inner_type(schema);
@@ -401,15 +433,49 @@ fn generate_next_following_node(
             } else {
                 quote! { as_ref() }
             };
-            quote! { #next_field_accessor.#inner_type_call.map(GetSpan::span) }
+            // Optional: returns Option<u32>
+            quote! { #next_field_accessor.#inner_type_call.map(|n| n.span().start) }
         }
         TypeDef::Vec(_) => {
-            quote! { #next_field_accessor.first().map(GetSpan::span) }
+            // Vec: returns Option<u32>
+            quote! { #next_field_accessor.first().map(|n| n.span().start) }
         }
         _ => return None,
     };
 
-    Some(following_span)
+    Some(following_span_start)
+}
+
+/// Generate a simple following_span_start expression using map_or (returns u32 directly).
+/// Used when there's no chain (just a single optional/vec field).
+fn generate_simple_following_node_start(
+    next_field: &FieldDef,
+    next_field_type_def: &TypeDef,
+    schema: &Schema,
+) -> Option<TokenStream> {
+    let next_field_ident = next_field.ident();
+    let next_field_accessor = quote! { self.inner.#next_field_ident };
+
+    // Generate map_or pattern for Optional/Vec fields (returns u32 directly)
+    let following_span_start = match next_field_type_def {
+        TypeDef::Option(option_def) => {
+            let inner_type = option_def.inner_type(schema);
+            let inner_type_call = if inner_type.is_box() {
+                quote! { as_deref() }
+            } else {
+                quote! { as_ref() }
+            };
+            // Using map_or: returns u32 directly
+            quote! { #next_field_accessor.#inner_type_call.map_or(0, |n| n.span().start) }
+        }
+        TypeDef::Vec(_) => {
+            // Using map_or: returns u32 directly
+            quote! { #next_field_accessor.first().map_or(0, |n| n.span().start) }
+        }
+        _ => return None,
+    };
+
+    Some(following_span_start)
 }
 
 fn build_following_node_chain_until_non_option(
@@ -421,11 +487,20 @@ fn build_following_node_chain_until_non_option(
 
     for field in fields {
         let field_type_def = field.type_def(schema);
-        if let Some(following_span) = generate_next_following_node(field, field_type_def, schema) {
-            result = quote! {
-                #result.or_else(|| #following_span)
-            };
-            if !field_type_def.is_option() && !field_type_def.is_vec() {
+        if let Some(following_span_start) =
+            generate_next_following_node_start(field, field_type_def, schema)
+        {
+            // Non-optional fields return plain u32, need to wrap in Some() for .or_else()
+            // Optional/Vec fields return Option<u32>, use directly
+            if field_type_def.is_option() || field_type_def.is_vec() {
+                result = quote! {
+                    #result.or_else(|| #following_span_start)
+                };
+            } else {
+                // Non-optional field terminates the chain
+                result = quote! {
+                    #result.or_else(|| Some(#following_span_start))
+                };
                 return result;
             }
         }
@@ -434,7 +509,7 @@ fn build_following_node_chain_until_non_option(
     if should_not_have_following_node {
         result
     } else {
-        quote! { #result.or(self.following_span) }
+        quote! { #result.or(Some(self.following_span_start)) }
     }
 }
 
@@ -464,7 +539,7 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
                     inner: #inner_expr,
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         } else {
@@ -492,7 +567,7 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
                     inner: it.#to_fn_ident(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }))
             }
         } else {
@@ -501,7 +576,7 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
                     inner: it.#to_fn_ident(),
                     parent,
                     allocator: self.allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }).as_ast_nodes();
             }
         };

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -278,7 +278,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     inner,
                     parent,
                     allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }).fmt(f);
             },
         })
@@ -301,7 +301,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
                     inner,
                     parent,
                     allocator,
-                    following_span: self.following_span,
+                    following_span_start: self.following_span_start,
                 }).fmt(f);
             },
         };


### PR DESCRIPTION
## Summary

This PR reduces `AstNode` size by 8 bytes (from 40 to 32 bytes, a 20% reduction) by optimizing the `following_span` field:

**Before:**
```rust
pub struct AstNode<'a, T> {
    pub(super) inner: &'a T,                      // 8 bytes
    pub parent: &'a AstNodes<'a>,                 // 8 bytes
    pub(super) allocator: &'a Allocator,          // 8 bytes
    pub(super) following_span: Option<Span>,      // 16 bytes (Option adds padding)
}
// Total: 40 bytes
```

**After:**
```rust
pub struct AstNode<'a, T> {
    pub(super) inner: &'a T,                      // 8 bytes
    pub parent: &'a AstNodes<'a>,                 // 8 bytes
    pub(super) allocator: &'a Allocator,          // 8 bytes
    pub(super) following_span_start: u32,         // 4 bytes + 4 bytes padding
}
// Total: 32 bytes
```

### Why this works

1. **Only `start` is used**: The `following_span` field was `Option<Span>` but only the `start` position was ever accessed (in `comments.rs` for trailing comment handling)

2. **`0` as sentinel**: Using `0` as a sentinel value for "no following node" is safe because:
   - Source positions start at 0, but a span starting at position 0 would be at the very beginning of the file
   - In practice, this means the first node in a file has no "previous" node to attach trailing comments to anyway

### Benchmark

2% performance improvements in each benchmark file
<img width="1121" height="762" alt="image" src="https://github.com/user-attachments/assets/76aff70f-8c52-4e18-80e7-b0b7c102ad11" />
