### PR TITLE
refactor(parser): use Context::TopLevel instead of function_depth

### DIFF
--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -47,6 +47,10 @@ bitflags! {
         ///   * ambient variable declaration => `declare var $: any`
         ///   * ambient class declaration => `declare class C { foo(); } , etc..`
         const Ambient = 1 << 6;
+
+        /// Parsing at the top level of the program (not inside any function).
+        /// Used to detect top-level await in unambiguous mode.
+        const TopLevel = 1 << 7;
     }
 }
 
@@ -90,6 +94,11 @@ impl Context {
     #[inline]
     pub(crate) fn has_ambient(self) -> bool {
         self.contains(Self::Ambient)
+    }
+
+    #[inline]
+    pub(crate) fn has_top_level(self) -> bool {
+        self.contains(Self::TopLevel)
     }
 
     #[inline]
@@ -151,7 +160,6 @@ impl Context {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum StatementContext {
     StatementList,
-    TopLevelStatementList,
     If,
     Label,
     Do,
@@ -162,10 +170,6 @@ pub enum StatementContext {
 
 impl StatementContext {
     pub(crate) fn is_single_statement(self) -> bool {
-        !matches!(self, Self::StatementList | Self::TopLevelStatementList)
-    }
-
-    pub(crate) fn is_top_level(self) -> bool {
-        self == Self::TopLevelStatementList
+        self != Self::StatementList
     }
 }

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use oxc_syntax::precedence::Precedence;
 
 use super::{FunctionKind, Tristate};
-use crate::{ParserImpl, diagnostics, lexer::Kind};
+use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
 struct ArrowFunctionHead<'a> {
     type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -295,11 +295,10 @@ impl<'a> ParserImpl<'a> {
 
         let expression = !self.at(Kind::LCurly);
         let body = if expression {
-            // Track function depth for expression bodies too
-            self.state.function_depth += 1;
-            let expr = self
-                .parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
-            self.state.function_depth -= 1;
+            // Remove TopLevel context for arrow function expression body
+            let expr = self.context_remove(Context::TopLevel, |p| {
+                p.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function)
+            });
             let span = expr.span();
             let expr_stmt = self.ast.statement_expression(span, expr);
             self.ast.alloc_function_body(span, self.ast.vec(), self.ast.vec1(expr_stmt))

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -33,11 +33,9 @@ impl<'a> ParserImpl<'a> {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
 
-        self.state.function_depth += 1;
-        let (directives, statements) = self.context_add(Context::Return, |p| {
-            p.parse_directives_and_statements(/* is_top_level */ false)
-        });
-        self.state.function_depth -= 1;
+        // Add Return context, remove TopLevel context
+        let (directives, statements) =
+            self.context(Context::Return, Context::TopLevel, Self::parse_directives_and_statements);
 
         self.expect_closing(Kind::RCurly, opening_span);
         self.ast.alloc_function_body(self.end_span(span), directives, statements)

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -31,16 +31,12 @@ impl<'a> ParserImpl<'a> {
     ///     `StatementList`[?Yield, ?Await, ?Return] `StatementListItem`[?Yield, ?Await, ?Return]
     pub(crate) fn parse_directives_and_statements(
         &mut self,
-        is_top_level: bool,
     ) -> (Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>) {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
 
-        let stmt_ctx = if is_top_level {
-            StatementContext::TopLevelStatementList
-        } else {
-            StatementContext::StatementList
-        };
+        let is_top_level = self.ctx.has_top_level();
+        let stmt_ctx = StatementContext::StatementList;
 
         // Check if we need to track potential await reparsing.
         // This is only needed in unambiguous mode at top level when not in await context.
@@ -61,25 +57,16 @@ impl<'a> ParserImpl<'a> {
             }
 
             // Take checkpoint for every statement when tracking await reparse.
-            // We reset the flags and only store the checkpoint if an await identifier
+            // We reset the flag and only store the checkpoint if an await identifier
             // was actually encountered during parsing.
             let checkpoint = if track_await_reparse {
                 self.state.encountered_await_identifier = false;
-                self.state.encountered_unambiguous_await = false;
                 Some((statements.len(), self.checkpoint()))
             } else {
                 None
             };
 
             let stmt = self.parse_statement_list_item(stmt_ctx);
-
-            // If unambiguous await was encountered at top level, upgrade to ESM
-            // This is like Babel's `sawUnambiguousESM` flag
-            if track_await_reparse && self.state.encountered_unambiguous_await {
-                self.module_record_builder.found_unambiguous_await();
-                track_await_reparse = false;
-                self.ctx = self.ctx.and_await(true);
-            }
 
             // Store checkpoint only if await identifier was encountered
             if let Some((stmt_index, checkpoint)) = checkpoint
@@ -143,9 +130,7 @@ impl<'a> ParserImpl<'a> {
                 &Modifiers::empty(),
                 self.ast.vec(),
             ),
-            Kind::Export => {
-                self.parse_export_declaration(self.start_span(), self.ast.vec(), stmt_ctx)
-            }
+            Kind::Export => self.parse_export_declaration(self.start_span(), self.ast.vec()),
             // [+Return] ReturnStatement[?Yield, ?Await]
             Kind::Return => self.parse_return_statement(),
             Kind::Var => {
@@ -160,7 +145,7 @@ impl<'a> ParserImpl<'a> {
             Kind::At => self.parse_decorated_statement(stmt_ctx),
             Kind::Let if !self.cur_token().escaped() => self.parse_let(stmt_ctx),
             Kind::Async => self.parse_async_statement(self.start_span(), stmt_ctx),
-            Kind::Import => self.parse_import_statement(stmt_ctx),
+            Kind::Import => self.parse_import_statement(),
             Kind::Const => self.parse_const_statement(stmt_ctx),
             Kind::Using if self.is_using_declaration() => self.parse_using_statement(stmt_ctx),
             Kind::Await if self.is_using_statement() => self.parse_using_statement(stmt_ctx),
@@ -809,7 +794,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Parse import statement or import expression.
-    fn parse_import_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
+    fn parse_import_statement(&mut self) -> Statement<'a> {
         let checkpoint = self.checkpoint();
         let span = self.start_span();
         self.bump_any();
@@ -818,7 +803,7 @@ impl<'a> ParserImpl<'a> {
             self.rewind(checkpoint);
             self.parse_expression_or_labeled_statement()
         } else {
-            self.parse_import_declaration(span, stmt_ctx.is_top_level())
+            self.parse_import_declaration(span, self.ctx.has_top_level())
         }
     }
 
@@ -844,7 +829,7 @@ impl<'a> ParserImpl<'a> {
         let kind = self.cur_kind();
         if kind == Kind::Export {
             // Export span.start starts after decorators.
-            return self.parse_export_declaration(self.start_span(), decorators, stmt_ctx);
+            return self.parse_export_declaration(self.start_span(), decorators);
         }
         let modifiers = self.parse_modifiers(false, false);
         if self.at(Kind::Class) {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -530,8 +530,8 @@ impl<'a> ParserImpl<'a> {
         self.token = self.lexer.first_token();
 
         let hashbang = self.parse_hashbang();
-        let (directives, mut statements) =
-            self.parse_directives_and_statements(/* is_top_level */ true);
+        self.ctx |= Context::TopLevel;
+        let (directives, mut statements) = self.parse_directives_and_statements();
 
         // In unambiguous mode, if ESM syntax was detected (import/export/import.meta),
         // we need to reparse statements that were originally parsed with `await` as identifier.
@@ -571,9 +571,9 @@ impl<'a> ParserImpl<'a> {
             // Rewind to the checkpoint
             self.rewind(checkpoint);
 
-            // Parse the statement with await context enabled
+            // Parse the statement with await context enabled (TopLevel context is already set)
             let stmt = self.context_add(Context::Await, |p| {
-                p.parse_statement_list_item(StatementContext::TopLevelStatementList)
+                p.parse_statement_list_item(StatementContext::StatementList)
             });
 
             // Replace the statement if the index is valid

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -31,14 +31,6 @@ pub struct ParserState<'a> {
     /// Used to determine if a statement needs to be stored for potential reparsing
     /// in unambiguous mode.
     pub encountered_await_identifier: bool,
-
-    /// Flag to track if an unambiguous await expression was encountered during statement parsing.
-    /// Used to upgrade to ESM when top-level unambiguous await is detected.
-    pub encountered_unambiguous_await: bool,
-
-    /// Depth counter for function body parsing.
-    /// Used to detect if we're inside a function body (depth > 0) vs at top level (depth == 0).
-    pub function_depth: u32,
 }
 
 impl ParserState<'_> {
@@ -49,8 +41,6 @@ impl ParserState<'_> {
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),
             encountered_await_identifier: false,
-            encountered_unambiguous_await: false,
-            function_depth: 0,
         }
     }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    ParserImpl, diagnostics,
+    Context, ParserImpl, diagnostics,
     js::{FunctionKind, VariableDeclarationParent},
     lexer::Kind,
     modifiers::{ModifierFlags, ModifierKind, Modifiers},
@@ -345,8 +345,9 @@ impl<'a> ParserImpl<'a> {
     fn parse_ts_module_block(&mut self) -> Box<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
+        // Remove TopLevel context for module block
         let (directives, statements) =
-            self.parse_directives_and_statements(/* is_top_level */ false);
+            self.context_remove(Context::TopLevel, Self::parse_directives_and_statements);
         self.expect(Kind::RCurly);
         self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
     }


### PR DESCRIPTION
## Summary

- Replace `function_depth` state variable with `Context::TopLevel` bitflag for tracking top-level parsing context
- Remove `TopLevelStatementList` from `StatementContext` enum
- Remove `is_top_level` parameter from `parse_directives_and_statements`
- Remove unused `stmt_ctx` parameters from export/import functions
- Use `context()` and `context_remove()` helpers to manage TopLevel flag

This simplifies the code by using the existing Context bitflags mechanism instead of a separate depth counter, and removes parameter threading through multiple function calls.

🤖 Generated with [Claude Code](https://claude.ai/code)