### PR TITLE
fix(linter): Update eslint/sort-imports to validate options.

### DIFF
--- a/apps/oxlint/fixtures/invalid_config_sort_imports/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_sort_imports/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["eslint"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    // Invalid config, memberSyntaxSortOrder must have all 4 values.
+    "eslint/sort-imports": ["error", { "memberSyntaxSortOrder": ["none", "all", "multiple"] }]
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1519,6 +1519,13 @@ export { redundant };
     }
 
     #[test]
+    fn test_invalid_config_invalid_config_sort_imports() {
+        Tester::new()
+            .with_cwd("fixtures/invalid_config_sort_imports".into())
+            .test_and_snapshot(&[]);
+    }
+
+    #[test]
     fn test_valid_complex_config() {
         Tester::new().with_cwd("fixtures/valid_complex_config".into()).test_and_snapshot(&[]);
     }

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_sort_imports_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_sort_imports_@oxlint.snap
@@ -1,0 +1,16 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/invalid_config_sort_imports
+----------
+Failed to parse oxlint configuration file.
+
+  x Invalid configuration for rule `sort-imports`:
+  |   memberSyntaxSortOrder must contain exactly 4 kinds, got 3
+  |   received config: `{ "memberSyntaxSortOrder": [ "none", "all", "multiple" ] }`
+
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
This retains the ability to enforce the length requirement for the `memberSyntaxSortOrder`.

This rule should potentially be deprecated and replaced by oxfmt in the future, but for now let's support this.