### PR TITLE
fix(coverage): parse ts-ignore comments

### DIFF
--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: f5ccf434
 
 parser_typescript Summary:
 AST Parsed     : 9844/9845 (99.99%)
-Positive Passed: 9836/9845 (99.91%)
+Positive Passed: 9839/9845 (99.94%)
 Negative Passed: 1500/2549 (58.85%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
@@ -2102,16 +2102,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
-
-  × 'with' statements are not allowed
-    ╭─[typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts:23:1]
- 22 │ // @ts-ignore suppress `with` statement error
- 23 │ with (window)
-    · ────
- 24 │     const enum H {}
-    ╰────
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDecorators.ts
 
   × Unexpected token
@@ -2121,15 +2111,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidat
     ·       ───
  19 │     }
     ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
-
-  × 'with' statements are not allowed
-   ╭─[typescript/tests/cases/compiler/withStatementInternalComments.ts:2:7]
- 1 │ // @ts-ignore
- 2 │ /*1*/ with /*2*/ ( /*3*/ false /*4*/ ) /*5*/ {}
-   ·       ────
-   ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
 
@@ -2153,16 +2134,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport
  2 │ function arguments() { } // this is allow as the file doesn't have implicit "use strict"
    ·          ─────────
    ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts
-
-  × 'with' statements are not allowed
-    ╭─[typescript/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts:64:1]
- 63 │ // @ts-ignore
- 64 │ with (_) {
-    · ────
- 65 │     var y = _;
-    ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -632,3 +632,9 @@ pub static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "18057", // String literal import and export names are not supported when the '--module' flag is set to 'es2015' or 'es2020'.
 ];
 // spellchecker:on
+
+/// Error messages that can be suppressed by `@ts-ignore` or `@ts-expect-error` comments.
+/// These are errors that TypeScript would normally report, but are intentionally ignored
+/// in the test cases using directive comments.
+pub static TS_IGNORE_SUPPRESSIBLE_ERRORS: phf::Set<&'static str> =
+    phf::phf_set!["'with' statements are not allowed",];

--- a/tasks/coverage/src/typescript/mod.rs
+++ b/tasks/coverage/src/typescript/mod.rs
@@ -5,6 +5,8 @@ mod transpile_runner;
 
 use std::path::{Path, PathBuf};
 
+use oxc::{diagnostics::OxcDiagnostic, span::Span};
+
 use self::meta::{CompilerSettings, TestCaseContent, TestUnitData};
 pub use self::transpile_runner::{TranspileRunner, TypeScriptTranspileCase};
 use crate::suite::{Case, Suite, TestResult};
@@ -69,6 +71,54 @@ impl TypeScriptCase {
     pub fn should_fail_with_any_error_codes(&self) -> bool {
         !self.error_codes.is_empty()
     }
+
+    /// Check if a diagnostic error is suppressed by a `@ts-ignore` or `@ts-expect-error`
+    /// comment on the preceding line.
+    fn is_error_suppressed_by_ts_ignore(
+        error: &OxcDiagnostic,
+        source_text: &str,
+        ts_ignore_spans: &[Span],
+    ) -> bool {
+        // Check if this error message is suppressible
+        let error_message = error.to_string();
+        if !constants::TS_IGNORE_SUPPRESSIBLE_ERRORS.contains(error_message.as_str()) {
+            return false;
+        }
+
+        // Get the error's byte offset from the first label
+        let Some(labels) = &error.labels else {
+            return false;
+        };
+        let Some(first_label) = labels.first() else {
+            return false;
+        };
+        let error_offset = first_label.offset();
+
+        // Check if any ts-ignore span covers the line before this error
+        for ts_ignore_span in ts_ignore_spans {
+            let after_comment = &source_text[ts_ignore_span.end as usize..];
+
+            // Find the first newline (end of the comment line)
+            let Some(first_newline_pos) = after_comment.find('\n') else {
+                continue;
+            };
+
+            // The next line starts after the first newline
+            let next_line_start = ts_ignore_span.end as usize + first_newline_pos + 1;
+
+            // Find the end of the next line (second newline or end of string)
+            let next_line_end = source_text[next_line_start..]
+                .find('\n')
+                .map_or(source_text.len(), |pos| next_line_start + pos);
+
+            // Check if the error offset falls within the next line
+            if error_offset >= next_line_start && error_offset < next_line_end {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 impl Case for TypeScriptCase {
@@ -105,7 +155,29 @@ impl Case for TypeScriptCase {
         let result = self
             .units
             .iter()
-            .map(|unit| self.parse(&unit.content, unit.source_type))
+            .map(|unit| {
+                let parse_result = self.parse(&unit.content, unit.source_type);
+                // If parsing failed, check if all errors are suppressed by @ts-ignore
+                match parse_result {
+                    Err((errors, error_output, panicked)) => {
+                        // Filter out errors that are suppressed by ts-ignore
+                        let has_unsuppressed_errors = errors.iter().any(|error| {
+                            !Self::is_error_suppressed_by_ts_ignore(
+                                error,
+                                &unit.content,
+                                &unit.ts_ignore_spans,
+                            )
+                        });
+
+                        if has_unsuppressed_errors {
+                            Err((errors, error_output, panicked))
+                        } else {
+                            Ok(())
+                        }
+                    }
+                    Ok(()) => Ok(()),
+                }
+            })
             .find(Result::is_err)
             .unwrap_or(Ok(()));
         self.result = self.evaluate_result(result);


### PR DESCRIPTION
Some errors in TypeScript conformance tests are ignored with `// @ts-ignore`. We should respect these comments when considering if the test file "passed" or not. In this PR, we are suppressing errors for `with` statements which are expected to raise an error but are not relevant to the test files.

This adds an extra step when parsing the test files to keep track of these ignore comments. Then if we encounter an error later, we will check if the error falls inside of the range of the ignore comment.