### PR TITLE
docs(linter): Fix docs for the curly rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -178,12 +178,12 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// #### `{ "consistent": true }`
+    /// #### `"consistent"`
     ///
-    /// When enabled, `consistent: true` enforces consistent use of braces within an `if-else` chain.
+    /// When enabled, `"consistent"` enforces consistent use of braces within an `if-else` chain.
     /// If one branch of the chain uses braces, then all branches must use braces, even if not strictly required by the first option.
     ///
-    /// Examples of **incorrect** code with `"multi"` and `consistent: true`:
+    /// Examples of **incorrect** code with `"multi"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi", "consistent"] */
     ///
@@ -199,7 +199,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of **correct** code with `"multi"` and `consistent: true`:
+    /// Examples of **correct** code with `"multi"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi", "consistent"] */
     ///
@@ -218,7 +218,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of **incorrect** code with `"multi-line"` and `consistent: true`:
+    /// Examples of **incorrect** code with `"multi-line"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi-line", "consistent"] */
     ///
@@ -228,7 +228,7 @@ declare_oxc_lint!(
     ///   baz();
     /// ```
     ///
-    /// Examples of **correct** code with `"multi-line"` and `consistent: true`:
+    /// Examples of **correct** code with `"multi-line"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi-line", "consistent"] */
     ///
@@ -239,7 +239,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
-    /// Examples of **incorrect** code with `"multi-or-nest"` and `consistent: true`:
+    /// Examples of **incorrect** code with `"multi-or-nest"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi-or-nest", "consistent"] */
     ///
@@ -248,7 +248,7 @@ declare_oxc_lint!(
     /// } else qux();
     /// ```
     ///
-    /// Examples of **correct** code with `"multi-or-nest"` and `consistent: true`:
+    /// Examples of **correct** code with `"multi-or-nest"` and `"consistent"`:
     /// ```js
     /// /* curly: ["error", "multi-or-nest", "consistent"] */
     ///


### PR DESCRIPTION
Fixes #18371.