### PR TITLE
fix(ci): update benchmark workflow for cargo-codspeed v4.3.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -86,12 +86,12 @@ jobs:
               --bench minifier --bench codegen --bench formatter \
               --no-default-features --features ${{ matrix.feature }} --features codspeed
           fi
-          mkdir -p target/codspeed/simulation/oxc_benchmark
-          mv target/release/deps/${{ matrix.component }}-* target/codspeed/simulation/oxc_benchmark
-          rm target/codspeed/simulation/oxc_benchmark/*.d
+          mkdir -p target/codspeed/analysis/oxc_benchmark
+          mv target/release/deps/${{ matrix.component }}-* target/codspeed/analysis/oxc_benchmark
+          rm target/codspeed/analysis/oxc_benchmark/*.d
 
       - name: Run benchmark
-        uses: CodSpeedHQ/action@0700edb451d0e9f2426f99bd6977027e550fb2a6 # v4.7.0
+        uses: CodSpeedHQ/action@e736f0d2aeb36da38e9f08eca4dff7967408d154 # v4.8.2
         timeout-minutes: 30
         with:
           mode: simulation


### PR DESCRIPTION
## Summary

- Fix benchmark directory path: `target/codspeed/simulation/` → `target/codspeed/analysis/`
- Update CodSpeedHQ/action v4.7.0 → v4.8.2

## Root Cause

cargo-codspeed v4.3.0 ([CodSpeedHQ/codspeed-rust#159](https://github.com/CodSpeedHQ/codspeed-rust/pull/159)) changed internal build mode mapping so `MeasurementMode::Simulation` now maps to `BuildMode::Analysis`, which changed the expected directory from `target/codspeed/simulation/` to `target/codspeed/analysis/`.

## Test plan

- CI benchmark jobs should pass

🤖 Generated with [Claude Code](https://claude.ai/code)