### PR TITLE
chore(tasks): unify printing differences for mismatch code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,6 @@ dependencies = [
  "oxc_tasks_common",
  "oxc_tasks_transform_checker",
  "pico-args",
- "similar",
  "walkdir",
 ]
 
@@ -2473,7 +2472,6 @@ dependencies = [
  "oxc_traverse",
  "pico-args",
  "rustc-hash",
- "similar",
 ]
 
 [[package]]

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -39,7 +39,6 @@ rustc-hash = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 pico-args = { workspace = true }
-similar = { workspace = true }
 
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_minifier = { workspace = true }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -849,7 +849,6 @@ mod test {
     use std::path::Path;
 
     use rustc_hash::FxHashSet;
-    use similar::TextDiff;
 
     use oxc_allocator::Allocator;
     use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
@@ -857,7 +856,7 @@ mod test {
     use oxc_parser::Parser;
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
-    use oxc_tasks_common::print_text_diff;
+    use oxc_tasks_common::print_diff_in_terminal;
     use oxc_transformer::{JsxRuntime, TransformOptions, Transformer};
 
     use super::ModuleRunnerTransform;
@@ -920,8 +919,7 @@ mod test {
         let expected = format_expected_code(expected);
         let result = transform(source_text, false).unwrap().code;
         if result != expected {
-            let diff = TextDiff::from_lines(&expected, &result);
-            print_text_diff(&diff);
+            print_diff_in_terminal(&expected, &result);
             panic!("Expected code does not match the result");
         }
     }
@@ -931,8 +929,7 @@ mod test {
         let expected = format_expected_code(expected);
         let result = transform(source_text, true).unwrap().code;
         if result != expected {
-            let diff = TextDiff::from_lines(&expected, &result);
-            print_text_diff(&diff);
+            print_diff_in_terminal(&expected, &result);
             panic!("Expected code does not match the result");
         }
     }
@@ -943,8 +940,7 @@ mod test {
         let TransformReturn { code, deps: result_deps, dynamic_deps: result_dynamic_deps } =
             transform(source_text, false).unwrap();
         if code != expected {
-            let diff = TextDiff::from_lines(&expected, &code);
-            print_text_diff(&diff);
+            print_diff_in_terminal(&expected, &code);
             panic!("Expected code does not match the result");
         }
         for dep in deps {

--- a/tasks/common/src/diff.rs
+++ b/tasks/common/src/diff.rs
@@ -28,6 +28,7 @@ const CONTEXT_LINES: usize = 3;
 /// +  43 │    new_code();
 ///    44 │}
 /// ```
+/// Simple API that creates a diff from two strings and prints it.
 pub fn print_diff_in_terminal(expected: &str, result: &str) {
     let diff = TextDiff::from_lines(expected, result);
     print_text_diff(&diff);

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -26,7 +26,6 @@ oxc = { workspace = true, features = ["full", "isolated_declarations", "serializ
 oxc_formatter = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_tasks_transform_checker = { workspace = true }
-
 console = { workspace = true }
 encoding_rs = { workspace = true }
 encoding_rs_io = { workspace = true }

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -29,5 +29,4 @@ oxc_tasks_transform_checker = { workspace = true }
 cow-utils = { workspace = true }
 indexmap = { workspace = true }
 pico-args = { workspace = true }
-similar = { workspace = true }
 walkdir = { workspace = true }

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use cow_utils::CowUtils;
-use similar::TextDiff;
 
 use oxc::{
     allocator::Allocator,
@@ -14,7 +13,7 @@ use oxc::{
     span::{SourceType, VALID_EXTENSIONS},
     transformer::{BabelOptions, HelperLoaderMode, TransformOptions},
 };
-use oxc_tasks_common::{normalize_path, print_text_diff, project_root};
+use oxc_tasks_common::{normalize_path, print_diff_in_terminal, project_root};
 
 use crate::{
     TestRunnerOptions,
@@ -361,9 +360,8 @@ impl TestCase {
                 if let Some(actual_errors) = &actual_errors {
                     println!("{actual_errors}\n");
                     if !passed {
-                        let diff = TextDiff::from_lines(&output, actual_errors);
                         println!("Diff:\n");
-                        print_text_diff(&diff);
+                        print_diff_in_terminal(&output, actual_errors);
                     }
                 }
             } else {
@@ -376,9 +374,8 @@ impl TestCase {
                     println!("{actual_errors}\n");
                 }
                 if !passed {
-                    let diff = TextDiff::from_lines(&output, &self.transformed_code);
                     println!("Diff:\n");
-                    print_text_diff(&diff);
+                    print_diff_in_terminal(&output, &self.transformed_code);
                 }
             }
 


### PR DESCRIPTION
Instead of implementing printing diffs everywhere, use a unified method to make the code cleaner and maintain consistency.