### PR TITLE
docs(linter): Add missing "What it does" section in prefer-reflect-apply rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -20,6 +20,7 @@ pub struct PreferReflectApply;
 declare_oxc_lint!(
     /// ### What it does
     ///
+    /// Disallows the use of `Function.prototype.apply()` and suggests using `Reflect.apply()` instead.
     ///
     /// ### Why is this bad?
     ///


### PR DESCRIPTION
It did not have it, so now it does.