### PR TITLE
feat(semantic)!: remove `Scoping::scope_build_child_ids` and all related APIs

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -191,12 +191,6 @@ impl<'a> SemanticBuilder<'a> {
         self
     }
 
-    #[must_use]
-    pub fn with_scope_tree_child_ids(mut self, yes: bool) -> Self {
-        self.scoping.scope_build_child_ids = yes;
-        self
-    }
-
     /// Provide statistics about AST to optimize memory usage of semantic analysis.
     ///
     /// Accurate statistics can greatly improve performance, especially for large ASTs.

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -175,7 +175,6 @@ impl<'a> SemanticTester<'a> {
         SemanticBuilder::new()
             .with_check_syntax_error(true)
             .with_cfg(self.cfg)
-            .with_scope_tree_child_ids(self.scope_tree_child_ids)
             .build(self.allocator.alloc(parse.program))
     }
 

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -134,14 +134,10 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
             let mut statements = ctx.ast.vec_with_capacity(2);
             statements.push(assignment_statement);
             let stmt_body = &mut stmt.body;
-            if let Statement::BlockStatement(block) = stmt_body {
-                if block.body.is_empty() {
-                    // If the block is empty, we don’t need to add it to the body;
-                    // instead, we need to remove the useless scope.
-                    ctx.scoping_mut().delete_scope(block.scope_id());
-                } else {
-                    statements.push(stmt_body.take_in(ctx.ast));
-                }
+            if let Statement::BlockStatement(block) = stmt_body
+                && !block.body.is_empty()
+            {
+                statements.push(stmt_body.take_in(ctx.ast));
             }
             statements
         };

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -70,7 +70,6 @@ impl<'a> ClassProperties<'a, '_> {
         {
             return self.convert_static_block_with_single_expression_to_expression(
                 &mut stmt.expression,
-                scope_id,
                 make_sloppy_mode,
                 ctx,
             );
@@ -93,16 +92,12 @@ impl<'a> ClassProperties<'a, '_> {
     fn convert_static_block_with_single_expression_to_expression(
         &mut self,
         expr: &mut Expression<'a>,
-        scope_id: ScopeId,
         make_sloppy_mode: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // Note: Reparent scopes
         let mut replacer = StaticVisitor::new(make_sloppy_mode, true, self, ctx);
         replacer.visit_expression(expr);
-
-        // Delete scope for static block
-        ctx.scoping_mut().delete_scope(scope_id);
 
         expr.take_in(ctx.ast)
     }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -156,11 +156,6 @@ impl<'a> TraverseScoping<'a> {
         child_scope_ids: &[ScopeId],
         flags: ScopeFlags,
     ) -> ScopeId {
-        // Remove these scopes from parent's children
-        if self.scoping.has_scope_child_ids() {
-            self.scoping.remove_child_scopes(scope_id, child_scope_ids);
-        }
-
         // Create new scope as child of parent
         let new_scope_id = self.create_child_scope(scope_id, flags);
 
@@ -205,9 +200,6 @@ impl<'a> TraverseScoping<'a> {
             "Child scope must be a child of parent scope"
         );
 
-        if self.scoping.has_scope_child_ids() {
-            self.scoping.remove_child_scope(parent_id, child_id);
-        }
         self.scoping.set_scope_parent_id(child_id, Some(scope_id));
         scope_id
     }
@@ -234,8 +226,6 @@ impl<'a> TraverseScoping<'a> {
                 self.scoping.set_scope_parent_id(child_id, parent_id);
             }
         }
-
-        self.scoping.delete_scope(scope_id);
     }
 
     /// Add binding to `ScopeTree` and `SymbolTable`.

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -134,11 +134,7 @@ pub fn check_semantic_after_transform(
     // so the cloned AST will be "clean" of all semantic data, as if it had come fresh from the parser.
     let allocator = Allocator::default();
     let program = program.clone_in(&allocator);
-    let scoping_rebuilt = SemanticBuilder::new()
-        .with_scope_tree_child_ids(scoping_after_transform.has_scope_child_ids())
-        .build(&program)
-        .semantic
-        .into_scoping();
+    let scoping_rebuilt = SemanticBuilder::new().build(&program).semantic.into_scoping();
 
     let (scope_ids_rebuilt, symbol_ids_rebuilt, reference_ids_rebuilt, _) =
         SemanticIdsCollector::new(&mut errors).collect(&program);
@@ -367,16 +363,6 @@ impl PostTransformChecker<'_, '_> {
                 self.errors.push_mismatch("Scope parent mismatch", scope_ids, parent_ids);
             }
 
-            // Check children match
-            if self.scoping_after_transform.has_scope_child_ids() {
-                let child_ids = self.get_pair(scope_ids, |scoping, scope_id| {
-                    scoping.get_scope_child_ids(scope_id).to_vec()
-                });
-                if self.remap_scope_ids_sets(&child_ids).is_mismatch() {
-                    self.errors.push_mismatch("Scope children mismatch", scope_ids, child_ids);
-                }
-            }
-
             // NB: Skip checking node IDs match - transformer does not set `NodeId`s
         }
     }
@@ -536,28 +522,6 @@ impl PostTransformChecker<'_, '_> {
     /// Map `after_transform` scope ID to `rebuilt` scope ID
     fn remap_scope_ids(&self, scope_ids: Pair<ScopeId>) -> Pair<Option<ScopeId>> {
         Pair::new(self.scope_ids_map.get(scope_ids.after_transform), Some(scope_ids.rebuilt))
-    }
-
-    /// Remap pair of arrays of `ScopeId`s.
-    /// Map `after_transform` IDs to `rebuilt` IDs.
-    /// Sort both sets.
-    fn remap_scope_ids_sets<V: AsRef<Vec<ScopeId>>>(
-        &self,
-        scope_ids: &Pair<V>,
-    ) -> Pair<Vec<Option<ScopeId>>> {
-        let mut after_transform = scope_ids
-            .after_transform
-            .as_ref()
-            .iter()
-            .map(|&scope_id| self.scope_ids_map.get(scope_id))
-            .collect::<Vec<_>>();
-        let mut rebuilt =
-            scope_ids.rebuilt.as_ref().iter().copied().map(Option::Some).collect::<Vec<_>>();
-
-        after_transform.sort_unstable();
-        rebuilt.sort_unstable();
-
-        Pair::new(after_transform, rebuilt)
     }
 
     /// Remap pair of arrays of `SymbolId`s.


### PR DESCRIPTION
Remove `Scoping::scope_build_child_ids` and all related APIs to make the semantics cleaner. This could also make it easier for us to sync Scoping data since we don't need to worry about child scope IDs.

This is a breaking change, but it is okay because all use of `scope_build_child_ids` in the Oxc and Rolldown has been removed.