### PR TITLE
test(linter): Update snapshot tests for invalid config options.

### DIFF
--- a/apps/oxlint/fixtures/invalid_config_multiple_rules/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_multiple_rules/.oxlintrc.json
@@ -1,13 +1,34 @@
 {
-  "plugins": ["jest"],
+  "plugins": ["jest", "vue", "import", "typescript", "vitest"],
   "categories": {
     "correctness": "off"
   },
   "rules": {
-    // First invalid rule: unknown option field `foo`
+    // Unknown option field `foo`
     "jest/no-hooks": ["error", { "foo": "bar" }],
 
-    // Second invalid rule: invalid enum value
-    "eslint/no-return-assign": ["error", "foobar"]
+    // Invalid enum value
+    "eslint/no-return-assign": ["error", "foobar"],
+
+    // Invalid enum value inside object
+    "vue/define-emits-declaration": ["error", { "declaration": 0 }],
+
+    // preferInline should be boolean
+    "import/no-duplicates": ["error", { "preferInline": "maybe" }],
+
+    // Invalid value for enum, cannot be a number.
+    "eslint/no-cond-assign": ["error", 123],
+
+    // Unknown option field `foobar`
+    "import/no-absolute-path": ["error", { "foobar": true }],
+
+    // Invalid enum value, should not be a boolean.
+    "typescript/consistent-indexed-object-style": ["error", true],
+
+    // No extra values allowed.
+    "eslint/no-console": ["error", { "allow": ["info"], "extra": "value" }],
+
+    // Invalid enum value, cannot be "other".
+    "vitest/consistent-vitest-vi": ["error", { "fn": "other" }],
   }
 }

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
@@ -7,8 +7,15 @@ working directory: fixtures/invalid_config_multiple_rules
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `jest/no-hooks`: unknown field `foo`, expected `allow`, received `{ "foo": "bar" }`
+  x Invalid configuration for rule `import/no-absolute-path`: unknown field `foobar`, expected one of `esmodule`, `commonjs`, `amd`, received `{ "foobar": true }`
+  | Invalid configuration for rule `import/no-duplicates`: invalid type: string "maybe", expected a boolean, received `{ "preferInline": "maybe" }`
+  | Invalid configuration for rule `jest/no-hooks`: unknown field `foo`, expected `allow`, received `{ "foo": "bar" }`
+  | Invalid configuration for rule `no-cond-assign`: invalid type: integer `123`, expected string or map, received `123`
+  | Invalid configuration for rule `no-console`: unknown field `extra`, expected `allow`, received `{ "allow": [ "info" ], "extra": "value" }`
   | Invalid configuration for rule `no-return-assign`: unknown variant `foobar`, expected `always` or `except-parens`, received `"foobar"`
+  | Invalid configuration for rule `typescript/consistent-indexed-object-style`: invalid type: boolean `true`, expected string or map, received `true`
+  | Invalid configuration for rule `vitest/consistent-vitest-vi`: unknown variant `other`, expected `vi` or `vitest`, received `{ "fn": "other" }`
+  | Invalid configuration for rule `vue/define-emits-declaration`: unknown variant `declaration`, expected one of `type-based`, `type-literal`, `runtime`, received `{ "declaration": 0 }`
 
 ----------
 CLI result: InvalidOptionConfig


### PR DESCRIPTION
Add more invalid rules to the test config for the multiple rules test.

To ensure we handle each of these rules well and explain their invalidity.