### PR TITLE
perf(semantic): preserve precomputed identifier hash throughout semantic analysis

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
+use oxc_span::{IDENT_MATH, IDENT_NUMBER, IDENT_STRING};
 use oxc_syntax::number::ToJsString;
 
 use cow_utils::CowUtils;
@@ -300,7 +301,7 @@ fn try_fold_string_from_char_code<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("String", object) {
+    if !ctx.is_global_expr(&IDENT_STRING, object) {
         return None;
     }
     let mut s = String::with_capacity(args.len());
@@ -396,7 +397,7 @@ fn try_fold_number_methods<'a>(
     name: &str,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Number", object) {
+    if !ctx.is_global_expr(&IDENT_NUMBER, object) {
         return None;
     }
     if args.len() != 1 {
@@ -427,7 +428,7 @@ fn try_fold_roots<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) || !validate_arguments(args, 1) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) || !validate_arguments(args, 1) {
         return None;
     }
     let arg_val = args[0].to_expression().get_side_free_number_value(ctx)?;
@@ -451,7 +452,7 @@ fn try_fold_math_unary<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) || !validate_arguments(args, 1) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) || !validate_arguments(args, 1) {
         return None;
     }
     let arg_val = args[0].to_expression().get_side_free_number_value(ctx)?;
@@ -493,7 +494,7 @@ fn try_fold_math_variadic<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) {
         return None;
     }
     let mut numbers = std::vec::Vec::new();

--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::*;
+use oxc_span::{IDENT_DATE, IDENT_NUMBER};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{GlobalContext, to_numeric::ToNumeric, to_primitive::ToPrimitive};
@@ -270,7 +271,7 @@ impl<'a> DetermineValueType<'a> for LogicalExpression<'a> {
 impl<'a> DetermineValueType<'a> for StaticMemberExpression<'a> {
     fn value_type(&self, ctx: &impl GlobalContext<'a>) -> ValueType {
         if matches!(self.property.name.as_str(), "POSITIVE_INFINITY" | "NEGATIVE_INFINITY")
-            && ctx.is_global_expr("Number", &self.object)
+            && ctx.is_global_expr(&IDENT_NUMBER, &self.object)
         {
             return ValueType::Number;
         }
@@ -280,7 +281,7 @@ impl<'a> DetermineValueType<'a> for StaticMemberExpression<'a> {
 
 impl<'a> DetermineValueType<'a> for NewExpression<'a> {
     fn value_type(&self, ctx: &impl GlobalContext<'a>) -> ValueType {
-        if ctx.is_global_expr("Date", &self.callee) {
+        if ctx.is_global_expr(&IDENT_DATE, &self.callee) {
             return ValueType::Object;
         }
         ValueType::Undetermined

--- a/crates/oxc_ecmascript/src/global_context.rs
+++ b/crates/oxc_ecmascript/src/global_context.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_span::Ident;
 use oxc_syntax::reference::ReferenceId;
 
 use crate::constant_evaluation::ConstantValue;
@@ -7,9 +8,9 @@ pub trait GlobalContext<'a>: Sized {
     /// Whether the reference is a global reference.
     fn is_global_reference(&self, reference: &IdentifierReference<'a>) -> bool;
 
-    fn is_global_expr(&self, name: &str, expr: &Expression<'a>) -> bool {
+    fn is_global_expr(&self, name: &Ident<'_>, expr: &Expression<'a>) -> bool {
         expr.get_identifier_reference()
-            .filter(|ident| ident.name == name)
+            .filter(|ident| ident.name == *name)
             .is_some_and(|ident| self.is_global_reference(ident))
     }
 

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 };
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_semantic::{AstNode, AstNodes, IsGlobalReference, NodeId, ReferenceId, Semantic, SymbolId};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_REQUIRE, Span};
 use oxc_syntax::{
     identifier::is_irregular_whitespace,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -405,7 +405,7 @@ pub fn is_global_require_call(call_expr: &CallExpression, ctx: &Semantic) -> boo
     if call_expr.arguments.len() != 1 {
         return false;
     }
-    call_expr.callee.is_global_reference_name("require", ctx.scoping())
+    call_expr.callee.is_global_reference_name(&IDENT_REQUIRE, ctx.scoping())
 }
 
 pub fn is_function_node(node: &AstNode) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_ARRAY, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -79,7 +79,7 @@ impl Rule for NoArrayConstructor {
         let last_arg_is_spread = arguments.last().is_some_and(Argument::is_spread);
         let arg_len = arguments.len();
 
-        if ident.is_global_reference_name("Array", ctx.scoping())
+        if ident.is_global_reference_name(&IDENT_ARRAY, ctx.scoping())
             && (arg_len != 1 || last_arg_is_spread)
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -2,7 +2,7 @@ use oxc_ast::{AstKind, ast::IdentifierReference};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_FUNCTION, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -104,7 +104,7 @@ impl Rule for NoNewFunc {
 }
 
 fn check(ident: &IdentifierReference, span: Span, ctx: &LintContext) {
-    if ident.is_global_reference_name("Function", ctx.scoping()) {
+    if ident.is_global_reference_name(&IDENT_FUNCTION, ctx.scoping()) {
         ctx.diagnostic(no_new_func(span));
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -7,7 +7,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_AGGREGATE_ERROR, IDENT_ERROR, IDENT_TYPE_ERROR, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -194,13 +194,13 @@ fn is_builtin_error_constructor(expr: &Expression, ctx: &LintContext) -> bool {
         return false;
     };
 
-    ident.is_global_reference_name("Error", ctx.scoping())
-        || ident.is_global_reference_name("TypeError", ctx.scoping())
+    ident.is_global_reference_name(&IDENT_ERROR, ctx.scoping())
+        || ident.is_global_reference_name(&IDENT_TYPE_ERROR, ctx.scoping())
         || is_aggregate_error(ident, ctx)
 }
 
 fn is_aggregate_error(ident: &IdentifierReference, ctx: &LintContext) -> bool {
-    ident.is_global_reference_name("AggregateError", ctx.scoping())
+    ident.is_global_reference_name(&IDENT_AGGREGATE_ERROR, ctx.scoping())
 }
 
 fn has_cause_property(

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_EXPORTS, IDENT_MODULE, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,7 +19,7 @@ fn is_exports(node: &AssignmentTarget, ctx: &LintContext) -> bool {
     let AssignmentTarget::AssignmentTargetIdentifier(id) = node else {
         return false;
     };
-    id.is_global_reference_name("exports", ctx.scoping())
+    id.is_global_reference_name(&IDENT_EXPORTS, ctx.scoping())
 }
 
 fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool {
@@ -32,7 +32,7 @@ fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool
     };
 
     mem_expr.static_property_name() == Some("exports")
-        && obj_id.is_global_reference_name("module", ctx.scoping())
+        && obj_id.is_global_reference_name(&IDENT_MODULE, ctx.scoping())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -2,7 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, IDENT_PROCESS, Span};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
     let Some(obj_id) = object_expr.get_identifier_reference() else {
         return false;
     };
-    obj_id.is_global_reference_name("process", ctx.scoping())
+    obj_id.is_global_reference_name(&IDENT_PROCESS, ctx.scoping())
 }
 
 impl Rule for NoProcessEnv {

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, Span};
+use oxc_span::{CompactStr, IDENT_REQUIRE, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -133,7 +133,7 @@ impl Rule for NoRequireImports {
             AstKind::CallExpression(call_expr) => {
                 if node.scope_id() != ctx.scoping().root_scope_id()
                     && let Some(id) = call_expr.callee.get_identifier_reference()
-                    && !id.is_global_reference_name("require", ctx.scoping())
+                    && !id.is_global_reference_name(&IDENT_REQUIRE, ctx.scoping())
                 {
                     return;
                 }

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 };
 use oxc_regular_expression::{ConstructorParser, Options, ast::Pattern};
 use oxc_semantic::IsGlobalReference;
-use oxc_span::Span;
+use oxc_span::{IDENT_GLOBAL_THIS, IDENT_REGEXP, Span};
 
 use crate::{AstNode, context::LintContext};
 
@@ -94,13 +94,13 @@ where
 
 // Accepts both RegExp and globalThis.RegExp
 fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
-    if callee.is_global_reference_name("RegExp", ctx.semantic().scoping()) {
+    if callee.is_global_reference_name(&IDENT_REGEXP, ctx.semantic().scoping()) {
         return true;
     }
     // Check for globalThis.RegExp (StaticMemberExpression)
     if let Expression::StaticMemberExpression(member) = callee
         && let Expression::Identifier(obj) = &member.object
-        && obj.is_global_reference_name("globalThis", ctx.semantic().scoping())
+        && obj.is_global_reference_name(&IDENT_GLOBAL_THIS, ctx.semantic().scoping())
         && member.property.name == "RegExp"
     {
         return true;

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -5,7 +5,7 @@ use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType, ValueType},
     side_effects::MayHaveSideEffects,
 };
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, IDENT_NUMBER, SPAN};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::ctx::Ctx;
@@ -523,7 +523,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn fold_call_expression(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::CallExpression(e) = expr else { return };
-        if !ctx.is_global_expr("Number", &e.callee) {
+        if !ctx.is_global_expr(&IDENT_NUMBER, &e.callee) {
             return;
         }
         if e.arguments.len() != 1 {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -7,8 +7,7 @@ use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, Det
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::GetSpan;
-use oxc_span::SPAN;
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_syntax::precedence::GetPrecedence;
 use oxc_syntax::{
     number::NumberBase,
@@ -19,6 +18,8 @@ use oxc_traverse::Ancestor;
 use crate::ctx::Ctx;
 
 use super::PeepholeOptimizations;
+
+const IDENT_OBJECT: Ident<'static> = Ident::new_const("Object");
 
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
@@ -1225,7 +1226,7 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                let reference_id = ctx.create_unbound_reference("Object", ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(IDENT_OBJECT, ReferenceFlags::Read);
                 call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
                     call_expr.callee.span(),
                     "Object",

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -392,13 +392,13 @@ impl<'a> Binder<'a> for TSEnumMember<'a> {
         let name = match &self.id {
             TSEnumMemberName::Identifier(ident) => ident.name,
             TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => {
-                Ident::from(lit.value.as_str())
+                Ident::from(lit.value)
             }
             TSEnumMemberName::ComputedTemplateString(template) => {
                 let quasi = template.single_quasi().expect(
                     "`TSEnumMemberName::TemplateString` should have no substitution and at least one quasi",
                 );
-                Ident::from(quasi.as_str())
+                Ident::from(quasi)
             }
         };
         builder.declare_symbol(

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -411,13 +411,8 @@ impl<'a> SemanticBuilder<'a> {
             return symbol_id;
         }
 
-        let symbol_id = self.scoping.create_symbol(
-            span,
-            name.as_str(),
-            includes,
-            scope_id,
-            self.current_node_id,
-        );
+        let symbol_id =
+            self.scoping.create_symbol(span, name, includes, scope_id, self.current_node_id);
 
         self.scoping.add_binding(scope_id, name, symbol_id);
         symbol_id
@@ -501,7 +496,7 @@ impl<'a> SemanticBuilder<'a> {
     ) -> SymbolId {
         let symbol_id = self.scoping.create_symbol(
             span,
-            name.as_str(),
+            name,
             includes,
             self.current_scope_id,
             self.current_node_id,

--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_span::Ident;
 
 use crate::{ReferenceId, Scoping};
 
@@ -26,7 +27,7 @@ use crate::{ReferenceId, Scoping};
 /// See: <https://github.com/oxc-project/oxc/issues/8365>
 pub trait IsGlobalReference {
     fn is_global_reference(&self, scoping: &Scoping) -> bool;
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool;
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool;
 }
 
 impl IsGlobalReference for ReferenceId {
@@ -34,7 +35,7 @@ impl IsGlobalReference for ReferenceId {
         scoping.references[*self].symbol_id().is_none()
     }
 
-    fn is_global_reference_name(&self, _name: &str, _scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, _name: &Ident<'_>, _scoping: &Scoping) -> bool {
         panic!("This function is pointless to be called.");
     }
 }
@@ -46,8 +47,8 @@ impl IsGlobalReference for IdentifierReference<'_> {
             .is_some_and(|reference_id| reference_id.is_global_reference(scoping))
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
-        self.name == name && self.is_global_reference(scoping)
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool {
+        self.name == *name && self.is_global_reference(scoping)
     }
 }
 
@@ -59,7 +60,7 @@ impl IsGlobalReference for Expression<'_> {
         false
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool {
         if let Expression::Identifier(ident) = self {
             return ident.is_global_reference_name(name, scoping);
         }

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -10,9 +10,11 @@ mod span;
 
 pub use cmp::ContentEq;
 pub use oxc_str::{
-    ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet, IdentHasher,
-    IncrementalIdentHasher, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str,
-    format_ident,
+    ArenaIdentHashMap, Atom, CompactStr, IDENT_AGGREGATE_ERROR, IDENT_ARRAY, IDENT_DATE,
+    IDENT_ERROR, IDENT_EXPORTS, IDENT_FUNCTION, IDENT_GLOBAL_THIS, IDENT_MATH, IDENT_MODULE,
+    IDENT_NUMBER, IDENT_PROCESS, IDENT_REGEXP, IDENT_REQUIRE, IDENT_STRING, IDENT_TYPE_ERROR,
+    Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
+    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -92,6 +92,11 @@ pub struct Ident<'a> {
     _marker: PhantomData<&'a str>,
 }
 
+// SAFETY: `Ident` only contains a pointer to immutable string data,
+// which is safe to share across threads.
+unsafe impl Sync for Ident<'_> {}
+unsafe impl Send for Ident<'_> {}
+
 impl Ident<'static> {
     /// Get an [`Ident`] containing a static string.
     #[expect(clippy::inline_always)]
@@ -420,6 +425,13 @@ impl hash::Hash for Ident<'_> {
         // This gives good entropy as long as HashMap contains less than 33 million entries.
         let hash = (self.hash as u64).rotate_left(64 - 7);
         hasher.write_u64(hash);
+    }
+}
+
+impl std::borrow::Borrow<str> for Ident<'_> {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/crates/oxc_str/src/ident_consts.rs
+++ b/crates/oxc_str/src/ident_consts.rs
@@ -1,0 +1,29 @@
+//! Compile-time identifier constants with precomputed hashes.
+//!
+//! These constants use `Ident::new_const` to compute hashes at compile time,
+//! enabling fast hash-based comparisons for commonly used identifier names.
+
+use crate::Ident;
+
+// === General ===
+pub const IDENT_EXPORTS: Ident<'static> = Ident::new_const("exports");
+pub const IDENT_MODULE: Ident<'static> = Ident::new_const("module");
+pub const IDENT_REQUIRE: Ident<'static> = Ident::new_const("require");
+
+// === Global Objects ===
+pub const IDENT_GLOBAL_THIS: Ident<'static> = Ident::new_const("globalThis");
+pub const IDENT_PROCESS: Ident<'static> = Ident::new_const("process");
+
+// === Built-in Constructors ===
+pub const IDENT_ARRAY: Ident<'static> = Ident::new_const("Array");
+pub const IDENT_DATE: Ident<'static> = Ident::new_const("Date");
+pub const IDENT_FUNCTION: Ident<'static> = Ident::new_const("Function");
+pub const IDENT_MATH: Ident<'static> = Ident::new_const("Math");
+pub const IDENT_NUMBER: Ident<'static> = Ident::new_const("Number");
+pub const IDENT_REGEXP: Ident<'static> = Ident::new_const("RegExp");
+pub const IDENT_STRING: Ident<'static> = Ident::new_const("String");
+
+// === Error Types ===
+pub const IDENT_AGGREGATE_ERROR: Ident<'static> = Ident::new_const("AggregateError");
+pub const IDENT_ERROR: Ident<'static> = Ident::new_const("Error");
+pub const IDENT_TYPE_ERROR: Ident<'static> = Ident::new_const("TypeError");

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -7,12 +7,15 @@
 mod atom;
 mod compact_str;
 mod ident;
+#[expect(missing_docs)]
+mod ident_consts;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{
     ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
 };
+pub use ident_consts::*;
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1027,7 +1027,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name.as_str()));
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name));
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -430,11 +430,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.scoping_mut().rename_symbol(
-                symbol_id,
-                constructor_scope_id,
-                Ident::from(new_name.as_str()),
-            );
+            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, Ident::from(new_name));
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -93,7 +93,7 @@ use oxc_allocator::{
 };
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     identifier::is_white_space_single_line, line_terminator::is_line_terminator,
     reference::ReferenceFlags, symbol::SymbolFlags, xml_entities::XML_ENTITIES,
@@ -1197,7 +1197,8 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let reference_id = ctx.create_reference_in_current_scope(name.as_str(), ReferenceFlags::Read);
+    let reference_id =
+        ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
     let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
     Expression::Identifier(ident)
 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -78,7 +78,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
     pub fn to_expression(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         match self {
             Self::Identifier(ident) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,
@@ -86,7 +86,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 )
             }
             Self::Member((ident, property)) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 let ident = ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,8 +1,10 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::reference::ReferenceFlags;
+
+const IDENT_MODULE: Ident<'static> = Ident::new_const("module");
 use oxc_traverse::Traverse;
 
 use super::diagnostics;
@@ -73,7 +75,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         // module.exports
         let module_exports = {
             let reference_id =
-                ctx.create_reference_in_current_scope("module", ReferenceFlags::Read);
+                ctx.create_reference_in_current_scope(IDENT_MODULE, ReferenceFlags::Read);
             let reference =
                 ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, "module", reference_id);
             let object = Expression::Identifier(reference);

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -54,7 +54,7 @@ use oxc_allocator::{Allocator, Box as ArenaBox, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::identifier::is_identifier_name;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, traverse_mut};
 
@@ -329,7 +329,8 @@ impl<'a> ModuleRunnerTransform<'a> {
                 let mut local = specifier.unbox().local;
                 local.name = self.generate_import_binding_name(ctx).into();
                 let binding = BoundIdentifier::from_binding_ident(&local);
-                ctx.scoping_mut().set_symbol_name(binding.symbol_id, &binding.name);
+                ctx.scoping_mut()
+                    .set_symbol_name(binding.symbol_id, Ident::from(binding.name.as_str()));
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
                 BindingPattern::BindingIdentifier(ctx.alloc(local))

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -766,7 +766,7 @@ struct UpdateReplacedExpression<'a, 'b> {
 impl VisitMut<'_> for UpdateReplacedExpression<'_, '_> {
     fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'_>) {
         let reference_id =
-            self.ctx.create_reference_in_current_scope(ident.name.as_str(), ReferenceFlags::Read);
+            self.ctx.create_reference_in_current_scope(ident.name, ReferenceFlags::Read);
         ident.set_reference_id(reference_id);
         walk_mut::walk_identifier_reference(self, ident);
     }

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     ast::{Expression, IdentifierReference, Statement},
 };
 use oxc_semantic::Scoping;
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, Ident, Span};
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -414,7 +414,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ) -> BoundIdentifier<'a> {
         // Get name for UID
         let name = self.generate_uid_name(name);
-        let symbol_id = self.scoping.add_binding(&name, scope_id, flags);
+        let symbol_id = self.scoping.add_binding(Ident::from(name), scope_id, flags);
         BoundIdentifier::new(name, symbol_id)
     }
 
@@ -536,7 +536,11 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
     #[inline]
-    pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flags)
     }
 
@@ -547,7 +551,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         name: Atom<'a>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_unbound_reference(name.as_str(), flags);
+        let reference_id = self.create_unbound_reference(Ident::from(name), flags);
         self.ast.identifier_reference_with_reference_id(span, name, reference_id)
     }
 
@@ -571,7 +575,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
@@ -620,7 +624,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference_in_current_scope(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_reference_in_current_scope(name, flags)
@@ -631,7 +635,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// Provided `name` must match `reference_id`.
     ///
     /// This is a shortcut for `ctx.scoping.delete_reference`.
-    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
         self.scoping.delete_reference(reference_id, name);
     }
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -6,7 +6,7 @@ cal.com.tsx                | 1.06 MB        ||          21098 |            474 |
 
 RadixUIAdoptionSection.jsx | 2.52 kB        ||             58 |              3 ||             30 |              6
 
-pdf.mjs                    | 567.30 kB      ||           4691 |            569 ||          47464 |           7730
+pdf.mjs                    | 567.30 kB      ||           4692 |            569 ||          47464 |           7730
 
 antd.js                    | 6.69 MB        ||          10728 |           2514 ||         331644 |          69358
 


### PR DESCRIPTION
- Change `symbol_names` storage from `Vec<Atom>` to `Vec<Ident>` to preserve hash
- Update `create_symbol` and `set_symbol_name` to accept `Ident` instead of `&str`
- Use `clone_in` in scoping methods instead of reconstructing from `&str`
- Update traverse context APIs to use `Ident<'_>` instead of `&str`
- Optimize mangler to compute `Ident` once per unique name, not per symbol
- Update all callers in transformer, minifier, and transformer_plugins

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>