### PR TITLE
feat(oxlint): support maxWarnings in oxlintrc.json

### DIFF
--- a/apps/oxlint/test/fixtures/max_warnings_config_nested/files/nested/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/max_warnings_config_nested/files/nested/.oxlintrc.json
@@ -1,0 +1,1 @@
+{"maxWarnings": 1}

--- a/apps/oxlint/test/fixtures/max_warnings_config_nested/files/nested/test.js
+++ b/apps/oxlint/test/fixtures/max_warnings_config_nested/files/nested/test.js
@@ -1,0 +1,1 @@
+console.log(1);

--- a/apps/oxlint/test/fixtures/max_warnings_config_nested/options.json
+++ b/apps/oxlint/test/fixtures/max_warnings_config_nested/options.json
@@ -1,0 +1,3 @@
+{
+  "oxlint": true
+}

--- a/apps/oxlint/test/fixtures/max_warnings_config_nested/output.snap.md
+++ b/apps/oxlint/test/fixtures/max_warnings_config_nested/output.snap.md
@@ -1,0 +1,13 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse oxlint configuration file.
+
+  x `maxWarnings` is only allowed in the root configuration file. Nested config found at <fixture>/files/nested/.oxlintrc.json
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/max_warnings_config_root/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/max_warnings_config_root/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "maxWarnings": 0,
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/apps/oxlint/test/fixtures/max_warnings_config_root/files/test.js
+++ b/apps/oxlint/test/fixtures/max_warnings_config_root/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/max_warnings_config_root/options.json
+++ b/apps/oxlint/test/fixtures/max_warnings_config_root/options.json
@@ -1,0 +1,3 @@
+{
+  "oxlint": true
+}

--- a/apps/oxlint/test/fixtures/max_warnings_config_root/output.snap.md
+++ b/apps/oxlint/test/fixtures/max_warnings_config_root/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Exceeded maximum number of warnings. Found 1.
+Finished in Xms on 1 file with 90 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/max_warnings_fail/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/max_warnings_fail/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "maxWarnings": 0,
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/apps/oxlint/test/fixtures/max_warnings_fail/files/test.js
+++ b/apps/oxlint/test/fixtures/max_warnings_fail/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/max_warnings_fail/options.json
+++ b/apps/oxlint/test/fixtures/max_warnings_fail/options.json
@@ -1,0 +1,3 @@
+{
+  "oxlint": true
+}

--- a/apps/oxlint/test/fixtures/max_warnings_fail/output.snap.md
+++ b/apps/oxlint/test/fixtures/max_warnings_fail/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Exceeded maximum number of warnings. Found 1.
+Finished in Xms on 1 file with 90 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/max_warnings_pass/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/max_warnings_pass/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "maxWarnings": 1,
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/apps/oxlint/test/fixtures/max_warnings_pass/files/test.js
+++ b/apps/oxlint/test/fixtures/max_warnings_pass/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/max_warnings_pass/options.json
+++ b/apps/oxlint/test/fixtures/max_warnings_pass/options.json
@@ -1,0 +1,3 @@
+{
+  "oxlint": true
+}

--- a/apps/oxlint/test/fixtures/max_warnings_pass/output.snap.md
+++ b/apps/oxlint/test/fixtures/max_warnings_pass/output.snap.md
@@ -1,0 +1,19 @@
+# Exit code
+0
+
+# stdout
+```
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in Xms on 1 file with 90 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -588,6 +588,9 @@ mod test {
         let config: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
         assert_eq!(config.max_warnings, Some(10));
 
+        let config: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 0}"#).unwrap();
+        assert_eq!(config.max_warnings, Some(0));
+
         let config: Oxlintrc = serde_json::from_str(r"{}").unwrap();
         assert_eq!(config.max_warnings, None);
 
@@ -601,5 +604,10 @@ mod test {
         let config2: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 20}"#).unwrap();
         let merged = config1.merge(config2);
         assert_eq!(merged.max_warnings, Some(20));
+
+        let config1: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
+        let config2: Oxlintrc = serde_json::from_str(r"{}").unwrap();
+        let merged = config1.merge(config2);
+        assert_eq!(merged.max_warnings, Some(10));
     }
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -539,7 +539,6 @@ mod test {
         let merged = config1.merge(config2);
         assert_eq!(merged.schema, Some("schema2.json".to_string()));
     }
-
     #[test]
     fn test_set_config_dir() {
         let mut config: Oxlintrc = serde_json::from_str(
@@ -582,5 +581,25 @@ mod test {
         for entry in override_plugins {
             assert_eq!(entry.config_dir, new_config_dir);
         }
+    }
+
+    #[test]
+    fn test_oxlintrc_max_warnings() {
+        let config: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
+        assert_eq!(config.max_warnings, Some(10));
+
+        let config: Oxlintrc = serde_json::from_str(r"{}").unwrap();
+        assert_eq!(config.max_warnings, None);
+
+        // Test merge
+        let config1: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
+        let config2: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 20}"#).unwrap();
+        let merged = config1.merge(config2);
+        assert_eq!(merged.max_warnings, Some(10));
+
+        let config1: Oxlintrc = serde_json::from_str(r"{}").unwrap();
+        let config2: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 20}"#).unwrap();
+        let merged = config1.merge(config2);
+        assert_eq!(merged.max_warnings, Some(20));
     }
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -415,28 +415,6 @@ mod test {
     }
 
     #[test]
-    fn test_oxlintrc_max_warnings() {
-        let config: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
-        assert_eq!(config.max_warnings, Some(10));
-
-        let config: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 0}"#).unwrap();
-        assert_eq!(config.max_warnings, Some(0));
-
-        let config: Oxlintrc = serde_json::from_str(r#"{}"#).unwrap();
-        assert_eq!(config.max_warnings, None);
-
-        let config1: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 10}"#).unwrap();
-        let config2: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 20}"#).unwrap();
-        let merged = config1.merge(config2);
-        assert_eq!(merged.max_warnings, Some(10));
-
-        let config1: Oxlintrc = serde_json::from_str(r#"{}"#).unwrap();
-        let config2: Oxlintrc = serde_json::from_str(r#"{"maxWarnings": 20}"#).unwrap();
-        let merged = config1.merge(config2);
-        assert_eq!(merged.max_warnings, Some(20));
-    }
-
-    #[test]
     fn test_oxlintrc_js_plugins() {
         let config: Oxlintrc = serde_json::from_str(
             r#"{"jsPlugins": ["./plugin.ts", { "name": "custom", "specifier": "./plugin2.ts" }]}"#,


### PR DESCRIPTION
Fixes #15020.

This PR adds support for the `maxWarnings` option in the `.oxlintrc.json` configuration file.

### Summary of Changes
1.  Added `max_warnings` field to the `Oxlintrc` struct in `crates/oxc_linter`.
2.  Updated `oxlint` CLI to respect the `maxWarnings` value from the config file if the command-line flag is not provided.
3.  Implemented a check to ensure `maxWarnings` is only allowed in the root configuration file. A nested configuration containing this field will now result in an error.

### Verification
Created a test project with `.oxlintrc.json` setting `maxWarnings: 0`.
- Running `oxlint .` correctly exited with code 1 when warnings were found.
- Providing `--max-warnings 1` via CLI correctly overrode the config and exited with code 0.
- Placing `maxWarnings` in a nested config correctly triggered the error: `maxWarnings is only allowed in the root configuration file`.