### PR TITLE
feat(linter/plugins): `RuleTester` support settings

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -22,6 +22,7 @@ import type { RequireAtLeastOne } from "type-fest";
 import type { Plugin, Rule } from "../plugins/load.ts";
 import type { Options } from "../plugins/options.ts";
 import type { DiagnosticData, Suggestion } from "../plugins/report.ts";
+import type { Settings } from "../plugins/settings.ts";
 import type { ParseOptions } from "./parse.ts";
 
 // ------------------------------------------------------------------------------
@@ -248,6 +249,7 @@ const TEST_CASE_PROP_KEYS = new Set([
   "only",
   "filename",
   "options",
+  "settings",
   "before",
   "after",
   "output",
@@ -265,6 +267,7 @@ interface TestCase extends Config {
   only?: boolean;
   filename?: string;
   options?: Options;
+  settings?: Settings;
   before?: (this: this) => void;
   after?: (this: this) => void;
 }
@@ -985,8 +988,8 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
     if (CONFORMANCE) setEcmaVersionAndFeatures(test);
 
     // Get globals and settings
-    const globalsJSON: string = getGlobalsJson(test);
-    const settingsJSON = "{}"; // TODO
+    const globalsJSON = getGlobalsJson(test);
+    const settingsJSON = JSON.stringify(test.settings ?? {});
 
     // Lint file.
     // Buffer is stored already, at index 0. No need to pass it.

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -3109,4 +3109,65 @@ describe("RuleTester", () => {
       });
     });
   });
+
+  describe("settings", () => {
+    const settingsReporterRule: Rule = {
+      create(context) {
+        return {
+          Program(node) {
+            context.report({
+              message: `settings: ${JSON.stringify(context.settings)}`,
+              node,
+            });
+          },
+        };
+      },
+    };
+
+    it("is empty object if no settings defined", () => {
+      const tester = new RuleTester();
+      tester.run("no-foo", settingsReporterRule, {
+        valid: [],
+        invalid: [
+          {
+            code: "",
+            errors: [
+              {
+                message: "settings: {}",
+              },
+            ],
+          },
+        ],
+      });
+      expect(runCases()).toEqual([null]);
+    });
+
+    it("reflects defined settings", () => {
+      const tester = new RuleTester();
+      tester.run("no-foo", settingsReporterRule, {
+        valid: [],
+        invalid: [
+          {
+            code: "",
+            settings: { foo: 123, nested: { bar: true, qux: null } },
+            errors: [
+              {
+                message: 'settings: {"foo":123,"nested":{"bar":true,"qux":null}}',
+              },
+            ],
+          },
+          {
+            code: "",
+            settings: { x: "y" },
+            errors: [
+              {
+                message: 'settings: {"x":"y"}',
+              },
+            ],
+          },
+        ],
+      });
+      expect(runCases()).toEqual([null, null]);
+    });
+  });
 });


### PR DESCRIPTION
Support `settings` in test case config in `RuleTester`. The settings from config are available in the rule as `context.settings`.