### PR TITLE
chore(formatter): support `--diff` in example

### DIFF
--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -37,7 +37,7 @@ unicode-width = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-oxc_tasks_common = { path = "../../tasks/common" }
+oxc_tasks_common = { workspace = true }
 pico-args = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Pass `--diff` to compare the formatted code to the input, which is very useful when you copy the Prettier output here to check if it is formatted as expected or for idempotency testing.