### PR TITLE
refactor(oxc_str): add IncrementalIdentHasher for byte-by-byte hash computation

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
@@ -15,18 +15,18 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── Read-only global 'String' should not be modified.
    ╰────
 
-  ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
-   ╭─[no_global_assign.tsx:1:3]
- 1 │ ({Object = 0, String = 0} = {});
-   ·   ───┬──
-   ·      ╰── Read-only global 'Object' should not be modified.
-   ╰────
-
   ⚠ eslint(no-global-assign): Read-only global 'String' should not be modified.
    ╭─[no_global_assign.tsx:1:15]
  1 │ ({Object = 0, String = 0} = {});
    ·               ───┬──
    ·                  ╰── Read-only global 'String' should not be modified.
+   ╰────
+
+  ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
+   ╭─[no_global_assign.tsx:1:3]
+ 1 │ ({Object = 0, String = 0} = {});
+   ·   ───┬──
+   ·      ╰── Read-only global 'Object' should not be modified.
    ╰────
 
   ⚠ eslint(no-global-assign): Read-only global 'top' should not be modified.

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -17,6 +17,22 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
@@ -27,20 +43,12 @@ source: crates/oxc_linter/src/tester.rs
   help: Only the last call to `jest.setTimeout` will have an effect.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
+   ╭─[no_confusing_set_timeout.tsx:3:21]
+ 2 │                 describe('A', () => {
+ 3 │                     jest.setTimeout(800);
+   ·                     ───────────────
+ 4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+   ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
@@ -51,22 +59,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:3:21]
- 2 │                 describe('A', () => {
- 3 │                     jest.setTimeout(800);
-   ·                     ───────────────
- 4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
-   ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
-   ╭─[no_confusing_set_timeout.tsx:5:25]
- 4 │                         await new Promise((resolve) => {
- 5 │                         jest.setTimeout(1000);
-   ·                         ───────────────
- 6 │                         setTimeout(resolve, 10000).unref();
-   ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);
@@ -83,6 +75,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+   ╭─[no_confusing_set_timeout.tsx:5:25]
+ 4 │                         await new Promise((resolve) => {
+ 5 │                         jest.setTimeout(1000);
+   ·                         ───────────────
+ 6 │                         setTimeout(resolve, 10000).unref();
+   ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                 });
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);

--- a/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
@@ -29,11 +29,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of test.
 
   ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:21]
- 1 │ 
+   ╭─[no_identical_title.tsx:3:20]
  2 │               xtest('this', () => {});
-   ·                     ──────
  3 │               test('this', () => {});
+   ·                    ──────
+ 4 │             
    ╰────
   help: Change the title of test.
 
@@ -83,11 +83,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:3:24]
+   ╭─[no_identical_title.tsx:2:25]
+ 1 │ 
  2 │               fdescribe('foo', () => {});
+   ·                         ─────
  3 │               describe('foo', () => {});
-   ·                        ─────
- 4 │             
    ╰────
   help: Change the title of describe block.
 

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -16,14 +16,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
-   ╭─[padding_around_test_blocks.tsx:3:1]
- 2 │ fit('bar', () => {});
- 3 │ test('baz', () => {});
-   · ▲
-   ╰────
-  help: Make sure there is an empty new line before the test block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
    ╭─[padding_around_test_blocks.tsx:2:1]
  1 │ it('foo', () => {});
@@ -33,14 +25,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the fit block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
-    ╭─[padding_around_test_blocks.tsx:26:2]
- 25 │    .skip('skippy skip', () => {});
- 26 │  xit('bar foo', () => {});
-    ·  ▲
- 27 │             
-    ╰────
-  help: Make sure there is an empty new line before the xit block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+   ╭─[padding_around_test_blocks.tsx:3:1]
+ 2 │ fit('bar', () => {});
+ 3 │ test('baz', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the test block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:4:1]
@@ -68,24 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  23 │  });xtest('weird', () => {});
     ╰────
   help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
-    ╭─[padding_around_test_blocks.tsx:23:5]
- 22 │      it.skip('skipping too', () => {});
- 23 │  });xtest('weird', () => {});
-    ·     ▲
- 24 │  test
-    ╰────
-  help: Make sure there is an empty new line before the xtest block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
-   ╭─[padding_around_test_blocks.tsx:7:1]
- 6 │ });
- 7 │ fit('bar', () => {
-   · ▲
- 8 │   // stuff
-   ╰────
-  help: Make sure there is an empty new line before the fit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:10:1]
@@ -131,6 +104,33 @@ source: crates/oxc_linter/src/tester.rs
  25 │    .skip('skippy skip', () => {});
     ╰────
   help: Make sure there is an empty new line before the test block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
+    ╭─[padding_around_test_blocks.tsx:26:2]
+ 25 │    .skip('skippy skip', () => {});
+ 26 │  xit('bar foo', () => {});
+    ·  ▲
+ 27 │             
+    ╰────
+  help: Make sure there is an empty new line before the xit block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
+    ╭─[padding_around_test_blocks.tsx:23:5]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
+    ·     ▲
+ 24 │  test
+    ╰────
+  help: Make sure there is an empty new line before the xtest block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
+   ╭─[padding_around_test_blocks.tsx:7:1]
+ 6 │ });
+ 7 │ fit('bar', () => {
+   · ▲
+ 8 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the fit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:5:5]

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -18,7 +18,8 @@ use serde::{Serialize, Serializer as SerdeSerializer};
 use crate::{Atom, CompactStr};
 
 /// Multiplier constant for incremental hashing.
-const K: usize = 0xf135_7aea_2e62_a9c5;
+/// Uses u64 to ensure consistent behavior on 32-bit and 64-bit platforms.
+const K: u64 = 0xf135_7aea_2e62_a9c5;
 
 /// Incremental hasher for computing Ident hashes byte-by-byte.
 ///
@@ -26,7 +27,7 @@ const K: usize = 0xf135_7aea_2e62_a9c5;
 /// avoiding a second pass over the data.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct IncrementalIdentHasher {
-    state: usize,
+    state: u64,
 }
 
 impl IncrementalIdentHasher {
@@ -39,7 +40,7 @@ impl IncrementalIdentHasher {
     /// Add a byte to the hash.
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
-        self.state = self.state.wrapping_add(byte as usize).wrapping_mul(K);
+        self.state = self.state.wrapping_add(byte as u64).wrapping_mul(K);
     }
 
     /// Add multiple bytes to the hash.
@@ -64,10 +65,10 @@ impl IncrementalIdentHasher {
 /// This is a const-compatible version for `Ident::new_const`.
 const fn compute_hash(s: &str) -> u32 {
     let bytes = s.as_bytes();
-    let mut state: usize = 0;
+    let mut state: u64 = 0;
     let mut i = 0;
     while i < bytes.len() {
-        state = state.wrapping_add(bytes[i] as usize).wrapping_mul(K);
+        state = state.wrapping_add(bytes[i] as u64).wrapping_mul(K);
         i += 1;
     }
     // 0xff marker

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -10,7 +10,9 @@ mod ident;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
-pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher};
+pub use ident::{
+    ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
+};
 
 #[doc(hidden)]
 pub mod __internal {

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -4569,12 +4569,12 @@ rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
 rebuilt        : [ReferenceId(30), ReferenceId(34)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(1), ReferenceId(20)]
-rebuilt        : [ReferenceId(13)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
+Unresolved reference IDs mismatch for "Promise":
+after transform: [ReferenceId(1), ReferenceId(20)]
+rebuilt        : [ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -10610,9 +10610,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_It
 Unresolved references mismatch:
 after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
-Unresolved reference IDs mismatch for "WeakRef":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(26)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
 rebuilt        : [ReferenceId(81), ReferenceId(84)]
@@ -10622,6 +10619,9 @@ rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(1), ReferenceId(14)]
 rebuilt        : [ReferenceId(10)]
+Unresolved reference IDs mismatch for "WeakRef":
+after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
+rebuilt        : [ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
 Unresolved references mismatch:
@@ -15713,12 +15713,12 @@ rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(39), ReferenceId(40)
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
-Unresolved reference IDs mismatch for "Boolean":
-after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Object":
 after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(51), ReferenceId(55), ReferenceId(63)]
 rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(42), ReferenceId(47), ReferenceId(57)]
+Unresolved reference IDs mismatch for "Boolean":
+after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
 Symbol reference IDs mismatch for "A":
@@ -23829,21 +23829,21 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
-Unresolved reference IDs mismatch for "Number":
-after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
-rebuilt        : [ReferenceId(4), ReferenceId(22)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
 rebuilt        : [ReferenceId(13), ReferenceId(28)]
-Unresolved reference IDs mismatch for "BigInt":
-after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
-rebuilt        : [ReferenceId(16), ReferenceId(31)]
+Unresolved reference IDs mismatch for "Number":
+after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
+rebuilt        : [ReferenceId(4), ReferenceId(22)]
 Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(7), ReferenceId(20), ReferenceId(30)]
 rebuilt        : [ReferenceId(7), ReferenceId(25)]
 Unresolved reference IDs mismatch for "String":
 after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
 rebuilt        : [ReferenceId(1), ReferenceId(19)]
+Unresolved reference IDs mismatch for "BigInt":
+after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
+rebuilt        : [ReferenceId(16), ReferenceId(31)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 Bindings mismatch:
@@ -24772,12 +24772,12 @@ after transform: SymbolId(3): [ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(2)]
 Unresolved reference IDs mismatch for "Uint8Array":
 after transform: [ReferenceId(7), ReferenceId(9), ReferenceId(13)]
 rebuilt        : [ReferenceId(4)]
+Unresolved reference IDs mismatch for "Int32Array":
+after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
+rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
 Symbol reference IDs mismatch for "FOO_SYMBOL":
@@ -24938,36 +24938,36 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Unresolved reference IDs mismatch for "Int16Array":
-after transform: [ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(2)]
+Unresolved reference IDs mismatch for "Float32Array":
+after transform: [ReferenceId(12), ReferenceId(13)]
+rebuilt        : [ReferenceId(6)]
 Unresolved reference IDs mismatch for "Int8Array":
 after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "Float64Array":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "BigInt64Array":
-after transform: [ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(8)]
+Unresolved reference IDs mismatch for "Uint8Array":
+after transform: [ReferenceId(2), ReferenceId(3)]
+rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "Int32Array":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(4)]
 Unresolved reference IDs mismatch for "Uint32Array":
 after transform: [ReferenceId(10), ReferenceId(11)]
 rebuilt        : [ReferenceId(5)]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
+Unresolved reference IDs mismatch for "Int16Array":
+after transform: [ReferenceId(4), ReferenceId(5)]
+rebuilt        : [ReferenceId(2)]
+Unresolved reference IDs mismatch for "Uint16Array":
+after transform: [ReferenceId(6), ReferenceId(7)]
+rebuilt        : [ReferenceId(3)]
+Unresolved reference IDs mismatch for "Float64Array":
+after transform: [ReferenceId(14), ReferenceId(15)]
+rebuilt        : [ReferenceId(7)]
 Unresolved reference IDs mismatch for "BigUint64Array":
 after transform: [ReferenceId(18), ReferenceId(19)]
 rebuilt        : [ReferenceId(9)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
+Unresolved reference IDs mismatch for "BigInt64Array":
+after transform: [ReferenceId(16), ReferenceId(17)]
+rebuilt        : [ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -38155,12 +38155,12 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "M":
 after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(13)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
 Scope flags mismatch:
@@ -38487,12 +38487,12 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "M":
 after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(13)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
 Symbol reference IDs mismatch for "p":


### PR DESCRIPTION
Replace the complex const FxHash implementation with a simpler incremental
hasher that can compute hashes byte-by-byte during lexing.

- Add `IncrementalIdentHasher` struct with `write_byte()`, `write_bytes()`, and `finish()` methods
- Add `Ident::new_with_hash()` for creating Idents with precomputed hash
- Simplify `compute_hash()` const function to use the same incremental algorithm
- Update `Ident::new()` to use the incremental hasher

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>