### PR TITLE
fix(linter): `react/no_array_index_key` continue search for other attributes

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -240,6 +240,10 @@ fn test() {
           ));
         ",
         r"things.map((thing, index) => (
+            <Hello thing={thing} key={index} />
+          ));
+        ",
+        r"things.map((thing, index) => (
             React.cloneElement(thing, { key: index })
           ));
         ",

--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -64,23 +64,23 @@ fn check_jsx_element<'a>(
 
     for attr in &jsx.opening_element.attributes {
         let JSXAttributeItem::Attribute(attr) = attr else {
-            return;
+            continue;
         };
 
         let JSXAttributeName::Identifier(ident) = &attr.name else {
-            return;
+            continue;
         };
 
         if ident.name.as_str() != prop_name {
-            return;
+            continue;
         }
 
         let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value else {
-            return;
+            continue;
         };
 
         let JSXExpression::Identifier(expr) = &container.expression else {
-            return;
+            continue;
         };
 
         if expr.name.as_str() == index_param_name {

--- a/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
@@ -11,6 +11,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a unique data-dependent key to avoid unnecessary rerenders
 
   ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
+   ╭─[no_array_index_key.tsx:2:34]
+ 1 │ things.map((thing, index) => (
+ 2 │             <Hello thing={thing} key={index} />
+   ·                                  ───────────
+ 3 │           ));
+   ╰────
+  help: Use a unique data-dependent key to avoid unnecessary rerenders
+
+  ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
    ╭─[no_array_index_key.tsx:2:39]
  1 │ things.map((thing, index) => (
  2 │             React.cloneElement(thing, { key: index })


### PR DESCRIPTION
The test can be seen fail before the fix. Happy to align the commit messages or reorder them if needed.