### PR TITLE
fix(linter/plugins): tokenize `let`, `static` and `yield` as `Keyword`s

### DIFF
--- a/apps/oxlint/conformance/snapshot.md
+++ b/apps/oxlint/conformance/snapshot.md
@@ -18,9 +18,9 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests | 33090 | 100.0% |
-| Passing     | 32799 |  99.1% |
+| Passing     | 32803 |  99.1% |
 | Failing     |     6 |   0.0% |
-| Skipped     |   285 |   0.9% |
+| Skipped     |   281 |   0.8% |
 
 ## Fully Passing Rules
 
@@ -142,7 +142,7 @@
 - `no-extra-bind` (43 tests)
 - `no-extra-boolean-cast` (501 tests) (1 skipped)
 - `no-extra-label` (34 tests)
-- `no-extra-parens` (1072 tests) (5 skipped)
+- `no-extra-parens` (1072 tests) (1 skipped)
 - `no-extra-semi` (53 tests)
 - `no-fallthrough` (87 tests) (1 skipped)
 - `no-floating-decimal` (8 tests)

--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -171,14 +171,6 @@ function shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Err
     return true;
   }
 
-  // TypeScript parser incorrectly tokenizes `let` as a `Keyword` instead of an `Identifier` token
-  if (
-    ruleName === "no-extra-parens" &&
-    ["(let[a] = b);", "(let)\nfoo", "(let[foo]) = 1", "(let)[foo]"].includes(code)
-  ) {
-    return true;
-  }
-
   return false;
 }
 

--- a/apps/oxlint/src-js/plugins/tokens_parse.ts
+++ b/apps/oxlint/src-js/plugins/tokens_parse.ts
@@ -244,6 +244,13 @@ function getTokenType(token: ts.Identifier | ts.Token<ts.SyntaxKind>): Token["ty
       ) {
         return "JSXIdentifier";
       }
+
+      // `espree` (ESLint's parser) produces `Keyword` tokens for `let`, `static`, and `yield`.
+      // TS-ESLint parser produces `Identifier` tokens for these keywords, but we go with ESLint's behavior.
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11989
+      // @ts-expect-error - `escapedText` is not public
+      const name = token.escapedText;
+      if (name === "let" || name === "static" || name === "yield") return "Keyword";
     }
 
     /*

--- a/apps/oxlint/test/fixtures/tokens/files/keywords.js
+++ b/apps/oxlint/test/fixtures/tokens/files/keywords.js
@@ -1,0 +1,9 @@
+const obj = {
+  // Identifier tokens
+  foo: foo,
+  async: async,
+  // Keyword tokens
+  let: let,
+  static: static,
+  yield: yield,
+};

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -772,8 +772,306 @@
    :                     ^
    `----
 
-Found 0 warnings and 79 errors.
-Finished in Xms on 3 files with 1 rules using X threads.
+  x tokens-plugin(tokens): Keyword ("const")
+   ,-[files/keywords.js:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Tokens:
+  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
+  | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
+  | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
+  | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
+  | Identifier        loc= 3:2 - 3:5    range= 39-42   "foo"
+  | Punctuator        loc= 3:5 - 3:6    range= 42-43   ":"
+  | Identifier        loc= 3:7 - 3:10   range= 44-47   "foo"
+  | Punctuator        loc= 3:10 - 3:11  range= 47-48   ","
+  | Identifier        loc= 4:2 - 4:7    range= 51-56   "async"
+  | Punctuator        loc= 4:7 - 4:8    range= 56-57   ":"
+  | Identifier        loc= 4:9 - 4:14   range= 58-63   "async"
+  | Punctuator        loc= 4:14 - 4:15  range= 63-64   ","
+  | Keyword           loc= 6:2 - 6:5    range= 87-90   "let"
+  | Punctuator        loc= 6:5 - 6:6    range= 90-91   ":"
+  | Keyword           loc= 6:7 - 6:10   range= 92-95   "let"
+  | Punctuator        loc= 6:10 - 6:11  range= 95-96   ","
+  | Keyword           loc= 7:2 - 7:8    range= 99-105  "static"
+  | Punctuator        loc= 7:8 - 7:9    range= 105-106 ":"
+  | Keyword           loc= 7:10 - 7:16  range= 107-113 "static"
+  | Punctuator        loc= 7:16 - 7:17  range= 113-114 ","
+  | Keyword           loc= 8:2 - 8:7    range= 117-122 "yield"
+  | Punctuator        loc= 8:7 - 8:8    range= 122-123 ":"
+  | Keyword           loc= 8:9 - 8:14   range= 124-129 "yield"
+  | Punctuator        loc= 8:14 - 8:15  range= 129-130 ","
+  | Punctuator        loc= 9:0 - 9:1    range= 131-132 "}"
+  | Punctuator        loc= 9:1 - 9:2    range= 132-133 ";"
+   ,-[files/keywords.js:1:1]
+ 1 | ,-> const obj = {
+ 2 | |     // Identifier tokens
+ 3 | |     foo: foo,
+ 4 | |     async: async,
+ 5 | |     // Keyword tokens
+ 6 | |     let: let,
+ 7 | |     static: static,
+ 8 | |     yield: yield,
+ 9 | `-> };
+   `----
+
+  x tokens-plugin(tokens): Tokens and comments:
+  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
+  | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
+  | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
+  | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
+  | Line              loc= 2:2 - 2:22   range= 16-36   " Identifier tokens"
+  | Identifier        loc= 3:2 - 3:5    range= 39-42   "foo"
+  | Punctuator        loc= 3:5 - 3:6    range= 42-43   ":"
+  | Identifier        loc= 3:7 - 3:10   range= 44-47   "foo"
+  | Punctuator        loc= 3:10 - 3:11  range= 47-48   ","
+  | Identifier        loc= 4:2 - 4:7    range= 51-56   "async"
+  | Punctuator        loc= 4:7 - 4:8    range= 56-57   ":"
+  | Identifier        loc= 4:9 - 4:14   range= 58-63   "async"
+  | Punctuator        loc= 4:14 - 4:15  range= 63-64   ","
+  | Line              loc= 5:2 - 5:19   range= 67-84   " Keyword tokens"
+  | Keyword           loc= 6:2 - 6:5    range= 87-90   "let"
+  | Punctuator        loc= 6:5 - 6:6    range= 90-91   ":"
+  | Keyword           loc= 6:7 - 6:10   range= 92-95   "let"
+  | Punctuator        loc= 6:10 - 6:11  range= 95-96   ","
+  | Keyword           loc= 7:2 - 7:8    range= 99-105  "static"
+  | Punctuator        loc= 7:8 - 7:9    range= 105-106 ":"
+  | Keyword           loc= 7:10 - 7:16  range= 107-113 "static"
+  | Punctuator        loc= 7:16 - 7:17  range= 113-114 ","
+  | Keyword           loc= 8:2 - 8:7    range= 117-122 "yield"
+  | Punctuator        loc= 8:7 - 8:8    range= 122-123 ":"
+  | Keyword           loc= 8:9 - 8:14   range= 124-129 "yield"
+  | Punctuator        loc= 8:14 - 8:15  range= 129-130 ","
+  | Punctuator        loc= 9:0 - 9:1    range= 131-132 "}"
+  | Punctuator        loc= 9:1 - 9:2    range= 132-133 ";"
+   ,-[files/keywords.js:1:1]
+ 1 | ,-> const obj = {
+ 2 | |     // Identifier tokens
+ 3 | |     foo: foo,
+ 4 | |     async: async,
+ 5 | |     // Keyword tokens
+ 6 | |     let: let,
+ 7 | |     static: static,
+ 8 | |     yield: yield,
+ 9 | `-> };
+   `----
+
+  x tokens-plugin(tokens): Identifier ("obj")
+   ,-[files/keywords.js:1:7]
+ 1 | const obj = {
+   :       ^^^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Punctuator ("=")
+   ,-[files/keywords.js:1:11]
+ 1 | const obj = {
+   :           ^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Punctuator ("{")
+   ,-[files/keywords.js:1:13]
+ 1 | const obj = {
+   :             ^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Line (" Identifier tokens")
+   ,-[files/keywords.js:2:3]
+ 1 | const obj = {
+ 2 |   // Identifier tokens
+   :   ^^^^^^^^^^^^^^^^^^^^
+ 3 |   foo: foo,
+   `----
+
+  x tokens-plugin(tokens): Identifier ("foo")
+   ,-[files/keywords.js:3:3]
+ 2 |   // Identifier tokens
+ 3 |   foo: foo,
+   :   ^^^
+ 4 |   async: async,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+   ,-[files/keywords.js:3:6]
+ 2 |   // Identifier tokens
+ 3 |   foo: foo,
+   :      ^
+ 4 |   async: async,
+   `----
+
+  x tokens-plugin(tokens): Identifier ("foo")
+   ,-[files/keywords.js:3:8]
+ 2 |   // Identifier tokens
+ 3 |   foo: foo,
+   :        ^^^
+ 4 |   async: async,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+   ,-[files/keywords.js:3:11]
+ 2 |   // Identifier tokens
+ 3 |   foo: foo,
+   :           ^
+ 4 |   async: async,
+   `----
+
+  x tokens-plugin(tokens): Identifier ("async")
+   ,-[files/keywords.js:4:3]
+ 3 |   foo: foo,
+ 4 |   async: async,
+   :   ^^^^^
+ 5 |   // Keyword tokens
+   `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+   ,-[files/keywords.js:4:8]
+ 3 |   foo: foo,
+ 4 |   async: async,
+   :        ^
+ 5 |   // Keyword tokens
+   `----
+
+  x tokens-plugin(tokens): Identifier ("async")
+   ,-[files/keywords.js:4:10]
+ 3 |   foo: foo,
+ 4 |   async: async,
+   :          ^^^^^
+ 5 |   // Keyword tokens
+   `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+   ,-[files/keywords.js:4:15]
+ 3 |   foo: foo,
+ 4 |   async: async,
+   :               ^
+ 5 |   // Keyword tokens
+   `----
+
+  x tokens-plugin(tokens): Line (" Keyword tokens")
+   ,-[files/keywords.js:5:3]
+ 4 |   async: async,
+ 5 |   // Keyword tokens
+   :   ^^^^^^^^^^^^^^^^^
+ 6 |   let: let,
+   `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+   ,-[files/keywords.js:6:3]
+ 5 |   // Keyword tokens
+ 6 |   let: let,
+   :   ^^^
+ 7 |   static: static,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+   ,-[files/keywords.js:6:6]
+ 5 |   // Keyword tokens
+ 6 |   let: let,
+   :      ^
+ 7 |   static: static,
+   `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+   ,-[files/keywords.js:6:8]
+ 5 |   // Keyword tokens
+ 6 |   let: let,
+   :        ^^^
+ 7 |   static: static,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+   ,-[files/keywords.js:6:11]
+ 5 |   // Keyword tokens
+ 6 |   let: let,
+   :           ^
+ 7 |   static: static,
+   `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+   ,-[files/keywords.js:7:3]
+ 6 |   let: let,
+ 7 |   static: static,
+   :   ^^^^^^
+ 8 |   yield: yield,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+   ,-[files/keywords.js:7:9]
+ 6 |   let: let,
+ 7 |   static: static,
+   :         ^
+ 8 |   yield: yield,
+   `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+   ,-[files/keywords.js:7:11]
+ 6 |   let: let,
+ 7 |   static: static,
+   :           ^^^^^^
+ 8 |   yield: yield,
+   `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+   ,-[files/keywords.js:7:17]
+ 6 |   let: let,
+ 7 |   static: static,
+   :                 ^
+ 8 |   yield: yield,
+   `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+   ,-[files/keywords.js:8:3]
+ 7 |   static: static,
+ 8 |   yield: yield,
+   :   ^^^^^
+ 9 | };
+   `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+   ,-[files/keywords.js:8:8]
+ 7 |   static: static,
+ 8 |   yield: yield,
+   :        ^
+ 9 | };
+   `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+   ,-[files/keywords.js:8:10]
+ 7 |   static: static,
+ 8 |   yield: yield,
+   :          ^^^^^
+ 9 | };
+   `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+   ,-[files/keywords.js:8:15]
+ 7 |   static: static,
+ 8 |   yield: yield,
+   :               ^
+ 9 | };
+   `----
+
+  x tokens-plugin(tokens): Punctuator ("}")
+   ,-[files/keywords.js:9:1]
+ 8 |   yield: yield,
+ 9 | };
+   : ^
+   `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+   ,-[files/keywords.js:9:2]
+ 8 |   yield: yield,
+ 9 | };
+   :  ^
+   `----
+
+Found 0 warnings and 109 errors.
+Finished in Xms on 4 files with 1 rules using X threads.
 ```
 
 # stderr


### PR DESCRIPTION
Espree (ESLint's parser) has the surprising behavior that it produces `Keyword` tokens for identifiers called `let`, `static`, and `yield`.

Fix our tokens to match Espree.

#18345 skipped 4 conformance tests for `no-extra-parens` rule. These tests now don't need to be skipped and they pass.

Related: https://github.com/typescript-eslint/typescript-eslint/issues/11989