### PR TITLE
fix(oxlint/lsp): skip dangerous fixes/suggestions for "fix all" code action and command

### DIFF
--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -1,3 +1,4 @@
+use oxc_linter::FixKind;
 use tower_lsp_server::ls_types::{CodeAction, CodeActionKind, TextEdit, Uri, WorkspaceEdit};
 use tracing::debug;
 
@@ -94,6 +95,13 @@ pub fn fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) -> Vec
         // For multiple fixes, we take the first one as a representative fix.
         // Applying all possible fixes at once is not possible in this context.
         let fixed_content = action.fixed_content.into_iter().next().unwrap();
+
+        // Only safe fixes or suggestions are applied in "fix all" action/command.
+        if !FixKind::SafeFixOrSuggestion.can_apply(fixed_content.kind) {
+            debug!("Skipping unsafe fix for fix all action: {}", fixed_content.message);
+            continue;
+        }
+
         // when source.fixAll.oxc we collect all changes at ones
         // and return them as one workspace edit.
         // it is possible that one fix will change the range for the next fix

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -7,7 +7,7 @@ use tower_lsp_server::ls_types::{
 
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_diagnostics::{OxcCode, Severity};
-use oxc_linter::{Fix, Message, PossibleFixes};
+use oxc_linter::{Fix, FixKind, Message, PossibleFixes};
 
 #[derive(Debug, Clone, Default)]
 pub struct DiagnosticReport {
@@ -26,6 +26,7 @@ pub struct FixedContent {
     pub message: String,
     pub code: String,
     pub range: Range,
+    pub kind: FixKind,
 }
 
 // clippy: the source field is checked and assumed to be less than 4GB, and
@@ -175,6 +176,7 @@ fn fix_to_fixed_content(fix: &Fix, rope: &Rope, source_text: &str) -> FixedConte
         message: fix.message.as_ref().map(std::string::ToString::to_string).unwrap_or_default(),
         code: fix.content.to_string(),
         range: Range::new(start_position, end_position),
+        kind: fix.kind,
     }
 }
 
@@ -333,6 +335,7 @@ fn disable_for_this_line(
             "{content_prefix}{whitespace_string}// oxlint-disable-next-line {rule_name}\n"
         ),
         range: Range::new(position, position),
+        kind: FixKind::SafeFix,
     }
 }
 
@@ -354,6 +357,7 @@ fn disable_for_this_section(
         message: format!("Disable {rule_name} for this whole file"),
         code: content,
         range: Range::new(position, position),
+        kind: FixKind::SafeFix,
     }
 }
 

--- a/editors/vscode/tests/integration/e2e_server_linter.spec.ts
+++ b/editors/vscode/tests/integration/e2e_server_linter.spec.ts
@@ -181,11 +181,10 @@ suite("E2E Server Linter", () => {
   // but to be safe that everything works, we will check the applied changes.
   // This way we can be sure that everything works as expected.
   test("auto detect changing `fixKind` with fixAll command", async () => {
-    const originalContent = "if (foo == null) { bar();}";
-
+    const originalContent = "if (x === -0) { bar();}";
     await createOxlintConfiguration({
       rules: {
-        "no-eq-null": "error",
+        "no-compare-neg-zero": "error",
       },
     });
 
@@ -206,7 +205,7 @@ suite("E2E Server Linter", () => {
     const content = await workspace.fs.readFile(fileUri);
 
     strictEqual(content.toString(), originalContent);
-    await workspace.getConfiguration("oxc").update("fixKind", "all");
+    await workspace.getConfiguration("oxc").update("fixKind", "safe_fix_or_suggestion");
     // wait for server to update the internal linter
     await sleep(500);
     await workspace.saveAll();
@@ -218,7 +217,7 @@ suite("E2E Server Linter", () => {
     await workspace.saveAll();
     const contentWithFixAll = await workspace.fs.readFile(fileUri);
 
-    strictEqual(contentWithFixAll.toString(), "if (foo === null) { bar();}");
+    strictEqual(contentWithFixAll.toString(), "if (Object.is(x, -0)) { bar();}");
   });
 
   test("nested configs severity", async () => {


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
> /**
	 * Base kind for a 'fix all' source action: `source.fixAll`.
	 *
	 * 'Fix all' actions automatically fix errors that have a clear fix that
	 * do not require user input. They should not suppress errors or perform
	 * unsafe fixes such as generating new types or classes.
	 *
	 * @\since 3.17.0
	 */
	export const SourceFixAll: [CodeActionKind](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind) = 'source.fixAll';

closes https://github.com/oxc-project/oxc/issues/17969