### PR TITLE
fix(formatter): preserve trailing comments inside ternary alternate branch

### DIFF
--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -45,8 +45,24 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
             && arrow.expression
         {
             f.context().comments().comments_before(arrow.span.end)
-        } else if matches!(self.parent(), AstNodes::ConditionalExpression(_)) {
-            f.context().comments().end_of_line_comments_after(self.span().end)
+        } else if let AstNodes::ConditionalExpression(conditional) = self.parent() {
+            if self.span() == conditional.alternate.span() {
+                // Since `preserveParens` is disabled, `conditional.alternate.span` only covers
+                // `<Success />`, not the surrounding parentheses or comments within them:
+                // ```jsx
+                // false ? (
+                //   <Error />
+                // ) : (
+                //   <Success />
+                //   /* comment */
+                // )
+                // ```
+                // To capture comments like the one above, we get all comments before the
+                // conditional expression's end (which includes the closing paren).
+                f.context().comments().comments_before(conditional.span.end)
+            } else {
+                f.context().comments().end_of_line_comments_after(self.span().end)
+            }
         } else {
             // Fall back to default trailing comments behavior
             return match self {

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx
@@ -49,3 +49,15 @@ const x = (
     )}
   </>
 );
+
+// https://github.com/oxc-project/oxc/issues/18419
+const Component = () => (
+  <div>
+    {"error" ? (
+      <Error />
+    ) : (
+      <Success />
+      /* This is a comment inside the expression */
+    )}
+  </div>
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/ternary-with-comment.jsx.snap
@@ -54,6 +54,18 @@ const x = (
   </>
 );
 
+// https://github.com/oxc-project/oxc/issues/18419
+const Component = () => (
+  <div>
+    {"error" ? (
+      <Error />
+    ) : (
+      <Success />
+      /* This is a comment inside the expression */
+    )}
+  </div>
+);
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -112,6 +124,18 @@ const x = (
   </>
 );
 
+// https://github.com/oxc-project/oxc/issues/18419
+const Component = () => (
+  <div>
+    {"error" ? (
+      <Error />
+    ) : (
+      <Success />
+      /* This is a comment inside the expression */
+    )}
+  </div>
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -167,6 +191,18 @@ const x = (
       <div />
     )}
   </>
+);
+
+// https://github.com/oxc-project/oxc/issues/18419
+const Component = () => (
+  <div>
+    {"error" ? (
+      <Error />
+    ) : (
+      <Success />
+      /* This is a comment inside the expression */
+    )}
+  </div>
 );
 
 ===================== End =====================


### PR DESCRIPTION
Fixes: #18419
