### PR TITLE
chore(linter): Improve the error message formatting for rule configuration errors.

### DIFF
--- a/apps/oxlint/fixtures/extends_invalid_config/.oxlintrc.json
+++ b/apps/oxlint/fixtures/extends_invalid_config/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  // Ensure that invalid config options from an extended config works fine.
+  "extends": ["./invalid_config.json"]
+}

--- a/apps/oxlint/fixtures/extends_invalid_config/invalid_config.json
+++ b/apps/oxlint/fixtures/extends_invalid_config/invalid_config.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["jest"],
+  "rules": {
+    // Invalid config: `allow` should only have string values
+    "jest/no-hooks": ["error", { "allow": [true, false] }]
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1514,6 +1514,11 @@ export { redundant };
     }
 
     #[test]
+    fn test_invalid_config_invalid_config_extends() {
+        Tester::new().with_cwd("fixtures/extends_invalid_config".into()).test_and_snapshot(&[]);
+    }
+
+    #[test]
     fn test_valid_complex_config() {
         Tester::new().with_cwd("fixtures/valid_complex_config".into()).test_and_snapshot(&[]);
     }

--- a/apps/oxlint/src/snapshots/fixtures__extends_invalid_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_invalid_config_@oxlint.snap
@@ -3,7 +3,7 @@ source: apps/oxlint/src/tester.rs
 ---
 ########## 
 arguments: 
-working directory: fixtures/invalid_config_type_difference
+working directory: fixtures/extends_invalid_config
 ----------
 Failed to parse oxlint configuration file.
 

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_complex_enum_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_complex_enum_@oxlint.snap
@@ -7,7 +7,9 @@ working directory: fixtures/invalid_config_complex_enum
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `react/jsx-fragments`: data did not match any variant of untagged enum JsxFragments, received `"somethingelse"`
+  x Invalid configuration for rule `react/jsx-fragments`:
+  |   data did not match any variant of untagged enum JsxFragments
+  |   received config: `"somethingelse"`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_enum_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_enum_@oxlint.snap
@@ -7,7 +7,9 @@ working directory: fixtures/invalid_config_enum
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `no-return-assign`: unknown variant `foobar`, expected `always` or `except-parens`, received `"foobar"`
+  x Invalid configuration for rule `no-return-assign`:
+  |   unknown variant `foobar`, expected `always` or `except-parens`
+  |   received config: `"foobar"`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_extra_options_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_extra_options_@oxlint.snap
@@ -7,7 +7,9 @@ working directory: fixtures/invalid_config_extra_options
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `jest/no-hooks`: unknown field `foo`, expected `allow`, received `{ "foo": "bar" }`
+  x Invalid configuration for rule `jest/no-hooks`:
+  |   unknown field `foo`, expected `allow`
+  |   received config: `{ "foo": "bar" }`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_in_override_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_in_override_@oxlint.snap
@@ -7,7 +7,9 @@ working directory: fixtures/invalid_config_in_override
 ----------
 Failed to build configuration.
 
-  x Invalid configuration for rule `jest/no-hooks`: invalid type: boolean `true`, expected a string, received `{ "allow": [ true, false ] }`
+  x Invalid configuration for rule `jest/no-hooks`:
+  |   invalid type: boolean `true`, expected a string
+  |   received config: `{ "allow": [ true, false ] }`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_multiple_rules_@oxlint.snap
@@ -7,15 +7,41 @@ working directory: fixtures/invalid_config_multiple_rules
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `import/no-absolute-path`: unknown field `foobar`, expected one of `esmodule`, `commonjs`, `amd`, received `{ "foobar": true }`
-  | Invalid configuration for rule `import/no-duplicates`: invalid type: string "maybe", expected a boolean, received `{ "preferInline": "maybe" }`
-  | Invalid configuration for rule `jest/no-hooks`: unknown field `foo`, expected `allow`, received `{ "foo": "bar" }`
-  | Invalid configuration for rule `no-cond-assign`: invalid type: integer `123`, expected string or map, received `123`
-  | Invalid configuration for rule `no-console`: unknown field `extra`, expected `allow`, received `{ "allow": [ "info" ], "extra": "value" }`
-  | Invalid configuration for rule `no-return-assign`: unknown variant `foobar`, expected `always` or `except-parens`, received `"foobar"`
-  | Invalid configuration for rule `typescript/consistent-indexed-object-style`: invalid type: boolean `true`, expected string or map, received `true`
-  | Invalid configuration for rule `vitest/consistent-vitest-vi`: unknown variant `other`, expected `vi` or `vitest`, received `{ "fn": "other" }`
-  | Invalid configuration for rule `vue/define-emits-declaration`: unknown variant `declaration`, expected one of `type-based`, `type-literal`, `runtime`, received `{ "declaration": 0 }`
+  x Invalid configuration for rule `import/no-absolute-path`:
+  |   unknown field `foobar`, expected one of `esmodule`, `commonjs`, `amd`
+  |   received config: `{ "foobar": true }`
+  | 
+  | Invalid configuration for rule `import/no-duplicates`:
+  |   invalid type: string "maybe", expected a boolean
+  |   received config: `{ "preferInline": "maybe" }`
+  | 
+  | Invalid configuration for rule `jest/no-hooks`:
+  |   unknown field `foo`, expected `allow`
+  |   received config: `{ "foo": "bar" }`
+  | 
+  | Invalid configuration for rule `no-cond-assign`:
+  |   invalid type: integer `123`, expected string or map
+  |   received config: `123`
+  | 
+  | Invalid configuration for rule `no-console`:
+  |   unknown field `extra`, expected `allow`
+  |   received config: `{ "allow": [ "info" ], "extra": "value" }`
+  | 
+  | Invalid configuration for rule `no-return-assign`:
+  |   unknown variant `foobar`, expected `always` or `except-parens`
+  |   received config: `"foobar"`
+  | 
+  | Invalid configuration for rule `typescript/consistent-indexed-object-style`:
+  |   invalid type: boolean `true`, expected string or map
+  |   received config: `true`
+  | 
+  | Invalid configuration for rule `vitest/consistent-vitest-vi`:
+  |   unknown variant `other`, expected `vi` or `vitest`
+  |   received config: `{ "fn": "other" }`
+  | 
+  | Invalid configuration for rule `vue/define-emits-declaration`:
+  |   unknown variant `declaration`, expected one of `type-based`, `type-literal`, `runtime`
+  |   received config: `{ "declaration": 0 }`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_tuple_rules_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_tuple_rules_@oxlint.snap
@@ -7,9 +7,14 @@ working directory: fixtures/invalid_config_tuple_rules
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `eqeqeq`: invalid type: string "foo", expected struct EqeqeqOptions, received `[ "always", "foo" ]`
-  | Invalid configuration for rule `sort-keys`: unknown variant `foo`, expected `desc` or `asc`, received `[ "foo", { "allowLineSeparatedGroups": true } ]`
-  | Invalid configuration for rule `yoda`: invalid type: integer `123`, expected a boolean, received `[ "never", { "exceptRange": 123 } ]`
+  x Invalid configuration for rule `eqeqeq`:
+  |   invalid type: string "foo", expected struct EqeqeqOptions, received `[ "always", "foo" ]`
+  | 
+  | Invalid configuration for rule `sort-keys`:
+  |   unknown variant `foo`, expected `desc` or `asc`, received `[ "foo", { "allowLineSeparatedGroups": true } ]`
+  | 
+  | Invalid configuration for rule `yoda`:
+  |   invalid type: integer `123`, expected a boolean, received `[ "never", { "exceptRange": 123 } ]`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_with_rule_alias_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_with_rule_alias_@oxlint.snap
@@ -7,7 +7,9 @@ working directory: fixtures/invalid_config_with_rule_alias
 ----------
 Failed to parse oxlint configuration file.
 
-  x Invalid configuration for rule `vitest/no-hooks`: invalid type: integer `123`, expected a sequence, received `{ "allow": 123 }`
+  x Invalid configuration for rule `vitest/no-hooks`:
+  |   invalid type: integer `123`, expected a sequence
+  |   received config: `{ "allow": 123 }`
 
 ----------
 CLI result: InvalidOptionConfig

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -712,7 +712,7 @@ impl Display for ConfigBuilderError {
             ConfigBuilderError::RuleConfigurationErrors { errors } => {
                 for (i, error) in errors.iter().enumerate() {
                     if i > 0 {
-                        f.write_str("\n")?;
+                        f.write_str("\n\n")?;
                     }
                     write!(f, "{error}")?;
                 }

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -38,7 +38,7 @@ impl fmt::Display for OverrideRulesError {
         match self {
             OverrideRulesError::ExternalRuleLookup(e) => write!(f, "{e}"),
             OverrideRulesError::RuleConfiguration { rule_name, message } => {
-                write!(f, "Invalid configuration for rule `{rule_name}`: {message}")
+                write!(f, "Invalid configuration for rule `{rule_name}`:\n  {message}")
             }
         }
     }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -129,7 +129,7 @@ where
                     // Collapse any whitespace so we emit a single-line message.
                     if let Ok(value_str) = serde_json::to_string_pretty(&v) {
                         let compact = value_str.split_whitespace().collect::<Vec<_>>().join(" ");
-                        D::Error::custom(format!("{e}, received `{compact}`"))
+                        D::Error::custom(format!("{e}\n  received config: `{compact}`"))
                     } else {
                         D::Error::custom(e)
                     }


### PR DESCRIPTION
This should make the rule config errors a lot easier to understand and read :)

<img width="1190" height="735" alt="Screenshot 2026-01-21 at 8 34 22 PM" src="https://github.com/user-attachments/assets/38cc60cd-ee3f-4792-b4fd-f745ec1e351d" />

I'm not sure if there's a good way to make the text entirely red? Or at least the first line of each distinct error.