### PR TITLE
feat(ast)!: add `Ident` type

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -25,7 +25,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, UnstableAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, SourceType, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Ident, SourceType, Span};
 use oxc_syntax::{
     operator::{
         AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
@@ -234,7 +234,7 @@ pub use match_expression;
 pub struct IdentifierName<'a> {
     pub span: Span,
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
 }
 
 /// `x` inside `func` in `const x = 0; function func() { console.log(x); }`
@@ -254,7 +254,7 @@ pub struct IdentifierReference<'a> {
     pub span: Span,
     /// The name of the identifier being referenced.
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
     /// Reference ID
     ///
     /// Identifies what identifier this refers to, and how it is used. This is
@@ -283,7 +283,7 @@ pub struct BindingIdentifier<'a> {
     pub span: Span,
     /// The identifier name being bound.
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
     /// Unique identifier for this binding.
     ///
     /// This gets initialized during [`semantic analysis`] in the bind step. If
@@ -309,7 +309,7 @@ pub struct BindingIdentifier<'a> {
 pub struct LabelIdentifier<'a> {
     pub span: Span,
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
 }
 
 /// `this` in `return this.prop;`
@@ -2282,7 +2282,7 @@ pub enum MethodDefinitionKind {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 pub struct PrivateIdentifier<'a> {
     pub span: Span,
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
 }
 
 /// Class Static Block

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{self, Display},
 };
 
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{Atom, GetSpan, Ident, Span};
 use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags};
 
 use crate::ast::*;
@@ -502,7 +502,7 @@ impl<'a> PropertyKey<'a> {
     ///
     /// - `#a: 1` in `class C { #a: 1 }` would return `a`
     /// - `a: 1` in `{ a: 1 }` would return `None`
-    pub fn private_name(&self) -> Option<Atom<'a>> {
+    pub fn private_name(&self) -> Option<Ident<'a>> {
         match self {
             Self::PrivateIdentifier(ident) => Some(ident.name),
             _ => None,
@@ -1259,7 +1259,7 @@ impl<'a> BindingPattern<'a> {
     /// - calling on `a = 1` in `let a = 1` would return `Some("a")`
     /// - calling on `a = 1` in `let {a = 1} = c` would return `Some("a")`
     /// - calling on `a: b` in `let {a: b} = c` would return `None`
-    pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
+    pub fn get_identifier_name(&self) -> Option<Ident<'a>> {
         match self {
             Self::BindingIdentifier(ident) => Some(ident.name),
             Self::AssignmentPattern(assign) => assign.left.get_identifier_name(),
@@ -1424,7 +1424,7 @@ impl ArrayPattern<'_> {
 impl<'a> Function<'a> {
     /// Returns this [`Function`]'s name, if it has one.
     #[inline]
-    pub fn name(&self) -> Option<Atom<'a>> {
+    pub fn name(&self) -> Option<Ident<'a>> {
         self.id.as_ref().map(|id| id.name)
     }
 
@@ -1580,7 +1580,7 @@ impl<'a> ArrowFunctionExpression<'a> {
 impl<'a> Class<'a> {
     /// Returns this [`Class`]'s name, if it has one.
     #[inline]
-    pub fn name(&self) -> Option<Atom<'a>> {
+    pub fn name(&self) -> Option<Ident<'a>> {
         self.id.as_ref().map(|id| id.name)
     }
 
@@ -1927,7 +1927,7 @@ impl<'a> ImportAttributeKey<'a> {
     /// Returns the string value of this import attribute key.
     pub fn as_atom(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(identifier) => identifier.name,
+            Self::Identifier(identifier) => identifier.name.into(),
             Self::StringLiteral(literal) => literal.value,
         }
     }
@@ -1988,8 +1988,8 @@ impl<'a> ModuleExportName<'a> {
     /// - `export { foo as "anything" }` => `"anything"`
     pub fn name(&self) -> Atom<'a> {
         match self {
-            Self::IdentifierName(identifier) => identifier.name,
-            Self::IdentifierReference(identifier) => identifier.name,
+            Self::IdentifierName(identifier) => identifier.name.into(),
+            Self::IdentifierReference(identifier) => identifier.name.into(),
             Self::StringLiteral(literal) => literal.value,
         }
     }
@@ -2001,7 +2001,7 @@ impl<'a> ModuleExportName<'a> {
     /// - `export { foo }` => `Some("foo")`
     /// - `export { foo as bar }` => `Some("bar")`
     /// - `export { foo as "anything" }` => `None`
-    pub fn identifier_name(&self) -> Option<Atom<'a>> {
+    pub fn identifier_name(&self) -> Option<Ident<'a>> {
         match self {
             Self::IdentifierName(identifier) => Some(identifier.name),
             Self::IdentifierReference(identifier) => Some(identifier.name),

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -53,7 +53,7 @@ impl<'a> JSXElementName<'a> {
     pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
         match self {
             Self::Identifier(id) => Some(id.as_ref().name),
-            Self::IdentifierReference(id) => Some(id.as_ref().name),
+            Self::IdentifierReference(id) => Some(id.as_ref().name.into()),
             _ => None,
         }
     }

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -16,7 +16,7 @@ impl<'a> TSEnumMemberName<'a> {
     /// Panics if `self` is a `TemplateString` with no quasi.
     pub fn static_name(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(ident) => ident.name,
+            Self::Identifier(ident) => ident.name.into(),
             Self::String(lit) | Self::ComputedString(lit) => lit.value,
             Self::ComputedTemplateString(template) => template
                 .single_quasi()
@@ -218,7 +218,7 @@ impl<'a> TSModuleDeclarationName<'a> {
     /// Get the static name of this module declaration name.
     pub fn name(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(ident) => ident.name,
+            Self::Identifier(ident) => ident.name.into(),
             Self::StringLiteral(lit) => lit.value,
         }
     }

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -4,7 +4,7 @@
 //! including type checking, conversions, and tree traversal helpers.
 
 use oxc_allocator::{Address, GetAddress, UnstableAddress};
-use oxc_span::{Atom, GetSpan};
+use oxc_span::{Atom, GetSpan, Ident};
 
 use super::{AstKind, ast::*};
 
@@ -174,7 +174,7 @@ impl<'a> AstKind<'a> {
     ///
     /// Returns the identifier name if this is any kind of identifier node,
     /// `None` otherwise.
-    pub fn identifier_name(self) -> Option<Atom<'a>> {
+    pub fn identifier_name(self) -> Option<Ident<'a>> {
         match self {
             Self::BindingIdentifier(ident) => Some(ident.name),
             Self::IdentifierReference(ident) => Some(ident.name),
@@ -392,7 +392,7 @@ impl AstKind<'_> {
             Self::VariableDeclaration(_) => "VariableDeclaration".into(),
             Self::VariableDeclarator(v) => format!(
                 "VariableDeclarator({})",
-                v.id.get_identifier_name().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
+                v.id.get_identifier_name().unwrap_or(Ident::from(DESTRUCTURE.as_ref()))
             )
             .into(),
 
@@ -474,7 +474,7 @@ impl AstKind<'_> {
             Self::FormalParameters(_) => "FormalParameters".into(),
             Self::FormalParameter(p) => format!(
                 "FormalParameter({})",
-                p.pattern.get_identifier_name().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
+                p.pattern.get_identifier_name().unwrap_or(Ident::from(DESTRUCTURE.as_ref()))
             )
             .into(),
             Self::FormalParameterRest(_) => "FormalParameterRest".into(),
@@ -629,7 +629,7 @@ impl<'a> MemberExpressionKind<'a> {
     pub fn static_property_name(&self) -> Option<Atom<'a>> {
         match self {
             Self::Computed(member_expr) => member_expr.static_property_name(),
-            Self::Static(member_expr) => Some(member_expr.property.name),
+            Self::Static(member_expr) => Some(member_expr.property.name.into()),
             Self::PrivateField(_) => None,
         }
     }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -17,7 +17,7 @@ use oxc_syntax::{
     comment_node::CommentNodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId,
 };
 
-use oxc_span::Atom;
+use oxc_span::{Atom, Ident};
 
 use crate::{AstBuilder, ast::*};
 
@@ -251,7 +251,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn expression_identifier<A1>(self, span: Span, name: A1) -> Expression<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Expression::Identifier(self.alloc_identifier_reference(span, name))
     }
@@ -272,7 +272,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> Expression<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Expression::Identifier(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -1230,7 +1230,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn identifier_name<A1>(self, span: Span, name: A1) -> IdentifierName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         IdentifierName { span, name: name.into() }
     }
@@ -1246,7 +1246,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_identifier_name<A1>(self, span: Span, name: A1) -> Box<'a, IdentifierName<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(self.identifier_name(span, name), self.allocator)
     }
@@ -1262,7 +1262,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn identifier_reference<A1>(self, span: Span, name: A1) -> IdentifierReference<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         IdentifierReference { span, name: name.into(), reference_id: Default::default() }
     }
@@ -1282,7 +1282,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> Box<'a, IdentifierReference<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(self.identifier_reference(span, name), self.allocator)
     }
@@ -1304,7 +1304,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> IdentifierReference<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         IdentifierReference { span, name: name.into(), reference_id: Cell::new(Some(reference_id)) }
     }
@@ -1326,7 +1326,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> Box<'a, IdentifierReference<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(
             self.identifier_reference_with_reference_id(span, name, reference_id),
@@ -1345,7 +1345,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn binding_identifier<A1>(self, span: Span, name: A1) -> BindingIdentifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         BindingIdentifier { span, name: name.into(), symbol_id: Default::default() }
     }
@@ -1365,7 +1365,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> Box<'a, BindingIdentifier<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(self.binding_identifier(span, name), self.allocator)
     }
@@ -1387,7 +1387,7 @@ impl<'a> AstBuilder<'a> {
         symbol_id: SymbolId,
     ) -> BindingIdentifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         BindingIdentifier { span, name: name.into(), symbol_id: Cell::new(Some(symbol_id)) }
     }
@@ -1409,7 +1409,7 @@ impl<'a> AstBuilder<'a> {
         symbol_id: SymbolId,
     ) -> Box<'a, BindingIdentifier<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), self.allocator)
     }
@@ -1422,7 +1422,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn label_identifier<A1>(self, span: Span, name: A1) -> LabelIdentifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         LabelIdentifier { span, name: name.into() }
     }
@@ -1664,7 +1664,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn property_key_static_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         PropertyKey::StaticIdentifier(self.alloc_identifier_name(span, name))
     }
@@ -1679,7 +1679,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn property_key_private_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         PropertyKey::PrivateIdentifier(self.alloc_private_identifier(span, name))
     }
@@ -2648,7 +2648,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> SimpleAssignmentTarget<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(
             self.alloc_identifier_reference(span, name),
@@ -2671,7 +2671,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> SimpleAssignmentTarget<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(
             self.alloc_identifier_reference_with_reference_id(span, name, reference_id),
@@ -5569,7 +5569,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn binding_pattern_binding_identifier<A1>(self, span: Span, name: A1) -> BindingPattern<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         BindingPattern::BindingIdentifier(self.alloc_binding_identifier(span, name))
     }
@@ -5590,7 +5590,7 @@ impl<'a> AstBuilder<'a> {
         symbol_id: SymbolId,
     ) -> BindingPattern<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         BindingPattern::BindingIdentifier(
             self.alloc_binding_identifier_with_symbol_id(span, name, symbol_id),
@@ -7188,7 +7188,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn private_identifier<A1>(self, span: Span, name: A1) -> PrivateIdentifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         PrivateIdentifier { span, name: name.into() }
     }
@@ -7208,7 +7208,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> Box<'a, PrivateIdentifier<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         Box::new_in(self.private_identifier(span, name), self.allocator)
     }
@@ -7876,7 +7876,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn import_attribute_key_identifier<A1>(self, span: Span, name: A1) -> ImportAttributeKey<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         ImportAttributeKey::Identifier(self.identifier_name(span, name))
     }
@@ -8427,7 +8427,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierName(self.identifier_name(span, name))
     }
@@ -8444,7 +8444,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierReference(self.identifier_reference(span, name))
     }
@@ -8463,7 +8463,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierReference(self.identifier_reference_with_reference_id(
             span,
@@ -9068,7 +9068,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> JSXElementName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         JSXElementName::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -9089,7 +9089,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> JSXElementName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         JSXElementName::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -9235,7 +9235,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> JSXMemberExpressionObject<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         JSXMemberExpressionObject::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -9256,7 +9256,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> JSXMemberExpressionObject<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         JSXMemberExpressionObject::IdentifierReference(
             self.alloc_identifier_reference_with_reference_id(span, name, reference_id),
@@ -9949,7 +9949,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn ts_enum_member_name_identifier<A1>(self, span: Span, name: A1) -> TSEnumMemberName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSEnumMemberName::Identifier(self.alloc_identifier_name(span, name))
     }
@@ -11926,7 +11926,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn ts_type_name_identifier_reference<A1>(self, span: Span, name: A1) -> TSTypeName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSTypeName::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -11947,7 +11947,7 @@ impl<'a> AstBuilder<'a> {
         reference_id: ReferenceId,
     ) -> TSTypeName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSTypeName::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -13518,7 +13518,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> TSTypePredicateName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSTypePredicateName::Identifier(self.alloc_identifier_name(span, name))
     }
@@ -13643,7 +13643,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSModuleDeclarationName::Identifier(self.binding_identifier(span, name))
     }
@@ -13662,7 +13662,7 @@ impl<'a> AstBuilder<'a> {
         symbol_id: SymbolId,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSModuleDeclarationName::Identifier(
             self.binding_identifier_with_symbol_id(span, name, symbol_id),
@@ -14136,7 +14136,7 @@ impl<'a> AstBuilder<'a> {
         name: A1,
     ) -> TSImportTypeQualifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Ident<'a>>,
     {
         TSImportTypeQualifier::Identifier(self.alloc_identifier_name(span, name))
     }

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -63,7 +63,7 @@ pub struct JSXElementIdentifierReference<'a, 'b>(pub &'b IdentifierReference<'a>
 
 impl ESTree for JSXElementIdentifierReference<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        JSXIdentifier { span: self.0.span, name: self.0.name }.serialize(serializer);
+        JSXIdentifier { span: self.0.span, name: self.0.name.into() }.serialize(serializer);
     }
 }
 

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -275,7 +275,7 @@ pub struct TSGlobalDeclarationId<'a, 'b>(pub &'b TSGlobalDeclaration<'a>);
 
 impl ESTree for TSGlobalDeclarationId<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let ident = IdentifierName { span: self.0.global_span, name: Atom::from("global") };
+        let ident = IdentifierName { span: self.0.global_span, name: Atom::from("global").into() };
         ident.serialize(serializer);
     }
 }

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -5,7 +5,7 @@ use std::mem::transmute;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Ident};
 
 use crate::ast_nodes::AstNode;
 use crate::formatter::{
@@ -1194,7 +1194,7 @@ impl<'a> AstNode<'a, Expression<'a>> {
 
 impl<'a> AstNode<'a, IdentifierName<'a>> {
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 
@@ -1209,7 +1209,7 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
 
 impl<'a> AstNode<'a, IdentifierReference<'a>> {
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 
@@ -1224,7 +1224,7 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
 
 impl<'a> AstNode<'a, BindingIdentifier<'a>> {
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 
@@ -1239,7 +1239,7 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
 
 impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 
@@ -4832,7 +4832,7 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
 
 impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -392,8 +392,8 @@ pub fn is_member_call_chain<'a>(
     MemberChain::from_call_expression(expression, f).tail.is_member_call_chain()
 }
 
-fn has_short_name(name: &Atom, tab_width: u8) -> bool {
-    name.as_str().len() <= tab_width as usize
+fn has_short_name(name: &str, tab_width: u8) -> bool {
+    name.len() <= tab_width as usize
 }
 
 fn chain_members_iter<'a, 'b>(

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -123,7 +123,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     return Some(ConstantValue::Number(f64::NAN));
                 }
 
-                if let Some(value) = prev_members.get(&ident.name) {
+                if let Some(value) = prev_members.get(ident.name.as_str()) {
                     return Some(value.clone());
                 }
 

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -90,6 +90,7 @@ impl<'a> FunctionReturnType<'a> {
             }
             _ => None,
         } {
+            let reference_name: Atom = reference_name.into();
             let is_defined_in_current_scope = if is_value {
                 visitor.value_bindings.contains(&reference_name)
             } else {
@@ -133,13 +134,13 @@ impl<'a> Visit<'a> for FunctionReturnType<'a> {
 
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         if self.scope_depth == 0 {
-            self.value_bindings.push(ident.name);
+            self.value_bindings.push(ident.name.into());
         }
     }
 
     fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
         if self.scope_depth == 0 {
-            self.type_bindings.push(decl.id.name);
+            self.type_bindings.push(decl.id.name.into());
         }
     }
 

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -102,19 +102,19 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
     }
 
     fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
-        self.add_reference(ident.name, KindFlags::Value);
+        self.add_reference(ident.name.into(), KindFlags::Value);
     }
 
     fn visit_binding_pattern(&mut self, pattern: &BindingPattern<'a>) {
         if let BindingPattern::BindingIdentifier(ident) = pattern {
-            self.add_binding(ident.name, KindFlags::Value);
+            self.add_binding(ident.name.into(), KindFlags::Value);
         }
         walk_binding_pattern(self, pattern);
     }
 
     fn visit_ts_type_name(&mut self, name: &TSTypeName<'a>) {
         if let TSTypeName::IdentifierReference(ident) = name {
-            self.add_reference(ident.name, KindFlags::Type);
+            self.add_reference(ident.name.into(), KindFlags::Type);
         } else {
             walk_ts_type_name(self, name);
         }
@@ -124,7 +124,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
     fn visit_ts_type_query(&mut self, ty: &TSTypeQuery<'a>) {
         if let Some(type_name) = ty.expr_name.as_ts_type_name() {
             if let Some(ident) = TSTypeName::get_identifier_reference(type_name) {
-                self.add_reference(ident.name, KindFlags::Value);
+                self.add_reference(ident.name.into(), KindFlags::Value);
                 // `typeof Type<Parameters>`
                 //              ^^^^^^^^^^^
                 if let Some(type_parameters) = &ty.type_arguments {
@@ -143,7 +143,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
             // export { ... }
             for specifier in &decl.specifiers {
                 if let Some(name) = specifier.local.identifier_name() {
-                    self.add_reference(name, KindFlags::All);
+                    self.add_reference(name.into(), KindFlags::All);
                 }
             }
         }
@@ -151,7 +151,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
         if let ExportDefaultDeclarationKind::Identifier(ident) = &decl.declaration {
-            self.add_reference(ident.name, KindFlags::All);
+            self.add_reference(ident.name.into(), KindFlags::All);
         } else {
             walk_export_default_declaration(self, decl);
         }
@@ -165,33 +165,33 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
             }
             Declaration::FunctionDeclaration(decl) => {
                 if let Some(id) = decl.id.as_ref() {
-                    self.add_binding(id.name, KindFlags::Value);
+                    self.add_binding(id.name.into(), KindFlags::Value);
                 }
             }
             Declaration::ClassDeclaration(decl) => {
                 if let Some(id) = decl.id.as_ref() {
-                    self.add_binding(id.name, KindFlags::Value);
+                    self.add_binding(id.name.into(), KindFlags::Value);
                 }
             }
             Declaration::TSTypeAliasDeclaration(decl) => {
-                self.add_binding(decl.id.name, KindFlags::Type);
+                self.add_binding(decl.id.name.into(), KindFlags::Type);
             }
             Declaration::TSInterfaceDeclaration(decl) => {
-                self.add_binding(decl.id.name, KindFlags::Type);
+                self.add_binding(decl.id.name.into(), KindFlags::Type);
             }
             Declaration::TSEnumDeclaration(decl) => {
-                self.add_binding(decl.id.name, KindFlags::All);
+                self.add_binding(decl.id.name.into(), KindFlags::All);
             }
             Declaration::TSModuleDeclaration(decl) => {
                 if let TSModuleDeclarationName::Identifier(ident) = &decl.id {
-                    self.add_binding(ident.name, KindFlags::All);
+                    self.add_binding(ident.name.into(), KindFlags::All);
                 }
             }
             Declaration::TSGlobalDeclaration(_) => {
                 // no binding
             }
             Declaration::TSImportEqualsDeclaration(decl) => {
-                self.add_binding(decl.id.name, KindFlags::Value);
+                self.add_binding(decl.id.name.into(), KindFlags::Value);
             }
         }
         walk_declaration(self, declaration);

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -10,7 +10,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::{identifier::is_identifier_name, keyword::is_reserved_keyword_or_global_object};
 
 use crate::{
@@ -467,8 +467,7 @@ fn guess_function_name<'a>(ctx: &LintContext<'a>, node_id: NodeId) -> Option<Cow
                 return decl
                     .id
                     .get_identifier_name()
-                    .as_ref()
-                    .map(Atom::as_str)
+                    .map(|n| n.as_str())
                     .filter(|name| is_valid_identifier_name(name))
                     .map(Cow::Borrowed);
             }

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -136,7 +136,7 @@ impl Rule for InlineScriptId {
                                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop
                                     && let PropertyKey::StaticIdentifier(ident) = &obj_prop.key
                                 {
-                                    prop_names_hash_set.insert(ident.name);
+                                    prop_names_hash_set.insert(ident.name.into());
                                 }
                             }
                         } else {

--- a/crates/oxc_linter/src/rules/react/forbid_elements.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_elements.rs
@@ -1,7 +1,7 @@
 use oxc_ast::{AstKind, ast::Argument};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 
@@ -211,13 +211,13 @@ fn add_configuration_forbid_from_object(
 
 // Match /^[A-Z_]/
 // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-elements.js#L109
-fn is_valid_identifier(str: &Atom) -> bool {
+fn is_valid_identifier(str: &str) -> bool {
     str.chars().next().is_some_and(|c| c.is_uppercase() || c == '_')
 }
 
 // Match /^[a-z][^.]*$/
 // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-elements.js#L111
-fn is_valid_literal(str: &Atom) -> bool {
+fn is_valid_literal(str: &str) -> bool {
     str.chars().next().is_some_and(char::is_lowercase) && !str.contains('.')
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -77,8 +77,9 @@ impl Rule for JsxPropsNoSpreadMulti {
             for spread_attr in spread_attrs {
                 let argument_without_parenthesized = spread_attr.argument.without_parentheses();
 
-                if let Some(identifier_name) =
-                    argument_without_parenthesized.get_identifier_reference().map(|arg| arg.name)
+                if let Some(identifier_name) = argument_without_parenthesized
+                    .get_identifier_reference()
+                    .map(|arg| Atom::from(arg.name))
                 {
                     identifier_names
                         .entry(identifier_name)

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -9,7 +9,7 @@ use oxc_ast_visit::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
-use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Ident, Span};
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -339,7 +339,7 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
             return false;
         };
         if let Some(Cow::Borrowed(name)) = id.static_name() {
-            self.target_symbol.replace(IdentifierName { name: Atom::from(name), span: id.span() });
+            self.target_symbol.replace(IdentifierName { name: Ident::from(name), span: id.span() });
             true
         } else {
             false

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -232,7 +232,7 @@ fn get_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Ato
             if matches!(&expr.object, Expression::ThisExpression(_)) =>
         {
             // this.property
-            Some(expr.property.name)
+            Some(expr.property.name.into())
         }
         AssignmentTarget::ComputedMemberExpression(expr)
             if matches!(&expr.object, Expression::ThisExpression(_)) =>

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -5,7 +5,7 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ReferenceId, ScopeFlags, ScopeId, SymbolId};
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -21,7 +21,7 @@ fn consistent_function_scoping(
     fn_span: Span,
     parent_scope_span: Option<Span>,
     parent_scope_kind: Option<&'static str>,
-    function_name: Option<Atom<'_>>,
+    function_name: Option<&str>,
 ) -> OxcDiagnostic {
     let function_label = if let Some(name) = function_name {
         format!("Function `{name}` does not capture any variables from its parent scope")
@@ -199,7 +199,7 @@ impl Rule for ConsistentFunctionScoping {
                     if let Some(binding_ident) = get_function_like_declaration(node, ctx) {
                         (
                             binding_ident.symbol_id(),
-                            Some(binding_ident.name),
+                            Some(binding_ident.name.as_str()),
                             function_body,
                             function.id.as_ref().map_or(
                                 Span::sized(function.span.start, 8),
@@ -210,7 +210,7 @@ impl Rule for ConsistentFunctionScoping {
                     } else if let Some(function_id) = &function.id {
                         (
                             function_id.symbol_id(),
-                            Some(function_id.name),
+                            Some(function_id.name.as_str()),
                             function_body,
                             function_id.span(),
                             func_scope_id,
@@ -226,7 +226,7 @@ impl Rule for ConsistentFunctionScoping {
 
                     (
                         binding_ident.symbol_id(),
-                        Some(binding_ident.name),
+                        Some(binding_ident.name.as_str()),
                         &arrow_function.body,
                         binding_ident.span(),
                         arrow_function.scope_id(),

--- a/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
+++ b/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
@@ -4,17 +4,17 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::Span;
 
 use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
 
-fn no_import_compiler_macros_diagnostic(span: Span, name: &Atom) -> OxcDiagnostic {
+fn no_import_compiler_macros_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is a compiler macro and doesn't need to be imported."))
         .with_help("Remove the import statement for this macro.")
         .with_label(span)
 }
 
-fn invalid_import_compiler_macros_diagnostic(span: Span, name: &Atom) -> OxcDiagnostic {
+fn invalid_import_compiler_macros_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "'{name}' is a compiler macro and can't be imported outside of `<script setup>`."
     ))

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -598,7 +598,7 @@ impl<'t> Mangler<'t> {
                     itertools::Either::Right(decl.id().into_iter())
                 }
             })
-            .map(|id| (id.name, id.symbol_id()))
+            .map(|id| (Atom::from(id.name), id.symbol_id()))
             .collect()
     }
 

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -45,7 +45,7 @@ impl<'a> Visit<'a> for KeepVar<'a> {
     fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
         if it.kind.is_var() {
             it.bound_names(&mut |ident| {
-                self.vars.push((ident.name, ident.span, ident.symbol_id.get()));
+                self.vars.push((ident.name.into(), ident.span, ident.symbol_id.get()));
             });
             if it.has_init() {
                 self.all_hoisted = false;

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -514,7 +514,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         if ctx.state.dce {
             return;
         }
-        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.field.name);
+        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.field.name.into());
     }
 
     fn exit_private_in_expression(
@@ -525,7 +525,7 @@ impl<'a> Traverse<'a, MinifierState<'a>> for PeepholeOptimizations {
         if ctx.state.dce {
             return;
         }
-        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.left.name);
+        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.left.name.into());
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
@@ -21,11 +21,8 @@ impl<'a> PeepholeOptimizations {
                 let PropertyKey::PrivateIdentifier(private_id) = &prop.key else {
                     return true;
                 };
-                if ctx
-                    .state
-                    .class_symbols_stack
-                    .is_private_member_used_in_current_class(&private_id.name)
-                {
+                let name: Atom = private_id.name.into();
+                if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name) {
                     return true;
                 }
                 prop.value.as_ref().is_some_and(|value| value.may_have_side_effects(ctx))
@@ -34,19 +31,15 @@ impl<'a> PeepholeOptimizations {
                 let PropertyKey::PrivateIdentifier(private_id) = &method.key else {
                     return true;
                 };
-                ctx.state
-                    .class_symbols_stack
-                    .is_private_member_used_in_current_class(&private_id.name)
+                let name: Atom = private_id.name.into();
+                ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name)
             }
             ClassElement::AccessorProperty(accessor) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &accessor.key else {
                     return true;
                 };
-                if ctx
-                    .state
-                    .class_symbols_stack
-                    .is_private_member_used_in_current_class(&private_id.name)
-                {
+                let name: Atom = private_id.name.into();
+                if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name) {
                     return true;
                 }
                 accessor.value.as_ref().is_some_and(|value| value.may_have_side_effects(ctx))
@@ -67,19 +60,19 @@ impl<'a> PeepholeOptimizations {
                 let PropertyKey::PrivateIdentifier(private_id) = &prop.key else {
                     return None;
                 };
-                Some(private_id.name)
+                Some(private_id.name.into())
             }
             ClassElement::MethodDefinition(method) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &method.key else {
                     return None;
                 };
-                Some(private_id.name)
+                Some(private_id.name.into())
             }
             ClassElement::AccessorProperty(accessor) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &accessor.key else {
                     return None;
                 };
-                Some(private_id.name)
+                Some(private_id.name.into())
             }
             ClassElement::StaticBlock(_) => None,
             ClassElement::TSIndexSignature(_) => {

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -210,17 +210,17 @@ impl<'a> ModuleRecordBuilder<'a> {
                             specifier.imported.name(),
                             specifier.imported.span(),
                         )),
-                        NameSpan::new(specifier.local.name, specifier.local.span),
+                        NameSpan::new(specifier.local.name.into(), specifier.local.span),
                         decl.import_kind.is_type() || specifier.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => (
                         ImportImportName::NamespaceObject,
-                        NameSpan::new(specifier.local.name, specifier.local.span),
+                        NameSpan::new(specifier.local.name.into(), specifier.local.span),
                         decl.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => (
                         ImportImportName::Default(specifier.span),
-                        NameSpan::new(specifier.local.name, specifier.local.span),
+                        NameSpan::new(specifier.local.name.into(), specifier.local.span),
                         decl.import_kind.is_type(),
                     ),
                 };
@@ -284,20 +284,20 @@ impl<'a> ModuleRecordBuilder<'a> {
     ) {
         let local_name = match &decl.declaration {
             ExportDefaultDeclarationKind::Identifier(ident) => {
-                ExportLocalName::Default(NameSpan::new(ident.name, ident.span))
+                ExportLocalName::Default(NameSpan::new(ident.name.into(), ident.span))
             }
             ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
                 func.id.as_ref().map_or_else(
                     || ExportLocalName::Null,
-                    |id| ExportLocalName::Name(NameSpan::new(id.name, id.span)),
+                    |id| ExportLocalName::Name(NameSpan::new(id.name.into(), id.span)),
                 )
             }
             ExportDefaultDeclarationKind::ClassDeclaration(class) => class.id.as_ref().map_or_else(
                 || ExportLocalName::Null,
-                |id| ExportLocalName::Name(NameSpan::new(id.name, id.span)),
+                |id| ExportLocalName::Name(NameSpan::new(id.name.into(), id.span)),
             ),
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(t) => {
-                ExportLocalName::Name(NameSpan::new(t.id.name, t.id.span))
+                ExportLocalName::Name(NameSpan::new(t.id.name.into(), t.id.span))
             }
             _ => ExportLocalName::Null,
         };
@@ -332,8 +332,10 @@ impl<'a> ModuleRecordBuilder<'a> {
 
         if let Some(d) = &decl.declaration {
             iter_binding_identifiers_of_declaration(d, &mut |ident| {
-                let export_name = ExportExportName::Name(NameSpan::new(ident.name, ident.span));
-                let local_name = ExportLocalName::Name(NameSpan::new(ident.name, ident.span));
+                let export_name =
+                    ExportExportName::Name(NameSpan::new(ident.name.into(), ident.span));
+                let local_name =
+                    ExportLocalName::Name(NameSpan::new(ident.name.into(), ident.span));
                 let export_entry = ExportEntry {
                     statement_span: decl.span,
                     span: d.span(),
@@ -344,7 +346,7 @@ impl<'a> ModuleRecordBuilder<'a> {
                     is_type: decl.export_kind.is_type(),
                 };
                 self.add_export_entry(export_entry);
-                self.add_export_binding(ident.name, ident.span);
+                self.add_export_binding(ident.name.into(), ident.span);
             });
         }
 

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -98,7 +98,11 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                 // Finally, add the variable to all hoisted scopes
                 // to support redeclaration checks when declaring variables with the same name later.
                 for &scope_id in &var_scope_ids {
-                    builder.hoisting_variables.entry(scope_id).or_default().insert(name, symbol_id);
+                    builder
+                        .hoisting_variables
+                        .entry(scope_id)
+                        .or_default()
+                        .insert(name.into(), symbol_id);
                 }
             });
         }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2524,7 +2524,7 @@ impl<'a> SemanticBuilder<'a> {
     fn reference_identifier(&mut self, ident: &IdentifierReference<'a>) {
         let flags = self.resolve_reference_usages();
         let reference = Reference::new(self.current_node_id, self.current_scope_id, flags);
-        let reference_id = self.declare_reference(ident.name, reference);
+        let reference_id = self.declare_reference(ident.name.into(), reference);
         ident.reference_id.set(Some(reference_id));
     }
 

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -93,7 +93,7 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
 fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
     let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
-        if let Some(old_span) = idents.insert(ident.name, ident.span) {
+        if let Some(old_span) = idents.insert(ident.name.into(), ident.span) {
             ctx.error(diagnostics::redeclaration(&ident.name, old_span, ident.span));
         }
     });

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -112,7 +112,7 @@ impl<'a> ClassTableBuilder<'a> {
 
             let reference = PrivateIdentifierReference::new(
                 current_node_id,
-                ident.name,
+                ident.name.into(),
                 ident.span,
                 element_ids,
             );

--- a/crates/oxc_span/src/ident.rs
+++ b/crates/oxc_span/src/ident.rs
@@ -1,0 +1,354 @@
+//! Identifier string type.
+
+use std::{
+    borrow::{Borrow, Cow},
+    fmt, hash,
+    ops::Deref,
+};
+
+use oxc_allocator::{Allocator, CloneIn, Dummy, FromIn, StringBuilder as ArenaStringBuilder};
+#[cfg(feature = "serialize")]
+use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Serializer as SerdeSerializer};
+
+use crate::{Atom, CompactStr, ContentEq};
+
+/// An identifier string for oxc_allocator.
+///
+/// Use [CompactStr] with [Ident::to_compact_str] or [Ident::into_compact_str] for
+/// the lifetimeless form.
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq)]
+pub struct Ident<'a>(&'a str);
+
+impl Ident<'static> {
+    /// Get an [`Ident`] containing a static string.
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    pub const fn new_const(s: &'static str) -> Self {
+        Ident(s)
+    }
+
+    /// Get an [`Ident`] containing the empty string (`""`).
+    #[inline]
+    pub const fn empty() -> Self {
+        Self::new_const("")
+    }
+}
+
+impl<'a> Ident<'a> {
+    /// Borrow a string slice.
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    pub fn as_str(&self) -> &'a str {
+        self.0
+    }
+
+    /// Convert this [`Ident`] into an [`Atom`].
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    pub fn as_atom(&self) -> Atom<'a> {
+        Atom::from(self.0)
+    }
+
+    /// Convert this [`Ident`] into a [`String`].
+    ///
+    /// This is the explicit form of [`Into<String>`], which [`Ident`] also implements.
+    #[inline]
+    pub fn into_string(self) -> String {
+        String::from(self.as_str())
+    }
+
+    /// Convert this [`Ident`] into a [`CompactStr`].
+    ///
+    /// This is the explicit form of [`Into<CompactStr>`], which [`Ident`] also implements.
+    #[inline]
+    pub fn into_compact_str(self) -> CompactStr {
+        CompactStr::new(self.as_str())
+    }
+
+    /// Convert this [`Ident`] into a [`CompactStr`] without consuming `self`.
+    #[inline]
+    pub fn to_compact_str(self) -> CompactStr {
+        CompactStr::new(self.as_str())
+    }
+
+    /// Create new [`Ident`] from a fixed-size array of `&str`s concatenated together,
+    /// allocated in the given `allocator`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the sum of length of all strings exceeds `isize::MAX`.
+    // `#[inline(always)]` because want compiler to be able to optimize where some of `strings`
+    // are statically known. See `Allocator::alloc_concat_strs_array`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    pub fn from_strs_array_in<const N: usize>(
+        strings: [&str; N],
+        allocator: &'a Allocator,
+    ) -> Ident<'a> {
+        Self::from(allocator.alloc_concat_strs_array(strings))
+    }
+
+    /// Convert a [`Cow<'a, str>`] to an [`Ident<'a>`].
+    ///
+    /// If the `Cow` borrows a string from arena, returns an `Ident` which references that same string,
+    /// without allocating a new one.
+    ///
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Ident`.
+    #[inline]
+    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &'a Allocator) -> Ident<'a> {
+        match value {
+            Cow::Borrowed(s) => Ident::from(*s),
+            Cow::Owned(s) => Ident::from_in(s, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for Ident<'_> {
+    type Cloned = Ident<'new_alloc>;
+
+    #[inline]
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        Ident::from_in(self.as_str(), allocator)
+    }
+}
+
+impl<'a> Dummy<'a> for Ident<'a> {
+    /// Create a dummy [`Ident`].
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn dummy(_allocator: &'a Allocator) -> Self {
+        Ident::empty()
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &Ident<'alloc>> for Ident<'alloc> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn from_in(s: &Ident<'alloc>, _: &'alloc Allocator) -> Self {
+        *s
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &str> for Ident<'alloc> {
+    #[inline]
+    fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {
+        Self::from(allocator.alloc_str(s))
+    }
+}
+
+impl<'alloc> FromIn<'alloc, String> for Ident<'alloc> {
+    #[inline]
+    fn from_in(s: String, allocator: &'alloc Allocator) -> Self {
+        Self::from_in(s.as_str(), allocator)
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &String> for Ident<'alloc> {
+    #[inline]
+    fn from_in(s: &String, allocator: &'alloc Allocator) -> Self {
+        Self::from_in(s.as_str(), allocator)
+    }
+}
+
+impl<'alloc> FromIn<'alloc, Cow<'_, str>> for Ident<'alloc> {
+    #[inline]
+    fn from_in(s: Cow<'_, str>, allocator: &'alloc Allocator) -> Self {
+        Self::from_in(&*s, allocator)
+    }
+}
+
+impl<'a> From<&'a str> for Ident<'a> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn from(s: &'a str) -> Self {
+        Self(s)
+    }
+}
+
+impl<'alloc> From<ArenaStringBuilder<'alloc>> for Ident<'alloc> {
+    #[inline]
+    fn from(s: ArenaStringBuilder<'alloc>) -> Self {
+        Self::from(s.into_str())
+    }
+}
+
+impl<'a> From<Ident<'a>> for &'a str {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn from(s: Ident<'a>) -> Self {
+        s.as_str()
+    }
+}
+
+impl<'a> From<Ident<'a>> for Atom<'a> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn from(s: Ident<'a>) -> Self {
+        s.as_atom()
+    }
+}
+
+impl<'a> From<Atom<'a>> for Ident<'a> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn from(s: Atom<'a>) -> Self {
+        Self(s.as_str())
+    }
+}
+
+impl From<Ident<'_>> for CompactStr {
+    #[inline]
+    fn from(val: Ident<'_>) -> Self {
+        val.into_compact_str()
+    }
+}
+
+impl From<Ident<'_>> for String {
+    #[inline]
+    fn from(val: Ident<'_>) -> Self {
+        val.into_string()
+    }
+}
+
+impl<'a> From<Ident<'a>> for Cow<'a, str> {
+    #[inline]
+    fn from(value: Ident<'a>) -> Self {
+        Cow::Borrowed(value.as_str())
+    }
+}
+
+impl Deref for Ident<'_> {
+    type Target = str;
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for Ident<'_> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for Ident<'_> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<T: AsRef<str>> PartialEq<T> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
+    }
+}
+
+impl PartialEq<Ident<'_>> for &str {
+    #[inline]
+    fn eq(&self, other: &Ident<'_>) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<str> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<Ident<'_>> for Cow<'_, str> {
+    #[inline]
+    fn eq(&self, other: &Ident<'_>) -> bool {
+        self.as_ref() == other.as_str()
+    }
+}
+
+impl ContentEq for Ident<'_> {
+    #[inline]
+    fn content_eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl hash::Hash for Ident<'_> {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
+        self.as_str().hash(hasher);
+    }
+}
+
+impl fmt::Debug for Ident<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Display for Ident<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl Serialize for Ident<'_> {
+    #[inline] // Because it just delegates
+    fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Serialize::serialize(self.as_str(), serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl ESTree for Ident<'_> {
+    #[inline] // Because it just delegates
+    fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
+        ESTree::serialize(self.as_str(), serializer);
+    }
+}
+
+/// Creates an [`Ident`] using interpolation of runtime expressions.
+///
+/// Identical to [`std`'s `format!` macro](std::format), except:
+///
+/// * First argument is the allocator.
+/// * Produces an [`Ident`] instead of a [`String`].
+///
+/// The string is built in the arena, without allocating an intermediate `String`.
+///
+/// # Panics
+///
+/// Panics if a formatting trait implementation returns an error.
+///
+/// # Example
+///
+/// ```
+/// use oxc_allocator::Allocator;
+/// use oxc_span::format_ident;
+/// let allocator = Allocator::new();
+///
+/// let s1 = "foo";
+/// let s2 = "bar";
+/// let formatted = format_ident!(&allocator, "{s1}.{s2}");
+/// assert_eq!(formatted, "foo.bar");
+/// ```
+#[macro_export]
+macro_rules! format_ident {
+    ($alloc:expr, $($arg:tt)*) => {{
+        use ::std::{write, fmt::Write};
+        use $crate::{Ident, __internal::ArenaStringBuilder};
+
+        let mut s = ArenaStringBuilder::new_in($alloc);
+        write!(s, $($arg)*).unwrap();
+        Ident::from(s)
+    }}
+}

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -7,12 +7,14 @@
 mod atom;
 mod cmp;
 mod compact_str;
+mod ident;
 mod source_type;
 mod span;
 
 pub use atom::Atom;
 pub use cmp::ContentEq;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN};
+pub use ident::Ident;
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,
     VALID_EXTENSIONS,

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1066,7 +1066,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             ctx.scoping_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }
 
-        ident.name = binding.name;
+        ident.name = binding.name.into();
     }
 
     /// Transform the binding identifier for `arguments` if it's affected after transformation.
@@ -1085,12 +1085,12 @@ impl<'a> ArrowFunctionConverter<'a> {
 
         self.arguments_var_stack.last_or_init(|| {
             let arguments_name = ctx.generate_uid_name("arguments");
-            ident.name = arguments_name;
+            ident.name = arguments_name.into();
             let symbol_id = ident.symbol_id();
             Self::rename_arguments_symbol(symbol_id, arguments_name, ctx);
             // Record the symbol ID as a renamed `arguments` variable.
             self.renamed_arguments_symbol_ids.insert(symbol_id);
-            BoundIdentifier::new(ident.name, symbol_id)
+            BoundIdentifier::new(arguments_name, symbol_id)
         });
     }
 

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -93,7 +93,7 @@ impl<'a> TransformCtx<'a> {
                         || !ctx.scoping().symbol_is_mutated(symbol_id))
                 {
                     // Reading bound identifier cannot have side effects, so no need for temp var
-                    let binding = BoundIdentifier::new(ident.name, symbol_id);
+                    let binding = BoundIdentifier::new(ident.name.into(), symbol_id);
                     let references =
                         array::from_fn(|_| binding.create_spanned_read_expression(ident.span, ctx));
                     return (expr, references);

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -613,13 +613,13 @@ impl<'a> LegacyDecorator<'a, '_> {
         // After: `class C {}` -> `let C = class {}`
         let class_binding = class.id.as_ref().map(|ident| {
             let new_class_binding =
-                ctx.generate_binding(ident.name, class.scope_id(), SymbolFlags::Class);
+                ctx.generate_binding(ident.name.into(), class.scope_id(), SymbolFlags::Class);
             let old_class_symbol_id = ident.symbol_id.replace(Some(new_class_binding.symbol_id));
             let old_class_symbol_id = old_class_symbol_id.expect("class always has a symbol id");
 
             *ctx.scoping_mut().symbol_flags_mut(old_class_symbol_id) =
                 SymbolFlags::BlockScopedVariable;
-            BoundIdentifier::new(ident.name, old_class_symbol_id)
+            BoundIdentifier::new(ident.name.into(), old_class_symbol_id)
         });
         let class_alias_binding = class_binding.as_ref().and_then(|id| {
             ClassReferenceChanger::new(id.clone(), ctx, self.ctx)

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -162,11 +162,12 @@ impl<'a> ExponentiationOperator<'a, '_> {
         let pow_left = if let Some(symbol_id) = reference.symbol_id() {
             // This variable is declared in scope so evaluating it multiple times can't trigger a getter.
             // No need for a temp var.
-            ctx.create_bound_ident_expr(SPAN, ident.name, symbol_id, ReferenceFlags::Read)
+            ctx.create_bound_ident_expr(SPAN, ident.name.into(), symbol_id, ReferenceFlags::Read)
         } else {
             // Unbound reference. Could possibly trigger a getter so we need to only evaluate it once.
             // Assign to a temp var.
-            let reference = ctx.create_unbound_ident_expr(SPAN, ident.name, ReferenceFlags::Read);
+            let reference =
+                ctx.create_unbound_ident_expr(SPAN, ident.name.into(), ReferenceFlags::Read);
             let binding = self.create_temp_var(reference, &mut temp_var_inits, ctx);
             binding.create_read_expression(ctx)
         };
@@ -488,7 +489,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
                     // No need for a temp var.
                     return ctx.create_bound_ident_expr(
                         SPAN,
-                        ident.name,
+                        ident.name.into(),
                         symbol_id,
                         ReferenceFlags::Read,
                     );

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -365,7 +365,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 // `function foo() { ... }` -> `function foo() {} return foo;`
                 let reference = ctx.create_bound_ident_expr(
                     SPAN,
-                    id.name,
+                    id.name.into(),
                     id.symbol_id(),
                     ReferenceFlags::Read,
                 );
@@ -550,7 +550,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         match ctx.parent() {
             // infer `foo` from `const foo = async function() {}`
             Ancestor::VariableDeclaratorInit(declarator) => {
-                declarator.id().get_binding_identifier().map(|id| id.name)
+                declarator.id().get_binding_identifier().map(|id| id.name.into())
             }
             // infer `foo` from `({ foo: async function() {} })`
             Ancestor::ObjectPropertyValue(property) if !*property.method() => {

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -94,7 +94,7 @@ impl<'a> NullishCoalescingOperator<'a, '_> {
                     // Check binding is not mutated.
                     // TODO(improve-on-babel): Remove this check. Whether binding is mutated or not is not relevant.
                     if ctx.scoping().get_resolved_references(symbol_id).all(|r| !r.is_write()) {
-                        let binding = BoundIdentifier::new(ident.name, symbol_id);
+                        let binding = BoundIdentifier::new(ident.name.into(), symbol_id);
                         let ident_span = ident.span;
                         return Self::create_conditional_expression(
                             logical_expr.left,

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -146,7 +146,8 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
         let symbol_id = reference.symbol_id();
         let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
 
-        let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);
+        let ident =
+            ctx.create_ident_reference(SPAN, ident.name.into(), symbol_id, ReferenceFlags::Write);
         let assign_target = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident));
         (left_expr, assign_target)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -97,7 +97,7 @@ impl<'a> ClassProperties<'a, '_> {
                         // Note: Current scope is outside class.
                         let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
                         private_props.insert(
-                            ident.name,
+                            ident.name.into(),
                             PrivateProp::new(binding, prop.r#static, None, false),
                         );
                     }
@@ -134,7 +134,7 @@ impl<'a> ClassProperties<'a, '_> {
                             SymbolFlags::Function,
                         );
 
-                        match private_props.entry(ident.name) {
+                        match private_props.entry(ident.name.into()) {
                             Entry::Occupied(mut entry) => {
                                 // If there's already a binding for this private property,
                                 // it's a setter or getter, so store the binding in `binding2`.
@@ -157,7 +157,7 @@ impl<'a> ClassProperties<'a, '_> {
                     if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
                         let dummy_binding = BoundIdentifier::new(Atom::empty(), SymbolId::new(0));
                         private_props.insert(
-                            ident.name,
+                            ident.name.into(),
                             PrivateProp::new(dummy_binding, prop.r#static, None, true),
                         );
                     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -130,7 +130,7 @@ impl<'a> ClassesStack<'a> {
         // TODO: Check there are tests for bindings in enclosing classes.
         for class in self.stack[1..].iter_mut().rev() {
             if let Some(private_props) = &mut class.private_props
-                && let Some(prop) = private_props.get(&ident.name)
+                && let Some(prop) = private_props.get(&Atom::from(ident.name))
             {
                 return ret_fn(prop, &mut class.bindings, class.is_declaration);
             }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -784,7 +784,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
     fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
         let symbol_id = ident.symbol_id();
         if let Some(new_name) = self.clashing_symbols.get(&symbol_id) {
-            ident.name = *new_name;
+            ident.name = (*new_name).into();
         }
     }
 
@@ -793,7 +793,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
         if let Some(symbol_id) = self.ctx.scoping().get_reference(reference_id).symbol_id()
             && let Some(new_name) = self.clashing_symbols.get(&symbol_id)
         {
-            ident.name = *new_name;
+            ident.name = (*new_name).into();
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -146,7 +146,7 @@ impl<'a> InstanceInitializerVisitor<'a, '_> {
         }
 
         // Record the symbol clash. Symbol in constructor needs to be renamed.
-        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name);
+        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name.into());
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -78,7 +78,7 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let private_props = self.current_class().private_props.as_ref().unwrap();
-        let prop = &private_props[&ident.name];
+        let prop = &private_props[&Atom::from(ident.name)];
         let arguments = ctx.ast.vec_from_array([
             Argument::from(ctx.ast.expression_this(SPAN)),
             Argument::from(prop.binding.create_read_expression(ctx)),
@@ -211,7 +211,7 @@ impl<'a> ClassProperties<'a, '_> {
         // Insert after class
         let class_details = self.current_class();
         let private_props = class_details.private_props.as_ref().unwrap();
-        let prop_binding = &private_props[&ident.name].binding;
+        let prop_binding = &private_props[&Atom::from(ident.name)].binding;
 
         if class_details.is_declaration {
             // `var _prop = {_: value};`
@@ -258,7 +258,7 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // In-built static props `name` and `length` need to be set with `_defineProperty`
-        let needs_define = |name| is_static && (name == "name" || name == "length");
+        let needs_define = |name: &str| is_static && (name == "name" || name == "length");
 
         let left = match &mut prop.key {
             PropertyKey::StaticIdentifier(ident) => {
@@ -378,7 +378,7 @@ impl<'a> ClassProperties<'a, '_> {
         );
 
         let private_props = self.current_class().private_props.as_ref().unwrap();
-        let prop_binding = &private_props[&ident.name].binding;
+        let prop_binding = &private_props[&Atom::from(ident.name)].binding;
         let arguments = ctx.ast.vec_from_array([
             Argument::from(assignee),
             Argument::from(prop_binding.create_read_expression(ctx)),

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -128,7 +128,7 @@ impl<'a> ClassProperties<'a, '_> {
 
         // Identifier is reference to class name. Rename it.
         let temp_binding = class_details.bindings.get_or_init_static_binding(ctx);
-        ident.name = temp_binding.name;
+        ident.name = temp_binding.name.into();
 
         let symbols = ctx.scoping_mut();
         symbols.get_reference_mut(reference_id).set_symbol_id(temp_binding.symbol_id);

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -84,10 +84,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName<'a, '_> {
                 // `foo = React.createClass({})`
                 Ancestor::AssignmentExpressionRight(assign_expr) => match assign_expr.left() {
                     AssignmentTarget::AssignmentTargetIdentifier(ident) => {
-                        break ident.name;
+                        break ident.name.into();
                     }
                     AssignmentTarget::StaticMemberExpression(expr) => {
-                        break expr.property.name;
+                        break expr.property.name.into();
                     }
                     // Babel does not handle computed member expressions e.g. `foo["bar"]`,
                     // so we diverge from Babel here, but that's probably an improvement
@@ -102,7 +102,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName<'a, '_> {
                 // `let foo = React.createClass({})`
                 Ancestor::VariableDeclaratorInit(declarator) => {
                     if let BindingPattern::BindingIdentifier(ident) = &declarator.id() {
-                        break ident.name;
+                        break ident.name.into();
                     }
                     return;
                 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -324,9 +324,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a, '_> {
             return;
         }
 
-        let hook_name = match &call_expr.callee {
-            Expression::Identifier(ident) => ident.name,
-            Expression::StaticMemberExpression(member) => member.property.name,
+        let hook_name: Atom = match &call_expr.callee {
+            Expression::Identifier(ident) => ident.name.into(),
+            Expression::StaticMemberExpression(member) => member.property.name.into(),
             _ => return,
         };
 
@@ -336,11 +336,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a, '_> {
 
         if !is_builtin_hook(&hook_name) {
             // Check if a corresponding binding exists where we emit the signature.
-            let (binding_name, is_member_expression) = match &call_expr.callee {
-                Expression::Identifier(ident) => (Some(ident.name), false),
+            let (binding_name, is_member_expression): (Option<Atom>, _) = match &call_expr.callee {
+                Expression::Identifier(ident) => (Some(ident.name.into()), false),
                 Expression::StaticMemberExpression(member) => {
                     if let Expression::Identifier(object) = &member.object {
-                        (Some(object.name), true)
+                        (Some(object.name.into()), true)
                     } else {
                         (None, false)
                     }
@@ -529,9 +529,9 @@ impl<'a> ReactRefresh<'a, '_> {
         id: &BindingIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let left = self.create_registration(id.name, ctx);
+        let left = self.create_registration(id.name.into(), ctx);
         let right =
-            ctx.create_bound_ident_expr(SPAN, id.name, id.symbol_id(), ReferenceFlags::Read);
+            ctx.create_bound_ident_expr(SPAN, id.name.into(), id.symbol_id(), ReferenceFlags::Read);
         let expr = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
         ctx.ast.statement_expression(SPAN, expr)
     }

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -554,9 +554,11 @@ impl<'a> StyledComponents<'a, '_> {
                         // want to pick the outer name because react-refresh will add HMR variables
                         // like this: X = _a = styled. We could also consider only doing this if the
                         // name starts with an underscore.
-                        AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name),
+                        AssignmentTarget::AssignmentTargetIdentifier(ident) => {
+                            Some(ident.name.into())
+                        }
                         AssignmentTarget::StaticMemberExpression(member) => {
-                            Some(member.property.name)
+                            Some(member.property.name.into())
                         }
                         _ => return None,
                     };
@@ -564,7 +566,7 @@ impl<'a> StyledComponents<'a, '_> {
                 // `const X = styled`
                 Ancestor::VariableDeclaratorInit(declarator) => {
                     return if let BindingPattern::BindingIdentifier(ident) = &declarator.id() {
-                        Some(ident.name)
+                        Some(ident.name.into())
                     } else {
                         None
                     };
@@ -572,7 +574,7 @@ impl<'a> StyledComponents<'a, '_> {
                 // `const X = { Y: styled }`
                 Ancestor::ObjectPropertyValue(property) => {
                     return if let PropertyKey::StaticIdentifier(ident) = property.key() {
-                        Some(ident.name)
+                        Some(ident.name.into())
                     } else {
                         None
                     };
@@ -580,7 +582,7 @@ impl<'a> StyledComponents<'a, '_> {
                 // `class Y { (static) X = styled }`
                 Ancestor::PropertyDefinitionValue(property) => {
                     return if let PropertyKey::StaticIdentifier(ident) = property.key() {
-                        Some(ident.name)
+                        Some(ident.name.into())
                     } else {
                         None
                     };

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -278,7 +278,7 @@ impl<'a> TypeScript<'a, '_> {
     ) -> Statement<'a> {
         let member = match key {
             PropertyKey::StaticIdentifier(ident) => {
-                create_this_property_access(SPAN, ident.name, ctx)
+                create_this_property_access(SPAN, ident.name.into(), ctx)
             }
             PropertyKey::PrivateIdentifier(_) => {
                 unreachable!("PrivateIdentifier is skipped in transform_class_fields");
@@ -384,7 +384,7 @@ impl<'a> TypeScript<'a, '_> {
             .filter(|param| param.has_modifier())
             .filter_map(|param| param.pattern.get_binding_identifier())
             .map(|id| {
-                let target = create_this_property_assignment(id.span, id.name, ctx);
+                let target = create_this_property_assignment(id.span, id.name.into(), ctx);
                 let value = BoundIdentifier::from_binding_ident(id).create_read_expression(ctx);
                 Self::create_assignment(target, value, ctx)
             })

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -84,7 +84,7 @@ impl<'a> TypeScriptEnum<'a> {
         let is_export = export_span.is_some();
         let is_not_top_scope = !ctx.scoping().scope_flags(ctx.current_scope_id()).is_top();
 
-        let enum_name = decl.id.name;
+        let enum_name: Atom = decl.id.name.into();
         let func_scope_id = decl.body.scope_id();
         let param_binding =
             ctx.generate_binding(enum_name, func_scope_id, SymbolFlags::FunctionScopedVariable);
@@ -375,7 +375,7 @@ impl<'a> TypeScriptEnum<'a> {
             match_member_expression!(Expression) => {
                 let expr = expr.to_member_expression();
                 let Expression::Identifier(ident) = expr.object() else { return None };
-                let members = self.enums.get(&ident.name)?;
+                let members = self.enums.get(&Atom::from(ident.name))?;
                 let property = expr.static_property_name()?;
                 *members.get(property)?
             }
@@ -386,7 +386,7 @@ impl<'a> TypeScriptEnum<'a> {
                     return Some(ConstantValue::Number(f64::NAN));
                 }
 
-                if let Some(value) = prev_members.get(&ident.name) {
+                if let Some(value) = prev_members.get(&Atom::from(ident.name)) {
                     return *value;
                 }
 
@@ -585,7 +585,7 @@ impl<'a, 'ctx, 'members> IdentifierReferenceRename<'a, 'ctx, 'members> {
 impl IdentifierReferenceRename<'_, '_, '_> {
     fn should_reference_enum_member(&self, ident: &IdentifierReference<'_>) -> bool {
         // Don't need to rename the identifier if it's not a member of the enum,
-        if !self.previous_enum_members.contains_key(&ident.name) {
+        if !self.previous_enum_members.contains_key(&Atom::from(ident.name)) {
             return false;
         }
 

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -327,7 +327,7 @@ impl<'a> ModuleRunnerTransform<'a> {
 
                 // Reuse the `vue` binding identifier by renaming it to `__vite_ssr_import_0__`
                 let mut local = specifier.unbox().local;
-                local.name = self.generate_import_binding_name(ctx);
+                local.name = self.generate_import_binding_name(ctx).into();
                 let binding = BoundIdentifier::from_binding_ident(&local);
                 ctx.scoping_mut().set_symbol_name(binding.symbol_id, &binding.name);
                 self.import_bindings.insert(binding.symbol_id, (binding, None));

--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -50,7 +50,7 @@ impl<'a> BoundIdentifier<'a> {
 
     /// Create `BoundIdentifier` from a `BindingIdentifier`
     pub fn from_binding_ident(ident: &BindingIdentifier<'a>) -> Self {
-        Self { name: ident.name, symbol_id: ident.symbol_id() }
+        Self { name: ident.name.into(), symbol_id: ident.symbol_id() }
     }
 
     /// Convert `BoundIdentifier` to `MaybeBoundIdentifier`

--- a/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
@@ -45,7 +45,7 @@ impl<'a> MaybeBoundIdentifier<'a> {
         ctx: &TraverseCtx<'a, State>,
     ) -> Self {
         let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id();
-        Self { name: ident.name, symbol_id }
+        Self { name: ident.name.into(), symbol_id }
     }
 
     /// Convert `MaybeBoundIdentifier` to `BoundIdentifier`.

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -498,7 +498,9 @@ impl<'s> StructSerializerGenerator<'s> {
             let value = match field.type_def(self.schema) {
                 TypeDef::Primitive(primitive_def) => match primitive_def.name() {
                     "&str" => Some(quote!( JsonSafeString(#self_path.#field_name_ident) )),
-                    "Atom" => Some(quote!( JsonSafeString(#self_path.#field_name_ident.as_str()) )),
+                    "Atom" | "Ident" => {
+                        Some(quote!( JsonSafeString(#self_path.#field_name_ident.as_str()) ))
+                    }
                     _ => None,
                 },
                 TypeDef::Option(option_def) => option_def
@@ -508,7 +510,7 @@ impl<'s> StructSerializerGenerator<'s> {
                         "&str" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s))
                         }),
-                        "Atom" => Some(quote! {
+                        "Atom" | "Ident" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s.as_str()))
                         }),
                         _ => None,
@@ -518,7 +520,7 @@ impl<'s> StructSerializerGenerator<'s> {
 
             value.unwrap_or_else(|| {
                 panic!(
-                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str` or `Atom`: {}::{}",
+                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str`, `Atom`, or `Ident`: {}::{}",
                     struct_def.name(),
                     field.name(),
                 )

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -475,6 +475,7 @@ fn calculate_layout_for_primitive(primitive_def: &PrimitiveDef) -> Layout {
         "f64" => Layout::from_type::<f64>(),
         "&str" => str_layout,
         "Atom" => str_layout,
+        "Ident" => str_layout,
         "NonZeroU8" => Layout::from_type_with_niche_for_zero::<num::NonZeroU8>(),
         "NonZeroU16" => Layout::from_type_with_niche_for_zero::<num::NonZeroU16>(),
         "NonZeroU32" => Layout::from_type_with_niche_for_zero::<num::NonZeroU32>(),

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -91,7 +91,7 @@ impl Generator for AstBuilderGenerator {
             };
 
             ///@@line_break
-            use oxc_span::Atom;
+            use oxc_span::{Atom, Ident};
 
             ///@@line_break
             use crate::{AstBuilder, ast::*};
@@ -408,7 +408,9 @@ fn get_struct_params<'s>(
             }
 
             let generic_details = match type_def {
-                TypeDef::Primitive(primitive_def) if primitive_def.name() == "Atom" => {
+                TypeDef::Primitive(primitive_def)
+                    if matches!(primitive_def.name(), "Atom" | "Ident") =>
+                {
                     atom_generic_count += 1;
                     Some((format_ident!("A{atom_generic_count}"), GenericType::Into))
                 }

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -108,7 +108,7 @@ impl Generator for FormatterAstNodesGenerator {
             ///@@line_break
             use oxc_allocator::Vec;
             use oxc_ast::ast::*;
-            use oxc_span::GetSpan;
+            use oxc_span::{GetSpan, Ident};
             ///@@line_break
             use crate::ast_nodes::AstNode;
             use crate::formatter::{

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -824,7 +824,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse deserializer for `&str`
-        "Atom" => return,
+        "Atom" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return uint8[pos] === 1;",
@@ -1258,8 +1258,8 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl DeserializeFunctionName for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Atom") {
-            // Use 1 deserializer for both `&str` and `Atom`
+        if matches!(type_name, "&str" | "Atom" | "Ident") {
+            // Use 1 deserializer for `&str`, `Atom`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {
             // Use zeroed type's deserializer for `NonZero*` types

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -570,7 +570,9 @@ impl<'s> LocalCacheTypes<'s> {
                     })
                 }
             }
-            TypeDef::Primitive(primitive_def) => matches!(primitive_def.name(), "&str" | "Atom"),
+            TypeDef::Primitive(primitive_def) => {
+                matches!(primitive_def.name(), "&str" | "Atom" | "Ident")
+            }
             TypeDef::Vec(_) => true,
             TypeDef::Option(option_def) => {
                 self.needs_cached_prop(option_def.inner_type(self.schema))
@@ -898,7 +900,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, state: &mut State, schema: &
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse constructor for `&str`
-        "Atom" => return,
+        "Atom" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return ast.buffer[pos] === 1;",
@@ -1245,8 +1247,8 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl FunctionNames for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Atom") {
-            // Use 1 constructor for both `&str` and `Atom`
+        if matches!(type_name, "&str" | "Atom" | "Ident") {
+            // Use 1 constructor for `&str`, `Atom`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {
             // Use zeroed type's constructor for `NonZero*` types

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -401,7 +401,7 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
             | "i8" | "i16" | "i32" | "i64" | "i128" | "isize"
             | "f32" | "f64" => "number",
             "bool" => "boolean",
-            "&str" | "Atom" => "string",
+            "&str" | "Atom" | "Ident" => "string",
             name => name,
         }),
         TypeDef::Option(option_def) => {

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -257,6 +257,7 @@ impl<'c> Parser<'c> {
             "AtomicPtr" => primitive("AtomicPtr"),
             "&str" => primitive("&str"),
             "Atom" => primitive("Atom"),
+            "Ident" => primitive("Ident"),
             "NonMaxU32" => primitive("NonMaxU32"),
             // TODO: Remove the need for this by adding
             // `#[cfg_attr(target_pointer_width = "64", repr(align(8)))]` to all AST types

--- a/tasks/ast_tools/src/schema/defs/primitive.rs
+++ b/tasks/ast_tools/src/schema/defs/primitive.rs
@@ -49,7 +49,7 @@ impl Def for PrimitiveDef {
     /// Get if type has a lifetime.
     #[expect(unused_variables)]
     fn has_lifetime(&self, schema: &Schema) -> bool {
-        self.name() == "&str" || self.name() == "Atom"
+        matches!(self.name(), "&str" | "Atom" | "Ident")
     }
 
     /// Get type signature (including lifetimes).
@@ -69,6 +69,13 @@ impl Def for PrimitiveDef {
                     quote!(Atom<'_>)
                 } else {
                     quote!(Atom<'a>)
+                }
+            }
+            "Ident" => {
+                if anon {
+                    quote!(Ident<'_>)
+                } else {
+                    quote!(Ident<'a>)
                 }
             }
             _ => {

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -654,7 +654,7 @@ impl<'a> Visit<'a> for SemanticIdsCollector<'a, '_> {
         let reference_id = ident.reference_id.get();
         self.reference_ids.push(reference_id);
         if reference_id.is_some() {
-            self.reference_names.push(ident.name);
+            self.reference_names.push(ident.name.into());
         } else {
             self.errors.push(format!("Missing ReferenceId: {:?}", ident.name));
         }


### PR DESCRIPTION
feat(span): add `Ident` type

Add a dedicated identifier string type that mirrors the `Atom` API.
This provides a foundation for future optimizations like pre-computed
hashing while maintaining API compatibility.

refactor(ast): use `Ident` type for identifier names in JS AST

Replace `Atom<'a>` with `Ident<'a>` for the `name` field in:
- `IdentifierName`
- `IdentifierReference`
- `BindingIdentifier`
- `LabelIdentifier`
- `PrivateIdentifier`

This builds on the `Ident` type added in the previous commit, providing
semantic distinction for identifier strings and enabling future
optimizations like pre-computed hashing.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>