### PR TITLE
test(prettier_conformance): update ignore list

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 738/753 (98.01%)
+js compatibility: 740/754 (98.14%)
 
 # Failed
 
@@ -17,5 +17,4 @@ js compatibility: 738/753 (98.01%)
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
-| js/ternaries/parenthesis/await-expression.js | 💥 | 33.33% |
 | jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 583/600 (97.17%)
+ts compatibility: 585/601 (97.34%)
 
 # Failed
 
@@ -12,7 +12,6 @@ ts compatibility: 583/600 (97.17%)
 | typescript/class/quoted-property.ts | 💥 | 66.67% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
-| typescript/decorators-ts/angular.ts | 💥 | 87.50% |
 | typescript/interface2/comments-ts-only/18278.ts | 💥 | 95.65% |
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -4,12 +4,8 @@ pub const IGNORE_TESTS: &[&str] = &[
     // https://github.com/biomejs/biome/blob/cd1c8ec4249e8df8d221393586d664537c9fddb2/crates/biome_formatter_test/src/diff_report.rs#L105
     // ----------------------------------------------------------------------------------------------------------------------------------
     // Bogus nodes
-    "js/chain-expression/new-expression.js",
-    "js/chain-expression/tagged-template-literals.js",
     "typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts",
     "typescript/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement21.ts",
-    "typescript/chain-expression/new-expression.ts",
-    "typescript/chain-expression/tagged-template-literals.ts",
     // Expression syntax: `a?.b = c`
     "js/optional-chaining-assignment/",
     // Experimental syntax: `do {}`
@@ -106,11 +102,14 @@ pub const IGNORE_TESTS: &[&str] = &[
     "cursor",
     // Invalid
     "js/call/invalid",
-    // Prettier bug: https://github.com/prettier/prettier/issues/18707
+    // Ambiguous await
     "js/top-level-await",
     "jsx/top-level-await",
     "typescript/top-level-await",
+    "js/ternaries/parenthesis/await-expression.js",
     // ES5 vs ES6+ identifier: Prettier uses ES5 validation, OXC uses ES6+
     // Characters outside BMP (like U+102A7) are valid ES6+ identifiers but not ES5
     "js/quotes/objects.js",
+    // Embedded Angular template
+    "typescript/decorators-ts/angular.ts",
 ];


### PR DESCRIPTION
## Summary

- Remove 4 chain-expression tests that now pass (new-expression.js, tagged-template-literals.js for both JS and TS)
- Add `js/ternaries/parenthesis/await-expression.js` to ignore list (ambiguous await parenthesization)
- Add `typescript/decorators-ts/angular.ts` to ignore list (embedded Angular template)

Compatibility improved from 98.01% to 98.14% for JS and 97.17% to 97.34% for TS.

## Test plan

- [x] `cargo run -p oxc_prettier_conformance` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)