### PR TITLE
fix(oxlint/lsp): respect code action `source.fixAll` as an alias for `source.fixAll.oxc`

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@debugger.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@debugger.ts.snap
@@ -71,3 +71,22 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable no-debugger\n",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 9,
+        },
+    },
+    new_text: "",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@dep-a.ts.snap
@@ -53,3 +53,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable import/no-cycle\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_extended_config@dep-a.ts.snap
@@ -53,3 +53,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable import/no-cycle\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module_nested_config@dep-a.ts_folder__folder-dep-a.ts.snap
@@ -9,6 +9,8 @@ File URI: file://<variable>/fixtures/lsp/cross_module_nested_config/dep-a.ts
 
 ########### Code Actions/Commands
 
+########### Fix All Action
+None
 ########## 
 Linted file: fixtures/lsp/cross_module_nested_config/folder/folder-dep-a.ts
 ----------
@@ -61,3 +63,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable import/no-cycle\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
@@ -53,3 +53,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable no-console\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
@@ -268,6 +268,64 @@ TextEdit: TextEdit {
 }
 
 
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 8,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 10,
+            character: 2,
+        },
+        end: Position {
+            line: 10,
+            character: 10,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 14,
+            character: 2,
+        },
+        end: Position {
+            line: 14,
+            character: 10,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 18,
+            character: 2,
+        },
+        end: Position {
+            line: 18,
+            character: 10,
+        },
+    },
+    new_text: "",
+}
+
+
 ########## 
 Linted file: fixtures/lsp/frameworks/vue/debugger.vue
 ----------
@@ -402,6 +460,38 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 4,
+            character: 8,
+        },
+        end: Position {
+            line: 4,
+            character: 17,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 8,
+            character: 4,
+        },
+        end: Position {
+            line: 8,
+            character: 13,
+        },
+    },
+    new_text: "",
 }
 
 
@@ -571,6 +661,25 @@ TextEdit: TextEdit {
 }
 
 
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 1,
+        },
+        end: Position {
+            line: 1,
+            character: 10,
+        },
+    },
+    new_text: "",
+}
+
+
 ########## 
 Linted file: fixtures/lsp/frameworks/nextjs/[[..rest]]/debugger.ts
 ----------
@@ -640,4 +749,23 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -9,6 +9,8 @@ File URI: file://<variable>/fixtures/lsp/ignore_patterns/ignored-file.ts
 
 ########### Code Actions/Commands
 
+########### Fix All Action
+None
 ########## 
 Linted file: fixtures/lsp/ignore_patterns/another_config/not-ignored-file.ts
 ----------
@@ -78,4 +80,23 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_invalid_syntax@debugger.ts_invalid.vue.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_invalid_syntax@debugger.ts_invalid.vue.snap
@@ -20,6 +20,8 @@ tags: None
 
 ########### Code Actions/Commands
 
+########### Fix All Action
+None
 ########## 
 Linted file: fixtures/lsp/invalid_syntax/invalid.vue
 ----------
@@ -38,3 +40,6 @@ source: Some("oxc")
 tags: None
 
 ########### Code Actions/Commands
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_14565@foo-bar.astro.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_14565@foo-bar.astro.snap
@@ -19,3 +19,6 @@ source: Some("oxc")
 tags: None
 
 ########### Code Actions/Commands
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
@@ -114,3 +114,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable typescript/no-non-null-asserted-optional-chain\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_js_plugins@index.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_js_plugins@index.js.snap
@@ -71,3 +71,22 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable no-debugger\n",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
@@ -89,3 +89,22 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable react/forward-ref-uses-ref\n",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 25,
+        },
+    },
+    new_text: "(props) => {}",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_no_errors@hello_world.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_no_errors@hello_world.js.snap
@@ -8,3 +8,6 @@ Linted file: fixtures/lsp/no_errors/hello_world.js
 File URI: file://<variable>/fixtures/lsp/no_errors/hello_world.js
 
 ########### Code Actions/Commands
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
@@ -118,3 +118,22 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable no-useless-escape\n",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 16,
+        },
+        end: Position {
+            line: 0,
+            character: 18,
+        },
+    },
+    new_text: "/",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ts_path_alias@deep__src__dep-a.ts.snap
@@ -53,3 +53,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable import/no-cycle\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
@@ -432,3 +432,61 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 7,
+            character: 0,
+        },
+        end: Position {
+            line: 7,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 9,
+            character: 0,
+        },
+        end: Position {
+            line: 9,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 11,
+            character: 0,
+        },
+        end: Position {
+            line: 11,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
@@ -100,3 +100,7 @@ TextEdit: TextEdit {
     },
     new_text: "// oxlint-disable typescript/no-floating-promises\n",
 }
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -205,3 +205,61 @@ TextEdit: TextEdit {
     },
     new_text: "",
 }
+
+
+########### Fix All Action
+CodeAction: 
+Title: quick fix
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 2,
+            character: 2,
+        },
+        end: Position {
+            line: 2,
+            character: 11,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 2,
+        },
+        end: Position {
+            line: 0,
+            character: 56,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 5,
+            character: 39,
+        },
+        end: Position {
+            line: 5,
+            character: 52,
+        },
+    },
+    new_text: "",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 8,
+            character: 2,
+        },
+        end: Position {
+            line: 8,
+            character: 52,
+        },
+    },
+    new_text: "",
+}


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/18333

> This pull request adds support for the standard LSP code action kind source.fixAll as an alias for the oxc-specific source.fixAll.oxc code action kind. This improves compatibility with LSP clients that expect the standard code action kind.