### PR TITLE
refactor(linter/plugins, napi/parser): remove pattern of destructuring globals at top level

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -22,8 +22,6 @@ type InvalidTestCase = RuleTester.InvalidTestCase;
 type Globals = RuleTester.Globals;
 export type TestCase = ValidTestCase | InvalidTestCase;
 
-const { isArray } = Array;
-
 // Get `@typescript-eslint/parser` module.
 // Load the instance which would be loaded by files in ESLint's `tests/lib/rules` directory.
 const require = createRequire(ESLINT_RULES_TESTS_DIR_PATH);
@@ -67,7 +65,7 @@ class RuleTesterShim extends RuleTester {
   // Apply filter to test cases.
   run(ruleName: string, rule: Rule, tests: TestCases): void {
     if (FILTER_ONLY_CODE !== null) {
-      const codeMatchesFilter = isArray(FILTER_ONLY_CODE)
+      const codeMatchesFilter = Array.isArray(FILTER_ONLY_CODE)
         ? (code: string) => FILTER_ONLY_CODE!.includes(code)
         : (code: string) => code === FILTER_ONLY_CODE;
 

--- a/apps/oxlint/conformance/src/run.ts
+++ b/apps/oxlint/conformance/src/run.ts
@@ -11,8 +11,6 @@ import { FILTER_ONLY_RULE, FILTER_EXCLUDE_RULE } from "./filter.ts";
 
 import type { RuleResult } from "./capture.ts";
 
-const { isArray } = Array;
-
 // Paths
 export const CONFORMANCE_DIR_PATH = pathJoin(fileURLToPath(import.meta.url), "../..");
 export const ESLINT_ROOT_DIR_PATH = pathJoin(CONFORMANCE_DIR_PATH, "submodules/eslint");
@@ -74,11 +72,11 @@ function findTestFiles(): string[] {
 
   let ruleNameMatchesFilter = null;
   if (FILTER_ONLY_RULE !== null) {
-    ruleNameMatchesFilter = isArray(FILTER_ONLY_RULE)
+    ruleNameMatchesFilter = Array.isArray(FILTER_ONLY_RULE)
       ? (ruleName: string) => FILTER_ONLY_RULE!.includes(ruleName)
       : (ruleName: string) => ruleName === FILTER_ONLY_RULE;
   } else if (FILTER_EXCLUDE_RULE !== null) {
-    ruleNameMatchesFilter = isArray(FILTER_EXCLUDE_RULE)
+    ruleNameMatchesFilter = Array.isArray(FILTER_EXCLUDE_RULE)
       ? (ruleName: string) => !FILTER_EXCLUDE_RULE!.includes(ruleName)
       : (ruleName: string) => ruleName !== FILTER_EXCLUDE_RULE;
   }

--- a/apps/oxlint/src-js/generated/walk.js
+++ b/apps/oxlint/src-js/generated/walk.js
@@ -17,11 +17,9 @@ function debugCheckAncestorsOnExit(lenBefore, node) {
     );
 }
 
-const { isArray } = Array;
-
 function walkNode(node, visitors) {
   if (node == null) return;
-  if (isArray(node)) {
+  if (Array.isArray(node)) {
     let len = node.length;
     for (let i = 0; i < len; i++) walkNode(node[i], visitors);
   } else

--- a/napi/parser/src-js/generated/visit/walk.js
+++ b/napi/parser/src-js/generated/visit/walk.js
@@ -3,11 +3,9 @@
 
 export { walkProgram };
 
-const { isArray } = Array;
-
 function walkNode(node, visitors) {
   if (node == null) return;
-  if (isArray(node)) {
+  if (Array.isArray(node)) {
     let len = node.length;
     for (let i = 0; i < len; i++) walkNode(node[i], visitors);
   } else

--- a/napi/parser/src-js/visit/visitor.js
+++ b/napi/parser/src-js/visit/visitor.js
@@ -78,8 +78,6 @@ import {
   NODE_TYPES_COUNT,
 } from "../generated/visit/type_ids.js";
 
-const { isArray } = Array;
-
 // Compiled visitor used for visiting each file.
 // Same array is reused for each file.
 //
@@ -225,7 +223,7 @@ export function addVisitorToCompiled(visitor) {
       // Leaf node - store just 1 function, not enter+exit pair
       if (existing === null) {
         compiledVisitor[typeId] = visitFn;
-      } else if (isArray(existing)) {
+      } else if (Array.isArray(existing)) {
         if (isExit) {
           existing.push(visitFn);
         } else {
@@ -256,7 +254,7 @@ export function addVisitorToCompiled(visitor) {
         const { exit } = existing;
         if (exit === null) {
           existing.exit = visitFn;
-        } else if (isArray(exit)) {
+        } else if (Array.isArray(exit)) {
           exit.push(visitFn);
         } else {
           existing.exit = createVisitFnArray(exit, visitFn);
@@ -266,7 +264,7 @@ export function addVisitorToCompiled(visitor) {
         const { enter } = existing;
         if (enter === null) {
           existing.enter = visitFn;
-        } else if (isArray(enter)) {
+        } else if (Array.isArray(enter)) {
           enter.push(visitFn);
         } else {
           existing.enter = createVisitFnArray(enter, visitFn);

--- a/napi/parser/test/parse-raw-worker.ts
+++ b/napi/parser/test/parse-raw-worker.ts
@@ -25,9 +25,6 @@ import { makeUnitsFromTest } from "./typescript-make-units-from-test.ts";
 
 import type { Node, ParserOptions } from "./parser.ts";
 
-const { hasOwn } = Object,
-  { isArray } = Array;
-
 type TestCaseProps = string | { filename: string; sourceText: string };
 
 // Run test case and return whether it passes.
@@ -279,7 +276,7 @@ function testRangeParent(
   function walk(node: null | Node[] | Node): void {
     if (node === null || typeof node !== "object") return;
 
-    if (isArray(node)) {
+    if (Array.isArray(node)) {
       for (const child of node) {
         walk(child);
       }
@@ -287,9 +284,9 @@ function testRangeParent(
     }
 
     // Check `range`
-    if (hasOwn(node, "start")) {
+    if (Object.hasOwn(node, "start")) {
       const { range } = node;
-      expect(isArray(range)).toBe(true);
+      expect(Array.isArray(range)).toBe(true);
       expect(range.length).toBe(2);
       expect(range[0]).toBe(node.start);
       expect(range[1]).toBe(node.end);
@@ -297,7 +294,7 @@ function testRangeParent(
 
     // Check `parent`
     const previousParent = parent;
-    const isNode = hasOwn(node, "type");
+    const isNode = Object.hasOwn(node, "type");
     if (isNode) {
       expect(node.parent).toBe(parent);
       parent = node;
@@ -305,7 +302,7 @@ function testRangeParent(
 
     // Walk children
     for (const key in node) {
-      if (!hasOwn(node, key)) continue;
+      if (!Object.hasOwn(node, key)) continue;
       if (
         key === "type" ||
         key === "start" ||

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -216,11 +216,9 @@ fn generate(codegen: &Codegen) -> Codes {
         }
         /* END_IF */
 
-        const { isArray } = Array;
-
         function walkNode(node, visitors) {
             if (node == null) return;
-            if (isArray(node)) {
+            if (Array.isArray(node)) {
                 const len = node.length;
                 for (let i = 0; i < len; i++) {
                     walkNode(node[i], visitors);


### PR DESCRIPTION
Pure refactor.

Remove a few remaining instances of the pattern where we destructure global objects at top level e.g. `const { isArray } = Array;`.

In Oxlint, TSDown plugin already performs this optimization. In `napi/parser`, we intend to build the package with TSDown, and we'll apply the same optimization in build process then too.