### PR TITLE
chore(deps): bump `typescript-eslint` packages to latest

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -31,7 +31,7 @@
     "@types/json-schema": "^7.0.15",
     "@types/json-stable-stringify-without-jsonify": "^1.0.2",
     "@types/node": "catalog:",
-    "@typescript-eslint/scope-manager": "8.48.1",
+    "@typescript-eslint/scope-manager": "8.53.1",
     "ajv": "^6.12.6",
     "cross-env": "catalog:",
     "eslint": "catalog:",

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -78,7 +78,7 @@
     "@napi-rs/cli": "catalog:",
     "@napi-rs/wasm-runtime": "catalog:",
     "@types/node": "catalog:",
-    "@typescript-eslint/visitor-keys": "^8.44.0",
+    "@typescript-eslint/visitor-keys": "^8.53.1",
     "@vitest/browser": "4.0.15",
     "@vitest/browser-playwright": "4.0.15",
     "esbuild": "^0.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: 'catalog:'
         version: 24.1.0
       '@typescript-eslint/scope-manager':
-        specifier: 8.48.1
-        version: 8.48.1
+        specifier: 8.53.1
+        version: 8.53.1
       ajv:
         specifier: ^6.12.6
         version: 6.12.6
@@ -236,8 +236,8 @@ importers:
         specifier: 'catalog:'
         version: 24.1.0
       '@typescript-eslint/visitor-keys':
-        specifier: ^8.44.0
-        version: 8.48.1
+        specifier: ^8.53.1
+        version: 8.53.1
       '@vitest/browser':
         specifier: 4.0.15
         version: 4.0.15(vite@7.3.0(@types/node@24.1.0)(jiti@2.6.1)(terser@5.44.1))(vitest@4.0.15)
@@ -2761,16 +2761,16 @@ packages:
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
-  '@typescript-eslint/scope-manager@8.48.1':
-    resolution: {integrity: sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==}
+  '@typescript-eslint/scope-manager@8.53.1':
+    resolution: {integrity: sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.48.1':
-    resolution: {integrity: sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==}
+  '@typescript-eslint/types@8.53.1':
+    resolution: {integrity: sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.48.1':
-    resolution: {integrity: sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==}
+  '@typescript-eslint/visitor-keys@8.53.1':
+    resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typespec/ts-http-runtime@0.3.2':
@@ -7921,16 +7921,16 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
-  '@typescript-eslint/scope-manager@8.48.1':
+  '@typescript-eslint/scope-manager@8.53.1':
     dependencies:
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
+      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/visitor-keys': 8.53.1
 
-  '@typescript-eslint/types@8.48.1': {}
+  '@typescript-eslint/types@8.53.1': {}
 
-  '@typescript-eslint/visitor-keys@8.48.1':
+  '@typescript-eslint/visitor-keys@8.53.1':
     dependencies:
-      '@typescript-eslint/types': 8.48.1
+      '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
   '@typespec/ts-http-runtime@0.3.2':


### PR DESCRIPTION
Bump `@typescript-eslint/scope-manager` and `@typescript-eslint/visitor-keys` dependencies to latest.