### PR TITLE
docs(linter): Improve docs for `oxc/only-used-in-recursion` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -32,20 +32,20 @@ declare_oxc_lint!(
     ///
     /// Checks for arguments that are only used in recursion with no side-effects.
     ///
-    /// Inspired by https://rust-lang.github.io/rust-clippy/master/#/only_used_in_recursion
+    /// Inspired by [the `only_used_in_recursion` rule in Clippy](https://rust-lang.github.io/rust-clippy/master/#only_used_in_recursion).
     ///
     /// ### Why is this bad?
     ///
     /// Supplying an argument that is only used in recursive calls is likely a mistake.
     ///
-    /// It increase cognitive complexity and may impact performance.
+    /// It increases cognitive complexity and may impact performance.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts
-    /// function test(only_used_in_recursion) {
-    ///     return test(only_used_in_recursion);
+    /// function test(onlyUsedInRecursion) {
+    ///     return test(onlyUsedInRecursion);
     /// }
     /// ```
     ///


### PR DESCRIPTION
Fix a broken link to the original rule as well.