### PR TITLE
fix(formatter): preserve trailing comments before the semicolon in class methods without a body

### DIFF
--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -125,7 +125,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
 
         if let Some(body) = &value.body() {
             write!(f, body);
+        } else {
+            let comments = f.context().comments().comments_before(self.span.end);
+            write!(f, FormatTrailingComments::Comments(comments));
         }
+
         if self.r#type().is_abstract()
             || matches!(value.r#type, FunctionType::TSEmptyBodyFunctionExpression)
         {

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 586/601 (97.50%)
+ts compatibility: 587/601 (97.67%)
 
 # Failed
 
@@ -11,7 +11,6 @@ ts compatibility: 586/601 (97.50%)
 | typescript/class/quoted-property.ts | 💥 | 66.67% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
-| typescript/interface2/comments-ts-only/18278.ts | 💥 | 95.65% |
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |


### PR DESCRIPTION
Fixes prettier test `typescript/interface2/comments-ts-only/18278.ts`