### PR TITLE
test(linter/plugins): ensure all tests use conformance `RuleTester`

### DIFF
--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -75,6 +75,8 @@ export function describe(name: string, fn: () => void): void {
   }
 }
 
+(globalThis as any).describe = describe;
+
 /**
  * `it` function that runs and records individual tests.
  * @param name - Name of the test
@@ -117,6 +119,8 @@ export function it(code: string, fn: () => void): void {
 
   currentRule!.tests.push(testResult);
 }
+
+(globalThis as any).it = it;
 
 /**
  * Determine if failing test case should be skipped.


### PR DESCRIPTION
Conformance tests work by mocking ESLint's built-in rule tester module to substitute Oxlint conformance `RuleTester`.

Make sure that all tests run using the conformance test version of `RuleTester` and not the original ESLint one by setting `describe` and `it` on `globalThis`. If the ESLint `RuleTester` is used, it'll call `it` internally and our `it` will spot that `currentTest = null` meaning that it's not been called from with the conformance `RuleTester`.