### PR TITLE
perf(linter): turn off `scope_build_child_ids` for SemanticBuilder

### DIFF
--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1029,7 +1029,6 @@ impl Runtime {
 
         let semantic_ret = SemanticBuilder::new()
             .with_cfg(true)
-            .with_scope_tree_child_ids(true)
             .with_check_syntax_error(check_syntax_errors)
             .build(allocator.alloc(ret.program));
 

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -31,10 +31,7 @@ fn bench_linter(criterion: &mut Criterion) {
 
                 let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
                 let path = Path::new("");
-                let semantic_ret = SemanticBuilder::new()
-                    .with_scope_tree_child_ids(true)
-                    .with_cfg(true)
-                    .build(&parser_ret.program);
+                let semantic_ret = SemanticBuilder::new().with_cfg(true).build(&parser_ret.program);
                 let semantic = semantic_ret.semantic;
                 let module_record =
                     Arc::new(ModuleRecord::new(path, &parser_ret.module_record, &semantic));


### PR DESCRIPTION
No use case in the linter after #18350 and #18335, so turn it off.