### PR TITLE
test(linter/plugins): add `eslint-plugin-react-hooks` to conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -2,13 +2,20 @@
 set -e
 
 ESLINT_SHA="8f360ad6a7a743d33a83eed8973ee4a50731e55b" # 10.0.0-rc.0
+REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
 
 # Delete existing `submodules` directory
 rm -rf submodules
+mkdir submodules
+cd submodules
+
+###############################################################################
+# ESLint
+###############################################################################
 
 # Clone ESLint repo into `submodules/eslint`
-git clone --single-branch --depth 1 https://github.com/eslint/eslint.git submodules/eslint
-cd submodules/eslint
+git clone --single-branch --depth 1 https://github.com/eslint/eslint.git eslint
+cd eslint
 git fetch --depth 1 origin "$ESLINT_SHA"
 git reset --hard "$ESLINT_SHA"
 git clean -f -q
@@ -23,3 +30,27 @@ cd node_modules/@typescript-eslint/parser
 
 # Install dependencies of TS-ESLint parser shim
 pnpm install --ignore-workspace
+
+# Return to `submodules` directory
+cd ../../../..
+
+###############################################################################
+# React
+###############################################################################
+
+# Clone React repo into `submodules/react`
+git clone --single-branch --depth 1 https://github.com/facebook/react.git react
+cd react
+git fetch --depth 1 origin "$REACT_SHA"
+git reset --hard "$REACT_SHA"
+git clean -f -q
+
+# Install dependencies
+yarn
+
+# Install `eslint-plugin-react-hooks` dependency
+cd packages/eslint-plugin-react-hooks
+yarn add eslint-plugin-react-hooks
+
+# Return to `submodules` directory
+cd ../../..

--- a/apps/oxlint/conformance/snapshots/react-hooks.md
+++ b/apps/oxlint/conformance/snapshots/react-hooks.md
@@ -1,0 +1,33 @@
+# Conformance test results - react-hooks
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |     3 | 100.0% |
+| Fully passing     |     3 | 100.0% |
+| Partially passing |     0 |   0.0% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |  5021 | 100.0% |
+| Passing     |  5007 |  99.7% |
+| Failing     |     0 |   0.0% |
+| Skipped     |    14 |   0.3% |
+
+## Fully Passing Rules
+
+- `exhaustive-deps` (3642 tests) (6 skipped)
+- `rules-of-hooks` (1376 tests) (8 skipped)
+- `compiler` (3 tests)
+
+## Rules with Failures
+
+No rules with failures

--- a/apps/oxlint/conformance/src/test_groups.ts
+++ b/apps/oxlint/conformance/src/test_groups.ts
@@ -65,4 +65,76 @@ export const TEST_GROUPS: TestGroup[] = [
     ruleTesters: ["../../../lib/rule-tester/rule-tester.js"],
     parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
   },
+
+  // React
+  {
+    name: "react-hooks",
+    submoduleName: "react",
+    testFilesDirPath: "packages/eslint-plugin-react-hooks/__tests__",
+
+    transformTestFilename: (filename: string) => {
+      switch (filename) {
+        case "ESLintRuleExhaustiveDeps-test.js":
+          return "exhaustive-deps";
+        case "ESLintRulesOfHooks-test.js":
+          return "rules-of-hooks";
+        case "ReactCompilerRuleTypescript-test.ts":
+          return "compiler";
+        default:
+          return null;
+      }
+    },
+
+    prepare(require, mock) {
+      // Add `default` export to `eslint-plugin-react-hooks` module
+      const plugin = require("eslint-plugin-react-hooks") as any;
+      plugin.default = plugin;
+
+      // Mock `react/packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts`
+      // to use actual `eslint-plugin-react-hooks` package.
+      // This avoids having to build the React compiler.
+      const { rules } = plugin;
+      const allRules = Object.fromEntries(
+        Object.entries(rules).map(([name, rule]) => [name, { rule }]),
+      );
+      mock("../src/shared/ReactCompiler.ts", { allRules });
+    },
+
+    shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
+      // Code is flow syntax
+      if (
+        ruleName.startsWith("rules-of-hooks/") &&
+        err.message === "Parsing failed" &&
+        code.match(/^\s*(\/\/[^\n]*\n)*(hook|component) [a-zA-Z]/)
+      ) {
+        return true;
+      }
+
+      // Code is TypeScript, but they're being parsed as JSX
+      if (
+        ruleName.startsWith("rules-of-hooks/") &&
+        err.message === "Parsing failed" &&
+        [
+          "function Example({ prop }) {\n  const bar = useEffect(<T>(a: T): Hello => {\n    prop();\n  }, [prop]);\n}",
+          "function Foo() {\n  const foo = ({}: any);\n  useMemo(() => {\n    console.log(foo);\n  }, [foo]);\n}",
+        ].includes(code.trim())
+      ) {
+        return true;
+      }
+
+      return false;
+    },
+
+    ruleTesters: ["eslint-v7", "eslint-v8", "eslint-v9"],
+
+    parsers: [
+      { specifier: "babel-eslint", lang: "jsx" },
+      { specifier: "@babel/eslint-parser", lang: "jsx" },
+      { specifier: "hermes-eslint", lang: "jsx" },
+      { specifier: "@typescript-eslint/parser-v2", lang: "tsx" },
+      { specifier: "@typescript-eslint/parser-v3", lang: "tsx" },
+      { specifier: "@typescript-eslint/parser-v4", lang: "tsx" },
+      { specifier: "@typescript-eslint/parser-v5", lang: "tsx" },
+    ],
+  },
 ];


### PR DESCRIPTION
Run all the tests from `eslint-plugin-react-hooks` in the conformance tester. All pass, including the React compiler rules.