### PR TITLE
refactor(napi/transform)!: remove `useBuiltIns` / `useSpread` options

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -251,23 +251,6 @@ export interface JsxOptions {
    */
   pragmaFrag?: string
   /**
-   * When spreading props, use `Object.assign` directly instead of an extend helper.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useBuiltIns?: boolean
-  /**
-   * When spreading props, use inline object with spread elements directly
-   * instead of an extend helper or Object.assign.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useSpread?: boolean
-  /**
    * Enable React Fast Refresh .
    *
    * Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -566,21 +566,6 @@ pub struct JsxOptions {
     /// @default 'React.Fragment'
     pub pragma_frag: Option<String>,
 
-    /// When spreading props, use `Object.assign` directly instead of an extend helper.
-    ///
-    /// Only used for `classic` {@link runtime}.
-    ///
-    /// @default false
-    pub use_built_ins: Option<bool>,
-
-    /// When spreading props, use inline object with spread elements directly
-    /// instead of an extend helper or Object.assign.
-    ///
-    /// Only used for `classic` {@link runtime}.
-    ///
-    /// @default false
-    pub use_spread: Option<bool>,
-
     /// Enable React Fast Refresh .
     ///
     /// Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
@@ -603,8 +588,8 @@ impl From<JsxOptions> for oxc::transformer::JsxOptions {
             import_source: options.import_source,
             pragma: options.pragma,
             pragma_frag: options.pragma_frag,
-            use_built_ins: options.use_built_ins,
-            use_spread: options.use_spread,
+            use_built_ins: None,
+            use_spread: None,
             refresh: options.refresh.and_then(|value| match value {
                 Either::A(b) => b.then(oxc::transformer::ReactRefreshOptions::default),
                 Either::B(options) => Some(oxc::transformer::ReactRefreshOptions::from(options)),


### PR DESCRIPTION
These options does not change the behavior so I think it's better not to expose these to users.
https://github.com/oxc-project/oxc/blob/671c2fc96d767eed91e19c3cec0986394d75c282/crates/oxc_transformer/src/jsx/options.rs#L96-L104
