### PR TITLE
refactor(formatter): use `AstNode::parent` method instead of accessing the `parent` field directly

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -74,19 +74,19 @@ impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
 
         match self.name.as_str() {
             "async" => {
-                matches!(self.parent, AstNodes::ForOfStatement(stmt) if !stmt.r#await && stmt.left.span().contains_inclusive(self.span))
+                matches!(self.parent(), AstNodes::ForOfStatement(stmt) if !stmt.r#await && stmt.left.span().contains_inclusive(self.span))
             }
             "let" => {
                 // `let[a]` at statement start looks like a lexical declaration, needs parens
                 // Only applies when `let` is the object of a computed member expression
-                if !matches!(self.parent, AstNodes::ComputedMemberExpression(m) if m.object.span() == self.span())
+                if !matches!(self.parent(), AstNodes::ComputedMemberExpression(m) if m.object.span() == self.span())
                 {
                     // Not `let[...]` - check special cases only
                     return self.ancestors().any(|parent| match parent {
                         AstNodes::ForOfStatement(s) => s.left.span().contains_inclusive(self.span),
                         AstNodes::ForInStatement(s) => {
                             s.left.span().contains_inclusive(self.span)
-                                && !matches!(self.parent, AstNodes::StaticMemberExpression(_))
+                                && !matches!(self.parent(), AstNodes::StaticMemberExpression(_))
                         }
                         AstNodes::TSSatisfiesExpression(e) => e.expression.span() == self.span(),
                         _ => false,
@@ -142,7 +142,7 @@ impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
                     return false;
                 }
 
-                let mut parent = self.parent;
+                let mut parent = self.parent();
                 while matches!(
                     parent,
                     AstNodes::TSSatisfiesExpression(_) | AstNodes::TSAsExpression(_)
@@ -151,7 +151,7 @@ impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
                 }
 
                 // Early return if the parent isn't a `TSSatisfiesExpression` or `TSAsExpression`
-                if ptr::eq(self.parent, parent) {
+                if ptr::eq(self.parent(), parent) {
                     return false;
                 }
 
@@ -219,7 +219,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NumericLiteral<'_>> {
             return false;
         }
 
-        if let AstNodes::StaticMemberExpression(member) = self.parent {
+        if let AstNodes::StaticMemberExpression(member) = self.parent() {
             return member.object.span() == self.span();
         }
         false
@@ -232,7 +232,7 @@ impl NeedsParentheses<'_> for AstNode<'_, StringLiteral<'_>> {
             return false;
         }
 
-        if let AstNodes::ExpressionStatement(stmt) = self.parent {
+        if let AstNodes::ExpressionStatement(stmt) = self.parent() {
             // `() => "foo"`
             !stmt.is_arrow_function_body()
         } else {
@@ -261,7 +261,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ObjectExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         is_class_extends(self.span, parent)
             || is_first_in_statement(
                 self.span,
@@ -314,7 +314,7 @@ impl NeedsParentheses<'_> for AstNode<'_, CallExpression<'_>> {
             return false;
         }
 
-        match self.parent {
+        match self.parent() {
             AstNodes::ExportDefaultDeclaration(_) => {
                 let callee = &self.callee();
                 let callee_span = callee.span();
@@ -338,7 +338,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NewExpression<'_>> {
             return false;
         }
 
-        is_class_extends(self.span, self.parent)
+        is_class_extends(self.span, self.parent())
     }
 }
 
@@ -348,7 +348,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UpdateExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         if self.prefix()
             && let AstNodes::UnaryExpression(unary) = parent
         {
@@ -369,7 +369,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UnaryExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         match parent {
             AstNodes::UnaryExpression(parent_unary) => {
                 let parent_operator = parent_unary.operator();
@@ -413,7 +413,7 @@ fn is_in_for_initializer(expr: &AstNode<'_, BinaryExpression<'_>>) -> bool {
                     continue;
                 }
                 // Block body: `() => { expr; }` - check if we're inside a FunctionBody
-                if matches!(stmt.parent, AstNodes::FunctionBody(_)) {
+                if matches!(stmt.parent(), AstNodes::FunctionBody(_)) {
                     continue;
                 }
 
@@ -446,8 +446,8 @@ impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
             return false;
         }
 
-        is_class_extends(self.span, self.parent)
-            || matches!(self.parent, AstNodes::UnaryExpression(_))
+        is_class_extends(self.span, self.parent())
+            || matches!(self.parent(), AstNodes::UnaryExpression(_))
     }
 }
 
@@ -457,7 +457,7 @@ impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         if let AstNodes::LogicalExpression(parent) = parent {
             parent.operator() != self.operator()
         } else if self.operator().is_coalesce()
@@ -476,7 +476,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ConditionalExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         if matches!(
             parent,
             AstNodes::UnaryExpression(_)
@@ -509,7 +509,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Function<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         matches!(parent, AstNodes::TaggedTemplateExpression(_))
             || self.is_call_like_callee()
             || is_first_in_statement(
@@ -526,7 +526,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
             return false;
         }
 
-        match self.parent {
+        match self.parent() {
             // Expression statements, only object destructuring needs parens:
             // - `a = b` = no parens
             // - `{ x } = obj` -> `({ x } = obj)` = needed to prevent parsing as block statement
@@ -540,7 +540,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
                 matches!(self.left, AssignmentTarget::ObjectAssignmentTarget(_))
                     && is_first_in_statement(
                         self.span,
-                        self.parent,
+                        self.parent(),
                         FirstInStatementMode::ExpressionStatementOrArrow,
                     )
             }
@@ -605,7 +605,7 @@ impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
             return false;
         }
 
-        match self.parent {
+        match self.parent() {
             AstNodes::ReturnStatement(_)
             | AstNodes::ThrowStatement(_)
             // There's a precedence for writing `x++, y++`
@@ -623,7 +623,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AwaitExpression<'_>> {
             return false;
         }
 
-        await_or_yield_needs_parens(self.span(), self.parent)
+        await_or_yield_needs_parens(self.span(), self.parent())
     }
 }
 
@@ -640,7 +640,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ChainExpression<'_>> {
         }
 
         // Check if chain expression needs parens based on how it's being accessed
-        chain_expression_needs_parens(self.span, self.parent)
+        chain_expression_needs_parens(self.span, self.parent())
     }
 }
 
@@ -681,10 +681,10 @@ impl NeedsParentheses<'_> for AstNode<'_, Class<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         matches!(parent, AstNodes::TaggedTemplateExpression(_))
             || self.is_call_like_callee()
-            || (is_class_extends(self.span, self.parent) && !self.decorators.is_empty())
+            || (is_class_extends(self.span, self.parent()) && !self.decorators.is_empty())
             || is_first_in_statement(
                 self.span,
                 parent,
@@ -705,7 +705,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ArrowFunctionExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         if matches!(
             parent,
             AstNodes::TSAsExpression(_)
@@ -733,7 +733,7 @@ impl NeedsParentheses<'_> for AstNode<'_, YieldExpression<'_>> {
             return false;
         }
 
-        let parent = self.parent;
+        let parent = self.parent();
         matches!(parent, AstNodes::AwaitExpression(_) | AstNodes::TSTypeAssertion(_))
             || await_or_yield_needs_parens(self.span(), parent)
     }
@@ -779,24 +779,24 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXEmptyExpression> {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSAsExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent)
+        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSSatisfiesExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent)
+        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSTypeAssertion<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSAsExpression(_) | AstNodes::TSSatisfiesExpression(_) => true,
             AstNodes::BinaryExpression(binary) => {
                 matches!(binary.operator, BinaryOperator::ShiftLeft)
             }
-            _ => type_cast_like_needs_parens(self.span(), self.parent),
+            _ => type_cast_like_needs_parens(self.span(), self.parent()),
         }
     }
 }
@@ -830,7 +830,7 @@ fn type_cast_like_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSNonNullExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        let parent = self.parent;
+        let parent = self.parent();
         is_class_extends(self.span, parent)
             || (self.is_new_callee() && member_chain_callee_needs_parens(&self.expression))
     }
@@ -838,7 +838,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSNonNullExpression<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSInstantiationExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        let expr = match self.parent {
+        let expr = match self.parent() {
             AstNodes::StaticMemberExpression(expr) => &expr.object,
             AstNodes::ComputedMemberExpression(expr) => &expr.object,
             AstNodes::PrivateFieldExpression(expr) => &expr.object,
@@ -928,8 +928,8 @@ enum UnaryLike<'a, 'b> {
 impl UnaryLike<'_, '_> {
     fn parent(&self) -> &AstNodes<'_> {
         match self {
-            Self::UpdateExpression(e) => e.parent,
-            Self::UnaryExpression(e) => e.parent,
+            Self::UpdateExpression(e) => e.parent(),
+            Self::UnaryExpression(e) => e.parent(),
         }
     }
 }
@@ -1142,7 +1142,7 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXElement<'_>> {
             return false;
         }
 
-        jsx_element_or_fragment_needs_paren(self.span, self.parent)
+        jsx_element_or_fragment_needs_paren(self.span, self.parent())
     }
 }
 
@@ -1152,6 +1152,6 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXFragment<'_>> {
             return false;
         }
 
-        jsx_element_or_fragment_needs_paren(self.span, self.parent)
+        jsx_element_or_fragment_needs_paren(self.span, self.parent())
     }
 }

--- a/crates/oxc_formatter/src/parentheses/ts_type.rs
+++ b/crates/oxc_formatter/src/parentheses/ts_type.rs
@@ -29,16 +29,16 @@ impl NeedsParentheses<'_> for AstNode<'_, TSType<'_>> {
 impl NeedsParentheses<'_> for AstNode<'_, TSFunctionType<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        function_like_type_needs_parentheses(self.span(), self.parent, Some(&self.return_type))
+        function_like_type_needs_parentheses(self.span(), self.parent(), Some(&self.return_type))
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSInferType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSIntersectionType(_) | AstNodes::TSUnionType(_) => true,
             AstNodes::TSRestType(_) => false,
-            _ => operator_type_or_higher_needs_parens(self.span, self.parent),
+            _ => operator_type_or_higher_needs_parens(self.span, self.parent()),
         }
     }
 }
@@ -46,13 +46,13 @@ impl NeedsParentheses<'_> for AstNode<'_, TSInferType<'_>> {
 impl NeedsParentheses<'_> for AstNode<'_, TSConstructorType<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        function_like_type_needs_parentheses(self.span(), self.parent, Some(&self.return_type))
+        function_like_type_needs_parentheses(self.span(), self.parent(), Some(&self.return_type))
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSUnionType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSUnionType(union) => self.types.len() > 1 && union.types.len() > 1,
             AstNodes::TSIntersectionType(intersection) => {
                 self.types.len() > 1 && intersection.types.len() > 1
@@ -75,7 +75,7 @@ fn function_like_type_needs_parentheses<'a>(
     match parent {
         // Arrow function return types need parens
         AstNodes::TSTypeAnnotation(type_annotation) => {
-            matches!(type_annotation.parent, AstNodes::ArrowFunctionExpression(_))
+            matches!(type_annotation.parent(), AstNodes::ArrowFunctionExpression(_))
         }
         // In conditional types
         AstNodes::TSConditionalType(conditional) => {
@@ -125,7 +125,7 @@ fn operator_type_or_higher_needs_parens(span: Span, parent: &AstNodes) -> bool {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSIntersectionType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSUnionType(union) => self.types.len() > 1 && union.types.len() > 1,
             AstNodes::TSIntersectionType(intersection) => {
                 self.types.len() > 1 && intersection.types.len() > 1
@@ -137,26 +137,26 @@ impl NeedsParentheses<'_> for AstNode<'_, TSIntersectionType<'_>> {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSConditionalType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSConditionalType(ty) => {
                 ty.extends_type().span() == self.span() || ty.check_type().span() == self.span()
             }
             AstNodes::TSUnionType(union) => union.types.len() > 1,
             AstNodes::TSIntersectionType(intersection) => intersection.types.len() > 1,
-            _ => operator_type_or_higher_needs_parens(self.span, self.parent),
+            _ => operator_type_or_higher_needs_parens(self.span, self.parent()),
         }
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSTypeOperator<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        operator_type_or_higher_needs_parens(self.span(), self.parent)
+        operator_type_or_higher_needs_parens(self.span(), self.parent())
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSTypeQuery<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
-        match self.parent {
+        match self.parent() {
             AstNodes::TSArrayType(_) => true,
             // Typeof operators are parenthesized when used as an object type in an indexed access
             // to avoid ambiguity of precedence, as it's higher than the JS equivalent:

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -27,7 +27,7 @@ impl<'a, 'b> ArrayElementList<'a, 'b> {
 impl<'a> Format<'a> for ArrayElementList<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let layout =
-            if can_concisely_print_array_list(self.elements.parent.span(), self.elements, f) {
+            if can_concisely_print_array_list(self.elements.parent().span(), self.elements, f) {
                 ArrayLayout::Fill
             } else {
                 ArrayLayout::OnePerLine

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -197,7 +197,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
 
                     let should_add_soft_line = is_last_call_arg
                         // if it's inside a JSXExpression (e.g. an attribute) we should align the expression's closing } with the line with the opening {.
-                        || (matches!(self.arrow.parent, AstNodes::JSXExpressionContainer(container)
+                        || (matches!(self.arrow.parent(), AstNodes::JSXExpressionContainer(container)
                             if !f.context().comments().has_comment_in_range(arrow.span.end, container.span.end)));
 
                     write!(
@@ -603,7 +603,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
         let format_tail_body = format_with(|f| {
             // if it's inside a JSXExpression (e.g. an attribute) we should align the expression's closing } with the line with the opening {.
             let should_add_soft_line =
-                matches!(self.head.parent, AstNodes::JSXExpressionContainer(_));
+                matches!(self.head.parent(), AstNodes::JSXExpressionContainer(_));
 
             if body_on_separate_line {
                 write!(

--- a/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent);
+        let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent());
         format_as_or_satisfies_expression(
             self.expression(),
             self.type_annotation(),
@@ -23,7 +23,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent);
+        let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent());
         format_as_or_satisfies_expression(
             self.expression(),
             self.type_annotation(),

--- a/crates/oxc_formatter/src/print/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/print/binary_like_expression.rs
@@ -77,8 +77,8 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
 
     pub fn parent(&self) -> &AstNodes<'a> {
         match self {
-            Self::LogicalExpression(expr) => expr.parent,
-            Self::BinaryExpression(expr) => expr.parent,
+            Self::LogicalExpression(expr) => expr.parent(),
+            Self::BinaryExpression(expr) => expr.parent(),
         }
     }
 
@@ -148,11 +148,11 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
             | AstNodes::ForStatement(_)
             | AstNodes::TemplateLiteral(_) => true,
             AstNodes::JSXExpressionContainer(container) => {
-                matches!(container.parent, AstNodes::JSXAttribute(_))
+                matches!(container.parent(), AstNodes::JSXAttribute(_))
             }
             AstNodes::ExpressionStatement(statement) => statement.is_arrow_function_body(),
             AstNodes::ConditionalExpression(conditional) => !matches!(
-                conditional.parent,
+                conditional.parent(),
                 AstNodes::ReturnStatement(_)
                     | AstNodes::ThrowStatement(_)
                     | AstNodes::CallExpression(_)

--- a/crates/oxc_formatter/src/print/block_statement.rs
+++ b/crates/oxc_formatter/src/print/block_statement.rs
@@ -21,7 +21,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "{");
 
-        let comments_before_catch_clause = if let AstNodes::CatchClause(catch) = self.parent {
+        let comments_before_catch_clause = if let AstNodes::CatchClause(catch) = self.parent() {
             f.context().get_cached_element(&catch.span)
         } else {
             None
@@ -51,7 +51,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
                         format_dangling_comments(self.span)
                     ))
                 );
-            } else if is_non_collapsible(self.parent) {
+            } else if is_non_collapsible(self.parent()) {
                 write!(f, hard_line_break());
             }
         } else {
@@ -83,7 +83,7 @@ fn is_non_collapsible(parent: &AstNodes<'_>) -> bool {
         | AstNodes::TSGlobalDeclaration(_) => false,
         AstNodes::CatchClause(catch) => {
             // prettier collapse the catch block when it don't have `finalizer`, insert a new line when it has `finalizer`
-            matches!(catch.parent, AstNodes::TryStatement(try_stmt) if try_stmt.finalizer().is_some())
+            matches!(catch.parent(), AstNodes::TryStatement(try_stmt) if try_stmt.finalizer().is_some())
         }
         _ => true,
     }

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -47,7 +47,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                 [
                     l_paren_token,
                     // `call/* comment1 */(/* comment2 */)` Both comments are dangling comments.
-                    format_dangling_comments(self.parent.span()).with_soft_block_indent(),
+                    format_dangling_comments(self.parent().span()).with_soft_block_indent(),
                     r_paren_token
                 ]
             );
@@ -56,7 +56,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         let is_simple_module_import = is_simple_module_import(self, f.comments());
 
         let call_expression =
-            if !is_simple_module_import && let AstNodes::CallExpression(call) = self.parent {
+            if !is_simple_module_import && let AstNodes::CallExpression(call) = self.parent() {
                 Some(call)
             } else {
                 None
@@ -143,7 +143,7 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
                     f.join_with(&separator).entries(self.iter());
                     write!(
                         f,
-                        [(!matches!(self.parent, AstNodes::ImportExpression(_)))
+                        [(!matches!(self.parent(), AstNodes::ImportExpression(_)))
                             .then_some(FormatTrailingCommas::All)]
                     );
                 })),
@@ -236,7 +236,7 @@ fn format_all_elements_broken_out<'a, 'b>(
 
                 write!(
                     f,
-                    [(!matches!(node.parent, AstNodes::ImportExpression(_)))
+                    [(!matches!(node.parent(), AstNodes::ImportExpression(_)))
                         .then_some(FormatTrailingCommas::All)]
                 );
             })),
@@ -270,7 +270,7 @@ fn format_all_args_broken_out<'a, 'b>(
 
                 write!(
                     f,
-                    [(!matches!(node.parent, AstNodes::ImportExpression(_)))
+                    [(!matches!(node.parent(), AstNodes::ImportExpression(_)))
                         .then_some(FormatTrailingCommas::All)]
                 );
             })),
@@ -968,7 +968,7 @@ pub fn is_simple_module_import(
         return false;
     }
 
-    match arguments.parent {
+    match arguments.parent() {
         AstNodes::ImportExpression(_) => {}
         AstNodes::CallExpression(call) => {
             match &call.callee {
@@ -1004,7 +1004,7 @@ pub fn is_simple_module_import(
     }
 
     matches!(arguments.as_ref()[0], Argument::StringLiteral(_))
-        && !comments.has_comment_before(arguments.parent.span().end)
+        && !comments.has_comment_before(arguments.parent().span().end)
 }
 
 /// Tests if amd's [`define`](https://github.com/amdjs/amdjs-api/wiki/AMD#define-function-) function.
@@ -1044,7 +1044,7 @@ fn is_commonjs_or_amd_call(
             }
         }
         "define" => {
-            let in_statement = matches!(call.parent, AstNodes::ExpressionStatement(_));
+            let in_statement = matches!(call.parent(), AstNodes::ExpressionStatement(_));
             if in_statement {
                 match arguments.len() {
                     1 => true,
@@ -1120,7 +1120,7 @@ fn is_react_hook_with_deps_array(
             }
 
             // Is there a comment that isn't around the callback or deps?
-            !comments.comments_before(arguments.parent.span().end).iter().any(|comment| {
+            !comments.comments_before(arguments.parent().span().end).iter().any(|comment| {
                 !callback.span.contains_inclusive(comment.span)
                     && !deps.span.contains_inclusive(comment.span)
             })

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -201,7 +201,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignature<'a>> {
         if self.readonly {
             write!(f, ["readonly", space()]);
         }
-        let is_class = matches!(self.parent, AstNodes::ClassBody(_));
+        let is_class = matches!(self.parent(), AstNodes::ClassBody(_));
         write!(
             f,
             [
@@ -291,7 +291,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
         // to ensure proper placement relative to the export keyword
         if self.is_expression()
             || !matches!(
-                self.parent,
+                self.parent(),
                 AstNodes::ExportNamedDeclaration(_) | AstNodes::ExportDefaultDeclaration(_)
             )
         {
@@ -498,7 +498,7 @@ fn should_group<'a>(class: &AstNode<Class<'a>>, f: &Formatter<'_, 'a>) -> bool {
         return true;
     }
 
-    if (!class.is_expression() || !matches!(class.parent, AstNodes::AssignmentExpression(_)))
+    if (!class.is_expression() || !matches!(class.parent(), AstNodes::AssignmentExpression(_)))
         && class
             .super_class
             .as_ref()

--- a/crates/oxc_formatter/src/print/decorators.rs
+++ b/crates/oxc_formatter/src/print/decorators.rs
@@ -19,7 +19,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
         }
 
         // Check parent to determine formatting context
-        match self.parent {
+        match self.parent() {
             AstNodes::PropertyDefinition(_)
             | AstNodes::MethodDefinition(_)
             | AstNodes::AccessorProperty(_) => {

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -95,7 +95,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
                 specifiers_iter.peek().map(AsRef::as_ref),
                 Some(ImportDeclarationSpecifier::ImportSpecifier(_))
             )
-            && f.comments().comments_before_character(self.parent.span().start, b'}').is_empty()
+            && f.comments().comments_before_character(self.parent().span().start, b'}').is_empty()
         {
             write!(
                 f,
@@ -221,7 +221,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
 
             if self.len() > 1
                 || self.first().is_some_and(|attribute| attribute.key.as_atom().as_str() != "type")
-                || f.comments().has_comment_before(self.parent.span().end)
+                || f.comments().has_comment_before(self.parent().span().end)
             {
                 write!(
                     f,

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -230,8 +230,8 @@ pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
         parent = stmt.grand_parent();
     }
     let maybe_jsx_expression_child = match parent {
-        AstNodes::ArrowFunctionExpression(arrow) if arrow.expression => match arrow.parent {
-            AstNodes::CallExpression(call) => call.parent,
+        AstNodes::ArrowFunctionExpression(arrow) if arrow.expression => match arrow.parent() {
+            AstNodes::CallExpression(call) => call.parent(),
             _ => return false,
         },
         _ => return false,
@@ -239,7 +239,7 @@ pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
     matches!(
         maybe_jsx_expression_child.without_chain_expression(),
         AstNodes::JSXExpressionContainer(container)
-        if matches!(container.parent, AstNodes::JSXElement(_) | AstNodes::JSXFragment(_))
+        if matches!(container.parent(), AstNodes::JSXElement(_) | AstNodes::JSXFragment(_))
     )
 }
 
@@ -278,8 +278,8 @@ impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
 
     fn parent(&self) -> &'b AstNodes<'a> {
         match self {
-            Self::Element(element) => element.parent,
-            Self::Fragment(fragment) => fragment.parent,
+            Self::Element(element) => element.parent(),
+            Self::Fragment(fragment) => fragment.parent(),
         }
     }
 

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -157,7 +157,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
         };
 
         // Expression child
-        if matches!(self.parent, AstNodes::JSXElement(_) | AstNodes::JSXFragment(_)) {
+        if matches!(self.parent(), AstNodes::JSXElement(_) | AstNodes::JSXFragment(_)) {
             if let JSXExpression::EmptyExpression(_) = self.expression {
                 let comments = f.context().comments().comments_before(self.span.end);
                 let has_line_comment = comments.iter().any(|c| c.is_line());

--- a/crates/oxc_formatter/src/print/member_expression.rs
+++ b/crates/oxc_formatter/src/print/member_expression.rs
@@ -89,7 +89,7 @@ fn layout<'a>(
     // `a.b.c!` and `a.b?.c`
     // `TSNonNullExpression` is a wrapper node for `!`, and `ChainExpression` is a wrapper node for `?.`,
     // so we need to skip them to find the real parent node.
-    let mut parent = node.parent;
+    let mut parent = node.parent();
     while matches!(parent, AstNodes::TSNonNullExpression(_) | AstNodes::ChainExpression(_)) {
         parent = parent.parent();
     }

--- a/crates/oxc_formatter/src/print/object_like.rs
+++ b/crates/oxc_formatter/src/print/object_like.rs
@@ -33,18 +33,18 @@ impl<'a> ObjectLike<'a, '_> {
         // const fn = ({ foo }: { foo: string }) => { ... };
         matches!(self, Self::TSTypeLiteral(node) if {
             // Check if parent is TSTypeAnnotation
-            matches!(node.parent, AstNodes::TSTypeAnnotation(type_ann) if {
-                match &type_ann.parent {
+            matches!(node.parent(), AstNodes::TSTypeAnnotation(type_ann) if {
+                match &type_ann.parent() {
                     AstNodes::FormalParameter(param) if param.initializer.is_none() => {
-                        let AstNodes::FormalParameters(parameters) = &param.parent else {
+                        let AstNodes::FormalParameters(parameters) = &param.parent() else {
                             unreachable!()
                         };
-                        let this_param = get_this_param(parameters.parent);
+                        let this_param = get_this_param(parameters.parent());
                         should_hug_function_parameters(parameters, this_param, false, f)
 
                     }
                     AstNodes::TSThisParameter(param) => {
-                        matches!(param.parent, AstNodes::Function(func) if {
+                        matches!(param.parent(), AstNodes::Function(func) if {
                             should_hug_function_parameters(func.params(), Some(param), false, f)
                         })
                     },
@@ -78,7 +78,7 @@ impl<'a> ObjectLike<'a, '_> {
     fn is_inside_jsx_spread(&self) -> bool {
         match self {
             Self::ObjectExpression(o) => {
-                matches!(o.parent, AstNodes::JSXSpreadAttribute(_) | AstNodes::JSXSpreadChild(_))
+                matches!(o.parent(), AstNodes::JSXSpreadAttribute(_) | AstNodes::JSXSpreadChild(_))
             }
             Self::TSTypeLiteral(_) => false,
         }

--- a/crates/oxc_formatter/src/print/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/print/object_pattern_like.rs
@@ -40,10 +40,10 @@ impl<'a> ObjectPatternLike<'a, '_> {
 
     fn is_inline(&self, _f: &Formatter<'_, 'a>) -> bool {
         match self {
-            Self::ObjectPattern(node) => match node.parent {
+            Self::ObjectPattern(node) => match node.parent() {
                 AstNodes::FormalParameter(_) => true,
                 AstNodes::AssignmentPattern(_) => {
-                    matches!(node.parent.parent(), AstNodes::FormalParameter(_))
+                    matches!(node.grand_parent(), AstNodes::FormalParameter(_))
                 }
                 _ => false,
             },
@@ -56,7 +56,7 @@ impl<'a> ObjectPatternLike<'a, '_> {
         match self {
             Self::ObjectPattern(node) => {
                 let parent_is_parameter_or_assignment_pattern = matches!(
-                    node.parent,
+                    node.parent(),
                     AstNodes::CatchParameter(_)
                         | AstNodes::FormalParameter(_)
                         | AstNodes::AssignmentPattern(_)
@@ -90,9 +90,9 @@ impl<'a> ObjectPatternLike<'a, '_> {
 
     fn is_in_assignment_like(&self) -> bool {
         match self {
-            Self::ObjectPattern(node) => matches!(node.parent, AstNodes::VariableDeclarator(_)),
+            Self::ObjectPattern(node) => matches!(node.parent(), AstNodes::VariableDeclarator(_)),
             Self::ObjectAssignmentTarget(node) => matches!(
-                node.parent,
+                node.parent(),
                 AstNodes::AssignmentExpression(_) | AstNodes::VariableDeclarator(_)
             ),
         }

--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -35,13 +35,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
             write!(f, [space(), FormatTrailingComments::Comments(comments)]);
         }
 
-        let parentheses_not_needed = if let AstNodes::ArrowFunctionExpression(arrow) = self.parent {
+        let parentheses_not_needed = if let AstNodes::ArrowFunctionExpression(arrow) = self.parent()
+        {
             can_avoid_parentheses(arrow, f)
         } else {
             false
         };
 
-        let this_param = get_this_param(self.parent);
+        let this_param = get_this_param(self.parent());
 
         let has_any_decorated_parameter =
             self.items.iter().any(|param| !param.decorators.is_empty());
@@ -53,7 +54,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
             ParameterLayout::NoParameters
         } else if can_hug || {
             // `self`: FormalParameters
-            // `self.parent`: ArrowFunctionExpression/Function
+            // `self.parent()`: ArrowFunctionExpression/Function
             // `self.grand_parent()`: CallExpression
             if let AstNodes::CallExpression(call) = self.grand_parent() {
                 // Check if parent is a test call, but exclude angular test wrappers
@@ -131,11 +132,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
             }
         });
 
-        let is_hug_parameter = matches!(self.parent, AstNodes::FormalParameters(params) if {
-            let (parentheses_not_needed, this_param) = if let AstNodes::ArrowFunctionExpression(arrow) = params.parent {
+        let is_hug_parameter = matches!(self.parent(), AstNodes::FormalParameters(params) if {
+            let (parentheses_not_needed, this_param) = if let AstNodes::ArrowFunctionExpression(arrow) = params.parent() {
                 (can_avoid_parentheses(arrow, f), None)
             } else {
-                (false, get_this_param(params.parent))
+                (false, get_this_param(params.parent()))
             };
             should_hug_function_parameters(params, this_param, parentheses_not_needed, f)
         });

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -150,7 +150,7 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
         };
 
         // Yield expressions only need to check the leading comments on the left side.
-        if matches!(argument.parent, AstNodes::YieldExpression(_)) {
+        if matches!(argument.parent(), AstNodes::YieldExpression(_)) {
             continue;
         }
 

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -29,8 +29,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
                 joiner.entries(expressions);
             });
 
-            if matches!(self.parent, AstNodes::ForStatement(_))
-                || (matches!(self.parent, AstNodes::ExpressionStatement(statement)
+            if matches!(self.parent(), AstNodes::ForStatement(_))
+                || (matches!(self.parent(), AstNodes::ExpressionStatement(statement)
                     if !statement.is_arrow_function_body()))
             {
                 write!(f, [indent(&rest)]);

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -838,11 +838,11 @@ fn try_format_embedded_template<'a>(
 /// <style jsx>{`div { color: red; }`}</style>
 /// ```
 fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
-    let AstNodes::JSXExpressionContainer(container) = node.parent else {
+    let AstNodes::JSXExpressionContainer(container) = node.parent() else {
         return false;
     };
 
-    match container.parent {
+    match container.parent() {
         AstNodes::JSXAttribute(attribute) => {
             if let JSXAttributeName::Identifier(ident) = &attribute.name
                 && ident.name == "css"
@@ -917,10 +917,10 @@ fn try_format_angular_component<'a>(
 /// })
 /// ```
 fn get_angular_component_language(node: &AstNode<'_, TemplateLiteral<'_>>) -> Option<&'static str> {
-    let prop = match node.parent {
+    let prop = match node.parent() {
         AstNodes::ObjectProperty(prop) => prop,
         AstNodes::ArrayExpression(arr) => {
-            let AstNodes::ObjectProperty(prop) = arr.parent else {
+            let AstNodes::ObjectProperty(prop) = arr.parent() else {
                 return None;
             };
             prop
@@ -937,10 +937,10 @@ fn get_angular_component_language(node: &AstNode<'_, TemplateLiteral<'_>>) -> Op
     };
 
     // Check parent chain: ObjectExpression -> CallExpression(Component) -> Decorator
-    let AstNodes::ObjectExpression(obj) = prop.parent else {
+    let AstNodes::ObjectExpression(obj) = prop.parent() else {
         return None;
     };
-    let AstNodes::CallExpression(call) = obj.parent else {
+    let AstNodes::CallExpression(call) = obj.parent() else {
         return None;
     };
     let Expression::Identifier(ident) = &call.callee else {
@@ -949,7 +949,7 @@ fn get_angular_component_language(node: &AstNode<'_, TemplateLiteral<'_>>) -> Op
     if ident.name.as_str() != "Component" {
         return None;
     }
-    if !matches!(call.parent, AstNodes::Decorator(_)) {
+    if !matches!(call.parent(), AstNodes::Decorator(_)) {
         return None;
     }
 

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -217,7 +217,7 @@ fn is_arrow_function_variable_type_argument<'a>(
         &node.grand_parent(),
         AstNodes::TSTypeAnnotation(type_annotation)
             if matches!(
-                &type_annotation.parent,
+                &type_annotation.parent(),
                 AstNodes::VariableDeclarator(var_decl)
                     if matches!(&var_decl.init, Some(Expression::ArrowFunctionExpression(_)))
             )

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -46,14 +46,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
         let leading_comments = f.context().comments().comments_before(self.span().start);
         let has_leading_comments = !leading_comments.is_empty();
         let mut union_type_at_top = self;
-        while let AstNodes::TSUnionType(parent) = union_type_at_top.parent
+        while let AstNodes::TSUnionType(parent) = union_type_at_top.parent()
             && parent.types().len() == 1
         {
             union_type_at_top = parent;
         }
 
         let should_indent = {
-            let parent = union_type_at_top.parent;
+            let parent = union_type_at_top.parent();
 
             // These parents have indent for their content, so we don't need to indent here
             match parent {
@@ -103,7 +103,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                 return write!(f, [indent(&types), soft_line_break()]);
             }
 
-            let is_inside_complex_tuple_type = match self.parent {
+            let is_inside_complex_tuple_type = match self.parent() {
                 AstNodes::TSTupleType(tuple) => tuple.element_types().len() > 1,
                 _ => false,
             };
@@ -217,7 +217,7 @@ fn format_union_types<'a>(
                 write!(f, [soft_line_break_or_space()]);
             }
             write!(f, ["|"]);
-        } else if let AstNodes::TSUnionType(parent) = element.parent
+        } else if let AstNodes::TSUnionType(parent) = element.parent()
             && parent.needs_parentheses(f)
         {
             // ```ts

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -16,7 +16,7 @@ use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let semicolon = match self.parent {
+        let semicolon = match self.parent() {
             AstNodes::ExportNamedDeclaration(_) => false,
             AstNodes::ForStatement(stmt) => {
                 stmt.init().is_some_and(|init| init.span() != self.span())
@@ -70,7 +70,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
         if length == 1 && !f.comments().has_comment_before(first_declarator.span().start) {
             return if first_declarator.init.is_none()
                 && f.comments()
-                    .has_comment_in_range(first_declarator.span.end, self.parent.span().end)
+                    .has_comment_in_range(first_declarator.span.end, self.parent().span().end)
             {
                 write!(f, indent(&first_declarator));
             } else {

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -500,13 +500,13 @@ impl<'a> AssignmentLike<'a, '_> {
             // First, we check if the current node is an assignment expression
             if let Self::AssignmentExpression(assignment) = self {
                 // Then we check if the parent is assignment expression or variable declarator
-                let parent = assignment.parent;
+                let parent = assignment.parent();
                 // Determine if the chain is eligible based on the following checks:
                 // 1. For variable declarators: only continue if this isn't the final assignment in the chain
                 (matches!(parent, AstNodes::VariableDeclarator(_)) && !right_is_tail) ||
                 // 2. For assignment expressions: continue unless this is the final assignment in an expression statement
                 matches!(parent, AstNodes::AssignmentExpression(parent_assignment)
-                    if !right_is_tail || !matches!(parent_assignment.parent, AstNodes::ExpressionStatement(_))
+                    if !right_is_tail || !matches!(parent_assignment.parent(), AstNodes::ExpressionStatement(_))
                 )
             } else {
                 false

--- a/crates/oxc_formatter/src/utils/call_expression.rs
+++ b/crates/oxc_formatter/src/utils/call_expression.rs
@@ -36,7 +36,7 @@ pub fn is_test_call_expression(call: &AstNode<CallExpression<'_>>) -> bool {
     match (args.next(), args.next(), args.next()) {
         (Some(argument), None, None) if arguments.len() == 1 => {
             if is_angular_test_wrapper(call) && {
-                if let AstNodes::CallExpression(call) = call.parent {
+                if let AstNodes::CallExpression(call) = call.parent() {
                     is_test_call_expression(call)
                 } else {
                     false

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -32,8 +32,8 @@ impl<'a> ConditionalLike<'a, '_> {
     #[inline]
     fn parent(&self) -> &AstNodes<'a> {
         match self {
-            ConditionalLike::ConditionalExpression(expr) => expr.parent,
-            ConditionalLike::TSConditionalType(ty) => ty.parent,
+            ConditionalLike::ConditionalExpression(expr) => expr.parent(),
+            ConditionalLike::TSConditionalType(ty) => ty.parent(),
         }
     }
 
@@ -251,7 +251,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
         };
 
         let mut expression_span = expr.span;
-        let mut parent = expr.parent;
+        let mut parent = expr.parent();
 
         // This tries to find the start of a member chain by iterating over all ancestors of the conditional.
         // The iteration "breaks" as soon as a non-member-chain node is found.
@@ -260,7 +260,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 AstNodes::ChainExpression(chain) => {
                     if chain.expression.span() == expression_span {
                         expression_span = chain.span();
-                        parent = chain.parent;
+                        parent = chain.parent();
                     } else {
                         break;
                     }
@@ -268,7 +268,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 AstNodes::StaticMemberExpression(member) => {
                     if member.object.span() == expression_span {
                         expression_span = member.span();
-                        parent = member.parent;
+                        parent = member.parent();
                     } else {
                         break;
                     }
@@ -276,7 +276,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 AstNodes::ComputedMemberExpression(member) => {
                     if member.object.span() == expression_span {
                         expression_span = member.span();
-                        parent = member.parent;
+                        parent = member.parent();
                     } else {
                         break;
                     }
@@ -284,7 +284,7 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 AstNodes::CallExpression(call) => {
                     if call.callee.span() == expression_span {
                         expression_span = call.span();
-                        parent = call.parent;
+                        parent = call.parent();
                     } else {
                         break;
                     }
@@ -292,27 +292,27 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 AstNodes::TSNonNullExpression(assertion) => {
                     if assertion.expression.span() == expression_span {
                         expression_span = assertion.span();
-                        parent = assertion.parent;
+                        parent = assertion.parent();
                     } else {
                         break;
                     }
                 }
                 AstNodes::NewExpression(new_expr) => {
-                    parent = new_expr.parent;
+                    parent = new_expr.parent();
                     if new_expr.callee.span() == expression_span {
                         expression_span = new_expr.span();
                     }
                     break;
                 }
                 AstNodes::TSAsExpression(as_expr) => {
-                    parent = as_expr.parent;
+                    parent = as_expr.parent();
                     if as_expr.expression.span() == expression_span {
                         expression_span = as_expr.span();
                     }
                     break;
                 }
                 AstNodes::TSSatisfiesExpression(satisfies) => {
-                    parent = satisfies.parent;
+                    parent = satisfies.parent();
                     if satisfies.expression.span() == expression_span {
                         expression_span = satisfies.span();
                     }

--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -84,7 +84,7 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
                 );
 
                 // `A.b /* comment */ (c)` -> `A.b(/* comment */ c)`
-                if !matches!(member.parent, AstNodes::CallExpression(call) if call.type_arguments.is_none() && !call.optional)
+                if !matches!(member.parent(), AstNodes::CallExpression(call) if call.type_arguments.is_none() && !call.optional)
                 {
                     member.format_trailing_comments(f);
                 }

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -52,7 +52,7 @@ impl<'a, 'b> MemberChain<'a, 'b> {
 
         // Here we check if the first element of Groups::groups can be moved inside the head.
         // If so, then we extract it and concatenate it together with the head.
-        member_chain.maybe_merge_with_first_group(call_expression.parent, f);
+        member_chain.maybe_merge_with_first_group(call_expression.parent(), f);
 
         member_chain
     }

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -24,7 +24,7 @@ use crate::ast_nodes::{AstNode, AstNodes};
 /// `connect(a, b, c)(d)`
 /// ```
 pub fn is_long_curried_call(call: &AstNode<'_, CallExpression<'_>>) -> bool {
-    if let AstNodes::CallExpression(parent_call) = call.parent
+    if let AstNodes::CallExpression(parent_call) = call.parent()
         && parent_call.is_callee_span(call.span)
     {
         return call.arguments().len() > parent_call.arguments().len()

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -14,7 +14,7 @@ use crate::{
 pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
     if let PropertyKey::StringLiteral(s) = key.as_ref() {
         // `"constructor"` property in the class should be kept quoted
-        let kind = if matches!(key.parent, AstNodes::PropertyDefinition(_))
+        let kind = if matches!(key.parent(), AstNodes::PropertyDefinition(_))
             && matches!(key.as_ref(), PropertyKey::StringLiteral(string) if string.value == "constructor")
         {
             StringLiteralParentKind::Expression

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -43,7 +43,7 @@ impl<'a> Format<'a> for FormatStatementBody<'a, '_> {
             write!(f, empty);
         } else if let AstNodes::BlockStatement(block) = self.body.as_ast_nodes() {
             write!(f, [space()]);
-            if matches!(self.body.parent, AstNodes::IfStatement(_)) {
+            if matches!(self.body.parent(), AstNodes::IfStatement(_)) {
                 write!(f, [block]);
             } else {
                 // Use `write` instead of `format` to avoid printing leading comments of the block.
@@ -67,7 +67,7 @@ impl<'a> Format<'a> for FormatStatementBody<'a, '_> {
 
                     let body_span = self.body.span();
                     let is_consequent_of_if_statement_parent = matches!(
-                        self.body.parent,
+                        self.body.parent(),
                         AstNodes::IfStatement(if_stmt)
                         if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
                     );

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -212,7 +212,7 @@ pub fn write_tailwind_string_literal<'a>(
         f.source_text().text_for(&string_literal),
         // `className="string"`
         //            ^^^^^^^^
-        matches!(string_literal.parent, AstNodes::JSXAttribute(_)),
+        matches!(string_literal.parent(), AstNodes::JSXAttribute(_)),
         StringLiteralParentKind::Expression,
     )
     .clean_text(f);


### PR DESCRIPTION
Prepare for #18428 

Additionally, I think this is a good change. Considering there are `grand_parent` and `ancestor` methods in the AstNode, this change maintains consistency in accessing related information.