### PR TITLE
fix(formatter): use HTML entity escaping for JSX attribute strings

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 740/754 (98.14%)
+js compatibility: 741/754 (98.28%)
 
 # Failed
 
@@ -17,4 +17,3 @@ js compatibility: 740/754 (98.14%)
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
 | js/sequence-expression/ignored.js | 💥 | 25.00% |
 | js/strings/template-literals.js | 💥💥 | 98.01% |
-| jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,10 +1,9 @@
-ts compatibility: 585/601 (97.34%)
+ts compatibility: 586/601 (97.50%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| jsx/jsx/quotes.js | 💥💥💥💥 | 79.41% |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 82.22% |


### PR DESCRIPTION
## Summary

- Fix JSX attribute strings to use HTML entity escaping (`&apos;`, `&quot;`) instead of JavaScript backslash escaping (`\'`, `\"`)
- Add JSX-specific string normalization that matches Prettier's algorithm
- Includes unit tests for the new JSX string normalization functions

**Before:**
```jsx
singleEscaped2="&apos;"  // Wrong: kept entity that should be unescaped
singleBoth='&apos; "'    // Wrong: different quote selection than Prettier
```

**After:**
```jsx
singleEscaped2="'"       // Correct: literal ' inside " doesn't need escaping
singleBoth="' &quot;"    // Correct: minimizes escaping by choosing "
```

## Test plan

- [x] `cargo run -p oxc_prettier_conformance -- --filter "jsx/jsx/quotes.js"` passes all 8 test configurations
- [x] `cargo test -p oxc_formatter` - all 41 unit tests and 146 integration tests pass
- [x] Full prettier conformance: JS 98.28%, TS 97.50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)