### PR TITLE
test(linter/plugins): `TestCase` type in conformance tester include internal properties

### DIFF
--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -2,7 +2,7 @@
  * `describe` and `it` functions for capturing test results.
  */
 
-import type { TestCase, LanguageOptionsInternal } from "./rule_tester.ts";
+import type { TestCase } from "./rule_tester.ts";
 
 /**
  * Result of running all tests in a rule file.
@@ -143,15 +143,13 @@ function shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Err
   // These are not handled by `RuleTester`.
   if (code.match(/\/\/\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
 
-  const languageOptions = test.languageOptions as LanguageOptionsInternal | undefined;
-
   // Tests rely on directives being parsed as plain `StringLiteral`s in ES3.
   // Oxc parser does not support parsing as ES3.
   if (
     (ruleName === "no-eval" ||
       ruleName === "no-invalid-this" ||
       ruleName === "no-unused-expressions") &&
-    languageOptions?.ecmaVersion === 3
+    test.languageOptions?.ecmaVersion === 3
   ) {
     return true;
   }
@@ -161,7 +159,7 @@ function shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Err
   if (
     ruleName === "no-use-before-define" &&
     code === '"use strict"; a(); { function a() {} }' &&
-    languageOptions?.ecmaVersion === 5
+    test.languageOptions?.ecmaVersion === 5
   ) {
     return true;
   }

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -12,14 +12,18 @@ import { FILTER_ONLY_CODE } from "./filter.ts";
 
 import type { Rule } from "#oxlint";
 import type { LanguageOptionsInternal } from "../../src-js/package/rule_tester.ts";
-export type { LanguageOptionsInternal };
 
 type DescribeFn = RuleTester.DescribeFn;
 type ItFn = RuleTester.ItFn;
 type TestCases = RuleTester.TestCases;
-type ValidTestCase = RuleTester.ValidTestCase;
-type InvalidTestCase = RuleTester.InvalidTestCase;
 type Globals = RuleTester.Globals;
+
+interface TestCaseExtension {
+  languageOptions?: LanguageOptionsInternal;
+}
+
+export type ValidTestCase = RuleTester.ValidTestCase & TestCaseExtension;
+export type InvalidTestCase = RuleTester.InvalidTestCase & TestCaseExtension;
 export type TestCase = ValidTestCase | InvalidTestCase;
 
 // Get `@typescript-eslint/parser` module.
@@ -96,7 +100,7 @@ function modifyTestCase(test: TestCase): void {
   test.eslintCompat = true;
 
   // Ignore parsing errors. ESLint's test cases include invalid code.
-  const languageOptions = { ...test.languageOptions } as LanguageOptionsInternal;
+  const languageOptions = { ...test.languageOptions };
   test.languageOptions = languageOptions;
 
   const parserOptions = { ...languageOptions.parserOptions };

--- a/apps/oxlint/conformance/tester.ts
+++ b/apps/oxlint/conformance/tester.ts
@@ -14,19 +14,10 @@ import { RuleTester as ESLintRuleTester } from "./submodules/eslint/lib/rule-tes
 import { builtinRules } from "./submodules/eslint/lib/unsupported-api.js";
 
 import type { Rule } from "#oxlint";
-import type { RuleTester as OxlintRuleTesterTypes } from "#oxlint";
-import type { LanguageOptionsInternal } from "./src/rule_tester.ts";
+import type { ValidTestCase, InvalidTestCase } from "./src/rule_tester.ts";
 
-type ValidTestCase = OxlintRuleTesterTypes.ValidTestCase;
-type InvalidTestCase = OxlintRuleTesterTypes.InvalidTestCase;
-
-interface TestCaseExtension {
-  code?: string;
-  languageOptions?: LanguageOptionsInternal;
-}
-
-type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & TestCaseExtension;
-type InvalidTestCaseWithoutCode = Omit<InvalidTestCase, "code"> & TestCaseExtension;
+type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & { code?: string };
+type InvalidTestCaseWithoutCode = Omit<InvalidTestCase, "code"> & { code?: string };
 type TestCaseWithoutCode = ValidTestCaseWithoutCode | InvalidTestCaseWithoutCode;
 
 // Reset `describe` + `it` to simple pass-through functions.


### PR DESCRIPTION
Pure refactor. Improve types in the conformance tester. Add internal version of `LanguageOptions` to `TestCase` types in conformance tester. This avoids type casting elsewhere, which simplifies the code.