### PR TITLE
chore(coverage): ignore Babel top-level-await-unambiguous tests

### DIFF
--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -1,5 +1,5 @@
 commit: fc58af40
 
 codegen_babel Summary:
-AST Parsed     : 2227/2227 (100.00%)
-Positive Passed: 2227/2227 (100.00%)
+AST Parsed     : 2223/2223 (100.00%)
+Positive Passed: 2223/2223 (100.00%)

--- a/tasks/coverage/snapshots/formatter_babel.snap
+++ b/tasks/coverage/snapshots/formatter_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 formatter_babel Summary:
-AST Parsed     : 2227/2227 (100.00%)
-Positive Passed: 2221/2227 (99.73%)
+AST Parsed     : 2223/2223 (100.00%)
+Positive Passed: 2217/2223 (99.73%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/async-arrow-function/input.js
 
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/basic/class-method/input.js

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -1,5 +1,5 @@
 commit: fc58af40
 
 minifier_babel Summary:
-AST Parsed     : 1789/1789 (100.00%)
-Positive Passed: 1789/1789 (100.00%)
+AST Parsed     : 1785/1785 (100.00%)
+Positive Passed: 1785/1785 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 parser_babel Summary:
-AST Parsed     : 2221/2227 (99.73%)
-Positive Passed: 2207/2227 (99.10%)
+AST Parsed     : 2217/2223 (99.73%)
+Positive Passed: 2204/2223 (99.15%)
 Negative Passed: 1649/1689 (97.63%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
@@ -83,16 +83,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-computed-properties/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/invalid-import-type-options-with-spread-element/input.ts
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js
-
-  × `await` is only allowed within async functions and at the top levels of modules
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js:1:1]
- 1 │ await 0
-   · ─────
- 2 │ 
-   ╰────
-  help: Either remove this `await` or add the `async` keyword to the enclosing function
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/valid-for-await-using-binding-escaped-of-of/input.mjs
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1,8 +1,8 @@
 commit: fc58af40
 
 semantic_babel Summary:
-AST Parsed     : 2227/2227 (100.00%)
-Positive Passed: 1941/2227 (87.16%)
+AST Parsed     : 2223/2223 (100.00%)
+Positive Passed: 1938/2223 (87.18%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -75,9 +75,6 @@ rebuilt        : ScopeId(2): ["f", "x"]
 Symbol scope ID mismatch for "_await":
 after transform: SymbolId(3): ScopeId(2)
 rebuilt        : SymbolId(2): ScopeId(0)
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js
-`await` is only allowed within async functions and at the top levels of modules
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/valid-await-using-comments/input.js
 Bindings mismatch:

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -1,11 +1,7 @@
 commit: fc58af40
 
 transformer_babel Summary:
-AST Parsed     : 2227/2227 (100.00%)
-Positive Passed: 2224/2227 (99.87%)
+AST Parsed     : 2223/2223 (100.00%)
+Positive Passed: 2222/2223 (99.96%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowYieldOutsideFunction-true-2/input.js
-
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/ambiguous-script/input.js
-
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js
 

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -51,6 +51,8 @@ impl<T: Case> Suite<T> for BabelSuite<T> {
             "typescript/arrow-function/arrow-like-in-conditional-2",
             // TypeScript allows `satisfies const`, Babel doesn't
             "typescript/cast/satisfies-const-error",
+            // Babel's heuristic for detecting module via unambiguous `await` - not in ES spec, we follow TypeScript
+            "es2022/top-level-await-unambiguous",
         ]
         .iter()
         .any(|p| path.to_string_lossy().replace('\\', "/").contains(p));


### PR DESCRIPTION
## Summary

- Ignore Babel's `top-level-await-unambiguous` tests in the parser conformance suite
- Babel has a heuristic for detecting module syntax via unambiguous `await` expressions (e.g., `await 0` on the same line is unambiguous module syntax)
- This heuristic is not in the ES spec - we follow TypeScript's behavior instead

## Test plan

- [x] `just ready` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)