### PR TITLE
feat(ecmascript): add `SideEffectInfo` for richer side effect analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
 name = "oxc_ecmascript"
 version = "0.110.0"
 dependencies = [
+ "bitflags",
  "cow-utils",
  "num-bigint",
  "num-traits",
@@ -1905,6 +1906,7 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
+ "phf",
 ]
 
 [[package]]

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -27,6 +27,8 @@ oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
+bitflags = { workspace = true }
 cow-utils = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+phf = { workspace = true }

--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -11,6 +11,15 @@ pub enum PropertyReadSideEffects {
     All,
 }
 
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyWriteSideEffects {
+    /// Treat all property write accesses as side effect free.
+    None,
+    /// Treat all property write accesses as possible side effects.
+    #[default]
+    All,
+}
+
 pub trait MayHaveSideEffectsContext<'a>: GlobalContext<'a> {
     /// Whether to respect the pure annotations.
     ///
@@ -32,6 +41,11 @@ pub trait MayHaveSideEffectsContext<'a>: GlobalContext<'a> {
     ///
     /// <https://rollupjs.org/configuration-options/#treeshake-propertyreadsideeffects>
     fn property_read_side_effects(&self) -> PropertyReadSideEffects;
+
+    /// Whether property write accesses have side effects.
+    ///
+    /// <https://rollupjs.org/configuration-options/#treeshake-propertywritesideeffects>
+    fn property_write_side_effects(&self) -> PropertyWriteSideEffects;
 
     /// Whether accessing a global variable has side effects.
     ///

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -693,11 +693,10 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
         }
 
         // Track global variable access from callee
-        if let Expression::Identifier(ident) = &self.callee {
-            if ctx.is_global_reference(ident) {
+        if let Expression::Identifier(ident) = &self.callee
+            && ctx.is_global_reference(ident) {
                 info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
             }
-        }
 
         // Determine if there's a side effect
         if self.may_have_side_effects(ctx) {
@@ -708,7 +707,7 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
     }
 }
 
-//// `[ValueProperties]: PURE` in <https://github.com/rollup/rollup/blob/master/src/ast/nodes/shared/knownGlobals.ts>
+/// `[ValueProperties]: PURE` in <https://github.com/rollup/rollup/blob/master/src/ast/nodes/shared/knownGlobals.ts>
 impl<'a> MayHaveSideEffects<'a> for NewExpression<'a> {
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
         if (self.pure && ctx.annotations()) || ctx.manual_pure_functions(&self.callee) {
@@ -734,11 +733,10 @@ impl<'a> MayHaveSideEffects<'a> for NewExpression<'a> {
         }
 
         // Track global variable access from callee
-        if let Expression::Identifier(ident) = &self.callee {
-            if ctx.is_global_reference(ident) {
+        if let Expression::Identifier(ident) = &self.callee
+            && ctx.is_global_reference(ident) {
                 info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
             }
-        }
 
         // Determine if there's a side effect
         if self.may_have_side_effects(ctx) {

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -694,9 +694,10 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
 
         // Track global variable access from callee
         if let Expression::Identifier(ident) = &self.callee
-            && ctx.is_global_reference(ident) {
-                info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
-            }
+            && ctx.is_global_reference(ident)
+        {
+            info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
+        }
 
         // Determine if there's a side effect
         if self.may_have_side_effects(ctx) {
@@ -734,9 +735,10 @@ impl<'a> MayHaveSideEffects<'a> for NewExpression<'a> {
 
         // Track global variable access from callee
         if let Expression::Identifier(ident) = &self.callee
-            && ctx.is_global_reference(ident) {
-                info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
-            }
+            && ctx.is_global_reference(ident)
+        {
+            info |= SideEffectInfo::GLOBAL_VAR_ACCESS;
+        }
 
         // Determine if there's a side effect
         if self.may_have_side_effects(ctx) {

--- a/crates/oxc_ecmascript/src/side_effects/info.rs
+++ b/crates/oxc_ecmascript/src/side_effects/info.rs
@@ -1,0 +1,62 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Rich side effect information for bundler tree-shaking.
+    ///
+    /// This provides more granular information than just a boolean,
+    /// allowing bundlers to make more informed decisions about code elimination.
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub struct SideEffectInfo: u8 {
+        /// The expression/statement has a side effect.
+        const SIDE_EFFECT = 1;
+        /// The expression accesses a global variable.
+        /// This is tracked separately because global variable access may affect
+        /// execution order even when marked as pure.
+        const GLOBAL_VAR_ACCESS = 1 << 1;
+        /// The expression has a pure annotation (`/*#__PURE__*/` or `/*@__PURE__*/`).
+        const PURE_ANNOTATION = 1 << 2;
+    }
+}
+
+impl SideEffectInfo {
+    /// Returns `true` if the expression/statement has a side effect.
+    #[inline]
+    pub fn has_side_effect(self) -> bool {
+        self.contains(Self::SIDE_EFFECT)
+    }
+
+    /// Returns `true` if the expression accesses a global variable.
+    #[inline]
+    pub fn has_global_var_access(self) -> bool {
+        self.contains(Self::GLOBAL_VAR_ACCESS)
+    }
+
+    /// Returns `true` if the expression has a pure annotation.
+    #[inline]
+    pub fn has_pure_annotation(self) -> bool {
+        self.contains(Self::PURE_ANNOTATION)
+    }
+
+    /// Create info indicating a side effect.
+    #[inline]
+    pub fn side_effect() -> Self {
+        Self::SIDE_EFFECT
+    }
+
+    /// Create info indicating no side effects.
+    #[inline]
+    pub fn no_side_effect() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<bool> for SideEffectInfo {
+    #[inline]
+    fn from(has_side_effect: bool) -> Self {
+        if has_side_effect {
+            Self::SIDE_EFFECT
+        } else {
+            Self::empty()
+        }
+    }
+}

--- a/crates/oxc_ecmascript/src/side_effects/info.rs
+++ b/crates/oxc_ecmascript/src/side_effects/info.rs
@@ -53,10 +53,6 @@ impl SideEffectInfo {
 impl From<bool> for SideEffectInfo {
     #[inline]
     fn from(has_side_effect: bool) -> Self {
-        if has_side_effect {
-            Self::SIDE_EFFECT
-        } else {
-            Self::empty()
-        }
+        if has_side_effect { Self::SIDE_EFFECT } else { Self::empty() }
     }
 }

--- a/crates/oxc_ecmascript/src/side_effects/known_globals.rs
+++ b/crates/oxc_ecmascript/src/side_effects/known_globals.rs
@@ -1,0 +1,167 @@
+//! Known global identifiers and side-effect-free member expressions.
+//!
+//! This module contains lists of known globals and their properties that can be accessed
+//! without side effects. This is used by bundlers for tree-shaking.
+
+/// Known global identifiers that can be accessed without side effects.
+///
+/// This includes:
+/// - Built-in JavaScript objects (Array, Object, Math, etc.)
+/// - Browser APIs (Document, Window, etc.)
+/// - Node.js globals (when applicable)
+static KNOWN_GLOBAL_IDENTS: phf::Set<&str> = phf::phf_set![
+    // Core JavaScript globals
+    "Infinity", "undefined", "NaN",
+    "Array", "Boolean", "Function", "Math", "Number", "Object", "RegExp", "String",
+    // Common globals in browser and node
+    "AbortController", "AbortSignal", "AggregateError", "ArrayBuffer", "BigInt",
+    "DataView", "Date", "Error", "EvalError", "Event", "EventTarget",
+    "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array",
+    "Intl", "JSON", "Map", "MessageChannel", "MessageEvent", "MessagePort",
+    "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "Set",
+    "Symbol", "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
+    "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray",
+    "WeakMap", "WeakSet", "WebAssembly",
+    "clearInterval", "clearTimeout", "console", "decodeURI", "decodeURIComponent",
+    "encodeURI", "encodeURIComponent", "escape", "globalThis", "isFinite", "isNaN",
+    "parseFloat", "parseInt", "queueMicrotask", "setInterval", "setTimeout", "unescape",
+];
+
+/// Math: Static properties and methods
+/// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math>
+static MATH_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    // Properties
+    "E", "LN10", "LN2", "LOG10E", "LOG2E", "PI", "SQRT1_2", "SQRT2",
+    // Methods
+    "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil",
+    "clz32", "cos", "cosh", "exp", "expm1", "floor", "fround", "hypot", "imul", "log",
+    "log10", "log1p", "log2", "max", "min", "pow", "random", "round", "sign", "sin",
+    "sinh", "sqrt", "tan", "tanh", "trunc",
+];
+
+/// Console methods (assumed side-effect-free for property access, not calls)
+/// <https://developer.mozilla.org/en-US/docs/Web/API/console>
+static CONSOLE_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    "assert", "clear", "count", "countReset", "debug", "dir", "dirxml", "error",
+    "group", "groupCollapsed", "groupEnd", "info", "log", "table", "time",
+    "timeEnd", "timeLog", "trace", "warn",
+];
+
+/// Reflect: Static methods
+/// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect>
+static REFLECT_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    "apply", "construct", "defineProperty", "deleteProperty", "get",
+    "getOwnPropertyDescriptor", "getPrototypeOf", "has", "isExtensible",
+    "ownKeys", "preventExtensions", "set", "setPrototypeOf",
+];
+
+/// Object: Static methods
+/// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object>
+static OBJECT_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    "assign", "create", "defineProperties", "defineProperty", "entries", "freeze",
+    "fromEntries", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors",
+    "getOwnPropertyNames", "getOwnPropertySymbols", "getPrototypeOf", "is",
+    "isExtensible", "isFrozen", "isSealed", "keys", "preventExtensions",
+    "seal", "setPrototypeOf", "values",
+];
+
+/// Symbol: Static properties
+/// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol>
+static SYMBOL_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    "asyncDispose", "asyncIterator", "dispose", "hasInstance", "isConcatSpreadable",
+    "iterator", "match", "matchAll", "replace", "search", "species", "split",
+    "toPrimitive", "toStringTag", "unscopables",
+];
+
+/// Object.prototype: Instance methods
+/// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object>
+static OBJECT_PROTOTYPE_PROPERTIES: phf::Set<&str> = phf::phf_set![
+    "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__",
+    "hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString",
+    "toString", "unwatch", "valueOf", "watch",
+];
+
+/// Check if an identifier is a known global that can be accessed without side effects.
+#[inline]
+pub fn is_known_global_ident(name: &str) -> bool {
+    KNOWN_GLOBAL_IDENTS.contains(name)
+}
+
+/// Check if a two-part member expression (like `Math.abs`, `JSON.stringify`) can be
+/// accessed without side effects.
+///
+/// # Arguments
+/// * `object` - The object part (e.g., "Math", "JSON")
+/// * `property` - The property part (e.g., "abs", "stringify")
+#[inline]
+pub fn is_side_effect_free_member_access(object: &str, property: &str) -> bool {
+    match object {
+        "Math" => MATH_PROPERTIES.contains(property),
+        "console" => CONSOLE_PROPERTIES.contains(property),
+        "Reflect" => REFLECT_PROPERTIES.contains(property),
+        "Object" => OBJECT_PROPERTIES.contains(property),
+        "Symbol" => SYMBOL_PROPERTIES.contains(property),
+        "JSON" => property == "stringify" || property == "parse",
+        _ => false,
+    }
+}
+
+/// Check if a three-part member expression (like `Object.prototype.hasOwnProperty`) can be
+/// accessed without side effects.
+///
+/// # Arguments
+/// * `object` - The object part (e.g., "Object")
+/// * `middle` - The middle part (e.g., "prototype")
+/// * `property` - The property part (e.g., "hasOwnProperty")
+#[inline]
+pub fn is_side_effect_free_nested_member_access(
+    object: &str,
+    middle: &str,
+    property: &str,
+) -> bool {
+    object == "Object" && middle == "prototype" && OBJECT_PROTOTYPE_PROPERTIES.contains(property)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_globals() {
+        assert!(is_known_global_ident("Math"));
+        assert!(is_known_global_ident("JSON"));
+        assert!(is_known_global_ident("Object"));
+        assert!(is_known_global_ident("console"));
+        assert!(is_known_global_ident("undefined"));
+        assert!(!is_known_global_ident("foo"));
+        assert!(!is_known_global_ident("myVariable"));
+    }
+
+    #[test]
+    fn test_member_access() {
+        assert!(is_side_effect_free_member_access("Math", "abs"));
+        assert!(is_side_effect_free_member_access("Math", "PI"));
+        assert!(is_side_effect_free_member_access("JSON", "stringify"));
+        assert!(is_side_effect_free_member_access("JSON", "parse"));
+        assert!(is_side_effect_free_member_access("Object", "assign"));
+        assert!(is_side_effect_free_member_access("console", "log"));
+        assert!(is_side_effect_free_member_access("Reflect", "apply"));
+        assert!(is_side_effect_free_member_access("Symbol", "iterator"));
+
+        assert!(!is_side_effect_free_member_access("Math", "unknown"));
+        assert!(!is_side_effect_free_member_access("foo", "bar"));
+        assert!(!is_side_effect_free_member_access("Object", "test"));
+    }
+
+    #[test]
+    fn test_nested_member_access() {
+        assert!(is_side_effect_free_nested_member_access(
+            "Object",
+            "prototype",
+            "hasOwnProperty"
+        ));
+        assert!(is_side_effect_free_nested_member_access("Object", "prototype", "toString"));
+        assert!(!is_side_effect_free_nested_member_access("Object", "prototype", "unknown"));
+        assert!(!is_side_effect_free_nested_member_access("Array", "prototype", "map"));
+    }
+}

--- a/crates/oxc_ecmascript/src/side_effects/known_globals.rs
+++ b/crates/oxc_ecmascript/src/side_effects/known_globals.rs
@@ -11,74 +11,194 @@
 /// - Node.js globals (when applicable)
 static KNOWN_GLOBAL_IDENTS: phf::Set<&str> = phf::phf_set![
     // Core JavaScript globals
-    "Infinity", "undefined", "NaN",
-    "Array", "Boolean", "Function", "Math", "Number", "Object", "RegExp", "String",
+    "Infinity",
+    "undefined",
+    "NaN",
+    "Array",
+    "Boolean",
+    "Function",
+    "Math",
+    "Number",
+    "Object",
+    "RegExp",
+    "String",
     // Common globals in browser and node
-    "AbortController", "AbortSignal", "AggregateError", "ArrayBuffer", "BigInt",
-    "DataView", "Date", "Error", "EvalError", "Event", "EventTarget",
-    "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array",
-    "Intl", "JSON", "Map", "MessageChannel", "MessageEvent", "MessagePort",
-    "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "Set",
-    "Symbol", "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
-    "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray",
-    "WeakMap", "WeakSet", "WebAssembly",
-    "clearInterval", "clearTimeout", "console", "decodeURI", "decodeURIComponent",
-    "encodeURI", "encodeURIComponent", "escape", "globalThis", "isFinite", "isNaN",
-    "parseFloat", "parseInt", "queueMicrotask", "setInterval", "setTimeout", "unescape",
+    "AbortController",
+    "AbortSignal",
+    "AggregateError",
+    "ArrayBuffer",
+    "BigInt",
+    "DataView",
+    "Date",
+    "Error",
+    "EvalError",
+    "Event",
+    "EventTarget",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Intl",
+    "JSON",
+    "Map",
+    "MessageChannel",
+    "MessageEvent",
+    "MessagePort",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "ReferenceError",
+    "Reflect",
+    "Set",
+    "Symbol",
+    "SyntaxError",
+    "TextDecoder",
+    "TextEncoder",
+    "TypeError",
+    "URIError",
+    "URL",
+    "URLSearchParams",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "WeakMap",
+    "WeakSet",
+    "WebAssembly",
+    "clearInterval",
+    "clearTimeout",
+    "console",
+    "decodeURI",
+    "decodeURIComponent",
+    "encodeURI",
+    "encodeURIComponent",
+    "escape",
+    "globalThis",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "queueMicrotask",
+    "setInterval",
+    "setTimeout",
+    "unescape",
 ];
 
 /// Math: Static properties and methods
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math>
 static MATH_PROPERTIES: phf::Set<&str> = phf::phf_set![
     // Properties
-    "E", "LN10", "LN2", "LOG10E", "LOG2E", "PI", "SQRT1_2", "SQRT2",
-    // Methods
-    "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil",
-    "clz32", "cos", "cosh", "exp", "expm1", "floor", "fround", "hypot", "imul", "log",
-    "log10", "log1p", "log2", "max", "min", "pow", "random", "round", "sign", "sin",
-    "sinh", "sqrt", "tan", "tanh", "trunc",
+    "E", "LN10", "LN2", "LOG10E", "LOG2E", "PI", "SQRT1_2", "SQRT2", // Methods
+    "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil", "clz32",
+    "cos", "cosh", "exp", "expm1", "floor", "fround", "hypot", "imul", "log", "log10", "log1p",
+    "log2", "max", "min", "pow", "random", "round", "sign", "sin", "sinh", "sqrt", "tan", "tanh",
+    "trunc",
 ];
 
 /// Console methods (assumed side-effect-free for property access, not calls)
 /// <https://developer.mozilla.org/en-US/docs/Web/API/console>
 static CONSOLE_PROPERTIES: phf::Set<&str> = phf::phf_set![
-    "assert", "clear", "count", "countReset", "debug", "dir", "dirxml", "error",
-    "group", "groupCollapsed", "groupEnd", "info", "log", "table", "time",
-    "timeEnd", "timeLog", "trace", "warn",
+    "assert",
+    "clear",
+    "count",
+    "countReset",
+    "debug",
+    "dir",
+    "dirxml",
+    "error",
+    "group",
+    "groupCollapsed",
+    "groupEnd",
+    "info",
+    "log",
+    "table",
+    "time",
+    "timeEnd",
+    "timeLog",
+    "trace",
+    "warn",
 ];
 
 /// Reflect: Static methods
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect>
 static REFLECT_PROPERTIES: phf::Set<&str> = phf::phf_set![
-    "apply", "construct", "defineProperty", "deleteProperty", "get",
-    "getOwnPropertyDescriptor", "getPrototypeOf", "has", "isExtensible",
-    "ownKeys", "preventExtensions", "set", "setPrototypeOf",
+    "apply",
+    "construct",
+    "defineProperty",
+    "deleteProperty",
+    "get",
+    "getOwnPropertyDescriptor",
+    "getPrototypeOf",
+    "has",
+    "isExtensible",
+    "ownKeys",
+    "preventExtensions",
+    "set",
+    "setPrototypeOf",
 ];
 
 /// Object: Static methods
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object>
 static OBJECT_PROPERTIES: phf::Set<&str> = phf::phf_set![
-    "assign", "create", "defineProperties", "defineProperty", "entries", "freeze",
-    "fromEntries", "getOwnPropertyDescriptor", "getOwnPropertyDescriptors",
-    "getOwnPropertyNames", "getOwnPropertySymbols", "getPrototypeOf", "is",
-    "isExtensible", "isFrozen", "isSealed", "keys", "preventExtensions",
-    "seal", "setPrototypeOf", "values",
+    "assign",
+    "create",
+    "defineProperties",
+    "defineProperty",
+    "entries",
+    "freeze",
+    "fromEntries",
+    "getOwnPropertyDescriptor",
+    "getOwnPropertyDescriptors",
+    "getOwnPropertyNames",
+    "getOwnPropertySymbols",
+    "getPrototypeOf",
+    "is",
+    "isExtensible",
+    "isFrozen",
+    "isSealed",
+    "keys",
+    "preventExtensions",
+    "seal",
+    "setPrototypeOf",
+    "values",
 ];
 
 /// Symbol: Static properties
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol>
 static SYMBOL_PROPERTIES: phf::Set<&str> = phf::phf_set![
-    "asyncDispose", "asyncIterator", "dispose", "hasInstance", "isConcatSpreadable",
-    "iterator", "match", "matchAll", "replace", "search", "species", "split",
-    "toPrimitive", "toStringTag", "unscopables",
+    "asyncDispose",
+    "asyncIterator",
+    "dispose",
+    "hasInstance",
+    "isConcatSpreadable",
+    "iterator",
+    "match",
+    "matchAll",
+    "replace",
+    "search",
+    "species",
+    "split",
+    "toPrimitive",
+    "toStringTag",
+    "unscopables",
 ];
 
 /// Object.prototype: Instance methods
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object>
 static OBJECT_PROTOTYPE_PROPERTIES: phf::Set<&str> = phf::phf_set![
-    "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__",
-    "hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString",
-    "toString", "unwatch", "valueOf", "watch",
+    "__defineGetter__",
+    "__defineSetter__",
+    "__lookupGetter__",
+    "__lookupSetter__",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toLocaleString",
+    "toString",
+    "unwatch",
+    "valueOf",
+    "watch",
 ];
 
 /// Check if an identifier is a known global that can be accessed without side effects.
@@ -155,11 +275,7 @@ mod tests {
 
     #[test]
     fn test_nested_member_access() {
-        assert!(is_side_effect_free_nested_member_access(
-            "Object",
-            "prototype",
-            "hasOwnProperty"
-        ));
+        assert!(is_side_effect_free_nested_member_access("Object", "prototype", "hasOwnProperty"));
         assert!(is_side_effect_free_nested_member_access("Object", "prototype", "toString"));
         assert!(!is_side_effect_free_nested_member_access("Object", "prototype", "unknown"));
         assert!(!is_side_effect_free_nested_member_access("Array", "prototype", "map"));

--- a/crates/oxc_ecmascript/src/side_effects/mod.rs
+++ b/crates/oxc_ecmascript/src/side_effects/mod.rs
@@ -1,10 +1,17 @@
 mod context;
 mod expressions;
+mod info;
+mod known_globals;
 mod pure_function;
 mod statements;
 
-pub use context::{MayHaveSideEffectsContext, PropertyReadSideEffects};
+pub use context::{MayHaveSideEffectsContext, PropertyReadSideEffects, PropertyWriteSideEffects};
 pub use expressions::is_valid_regexp;
+pub use info::SideEffectInfo;
+pub use known_globals::{
+    is_known_global_ident, is_side_effect_free_member_access,
+    is_side_effect_free_nested_member_access,
+};
 pub use pure_function::is_pure_function;
 
 /// Returns true if subtree changes application state.
@@ -19,11 +26,27 @@ pub use pure_function::is_pure_function;
 ///
 /// Ported from [closure-compiler](https://github.com/google/closure-compiler/blob/f3ce5ed8b630428e311fe9aa2e20d36560d975e2/src/com/google/javascript/jscomp/AstAnalyzer.java#L94)
 pub trait MayHaveSideEffects<'a> {
+    /// Returns `true` if the expression/statement may have side effects.
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool;
+
+    /// Returns rich side effect information for bundler tree-shaking.
+    ///
+    /// This provides more granular information than [`may_have_side_effects`],
+    /// including whether the expression accesses global variables or has pure annotations.
+    ///
+    /// The default implementation converts the boolean result to [`SideEffectInfo`].
+    /// Types that need to track additional information should override this method.
+    fn side_effect_info(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> SideEffectInfo {
+        self.may_have_side_effects(ctx).into()
+    }
 }
 
 impl<'a, T: MayHaveSideEffects<'a>> MayHaveSideEffects<'a> for Option<T> {
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
         self.as_ref().is_some_and(|t| t.may_have_side_effects(ctx))
+    }
+
+    fn side_effect_info(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> SideEffectInfo {
+        self.as_ref().map_or(SideEffectInfo::empty(), |t| t.side_effect_info(ctx))
     }
 }

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -5,7 +5,9 @@ use oxc_ecmascript::{
     constant_evaluation::{
         ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, binary_operation_evaluate_value,
     },
-    side_effects::{MayHaveSideEffects, PropertyReadSideEffects, is_pure_function},
+    side_effects::{
+        MayHaveSideEffects, PropertyReadSideEffects, PropertyWriteSideEffects, is_pure_function,
+    },
 };
 use oxc_semantic::{IsGlobalReference, Scoping, SymbolId};
 use oxc_span::format_atom;
@@ -77,6 +79,10 @@ impl<'a> oxc_ecmascript::side_effects::MayHaveSideEffectsContext<'a> for Ctx<'a,
 
     fn property_read_side_effects(&self) -> PropertyReadSideEffects {
         self.state.options.treeshake.property_read_side_effects
+    }
+
+    fn property_write_side_effects(&self) -> PropertyWriteSideEffects {
+        self.state.options.treeshake.property_write_side_effects
     }
 
     fn unknown_global_side_effects(&self) -> bool {

--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -1,7 +1,7 @@
 use oxc_compat::EngineTargets;
 use rustc_hash::FxHashSet;
 
-pub use oxc_ecmascript::side_effects::PropertyReadSideEffects;
+pub use oxc_ecmascript::side_effects::{PropertyReadSideEffects, PropertyWriteSideEffects};
 
 #[derive(Debug, Clone)]
 pub struct CompressOptions {
@@ -179,6 +179,13 @@ pub struct TreeShakeOptions {
     /// Default [PropertyReadSideEffects::All]
     pub property_read_side_effects: PropertyReadSideEffects,
 
+    /// Whether property write accesses have side effects.
+    ///
+    /// <https://rollupjs.org/configuration-options/#treeshake-propertywritesideeffects>
+    ///
+    /// Default [PropertyWriteSideEffects::All]
+    pub property_write_side_effects: PropertyWriteSideEffects,
+
     /// Whether accessing a global variable has side effects.
     ///
     /// Accessing a non-existing global variable will throw an error.
@@ -204,6 +211,7 @@ impl Default for TreeShakeOptions {
             annotations: true,
             manual_pure_functions: vec![],
             property_read_side_effects: PropertyReadSideEffects::default(),
+            property_write_side_effects: PropertyWriteSideEffects::default(),
             unknown_global_side_effects: true,
             invalid_import_side_effects: true,
         }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -7,7 +7,8 @@ use oxc_ast::ast::{Expression, IdentifierReference, Statement};
 use oxc_ecmascript::{
     GlobalContext,
     side_effects::{
-        MayHaveSideEffects, MayHaveSideEffectsContext, PropertyReadSideEffects, is_pure_function,
+        MayHaveSideEffects, MayHaveSideEffectsContext, PropertyReadSideEffects,
+        PropertyWriteSideEffects, is_pure_function,
     },
 };
 use oxc_parser::Parser;
@@ -18,6 +19,7 @@ struct Ctx {
     annotation: bool,
     pure_function_names: Vec<String>,
     property_read_side_effects: PropertyReadSideEffects,
+    property_write_side_effects: PropertyWriteSideEffects,
     unknown_global_side_effects: bool,
 }
 
@@ -32,6 +34,7 @@ impl Default for Ctx {
             annotation: true,
             pure_function_names: vec![],
             property_read_side_effects: PropertyReadSideEffects::All,
+            property_write_side_effects: PropertyWriteSideEffects::All,
             unknown_global_side_effects: true,
         }
     }
@@ -54,6 +57,10 @@ impl MayHaveSideEffectsContext<'_> for Ctx {
 
     fn property_read_side_effects(&self) -> PropertyReadSideEffects {
         self.property_read_side_effects
+    }
+
+    fn property_write_side_effects(&self) -> PropertyWriteSideEffects {
+        self.property_write_side_effects
     }
 
     fn unknown_global_side_effects(&self) -> bool {

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1196,10 +1196,7 @@ fn test_side_effect_info_pure_annotation() {
     );
 
     // Pure annotation on call with local callee (no GLOBAL_VAR_ACCESS)
-    test_side_effect_info(
-        "/* #__PURE__ */ localFunc()",
-        SideEffectInfo::PURE_ANNOTATION,
-    );
+    test_side_effect_info("/* #__PURE__ */ localFunc()", SideEffectInfo::PURE_ANNOTATION);
 
     // Pure annotation on new expression with global callee
     test_side_effect_info(
@@ -1235,9 +1232,6 @@ fn test_side_effect_info_combined() {
     );
 
     // Known global with unknown_global_side_effects = false: no side effect
-    let ctx = Ctx {
-        unknown_global_side_effects: false,
-        ..Default::default()
-    };
+    let ctx = Ctx { unknown_global_side_effects: false, ..Default::default() };
     test_side_effect_info_with_ctx("JSON", &ctx, SideEffectInfo::GLOBAL_VAR_ACCESS);
 }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1206,7 +1206,7 @@ fn test_side_effect_info_pure_annotation() {
 
     // Pure annotation with side-effectful argument (argument accesses global)
     let ctx = Ctx {
-        global_variable_names: ["bar"].iter().copied().collect(),
+        global_variable_names: std::iter::once("bar").collect(),
         unknown_global_side_effects: true,
         ..Default::default()
     };
@@ -1221,7 +1221,7 @@ fn test_side_effect_info_pure_annotation() {
 fn test_side_effect_info_combined() {
     // Unknown global with side effect
     let ctx = Ctx {
-        global_variable_names: ["unknownGlobal"].iter().copied().collect(),
+        global_variable_names: std::iter::once("unknownGlobal").collect(),
         unknown_global_side_effects: true,
         ..Default::default()
     };

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects_statements.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects_statements.rs
@@ -5,7 +5,7 @@ use oxc_ecmascript::{
     GlobalContext,
     side_effects::{MayHaveSideEffects, MayHaveSideEffectsContext},
 };
-use oxc_minifier::PropertyReadSideEffects;
+use oxc_minifier::{PropertyReadSideEffects, PropertyWriteSideEffects};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use rustc_hash::FxHashSet;
@@ -43,6 +43,10 @@ impl MayHaveSideEffectsContext<'_> for Ctx {
 
     fn property_read_side_effects(&self) -> PropertyReadSideEffects {
         PropertyReadSideEffects::All
+    }
+
+    fn property_write_side_effects(&self) -> PropertyWriteSideEffects {
+        PropertyWriteSideEffects::All
     }
 
     fn unknown_global_side_effects(&self) -> bool {

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -25,6 +25,12 @@ pub struct TreeShakeOptions {
     #[napi(ts_type = "boolean | 'always'")]
     pub property_read_side_effects: Option<Either<bool, String>>,
 
+    /// Whether property write accesses have side effects.
+    ///
+    /// @default 'always'
+    #[napi(ts_type = "boolean | 'always'")]
+    pub property_write_side_effects: Option<Either<bool, String>>,
+
     /// Whether accessing a global variable has side effects.
     ///
     /// Accessing a non-existing global variable will throw an error.
@@ -63,6 +69,17 @@ impl TryFrom<&TreeShakeOptions> for oxc_minifier::TreeShakeOptions {
                     ));
                 }
                 None => default.property_read_side_effects,
+            },
+            property_write_side_effects: match &o.property_write_side_effects {
+                Some(Either::A(false)) => oxc_minifier::PropertyWriteSideEffects::None,
+                Some(Either::A(true)) => oxc_minifier::PropertyWriteSideEffects::All,
+                Some(Either::B(s)) if s == "always" => oxc_minifier::PropertyWriteSideEffects::All,
+                Some(Either::B(s)) => {
+                    return Err(format!(
+                        "Invalid propertyWriteSideEffects value: '{s}'. Expected 'always'."
+                    ));
+                }
+                None => default.property_write_side_effects,
             },
             unknown_global_side_effects: o
                 .unknown_global_side_effects


### PR DESCRIPTION
## Summary

This PR adds richer side effect information to support bundler tree-shaking in rolldown. The goal is to allow rolldown to consolidate its duplicate `SideEffectDetector` implementation and reuse OXC's `MayHaveSideEffects` trait.

### Changes

- Add `SideEffectInfo` bitflags with:
  - `SIDE_EFFECT` - the expression has a side effect
  - `GLOBAL_VAR_ACCESS` - the expression accesses a global variable  
  - `PURE_ANNOTATION` - the expression has a pure annotation (`/*#__PURE__*/`)
- Add `side_effect_info()` method to `MayHaveSideEffects` trait (with default implementation)
- Add `PropertyWriteSideEffects` enum to context
- Add `known_globals.rs` with side-effect-free member access lists (Math, Object, JSON, etc.)
- Implement `side_effect_info()` for `IdentifierReference`, `CallExpression`, `NewExpression`

### Motivation

Rolldown currently has a separate `SideEffectDetector` (~1500 lines) that duplicates much of OXC's `MayHaveSideEffects` implementation. The key difference is that rolldown needs to track additional information:

1. **Global variable access** - tracked separately from side effects for wrapper optimization
2. **Pure annotations** - tracked separately for tree-shaking decisions
3. **Property write side effects** - rolldown has this option, OXC only had read

This PR allows rolldown to migrate to OXC's implementation while getting the richer information it needs.

🤖 Generated with [Claude Code](https://claude.ai/code)