### PR TITLE
test(linter/plugins): set rule filter in conformance tests to `null` by default

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -10,4 +10,4 @@ export const FILTER_ONLY_RULE: Filter | null = null;
 export const FILTER_ONLY_CODE: Filter | null = null;
 
 // Filter out rules where test failures are expected
-export const FILTER_EXCLUDE_RULE: Filter | null = [];
+export const FILTER_EXCLUDE_RULE: Filter | null = null;


### PR DESCRIPTION
Avoiding lookups in an empty array makes the conformance tests slightly faster.