### PR TITLE
refactor(linter): add `FixKind` to `Fix`

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -319,7 +319,9 @@ impl<'a> ContextHost<'a> {
                         OxcDiagnostic::error(message_for_disable)
                             .with_label(span)
                             .with_severity(rule_severity),
-                        PossibleFixes::Single(Fix::delete(span).with_message(fix_message)),
+                        PossibleFixes::Single(
+                            Fix::delete(span).with_kind(FixKind::Fix).with_message(fix_message),
+                        ),
                     ));
                 }
                 RuleCommentType::Single(rules_vec) => {

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use rust_lapper::{Interval, Lapper};
 use rustc_hash::FxHashMap;
 
-use crate::fixer::Fix;
+use crate::{FixKind, fixer::Fix};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum DisabledRule {
@@ -114,7 +114,8 @@ impl RuleCommentRule {
             return Fix::delete(Span::new(
                 self.name_span.start - comma_before_offset,
                 self.name_span.end,
-            ));
+            ))
+            .with_kind(FixKind::Fix);
         }
 
         let after_source = &source_text[self.name_span.end as usize..comment_span.end as usize];
@@ -136,7 +137,8 @@ impl RuleCommentRule {
             return Fix::delete(Span::new(
                 self.name_span.start,
                 self.name_span.end + comma_after_offset,
-            ));
+            ))
+            .with_kind(FixKind::Fix);
         }
 
         unreachable!(

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -425,6 +425,8 @@ mod test {
     use oxc_diagnostics::OxcDiagnostic;
     use oxc_span::{SourceType, Span};
 
+    use crate::FixKind;
+
     use super::{CompositeFix, Fix, FixResult, Fixer, Message, PossibleFixes};
 
     fn insert_at_end() -> OxcDiagnostic {
@@ -480,23 +482,51 @@ mod test {
     }
 
     const TEST_CODE: &str = "var answer = 6 * 7;";
-    const INSERT_AT_END: Fix =
-        Fix { span: Span::new(19, 19), content: Cow::Borrowed("// end"), message: None };
-    const INSERT_AT_START: Fix =
-        Fix { span: Span::new(0, 0), content: Cow::Borrowed("// start"), message: None };
-    const INSERT_AT_MIDDLE: Fix =
-        Fix { span: Span::new(13, 13), content: Cow::Borrowed("5 *"), message: None };
-    const REPLACE_ID: Fix =
-        Fix { span: Span::new(4, 10), content: Cow::Borrowed("foo"), message: None };
-    const REPLACE_VAR: Fix =
-        Fix { span: Span::new(0, 3), content: Cow::Borrowed("let"), message: None };
-    const REPLACE_NUM: Fix =
-        Fix { span: Span::new(13, 14), content: Cow::Borrowed("5"), message: None };
+    const INSERT_AT_END: Fix = Fix {
+        span: Span::new(19, 19),
+        content: Cow::Borrowed("// end"),
+        message: None,
+        kind: FixKind::None,
+    };
+    const INSERT_AT_START: Fix = Fix {
+        span: Span::new(0, 0),
+        content: Cow::Borrowed("// start"),
+        message: None,
+        kind: FixKind::None,
+    };
+    const INSERT_AT_MIDDLE: Fix = Fix {
+        span: Span::new(13, 13),
+        content: Cow::Borrowed("5 *"),
+        message: None,
+        kind: FixKind::None,
+    };
+    const REPLACE_ID: Fix = Fix {
+        span: Span::new(4, 10),
+        content: Cow::Borrowed("foo"),
+        message: None,
+        kind: FixKind::None,
+    };
+    const REPLACE_VAR: Fix = Fix {
+        span: Span::new(0, 3),
+        content: Cow::Borrowed("let"),
+        message: None,
+        kind: FixKind::None,
+    };
+    const REPLACE_NUM: Fix = Fix {
+        span: Span::new(13, 14),
+        content: Cow::Borrowed("5"),
+        message: None,
+        kind: FixKind::None,
+    };
     const REMOVE_START: Fix = Fix::delete(Span::new(0, 4));
     const REMOVE_MIDDLE: Fix = Fix::delete(Span::new(5, 10));
     const REMOVE_END: Fix = Fix::delete(Span::new(14, 18));
-    const REVERSE_RANGE: Fix =
-        Fix { span: Span::new(3, 0), content: Cow::Borrowed(" "), message: None };
+    const REVERSE_RANGE: Fix = Fix {
+        span: Span::new(3, 0),
+        content: Cow::Borrowed(" "),
+        message: None,
+        kind: FixKind::None,
+    };
 
     fn get_fix_result(messages: Vec<Message>) -> FixResult<'static> {
         Fixer::new(TEST_CODE, messages, Some(SourceType::default())).fix()

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -649,7 +649,7 @@ impl Linter {
                             // That's possible if UTF-16 offset points to middle of a surrogate pair.
                             let mut span = Span::new(fix.range[0], fix.range[1]);
                             span_converter.convert_span_back(&mut span);
-                            Fix::new(fix.text, span)
+                            Fix::new(fix.text, span).with_kind(FixKind::Fix)
                         });
 
                         if is_single {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -743,6 +743,7 @@ impl Message {
                     content: Cow::Owned(fix.text),
                     span: Span::new(fix.range.pos, fix.range.end),
                     message: None,
+                    kind: crate::fixer::FixKind::Fix,
                 })
                 .collect();
 
@@ -768,6 +769,7 @@ impl Message {
                         content: Cow::Owned(fix.text),
                         span: Span::new(fix.range.pos, fix.range.end),
                         message: Some(Cow::Owned(message)),
+                        kind: crate::fixer::FixKind::Suggestion,
                     }
                 })
                 .collect();
@@ -1278,6 +1280,7 @@ mod test {
                 content: "fixedhello".into(),
                 span: Span::new(0, 10),
                 message: None,
+                kind: crate::fixer::FixKind::Fix
             })
         );
     }
@@ -1326,11 +1329,13 @@ mod test {
                     content: "hello".into(),
                     span: Span::new(0, 5),
                     message: Some("Suggestion 1".into()),
+                    kind: crate::fixer::FixKind::Suggestion
                 },
                 crate::fixer::Fix {
                     content: "helloworld".into(),
                     span: Span::new(0, 10),
                     message: Some("Suggestion 2".into()),
+                    kind: crate::fixer::FixKind::Suggestion
                 },
             ])
         );
@@ -1364,11 +1369,17 @@ mod test {
         assert_eq!(
             message.fixes,
             PossibleFixes::Multiple(vec![
-                crate::fixer::Fix { content: "fixed".into(), span: Span::new(0, 5), message: None },
+                crate::fixer::Fix {
+                    content: "fixed".into(),
+                    span: Span::new(0, 5),
+                    message: None,
+                    kind: crate::fixer::FixKind::Fix
+                },
                 crate::fixer::Fix {
                     content: "Suggestion 1".into(),
                     span: Span::new(0, 5),
                     message: Some("Suggestion 1".into()),
+                    kind: crate::fixer::FixKind::Suggestion,
                 },
             ])
         );


### PR DESCRIPTION
Add `FixKind` to `Fix` so the language server can filter them out for "fix all" code actions / commands.