### PR TITLE
fix(linter): compatibility issue with `DiagnosticData` type in ESLint

### DIFF
--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -48,7 +48,7 @@ interface LocationWithOptionalEnd {
 /**
  * Data to interpolate into a diagnostic message.
  */
-export type DiagnosticData = Record<string, string | number>;
+export type DiagnosticData = Record<string, string | number | boolean | bigint | null | undefined>;
 
 /**
  * Suggested fix.


### PR DESCRIPTION
Hi, this is my first contribution here, so I'm not sure whether opening a PR directly is appropriate. 

If anything is wrong, please let me know!

---

In this PR, I've corrected the `DiagnosticData` type to `Record<string, string | number | boolean | bigint | null | undefined>;`

In ESLint v9.39.2 (which uses `@eslint/core@0.17.0`), this type was widened to `Record<string, unknown>`.

Refs:

- https://github.com/eslint/rewrite/releases/tag/core-v0.17.0
- https://github.com/eslint/rewrite/pull/298

However, in the ESLint v10.0.0 pre-release (which uses `@eslint/core@1.0.1`), this type have been narrowed to `Record<string, string | number | boolean | bigint | null | undefined>;`.

Refs:

- https://github.com/eslint/rewrite/releases/tag/core-v1.0.1
- https://github.com/eslint/rewrite/pull/327

If the type's intention is to ensure maximum compatibility with any ESLint version, then `Record<string, string | number | boolean | bigint | null | undefined>` seems the most appropriate choice here.

