### PR TITLE
perf(all): measure overall performance for `Ident` change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ dependencies = [
  "oxc-schemars",
  "oxc_allocator",
  "oxc_estree",
+ "rustc-hash",
  "serde",
 ]
 

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -71,7 +71,7 @@ pub use bitset::BitSet;
 pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
-pub use hash_map::HashMap;
+pub use hash_map::{HashMap, HashMapImpl};
 pub use hash_set::HashSet;
 #[cfg(feature = "pool")]
 pub use pool::*;

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use oxc_allocator::{Allocator, AllocatorAccessor, Box, FromIn, IntoIn, Vec};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     comment_node::CommentNodeId, number::NumberBase, operator::UnaryOperator, scope::ScopeId,
 };
@@ -102,6 +102,12 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn atom(self, value: &str) -> Atom<'a> {
         Atom::from_in(value, self.allocator)
+    }
+
+    /// Allocate an [`Ident`] from a string slice.
+    #[inline]
+    pub fn ident(self, value: &str) -> Ident<'a> {
+        Ident::from_in(value, self.allocator)
     }
 
     /// Allocate an [`Atom`] from an array of string slices.

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1647,27 +1647,27 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<Expression>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<IdentifierName>() == 16);
+    assert!(size_of::<IdentifierName>() == 20);
     assert!(align_of::<IdentifierName>() == 4);
     assert!(offset_of!(IdentifierName, span) == 0);
     assert!(offset_of!(IdentifierName, name) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<IdentifierReference>() == 20);
+    assert!(size_of::<IdentifierReference>() == 24);
     assert!(align_of::<IdentifierReference>() == 4);
     assert!(offset_of!(IdentifierReference, span) == 0);
     assert!(offset_of!(IdentifierReference, name) == 8);
-    assert!(offset_of!(IdentifierReference, reference_id) == 16);
+    assert!(offset_of!(IdentifierReference, reference_id) == 20);
 
     // Padding: 0 bytes
-    assert!(size_of::<BindingIdentifier>() == 20);
+    assert!(size_of::<BindingIdentifier>() == 24);
     assert!(align_of::<BindingIdentifier>() == 4);
     assert!(offset_of!(BindingIdentifier, span) == 0);
     assert!(offset_of!(BindingIdentifier, name) == 8);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 16);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 20);
 
     // Padding: 0 bytes
-    assert!(size_of::<LabelIdentifier>() == 16);
+    assert!(size_of::<LabelIdentifier>() == 20);
     assert!(align_of::<LabelIdentifier>() == 4);
     assert!(offset_of!(LabelIdentifier, span) == 0);
     assert!(offset_of!(LabelIdentifier, name) == 8);
@@ -1758,20 +1758,20 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ComputedMemberExpression, optional) == 24);
 
     // Padding: 3 bytes
-    assert!(size_of::<StaticMemberExpression>() == 36);
+    assert!(size_of::<StaticMemberExpression>() == 40);
     assert!(align_of::<StaticMemberExpression>() == 4);
     assert!(offset_of!(StaticMemberExpression, span) == 0);
     assert!(offset_of!(StaticMemberExpression, object) == 8);
     assert!(offset_of!(StaticMemberExpression, property) == 16);
-    assert!(offset_of!(StaticMemberExpression, optional) == 32);
+    assert!(offset_of!(StaticMemberExpression, optional) == 36);
 
     // Padding: 3 bytes
-    assert!(size_of::<PrivateFieldExpression>() == 36);
+    assert!(size_of::<PrivateFieldExpression>() == 40);
     assert!(align_of::<PrivateFieldExpression>() == 4);
     assert!(offset_of!(PrivateFieldExpression, span) == 0);
     assert!(offset_of!(PrivateFieldExpression, object) == 8);
     assert!(offset_of!(PrivateFieldExpression, field) == 16);
-    assert!(offset_of!(PrivateFieldExpression, optional) == 32);
+    assert!(offset_of!(PrivateFieldExpression, optional) == 36);
 
     // Padding: 2 bytes
     assert!(size_of::<CallExpression>() == 40);
@@ -1793,11 +1793,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(NewExpression, pure) == 36);
 
     // Padding: 0 bytes
-    assert!(size_of::<MetaProperty>() == 40);
+    assert!(size_of::<MetaProperty>() == 48);
     assert!(align_of::<MetaProperty>() == 4);
     assert!(offset_of!(MetaProperty, span) == 0);
     assert!(offset_of!(MetaProperty, meta) == 8);
-    assert!(offset_of!(MetaProperty, property) == 24);
+    assert!(offset_of!(MetaProperty, property) == 28);
 
     // Padding: 0 bytes
     assert!(size_of::<SpreadElement>() == 16);
@@ -1832,11 +1832,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(BinaryExpression, right) == 16);
 
     // Padding: 0 bytes
-    assert!(size_of::<PrivateInExpression>() == 32);
+    assert!(size_of::<PrivateInExpression>() == 36);
     assert!(align_of::<PrivateInExpression>() == 4);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
-    assert!(offset_of!(PrivateInExpression, right) == 24);
+    assert!(offset_of!(PrivateInExpression, right) == 28);
 
     // Padding: 3 bytes
     assert!(size_of::<LogicalExpression>() == 28);
@@ -1905,11 +1905,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<AssignmentTargetProperty>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 36);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 40);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 4);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 28);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 32);
 
     // Padding: 3 bytes
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 28);
@@ -2067,13 +2067,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ForOfStatement, scope_id) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<ContinueStatement>() == 24);
+    assert!(size_of::<ContinueStatement>() == 28);
     assert!(align_of::<ContinueStatement>() == 4);
     assert!(offset_of!(ContinueStatement, span) == 0);
     assert!(offset_of!(ContinueStatement, label) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<BreakStatement>() == 24);
+    assert!(size_of::<BreakStatement>() == 28);
     assert!(align_of::<BreakStatement>() == 4);
     assert!(offset_of!(BreakStatement, span) == 0);
     assert!(offset_of!(BreakStatement, label) == 8);
@@ -2108,11 +2108,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(SwitchCase, consequent) == 16);
 
     // Padding: 0 bytes
-    assert!(size_of::<LabeledStatement>() == 32);
+    assert!(size_of::<LabeledStatement>() == 36);
     assert!(align_of::<LabeledStatement>() == 4);
     assert!(offset_of!(LabeledStatement, span) == 0);
     assert!(offset_of!(LabeledStatement, label) == 8);
-    assert!(offset_of!(LabeledStatement, body) == 24);
+    assert!(offset_of!(LabeledStatement, body) == 28);
 
     // Padding: 0 bytes
     assert!(size_of::<ThrowStatement>() == 16);
@@ -2188,22 +2188,22 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(BindingRestElement, argument) == 8);
 
     // Padding: 2 bytes
-    assert!(size_of::<Function>() == 60);
+    assert!(size_of::<Function>() == 64);
     assert!(align_of::<Function>() == 4);
     assert!(offset_of!(Function, span) == 0);
-    assert!(offset_of!(Function, r#type) == 52);
+    assert!(offset_of!(Function, r#type) == 56);
     assert!(offset_of!(Function, id) == 8);
-    assert!(offset_of!(Function, generator) == 53);
-    assert!(offset_of!(Function, r#async) == 54);
-    assert!(offset_of!(Function, declare) == 55);
-    assert!(offset_of!(Function, type_parameters) == 28);
-    assert!(offset_of!(Function, this_param) == 32);
-    assert!(offset_of!(Function, params) == 36);
-    assert!(offset_of!(Function, return_type) == 40);
-    assert!(offset_of!(Function, body) == 44);
-    assert!(offset_of!(Function, scope_id) == 48);
-    assert!(offset_of!(Function, pure) == 56);
-    assert!(offset_of!(Function, pife) == 57);
+    assert!(offset_of!(Function, generator) == 57);
+    assert!(offset_of!(Function, r#async) == 58);
+    assert!(offset_of!(Function, declare) == 59);
+    assert!(offset_of!(Function, type_parameters) == 32);
+    assert!(offset_of!(Function, this_param) == 36);
+    assert!(offset_of!(Function, params) == 40);
+    assert!(offset_of!(Function, return_type) == 44);
+    assert!(offset_of!(Function, body) == 48);
+    assert!(offset_of!(Function, scope_id) == 52);
+    assert!(offset_of!(Function, pure) == 60);
+    assert!(offset_of!(Function, pife) == 61);
 
     assert!(size_of::<FunctionType>() == 1);
     assert!(align_of::<FunctionType>() == 1);
@@ -2268,20 +2268,20 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(YieldExpression, argument) == 8);
 
     // Padding: 1 bytes
-    assert!(size_of::<Class>() == 88);
+    assert!(size_of::<Class>() == 92);
     assert!(align_of::<Class>() == 4);
     assert!(offset_of!(Class, span) == 0);
-    assert!(offset_of!(Class, r#type) == 84);
+    assert!(offset_of!(Class, r#type) == 88);
     assert!(offset_of!(Class, decorators) == 8);
     assert!(offset_of!(Class, id) == 24);
-    assert!(offset_of!(Class, type_parameters) == 44);
-    assert!(offset_of!(Class, super_class) == 48);
-    assert!(offset_of!(Class, super_type_arguments) == 56);
-    assert!(offset_of!(Class, implements) == 60);
-    assert!(offset_of!(Class, body) == 76);
-    assert!(offset_of!(Class, r#abstract) == 85);
-    assert!(offset_of!(Class, declare) == 86);
-    assert!(offset_of!(Class, scope_id) == 80);
+    assert!(offset_of!(Class, type_parameters) == 48);
+    assert!(offset_of!(Class, super_class) == 52);
+    assert!(offset_of!(Class, super_type_arguments) == 60);
+    assert!(offset_of!(Class, implements) == 64);
+    assert!(offset_of!(Class, body) == 80);
+    assert!(offset_of!(Class, r#abstract) == 89);
+    assert!(offset_of!(Class, declare) == 90);
+    assert!(offset_of!(Class, scope_id) == 84);
 
     assert!(size_of::<ClassType>() == 1);
     assert!(align_of::<ClassType>() == 1);
@@ -2338,7 +2338,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<MethodDefinitionKind>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<PrivateIdentifier>() == 16);
+    assert!(size_of::<PrivateIdentifier>() == 20);
     assert!(align_of::<PrivateIdentifier>() == 4);
     assert!(offset_of!(PrivateIdentifier, span) == 0);
     assert!(offset_of!(PrivateIdentifier, name) == 8);
@@ -2396,21 +2396,21 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<ImportDeclarationSpecifier>() == 4);
 
     // Padding: 3 bytes
-    assert!(size_of::<ImportSpecifier>() == 64);
+    assert!(size_of::<ImportSpecifier>() == 68);
     assert!(align_of::<ImportSpecifier>() == 4);
     assert!(offset_of!(ImportSpecifier, span) == 0);
     assert!(offset_of!(ImportSpecifier, imported) == 8);
     assert!(offset_of!(ImportSpecifier, local) == 40);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 60);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 64);
 
     // Padding: 0 bytes
-    assert!(size_of::<ImportDefaultSpecifier>() == 28);
+    assert!(size_of::<ImportDefaultSpecifier>() == 32);
     assert!(align_of::<ImportDefaultSpecifier>() == 4);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<ImportNamespaceSpecifier>() == 28);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 32);
     assert!(align_of::<ImportNamespaceSpecifier>() == 4);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8);
@@ -2475,11 +2475,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<ModuleExportName>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<V8IntrinsicExpression>() == 40);
+    assert!(size_of::<V8IntrinsicExpression>() == 44);
     assert!(align_of::<V8IntrinsicExpression>() == 4);
     assert!(offset_of!(V8IntrinsicExpression, span) == 0);
     assert!(offset_of!(V8IntrinsicExpression, name) == 8);
-    assert!(offset_of!(V8IntrinsicExpression, arguments) == 24);
+    assert!(offset_of!(V8IntrinsicExpression, arguments) == 28);
 
     // Padding: 3 bytes
     assert!(size_of::<BooleanLiteral>() == 12);
@@ -2665,13 +2665,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSThisParameter, type_annotation) == 16);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSEnumDeclaration>() == 60);
+    assert!(size_of::<TSEnumDeclaration>() == 64);
     assert!(align_of::<TSEnumDeclaration>() == 4);
     assert!(offset_of!(TSEnumDeclaration, span) == 0);
     assert!(offset_of!(TSEnumDeclaration, id) == 8);
-    assert!(offset_of!(TSEnumDeclaration, body) == 28);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 56);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 57);
+    assert!(offset_of!(TSEnumDeclaration, body) == 32);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 60);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 61);
 
     // Padding: 0 bytes
     assert!(size_of::<TSEnumBody>() == 28);
@@ -2766,12 +2766,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTupleType, element_types) == 8);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSNamedTupleMember>() == 36);
+    assert!(size_of::<TSNamedTupleMember>() == 40);
     assert!(align_of::<TSNamedTupleMember>() == 4);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
     assert!(offset_of!(TSNamedTupleMember, label) == 8);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 24);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 32);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 28);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 36);
 
     // Padding: 0 bytes
     assert!(size_of::<TSOptionalType>() == 16);
@@ -2869,7 +2869,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSTypeName>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSQualifiedName>() == 32);
+    assert!(size_of::<TSQualifiedName>() == 36);
     assert!(align_of::<TSQualifiedName>() == 4);
     assert!(offset_of!(TSQualifiedName, span) == 0);
     assert!(offset_of!(TSQualifiedName, left) == 8);
@@ -2882,15 +2882,15 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8);
 
     // Padding: 1 bytes
-    assert!(size_of::<TSTypeParameter>() == 48);
+    assert!(size_of::<TSTypeParameter>() == 52);
     assert!(align_of::<TSTypeParameter>() == 4);
     assert!(offset_of!(TSTypeParameter, span) == 0);
     assert!(offset_of!(TSTypeParameter, name) == 8);
-    assert!(offset_of!(TSTypeParameter, constraint) == 28);
-    assert!(offset_of!(TSTypeParameter, default) == 36);
-    assert!(offset_of!(TSTypeParameter, r#in) == 44);
-    assert!(offset_of!(TSTypeParameter, out) == 45);
-    assert!(offset_of!(TSTypeParameter, r#const) == 46);
+    assert!(offset_of!(TSTypeParameter, constraint) == 32);
+    assert!(offset_of!(TSTypeParameter, default) == 40);
+    assert!(offset_of!(TSTypeParameter, r#in) == 48);
+    assert!(offset_of!(TSTypeParameter, out) == 49);
+    assert!(offset_of!(TSTypeParameter, r#const) == 50);
 
     // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterDeclaration>() == 24);
@@ -2899,14 +2899,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSTypeAliasDeclaration>() == 48);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 52);
     assert!(align_of::<TSTypeAliasDeclaration>() == 4);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0);
     assert!(offset_of!(TSTypeAliasDeclaration, id) == 8);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 28);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 32);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 44);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 40);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 32);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 36);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 48);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 44);
 
     assert!(size_of::<TSAccessibility>() == 1);
     assert!(align_of::<TSAccessibility>() == 1);
@@ -2919,15 +2919,15 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSClassImplements, type_arguments) == 16);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSInterfaceDeclaration>() == 60);
+    assert!(size_of::<TSInterfaceDeclaration>() == 64);
     assert!(align_of::<TSInterfaceDeclaration>() == 4);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 28);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 32);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 48);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 56);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 52);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 32);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 36);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 52);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 60);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56);
 
     // Padding: 0 bytes
     assert!(size_of::<TSInterfaceBody>() == 24);
@@ -3088,7 +3088,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSImportTypeQualifier>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSImportTypeQualifiedName>() == 32);
+    assert!(size_of::<TSImportTypeQualifiedName>() == 36);
     assert!(align_of::<TSImportTypeQualifiedName>() == 4);
     assert!(offset_of!(TSImportTypeQualifiedName, span) == 0);
     assert!(offset_of!(TSImportTypeQualifiedName, left) == 8);
@@ -3115,16 +3115,16 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSConstructorType, scope_id) == 20);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSMappedType>() == 60);
+    assert!(size_of::<TSMappedType>() == 64);
     assert!(align_of::<TSMappedType>() == 4);
     assert!(offset_of!(TSMappedType, span) == 0);
     assert!(offset_of!(TSMappedType, key) == 8);
-    assert!(offset_of!(TSMappedType, constraint) == 28);
-    assert!(offset_of!(TSMappedType, name_type) == 36);
-    assert!(offset_of!(TSMappedType, type_annotation) == 44);
-    assert!(offset_of!(TSMappedType, optional) == 56);
-    assert!(offset_of!(TSMappedType, readonly) == 57);
-    assert!(offset_of!(TSMappedType, scope_id) == 52);
+    assert!(offset_of!(TSMappedType, constraint) == 32);
+    assert!(offset_of!(TSMappedType, name_type) == 40);
+    assert!(offset_of!(TSMappedType, type_annotation) == 48);
+    assert!(offset_of!(TSMappedType, optional) == 60);
+    assert!(offset_of!(TSMappedType, readonly) == 61);
+    assert!(offset_of!(TSMappedType, scope_id) == 56);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
@@ -3158,12 +3158,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeAssertion, expression) == 16);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSImportEqualsDeclaration>() == 40);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 44);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0);
     assert!(offset_of!(TSImportEqualsDeclaration, id) == 8);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 28);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 36);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 32);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 40);
 
     assert!(size_of::<TSModuleReference>() == 8);
     assert!(align_of::<TSModuleReference>() == 4);
@@ -3193,7 +3193,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSExportAssignment, expression) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 24);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 28);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 4);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8);

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -224,9 +224,9 @@ impl<'a> Dummy<'a> for TemplateElementValue<'a> {
 impl<'a> Dummy<'a> for MemberExpression<'a> {
     /// Create a dummy [`MemberExpression`].
     ///
-    /// Has cost of making 2 allocations (64 bytes).
+    /// Has cost of making 3 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::StaticMemberExpression(Dummy::dummy(allocator))
+        Self::ComputedMemberExpression(Dummy::dummy(allocator))
     }
 }
 
@@ -1318,9 +1318,9 @@ impl<'a> Dummy<'a> for StaticBlock<'a> {
 impl<'a> Dummy<'a> for ModuleDeclaration<'a> {
     /// Create a dummy [`ModuleDeclaration`].
     ///
-    /// Has cost of making 1 allocation (32 bytes).
+    /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::TSNamespaceExportDeclaration(Dummy::dummy(allocator))
+        Self::ExportDefaultDeclaration(Dummy::dummy(allocator))
     }
 }
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
+use oxc_span::{IDENT_MATH, IDENT_NUMBER, IDENT_STRING};
 use oxc_syntax::number::ToJsString;
 
 use cow_utils::CowUtils;
@@ -300,7 +301,7 @@ fn try_fold_string_from_char_code<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("String", object) {
+    if !ctx.is_global_expr(&IDENT_STRING, object) {
         return None;
     }
     let mut s = String::with_capacity(args.len());
@@ -396,7 +397,7 @@ fn try_fold_number_methods<'a>(
     name: &str,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Number", object) {
+    if !ctx.is_global_expr(&IDENT_NUMBER, object) {
         return None;
     }
     if args.len() != 1 {
@@ -427,7 +428,7 @@ fn try_fold_roots<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) || !validate_arguments(args, 1) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) || !validate_arguments(args, 1) {
         return None;
     }
     let arg_val = args[0].to_expression().get_side_free_number_value(ctx)?;
@@ -451,7 +452,7 @@ fn try_fold_math_unary<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) || !validate_arguments(args, 1) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) || !validate_arguments(args, 1) {
         return None;
     }
     let arg_val = args[0].to_expression().get_side_free_number_value(ctx)?;
@@ -493,7 +494,7 @@ fn try_fold_math_variadic<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    if !ctx.is_global_expr("Math", object) {
+    if !ctx.is_global_expr(&IDENT_MATH, object) {
         return None;
     }
     let mut numbers = std::vec::Vec::new();

--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::*;
+use oxc_span::{IDENT_DATE, IDENT_NUMBER};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{GlobalContext, to_numeric::ToNumeric, to_primitive::ToPrimitive};
@@ -270,7 +271,7 @@ impl<'a> DetermineValueType<'a> for LogicalExpression<'a> {
 impl<'a> DetermineValueType<'a> for StaticMemberExpression<'a> {
     fn value_type(&self, ctx: &impl GlobalContext<'a>) -> ValueType {
         if matches!(self.property.name.as_str(), "POSITIVE_INFINITY" | "NEGATIVE_INFINITY")
-            && ctx.is_global_expr("Number", &self.object)
+            && ctx.is_global_expr(&IDENT_NUMBER, &self.object)
         {
             return ValueType::Number;
         }
@@ -280,7 +281,7 @@ impl<'a> DetermineValueType<'a> for StaticMemberExpression<'a> {
 
 impl<'a> DetermineValueType<'a> for NewExpression<'a> {
     fn value_type(&self, ctx: &impl GlobalContext<'a>) -> ValueType {
-        if ctx.is_global_expr("Date", &self.callee) {
+        if ctx.is_global_expr(&IDENT_DATE, &self.callee) {
             return ValueType::Object;
         }
         ValueType::Undetermined

--- a/crates/oxc_ecmascript/src/global_context.rs
+++ b/crates/oxc_ecmascript/src/global_context.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_span::Ident;
 use oxc_syntax::reference::ReferenceId;
 
 use crate::constant_evaluation::ConstantValue;
@@ -7,9 +8,9 @@ pub trait GlobalContext<'a>: Sized {
     /// Whether the reference is a global reference.
     fn is_global_reference(&self, reference: &IdentifierReference<'a>) -> bool;
 
-    fn is_global_expr(&self, name: &str, expr: &Expression<'a>) -> bool {
+    fn is_global_expr(&self, name: &Ident<'_>, expr: &Expression<'a>) -> bool {
         expr.get_identifier_reference()
-            .filter(|ident| ident.name == name)
+            .filter(|ident| ident.name == *name)
             .is_some_and(|ident| self.is_global_reference(ident))
     }
 

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -48,7 +48,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<VariableDeclarator<'a>> {
         if decl.id.is_destructuring_pattern() {
             decl.id.bound_names(&mut |id| {
-                if !check_binding || self.scope.has_value_reference(&id.name) {
+                if !check_binding || self.scope.has_value_reference(id.name) {
                     self.error(binding_element_export(id.span));
                 }
             });
@@ -57,7 +57,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         if check_binding
             && let Some(name) = decl.id.get_identifier_name()
-            && !self.scope.has_value_reference(&name)
+            && !self.scope.has_value_reference(name)
         {
             return None;
         }
@@ -167,7 +167,7 @@ impl<'a> IsolatedDeclarations<'a> {
         match decl {
             Declaration::FunctionDeclaration(func) => {
                 let needs_transform = !check_binding
-                    || func.id.as_ref().is_some_and(|id| self.scope.has_value_reference(&id.name));
+                    || func.id.as_ref().is_some_and(|id| self.scope.has_value_reference(id.name));
                 needs_transform
                     .then(|| Declaration::FunctionDeclaration(self.transform_function(func, None)))
             }
@@ -176,12 +176,12 @@ impl<'a> IsolatedDeclarations<'a> {
                 .map(Declaration::VariableDeclaration),
             Declaration::ClassDeclaration(decl) => {
                 let needs_transform = !check_binding
-                    || decl.id.as_ref().is_some_and(|id| self.scope.has_reference(&id.name));
+                    || decl.id.as_ref().is_some_and(|id| self.scope.has_reference(id.name));
                 needs_transform
                     .then(|| Declaration::ClassDeclaration(self.transform_class(decl, None)))
             }
             Declaration::TSTypeAliasDeclaration(alias_decl) => {
-                if !check_binding || self.scope.has_reference(&alias_decl.id.name) {
+                if !check_binding || self.scope.has_reference(alias_decl.id.name) {
                     let mut decl = decl.clone_in(self.ast.allocator);
                     self.visit_declaration(&mut decl);
                     Some(decl)
@@ -190,7 +190,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             Declaration::TSInterfaceDeclaration(interface_decl) => {
-                if !check_binding || self.scope.has_reference(&interface_decl.id.name) {
+                if !check_binding || self.scope.has_reference(interface_decl.id.name) {
                     let mut decl = decl.clone_in(self.ast.allocator);
                     self.visit_declaration(&mut decl);
                     Some(decl)
@@ -199,7 +199,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             Declaration::TSEnumDeclaration(enum_decl) => {
-                if !check_binding || self.scope.has_reference(&enum_decl.id.name) {
+                if !check_binding || self.scope.has_reference(enum_decl.id.name) {
                     Some(self.transform_ts_enum_declaration(enum_decl))
                 } else {
                     None
@@ -210,7 +210,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     || matches!(
                         &decl.id,
                         TSModuleDeclarationName::Identifier(ident)
-                            if self.scope.has_reference(&ident.name)
+                            if self.scope.has_reference(ident.name)
                     )
                 {
                     Some(Declaration::TSModuleDeclaration(
@@ -224,7 +224,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 Some(Declaration::TSGlobalDeclaration(decl.clone_in(self.ast.allocator)))
             }
             Declaration::TSImportEqualsDeclaration(decl) => {
-                if !check_binding || self.scope.has_reference(&decl.id.name) {
+                if !check_binding || self.scope.has_reference(decl.id.name) {
                     Some(Declaration::TSImportEqualsDeclaration(decl.clone_in(self.ast.allocator)))
                 } else {
                     None

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -13,7 +13,7 @@ use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{Atom, GetSpan, SPAN, SourceType};
+use oxc_span::{Atom, GetSpan, IdentHashSet, SPAN, SourceType};
 
 use crate::{diagnostics::function_with_assigning_properties, scope::ScopeTree};
 
@@ -575,7 +575,7 @@ impl<'a> IsolatedDeclarations<'a> {
         let assignable_properties_for_namespace =
             IsolatedDeclarations::get_assignable_properties_for_namespaces(stmts);
 
-        let mut can_expando_function_names = FxHashSet::default();
+        let mut can_expando_function_names = IdentHashSet::default();
         for stmt in stmts {
             match stmt {
                 Statement::ExportNamedDeclaration(decl) => match decl.declaration.as_ref() {
@@ -610,7 +610,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 Statement::FunctionDeclaration(func) => {
                     if func.body.is_some()
                         && let Some(name) = func.name()
-                        && self.scope.has_value_reference(&name)
+                        && self.scope.has_value_reference(name)
                     {
                         can_expando_function_names.insert(name);
                     }
@@ -620,7 +620,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         if declarator.type_annotation.is_none()
                             && declarator.init.as_ref().is_some_and(Expression::is_function)
                             && let Some(name) = declarator.id.get_identifier_name()
-                            && self.scope.has_value_reference(&name)
+                            && self.scope.has_value_reference(name)
                         {
                             can_expando_function_names.insert(name);
                         }

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -631,7 +631,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         && let AssignmentTarget::StaticMemberExpression(static_member_expr) =
                             &assignment.left
                         && let Expression::Identifier(ident) = &static_member_expr.object
-                        && can_expando_function_names.contains(ident.name.as_str())
+                        && can_expando_function_names.contains(&ident.name)
                         && !assignable_properties_for_namespace
                             .get(ident.name.as_str())
                             .is_some_and(|properties| {

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 };
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_semantic::{AstNode, AstNodes, IsGlobalReference, NodeId, ReferenceId, Semantic, SymbolId};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_REQUIRE, Span};
 use oxc_syntax::{
     identifier::is_irregular_whitespace,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -405,7 +405,7 @@ pub fn is_global_require_call(call_expr: &CallExpression, ctx: &Semantic) -> boo
     if call_expr.arguments.len() != 1 {
         return false;
     }
-    call_expr.callee.is_global_reference_name("require", ctx.scoping())
+    call_expr.callee.is_global_reference_name(&IDENT_REQUIRE, ctx.scoping())
 }
 
 pub fn is_function_node(node: &AstNode) -> bool {

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -200,13 +200,13 @@ impl<'a> LintContext<'a> {
     /// Checks if the provided identifier is a reference to a global variable.
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
         let name = ident.name.as_str();
-        self.scoping().root_unresolved_references().contains_key(name)
+        self.scoping().root_unresolved_references_contains_by_name(name)
             && !self.globals().get(name).is_some_and(|value| *value == GlobalValue::Off)
     }
 
     /// Checks if the provided identifier is a reference to a global variable.
     pub fn get_global_variable_value(&self, name: &str) -> Option<GlobalValue> {
-        if !self.scoping().root_unresolved_references().contains_key(name) {
+        if !self.scoping().root_unresolved_references_contains_by_name(name) {
             return None;
         }
 

--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -199,7 +199,7 @@ fn run_for_declaration(pattern: &BindingPattern, node_scope_id: ScopeId, ctx: &L
     // e.g. "var [a, b] = [1, 2]"
     for ident in pattern.get_binding_identifiers() {
         let name = ident.name.as_str();
-        let Some(symbol) = ctx.scoping().find_binding(node_scope_id, name) else {
+        let Some(symbol) = ctx.scoping().find_binding_by_name(node_scope_id, name) else {
             continue;
         };
 

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -264,7 +264,7 @@ fn is_recursive_function(func: &Function, func_name: &str, ctx: &LintContext) ->
         return false;
     };
 
-    if let Some(binding) = ctx.scoping().find_binding(func_scope_id, func_name) {
+    if let Some(binding) = ctx.scoping().find_binding_by_name(func_scope_id, func_name) {
         return ctx.semantic().symbol_references(binding).any(|reference| {
             let parent = ctx.nodes().parent_node(reference.node_id());
             // Check if this reference is the callee of a call expression (direct recursive call)
@@ -431,7 +431,7 @@ fn is_invalid_function(
 
 /// Returns whether it's safe to insert a function name without breaking shadowing rules
 fn can_safely_apply_fix(func: &Function, name: &str, ctx: &LintContext) -> bool {
-    !ctx.scoping().find_binding(func.scope_id(), name).is_some_and(|shadowed_var| {
+    !ctx.scoping().find_binding_by_name(func.scope_id(), name).is_some_and(|shadowed_var| {
         ctx.semantic().symbol_references(shadowed_var).any(|reference| {
             func.span.contains_inclusive(ctx.nodes().get_node(reference.node_id()).kind().span())
         })

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -86,7 +86,7 @@ fn is_global_this_ref_or_global_window<'a>(
 }
 
 fn is_shadowed<'a>(scope_id: ScopeId, name: &'a str, ctx: &LintContext<'a>) -> bool {
-    ctx.scoping().find_binding(scope_id, name).is_some()
+    ctx.scoping().find_binding_by_name(scope_id, name).is_some()
 }
 
 impl Rule for NoAlert {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_ARRAY, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -79,7 +79,7 @@ impl Rule for NoArrayConstructor {
         let last_arg_is_spread = arguments.last().is_some_and(Argument::is_spread);
         let arg_len = arguments.len();
 
-        if ident.is_global_reference_name("Array", ctx.scoping())
+        if ident.is_global_reference_name(&IDENT_ARRAY, ctx.scoping())
             && (arg_len != 1 || last_arg_is_spread)
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -105,7 +105,7 @@ impl Rule for NoConsole {
         };
 
         if ident.name != "console"
-            || !ctx.scoping().root_unresolved_references().contains_key("console")
+            || !ctx.scoping().root_unresolved_references_contains_by_name("console")
         {
             return;
         }

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -181,8 +181,7 @@ impl NoConstantBinaryExpression {
                     return ["Boolean", "String", "Number"].contains(&ident.name.as_str())
                         && ctx
                             .scoping()
-                            .root_unresolved_references()
-                            .contains_key(ident.name.as_str());
+                            .root_unresolved_references_contains_by_name(ident.name.as_str());
                 }
                 false
             }
@@ -305,16 +304,14 @@ impl NoConstantBinaryExpression {
             },
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
-                    let unresolved_references = ctx.scoping().root_unresolved_references();
-                    if (ident.name == "String" || ident.name == "Number")
-                        && unresolved_references.contains_key(ident.name.as_str())
-                    {
+                    let is_unresolved = ctx
+                        .scoping()
+                        .root_unresolved_references_contains_by_name(ident.name.as_str());
+                    if (ident.name == "String" || ident.name == "Number") && is_unresolved {
                         return true;
                     }
 
-                    if ident.name == "Boolean"
-                        && unresolved_references.contains_key(ident.name.as_str())
-                    {
+                    if ident.name == "Boolean" && is_unresolved {
                         return call_expr
                             .arguments
                             .iter()
@@ -358,8 +355,7 @@ impl NoConstantBinaryExpression {
                     return ctx.env_contains_var(ident.name.as_str())
                         && ctx
                             .scoping()
-                            .root_unresolved_references()
-                            .contains_key(ident.name.as_str());
+                            .root_unresolved_references_contains_by_name(ident.name.as_str());
                 }
                 false
             }

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -107,13 +107,14 @@ impl Rule for NoEval {
                     });
 
                 for name in globals {
-                    let Some(references) = ctx.scoping().root_unresolved_references().get(name)
+                    let Some(references) =
+                        ctx.scoping().get_root_unresolved_reference_by_name(name)
                     else {
                         continue;
                     };
 
                     for reference_id in references {
-                        let reference = ctx.scoping().get_reference(*reference_id);
+                        let reference = ctx.scoping().get_reference(reference_id);
                         let node = ctx.nodes().get_node(reference.node_id());
 
                         if name == "eval" {

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -2,7 +2,7 @@ use oxc_ast::{AstKind, ast::IdentifierReference};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_FUNCTION, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -104,7 +104,7 @@ impl Rule for NoNewFunc {
 }
 
 fn check(ident: &IdentifierReference, span: Span, ctx: &LintContext) {
-    if ident.is_global_reference_name("Function", ctx.scoping()) {
+    if ident.is_global_reference_name(&IDENT_FUNCTION, ctx.scoping()) {
         ctx.diagnostic(no_new_func(span));
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -57,7 +57,7 @@ impl Rule for NoNewNativeNonconstructor {
             return;
         };
         if matches!(ident.name.as_str(), "Symbol" | "BigInt")
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str())
         {
             let start = expr.span.start;
             let end = start + 3;

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -92,7 +92,7 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str()) {
+            if ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str()) {
                 let reference = ctx.scoping().get_reference(ident.reference_id());
                 if !reference.is_type() {
                     ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -138,7 +138,7 @@ impl NoUnusedVars {
         let scope_id = symbol.scope_id();
         let mut i = 0;
         let mut new_name = ignored_name.clone();
-        while scopes.scope_has_binding(scope_id, &new_name) {
+        while scopes.scope_has_binding_by_name(scope_id, &new_name) {
             new_name = format!("{ignored_name}{i}");
             i += 1;
         }

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -75,7 +75,8 @@ impl Rule for PreferObjectHasOwn {
 
         let object_property_name = object.static_property_name();
         let is_object = has_left_hand_object(object);
-        let is_global_scope = ctx.scoping().find_binding(node.scope_id(), "Object").is_none();
+        let is_global_scope =
+            ctx.scoping().find_binding_by_name(node.scope_id(), "Object").is_none();
 
         if is_method_call(call_expr, None, Some(&["call"]), Some(2), Some(2))
             && object_property_name == Some("hasOwnProperty")

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -87,12 +87,12 @@ impl Rule for PreferObjectSpread {
             return;
         };
 
-        let unresolved_references = ctx.scoping().root_unresolved_references();
-
         match callee.object().get_inner_expression() {
             Expression::Identifier(ident) => {
                 if ident.name != "Object"
-                    || !unresolved_references.contains_key(ident.name.as_str())
+                    || !ctx
+                        .scoping()
+                        .root_unresolved_references_contains_by_name(ident.name.as_str())
                 {
                     return;
                 }
@@ -100,7 +100,9 @@ impl Rule for PreferObjectSpread {
             Expression::StaticMemberExpression(member_expr) => {
                 if let Expression::Identifier(ident) = member_expr.object.get_inner_expression() {
                     if ident.name != "globalThis"
-                        || !unresolved_references.contains_key(ident.name.as_str())
+                        || !ctx
+                            .scoping()
+                            .root_unresolved_references_contains_by_name(ident.name.as_str())
                     {
                         return;
                     }

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -73,7 +73,7 @@ impl Rule for PreferRestParams {
             {
                 return;
             }
-            let binding = ctx.scoping().find_binding(node.scope_id(), "arguments");
+            let binding = ctx.scoping().find_binding_by_name(node.scope_id(), "arguments");
             if binding.is_none() {
                 ctx.diagnostic(prefer_rest_params_diagnostic(node.span()));
             }

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -7,7 +7,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_AGGREGATE_ERROR, IDENT_ERROR, IDENT_TYPE_ERROR, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -194,13 +194,13 @@ fn is_builtin_error_constructor(expr: &Expression, ctx: &LintContext) -> bool {
         return false;
     };
 
-    ident.is_global_reference_name("Error", ctx.scoping())
-        || ident.is_global_reference_name("TypeError", ctx.scoping())
+    ident.is_global_reference_name(&IDENT_ERROR, ctx.scoping())
+        || ident.is_global_reference_name(&IDENT_TYPE_ERROR, ctx.scoping())
         || is_aggregate_error(ident, ctx)
 }
 
 fn is_aggregate_error(ident: &IdentifierReference, ctx: &LintContext) -> bool {
-    ident.is_global_reference_name("AggregateError", ctx.scoping())
+    ident.is_global_reference_name(&IDENT_AGGREGATE_ERROR, ctx.scoping())
 }
 
 fn has_cause_property(

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -64,7 +64,7 @@ impl Rule for SymbolDescription {
 
         if ident.name == "Symbol"
             && call_expr.arguments.is_empty()
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str())
         {
             ctx.diagnostic(symbol_description_diagnostic(call_expr.span));
         }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -135,7 +135,7 @@ impl Rule for ValidTypeof {
 
         if let Expression::Identifier(ident) = sibling
             && ident.name == "undefined"
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str())
         {
             ctx.diagnostic_with_fix(
                 if self.require_string_literals {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -158,7 +158,8 @@ impl Rule for Namespace {
                 return;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(entry.local_name.name()) else {
+            let Some(symbol_id) = ctx.scoping().get_root_binding_by_name(entry.local_name.name())
+            else {
                 return;
             };
 

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -233,7 +233,11 @@ impl Rule for NoCommonjs {
                     return;
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), "require").is_some() {
+                if ctx
+                    .scoping()
+                    .find_binding_by_name(ctx.scoping().root_scope_id(), "require")
+                    .is_some()
+                {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -91,7 +91,8 @@ impl Rule for NoNamedAsDefaultMember {
                 continue;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(import_entry.local_name.name())
+            let Some(symbol_id) =
+                ctx.scoping().get_root_binding_by_name(import_entry.local_name.name())
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -79,7 +79,7 @@ impl Rule for NoJasmineGlobals {
             .scoping()
             .root_unresolved_references()
             .iter()
-            .filter(|(key, _)| NON_JASMINE_PROPERTY_NAMES.contains(key));
+            .filter(|(key, _)| NON_JASMINE_PROPERTY_NAMES.contains(&key.as_str()));
 
         for (name, reference_ids) in jasmine_references {
             for &reference_id in reference_ids {

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -70,12 +70,13 @@ impl Rule for NoMocksImport {
             }
         }
 
-        let Some(require_reference_ids) = ctx.scoping().root_unresolved_references().get("require")
+        let Some(require_reference_ids) =
+            ctx.scoping().get_root_unresolved_reference_by_name("require")
         else {
             return;
         };
 
-        for &reference_id in require_reference_ids {
+        for reference_id in require_reference_ids {
             let reference = ctx.scoping().get_reference(reference_id);
             let AstKind::CallExpression(call_expr) = ctx.nodes().parent_kind(reference.node_id())
             else {

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, IDENT_EXPORTS, IDENT_MODULE, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,7 +19,7 @@ fn is_exports(node: &AssignmentTarget, ctx: &LintContext) -> bool {
     let AssignmentTarget::AssignmentTargetIdentifier(id) = node else {
         return false;
     };
-    id.is_global_reference_name("exports", ctx.scoping())
+    id.is_global_reference_name(&IDENT_EXPORTS, ctx.scoping())
 }
 
 fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool {
@@ -32,7 +32,7 @@ fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool
     };
 
     mem_expr.static_property_name() == Some("exports")
-        && obj_id.is_global_reference_name("module", ctx.scoping())
+        && obj_id.is_global_reference_name(&IDENT_MODULE, ctx.scoping())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -2,7 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, IDENT_PROCESS, Span};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
     let Some(obj_id) = object_expr.get_identifier_reference() else {
         return false;
     };
-    obj_id.is_global_reference_name("process", ctx.scoping())
+    obj_id.is_global_reference_name(&IDENT_PROCESS, ctx.scoping())
 }
 
 impl Rule for NoProcessEnv {

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -60,7 +60,7 @@ impl Rule for ApproxConstant {
                 ctx.diagnostic_with_suggestion(
                     approx_constant_diagnostic(number_literal.span, name),
                     |fixer| {
-                        if ctx.scoping().find_binding(node.scope_id(), "Math").is_some() {
+                        if ctx.scoping().find_binding_by_name(node.scope_id(), "Math").is_some() {
                             fixer.noop()
                         } else {
                             Self::fix_with_math_constant(fixer, number_literal.span, name)

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -54,7 +54,7 @@ impl Rule for AvoidNew {
         };
 
         if ident.name == "Promise"
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str())
         {
             ctx.diagnostic(avoid_new_promise_diagnostic(expr.span));
         }

--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -209,9 +209,10 @@ impl Rule for DisplayName {
         }
 
         // Check for CommonJS module.exports by looking at references to 'module' global
-        if let Some(module_reference_ids) = ctx.scoping().root_unresolved_references().get("module")
+        if let Some(module_reference_ids) =
+            ctx.scoping().get_root_unresolved_reference_by_name("module")
         {
-            for &reference_id in module_reference_ids {
+            for reference_id in module_reference_ids {
                 let reference = ctx.scoping().get_reference(reference_id);
                 let node = ctx.nodes().get_node(reference.node_id());
 

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -327,7 +327,7 @@ fn find_var_in_scope<'c>(
     name: &str,
 ) -> Option<&'c AstNode<'c>> {
     ctx.scoping()
-        .find_binding(node.scope_id(), name)
+        .find_binding_by_name(node.scope_id(), name)
         .map(|symbol_id| ctx.semantic().symbol_declaration(symbol_id))
 }
 

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -65,11 +65,11 @@ impl Rule for ReactInJsxScope {
         };
         let scope = ctx.scoping();
         let react_name = "React";
-        if scope.get_binding(scope.root_scope_id(), react_name).is_some() {
+        if scope.get_binding_by_name(scope.root_scope_id(), react_name).is_some() {
             return;
         }
 
-        if scope.find_binding(node.scope_id(), react_name).is_none() {
+        if scope.find_binding_by_name(node.scope_id(), react_name).is_none() {
             ctx.diagnostic(react_in_jsx_scope_diagnostic(node_span));
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -170,7 +170,11 @@ impl Rule for NoRequireImports {
                     }
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), "require").is_some() {
+                if ctx
+                    .scoping()
+                    .find_binding_by_name(ctx.scoping().root_scope_id(), "require")
+                    .is_some()
+                {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, Span};
+use oxc_span::{CompactStr, IDENT_REQUIRE, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -133,7 +133,7 @@ impl Rule for NoRequireImports {
             AstKind::CallExpression(call_expr) => {
                 if node.scope_id() != ctx.scoping().root_scope_id()
                     && let Some(id) = call_expr.callee.get_identifier_reference()
-                    && !id.is_global_reference_name("require", ctx.scoping())
+                    && !id.is_global_reference_name(&IDENT_REQUIRE, ctx.scoping())
                 {
                     return;
                 }

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -94,7 +94,7 @@ fn is_expr_global_builtin<'a, 'b>(
     let expr = expr.without_parentheses();
     if let Expression::Identifier(ident) = expr {
         let name = ident.name.as_str();
-        if !ctx.scoping().root_unresolved_references().contains_key(name) {
+        if !ctx.scoping().root_unresolved_references_contains_by_name(name) {
             return None;
         }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -65,7 +65,7 @@ impl Rule for PreferGlobalThis {
 
         if !matches!(ident.name.as_str(), "window" | "self" | "global")
             || is_computed_member_expression_object(node, ctx)
-            || !ctx.scoping().root_unresolved_references().contains_key(&ident.name.as_str())
+            || !ctx.scoping().root_unresolved_references_contains_by_name(ident.name.as_str())
         {
             return;
         }

--- a/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
@@ -153,7 +153,7 @@ fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<
         if !LIFECYCLE_HOOKS.contains(&import_name) {
             continue;
         }
-        if let Some(symbol_id) = scoping.get_root_binding(import_entry.local_name.name()) {
+        if let Some(symbol_id) = scoping.get_root_binding_by_name(import_entry.local_name.name()) {
             symbol_to_import_entry.insert(symbol_id, import_entry);
         }
     }

--- a/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
@@ -15,18 +15,18 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── Read-only global 'String' should not be modified.
    ╰────
 
-  ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
-   ╭─[no_global_assign.tsx:1:3]
- 1 │ ({Object = 0, String = 0} = {});
-   ·   ───┬──
-   ·      ╰── Read-only global 'Object' should not be modified.
-   ╰────
-
   ⚠ eslint(no-global-assign): Read-only global 'String' should not be modified.
    ╭─[no_global_assign.tsx:1:15]
  1 │ ({Object = 0, String = 0} = {});
    ·               ───┬──
    ·                  ╰── Read-only global 'String' should not be modified.
+   ╰────
+
+  ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
+   ╭─[no_global_assign.tsx:1:3]
+ 1 │ ({Object = 0, String = 0} = {});
+   ·   ───┬──
+   ·      ╰── Read-only global 'Object' should not be modified.
    ╰────
 
   ⚠ eslint(no-global-assign): Read-only global 'top' should not be modified.

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -17,14 +17,6 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
@@ -42,6 +34,14 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
@@ -58,14 +58,6 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:5:25]
- 4 │                         await new Promise((resolve) => {
- 5 │                         jest.setTimeout(1000);
-   ·                         ───────────────
- 6 │                         setTimeout(resolve, 10000).unref();
-   ╰────
-
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
@@ -83,6 +75,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+   ╭─[no_confusing_set_timeout.tsx:5:25]
+ 4 │                         await new Promise((resolve) => {
+ 5 │                         jest.setTimeout(1000);
+   ·                         ───────────────
+ 6 │                         setTimeout(resolve, 10000).unref();
+   ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                 });
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -17,6 +17,22 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
@@ -27,20 +43,12 @@ source: crates/oxc_linter/src/tester.rs
   help: Only the last call to `jest.setTimeout` will have an effect.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
+   ╭─[no_confusing_set_timeout.tsx:3:21]
+ 2 │                 describe('A', () => {
+ 3 │                     jest.setTimeout(800);
+   ·                     ───────────────
+ 4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+   ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
@@ -51,22 +59,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:3:21]
- 2 │                 describe('A', () => {
- 3 │                     jest.setTimeout(800);
-   ·                     ───────────────
- 4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
-   ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
-   ╭─[no_confusing_set_timeout.tsx:5:25]
- 4 │                         await new Promise((resolve) => {
- 5 │                         jest.setTimeout(1000);
-   ·                         ───────────────
- 6 │                         setTimeout(resolve, 10000).unref();
-   ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);
@@ -83,6 +75,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+   ╭─[no_confusing_set_timeout.tsx:5:25]
+ 4 │                         await new Promise((resolve) => {
+ 5 │                         jest.setTimeout(1000);
+   ·                         ───────────────
+ 6 │                         setTimeout(resolve, 10000).unref();
+   ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                 });
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);

--- a/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
@@ -29,11 +29,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of test.
 
   ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:3:20]
+   ╭─[no_identical_title.tsx:2:21]
+ 1 │ 
  2 │               xtest('this', () => {});
+   ·                     ──────
  3 │               test('this', () => {});
-   ·                    ──────
- 4 │             
    ╰────
   help: Change the title of test.
 
@@ -83,11 +83,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:25]
- 1 │ 
+   ╭─[no_identical_title.tsx:3:24]
  2 │               fdescribe('foo', () => {});
-   ·                         ─────
  3 │               describe('foo', () => {});
+   ·                        ─────
+ 4 │             
    ╰────
   help: Change the title of describe block.
 

--- a/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
@@ -29,11 +29,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of test.
 
   ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:21]
- 1 │ 
+   ╭─[no_identical_title.tsx:3:20]
  2 │               xtest('this', () => {});
-   ·                     ──────
  3 │               test('this', () => {});
+   ·                    ──────
+ 4 │             
    ╰────
   help: Change the title of test.
 
@@ -83,11 +83,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:3:24]
+   ╭─[no_identical_title.tsx:2:25]
+ 1 │ 
  2 │               fdescribe('foo', () => {});
+   ·                         ─────
  3 │               describe('foo', () => {});
-   ·                        ─────
- 4 │             
    ╰────
   help: Change the title of describe block.
 

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -16,15 +16,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
-   ╭─[padding_around_test_blocks.tsx:2:1]
- 1 │ it('foo', () => {});
- 2 │ fit('bar', () => {});
-   · ▲
- 3 │ test('baz', () => {});
-   ╰────
-  help: Make sure there is an empty new line before the fit block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:3:1]
  2 │ fit('bar', () => {});
@@ -34,11 +25,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Make sure there is an empty new line before the test block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
-   ╭─[padding_around_test_blocks.tsx:7:1]
- 6 │ });
- 7 │ fit('bar', () => {
+   ╭─[padding_around_test_blocks.tsx:2:1]
+ 1 │ it('foo', () => {});
+ 2 │ fit('bar', () => {});
    · ▲
- 8 │   // stuff
+ 3 │ test('baz', () => {});
    ╰────
   help: Make sure there is an empty new line before the fit block
 
@@ -50,6 +41,51 @@ source: crates/oxc_linter/src/tester.rs
  27 │             
     ╰────
   help: Make sure there is an empty new line before the xit block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+   ╭─[padding_around_test_blocks.tsx:4:1]
+ 3 │ const bar = 'baz';
+ 4 │ it('foo', () => {
+   · ▲
+ 5 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:18:6]
+ 17 │      });
+ 18 │      // With a comment
+    ·      ▲
+ 19 │      it('is another bar w/ it', () => {
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:22:6]
+ 21 │      test.skip('skipping', () => {}); // Another comment
+ 22 │      it.skip('skipping too', () => {});
+    ·      ▲
+ 23 │  });xtest('weird', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
+    ╭─[padding_around_test_blocks.tsx:23:5]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
+    ·     ▲
+ 24 │  test
+    ╰────
+  help: Make sure there is an empty new line before the xtest block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
+   ╭─[padding_around_test_blocks.tsx:7:1]
+ 6 │ });
+ 7 │ fit('bar', () => {
+   · ▲
+ 8 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the fit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:10:1]
@@ -95,42 +131,6 @@ source: crates/oxc_linter/src/tester.rs
  25 │    .skip('skippy skip', () => {});
     ╰────
   help: Make sure there is an empty new line before the test block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
-    ╭─[padding_around_test_blocks.tsx:23:5]
- 22 │      it.skip('skipping too', () => {});
- 23 │  });xtest('weird', () => {});
-    ·     ▲
- 24 │  test
-    ╰────
-  help: Make sure there is an empty new line before the xtest block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-   ╭─[padding_around_test_blocks.tsx:4:1]
- 3 │ const bar = 'baz';
- 4 │ it('foo', () => {
-   · ▲
- 5 │   // stuff
-   ╰────
-  help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:18:6]
- 17 │      });
- 18 │      // With a comment
-    ·      ▲
- 19 │      it('is another bar w/ it', () => {
-    ╰────
-  help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:22:6]
- 21 │      test.skip('skipping', () => {}); // Another comment
- 22 │      it.skip('skipping too', () => {});
-    ·      ▲
- 23 │  });xtest('weird', () => {});
-    ╰────
-  help: Make sure there is an empty new line before the it block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:5:5]

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -16,14 +16,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
-   ╭─[padding_around_test_blocks.tsx:3:1]
- 2 │ fit('bar', () => {});
- 3 │ test('baz', () => {});
-   · ▲
-   ╰────
-  help: Make sure there is an empty new line before the test block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
    ╭─[padding_around_test_blocks.tsx:2:1]
  1 │ it('foo', () => {});
@@ -33,14 +25,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the fit block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
-    ╭─[padding_around_test_blocks.tsx:26:2]
- 25 │    .skip('skippy skip', () => {});
- 26 │  xit('bar foo', () => {});
-    ·  ▲
- 27 │             
-    ╰────
-  help: Make sure there is an empty new line before the xit block
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
+   ╭─[padding_around_test_blocks.tsx:3:1]
+ 2 │ fit('bar', () => {});
+ 3 │ test('baz', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the test block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:4:1]
@@ -68,24 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  23 │  });xtest('weird', () => {});
     ╰────
   help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
-    ╭─[padding_around_test_blocks.tsx:23:5]
- 22 │      it.skip('skipping too', () => {});
- 23 │  });xtest('weird', () => {});
-    ·     ▲
- 24 │  test
-    ╰────
-  help: Make sure there is an empty new line before the xtest block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
-   ╭─[padding_around_test_blocks.tsx:7:1]
- 6 │ });
- 7 │ fit('bar', () => {
-   · ▲
- 8 │   // stuff
-   ╰────
-  help: Make sure there is an empty new line before the fit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:10:1]
@@ -131,6 +104,33 @@ source: crates/oxc_linter/src/tester.rs
  25 │    .skip('skippy skip', () => {});
     ╰────
   help: Make sure there is an empty new line before the test block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
+    ╭─[padding_around_test_blocks.tsx:26:2]
+ 25 │    .skip('skippy skip', () => {});
+ 26 │  xit('bar foo', () => {});
+    ·  ▲
+ 27 │             
+    ╰────
+  help: Make sure there is an empty new line before the xit block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xtest block
+    ╭─[padding_around_test_blocks.tsx:23:5]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
+    ·     ▲
+ 24 │  test
+    ╰────
+  help: Make sure there is an empty new line before the xtest block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
+   ╭─[padding_around_test_blocks.tsx:7:1]
+ 6 │ });
+ 7 │ fit('bar', () => {
+   · ▲
+ 8 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the fit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:5:5]

--- a/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
@@ -179,15 +179,6 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Works!"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
-   ╭─[prefer_lowercase_title.tsx:3:30]
- 2 │                 describe('MyClass', () => {
- 3 │                     describe('MyMethod', () => {
-   ·                              ──────────
- 4 │                         it('Does things', () => {
-   ╰────
-  help: `"MyMethod"`s should begin with lowercase
-
-  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:4:28]
  3 │                     describe('MyMethod', () => {
  4 │                         it('Does things', () => {
@@ -195,6 +186,15 @@ source: crates/oxc_linter/src/tester.rs
  5 │                             //
    ╰────
   help: `"Does things"`s should begin with lowercase
+
+  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:3:30]
+ 2 │                 describe('MyClass', () => {
+ 3 │                     describe('MyMethod', () => {
+   ·                              ──────────
+ 4 │                         it('Does things', () => {
+   ╰────
+  help: `"MyMethod"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:4:29]
@@ -215,6 +215,15 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Does things"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:4:28]
+ 3 │                     describe('MyMethod', () => {
+ 4 │                         it('Does things', () => {
+   ·                            ─────────────
+ 5 │                             //
+   ╰────
+  help: `"Does things"`s should begin with lowercase
+
+  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:2:26]
  1 │ 
  2 │                 describe('MyClass', () => {
@@ -231,12 +240,3 @@ source: crates/oxc_linter/src/tester.rs
  4 │                         it('Does things', () => {
    ╰────
   help: `"MyMethod"`s should begin with lowercase
-
-  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
-   ╭─[prefer_lowercase_title.tsx:4:28]
- 3 │                     describe('MyMethod', () => {
- 4 │                         it('Does things', () => {
-   ·                            ─────────────
- 5 │                             //
-   ╰────
-  help: `"Does things"`s should begin with lowercase

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -260,7 +260,7 @@ fn collect_ids_referenced_to_global<'c>(
         .scoping()
         .root_unresolved_references()
         .iter()
-        .filter(|(name, _)| JEST_METHOD_NAMES.contains(name))
+        .filter(|(name, _)| JEST_METHOD_NAMES.contains(&name.as_str()))
         .flat_map(|(_, reference_ids)| reference_ids.iter().copied())
 }
 

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 };
 use oxc_regular_expression::{ConstructorParser, Options, ast::Pattern};
 use oxc_semantic::IsGlobalReference;
-use oxc_span::Span;
+use oxc_span::{IDENT_GLOBAL_THIS, IDENT_REGEXP, Span};
 
 use crate::{AstNode, context::LintContext};
 
@@ -94,13 +94,13 @@ where
 
 // Accepts both RegExp and globalThis.RegExp
 fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
-    if callee.is_global_reference_name("RegExp", ctx.semantic().scoping()) {
+    if callee.is_global_reference_name(&IDENT_REGEXP, ctx.semantic().scoping()) {
         return true;
     }
     // Check for globalThis.RegExp (StaticMemberExpression)
     if let Expression::StaticMemberExpression(member) = callee
         && let Expression::Identifier(obj) = &member.object
-        && obj.is_global_reference_name("globalThis", ctx.semantic().scoping())
+        && obj.is_global_reference_name(&IDENT_GLOBAL_THIS, ctx.semantic().scoping())
         && member.property.name == "RegExp"
     {
         return true;

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -333,8 +333,8 @@ impl<'t> Mangler<'t> {
             // Scopes with direct eval: collect binding names as reserved (they can be
             // accessed by eval at runtime) and skip slot assignment (keep original names).
             if scoping.scope_flags(scope_id).contains_direct_eval() {
-                for (&name, _) in bindings {
-                    eval_reserved_names.insert(name);
+                for (name, _) in bindings {
+                    eval_reserved_names.insert(name.as_str());
                 }
                 continue;
             }
@@ -449,8 +449,7 @@ impl<'t> Mangler<'t> {
             &slots,
         );
 
-        let root_unresolved_references = scoping.root_unresolved_references();
-        let root_bindings = scoping.get_bindings(scoping.root_scope_id());
+        let root_scope_id = scoping.root_scope_id();
 
         // Generate reserved names only for slots that have symbols (frequencies.len())
         // instead of all slots. This avoids generating unused names.
@@ -469,8 +468,8 @@ impl<'t> Mangler<'t> {
                 let n = name.as_str();
                 if !oxc_syntax::keyword::is_reserved_keyword(n)
                     && !is_special_name(n)
-                    && !root_unresolved_references.contains_key(n)
-                    && !(root_bindings.contains_key(n)
+                    && !scoping.root_unresolved_references_contains_by_name(n)
+                    && !(scoping.scope_has_binding_by_name(root_scope_id, n)
                         && (!self.options.top_level || exported_names.contains(n)))
                     // TODO: only skip the names that are kept in the current scope
                     && !keep_name_names.contains(n)

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -5,7 +5,7 @@ use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType, ValueType},
     side_effects::MayHaveSideEffects,
 };
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, IDENT_NUMBER, SPAN};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::ctx::Ctx;
@@ -523,7 +523,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn fold_call_expression(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
         let Expression::CallExpression(e) = expr else { return };
-        if !ctx.is_global_expr("Number", &e.callee) {
+        if !ctx.is_global_expr(&IDENT_NUMBER, &e.callee) {
             return;
         }
         if e.arguments.len() != 1 {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -7,8 +7,7 @@ use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, Det
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::GetSpan;
-use oxc_span::SPAN;
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_syntax::precedence::GetPrecedence;
 use oxc_syntax::{
     number::NumberBase,
@@ -19,6 +18,8 @@ use oxc_traverse::Ancestor;
 use crate::ctx::Ctx;
 
 use super::PeepholeOptimizations;
+
+const IDENT_OBJECT: Ident<'static> = Ident::new_const("Object");
 
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
@@ -1225,7 +1226,7 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                let reference_id = ctx.create_unbound_reference("Object", ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(IDENT_OBJECT, ReferenceFlags::Read);
                 call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
                     call_expr.callee.span(),
                     "Object",

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::Vec;
 use oxc_ast::ast::{BindingRestElement, RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{
     Context, ParserImpl, diagnostics,
@@ -72,6 +72,12 @@ impl<'a> ParserImpl<'a> {
     /// Get current string
     pub(crate) fn cur_string(&self) -> &'a str {
         self.lexer.get_string(self.token)
+    }
+
+    /// Get current identifier with precomputed hash
+    #[inline]
+    pub(crate) fn cur_ident(&self) -> Ident<'a> {
+        self.lexer.get_ident(self.token)
     }
 
     /// Get current template string

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -3,7 +3,7 @@ use oxc_allocator::{Box, TakeIn, Vec};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 use oxc_syntax::{
     number::{BigintBase, NumberBase},
     precedence::Precedence,
@@ -117,11 +117,11 @@ impl<'a> ParserImpl<'a> {
     }
 
     #[inline]
-    pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Atom<'a>) {
+    pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Ident<'a>) {
         let span = self.cur_token().span();
-        let name = self.cur_string();
+        let ident = self.cur_ident();
         self.bump_remap(kind);
-        (span, Atom::from(name))
+        (span, ident)
     }
 
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -414,6 +414,29 @@ macro_rules! byte_search {
         }
     };
 
+    // With provided `start` position and identifier hashing.
+    // Delegates to main implementation, then hashes the scanned bytes.
+    (
+        lexer: $lexer:ident,
+        table: $table:ident,
+        start: $start:ident,
+        hash_identifier: true,
+        handle_eof: $eof_handler:expr,
+    ) => {{
+        let hash_start = $start;
+        let result = byte_search! {
+            lexer: $lexer,
+            table: $table,
+            start: $start,
+            continue_if: (byte, pos) false,
+            handle_eof: $eof_handler,
+        };
+        // Hash the bytes that were scanned (from start to current position)
+        let scanned = $lexer.source.str_from_pos_to_current(hash_start);
+        $lexer.identifier_hasher.write_bytes(scanned.as_bytes());
+        result
+    }};
+
     // Actual implementation - with both `start` and `continue_if`
     (
         lexer: $lexer:ident,

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -277,6 +277,8 @@ impl<'a> Lexer<'a> {
     /// Get the current identifier with precomputed hash.
     #[inline]
     pub(crate) fn get_ident(&self, token: Token) -> Ident<'a> {
-        Ident::new(self.get_string(token))
+        let s = self.get_string(token);
+        let hash = self.identifier_hasher.finish();
+        Ident::new_with_hash(s, hash)
     }
 }

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
 use oxc_allocator::StringBuilder;
+use oxc_span::Ident;
 
 use crate::diagnostics;
 
@@ -271,5 +272,11 @@ impl<'a> Lexer<'a> {
             _ => {}
         }
         &source_text[start..end]
+    }
+
+    /// Get the current identifier with precomputed hash.
+    #[inline]
+    pub(crate) fn get_ident(&self, token: Token) -> Ident<'a> {
+        Ident::new(self.get_string(token))
     }
 }

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -12,6 +12,8 @@ use oxc_syntax::{
     line_terminator::{CR, LF, LS, PS, is_irregular_line_terminator},
 };
 
+use oxc_span::IncrementalIdentHasher;
+
 use super::{Kind, Lexer, Span};
 
 /// A Unicode escape sequence.
@@ -36,7 +38,10 @@ impl<'a> Lexer<'a> {
             c if is_identifier_start_unicode(c) => {
                 let start_pos = self.source.position();
                 self.consume_char();
-                self.identifier_tail_after_unicode(start_pos);
+                let id = self.identifier_tail_after_unicode(start_pos);
+                // Hash the full identifier for get_ident()
+                self.identifier_hasher = IncrementalIdentHasher::new();
+                self.identifier_hasher.write_bytes(id.as_bytes());
                 Kind::Ident
             }
             c if is_irregular_whitespace(c) => self.handle_irregular_whitespace(c),

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -392,13 +392,13 @@ impl<'a> Binder<'a> for TSEnumMember<'a> {
         let name = match &self.id {
             TSEnumMemberName::Identifier(ident) => ident.name,
             TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => {
-                Ident::from(lit.value.as_str())
+                Ident::from(lit.value)
             }
             TSEnumMemberName::ComputedTemplateString(template) => {
                 let quasi = template.single_quasi().expect(
                     "`TSEnumMemberName::TemplateString` should have no substitution and at least one quasi",
                 );
-                Ident::from(quasi.as_str())
+                Ident::from(quasi)
             }
         };
         builder.declare_symbol(

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -3,6 +3,7 @@
 use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
+use oxc_span::Ident;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, symbol::SymbolFlags};
 
 use crate::{SemanticBuilder, checker::is_function_decl_part_of_if_statement};
@@ -38,7 +39,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 
         if self.kind.is_lexical() {
             self.id.bound_names(&mut |ident| {
-                let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+                let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
                 ident.symbol_id.set(Some(symbol_id));
             });
         } else {
@@ -63,7 +64,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 
                 for &scope_id in &var_scope_ids {
                     if let Some(symbol_id) =
-                        builder.check_redeclaration(scope_id, span, &name, excludes, true)
+                        builder.check_redeclaration(scope_id, span, name, excludes, true)
                     {
                         builder.add_redeclare_variable(symbol_id, includes, span);
                         declared_symbol_id = Some(symbol_id);
@@ -73,8 +74,8 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                         if !builder.scoping.scope_has_binding(target_scope_id, &name) {
                             // remove current scope binding and add to target scope
                             // avoid same symbols appear in multi-scopes
-                            builder.scoping.remove_binding(scope_id, &name);
-                            builder.scoping.add_binding(target_scope_id, &name, symbol_id);
+                            builder.scoping.remove_binding(scope_id, name);
+                            builder.scoping.add_binding(target_scope_id, name, symbol_id);
                             builder.scoping.symbol_scope_ids[symbol_id] = target_scope_id;
                         }
                         break;
@@ -85,24 +86,14 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                 // we don't need to create another symbol with the same name
                 // to make sure they point to the same symbol.
                 let symbol_id = declared_symbol_id.unwrap_or_else(|| {
-                    builder.declare_symbol_on_scope(
-                        span,
-                        &name,
-                        target_scope_id,
-                        includes,
-                        excludes,
-                    )
+                    builder.declare_symbol_on_scope(span, name, target_scope_id, includes, excludes)
                 });
                 ident.symbol_id.set(Some(symbol_id));
 
                 // Finally, add the variable to all hoisted scopes
                 // to support redeclaration checks when declaring variables with the same name later.
                 for &scope_id in &var_scope_ids {
-                    builder
-                        .hoisting_variables
-                        .entry(scope_id)
-                        .or_default()
-                        .insert(name.into(), symbol_id);
+                    builder.hoisting_variables.entry(scope_id).or_default().insert(name, symbol_id);
                 }
             });
         }
@@ -123,7 +114,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 }
 
 impl<'a> Binder<'a> for Class<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let includes = if self.declare {
             SymbolFlags::Class | SymbolFlags::Ambient
         } else {
@@ -131,13 +122,13 @@ impl<'a> Binder<'a> for Class<'a> {
         };
         let Some(ident) = &self.id else { return };
         let symbol_id =
-            builder.declare_symbol(ident.span, &ident.name, includes, SymbolFlags::ClassExcludes);
+            builder.declare_symbol(ident.span, ident.name, includes, SymbolFlags::ClassExcludes);
         ident.symbol_id.set(Some(symbol_id));
     }
 }
 
 impl<'a> Binder<'a> for Function<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let is_declaration = self.is_declaration();
 
         if let Some(ident) = &self.id {
@@ -158,7 +149,7 @@ impl<'a> Binder<'a> for Function<'a> {
                 SymbolFlags::FunctionExcludes - SymbolFlags::FunctionScopedVariable
             };
 
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+            let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
 
             // Save `@__NO_SIDE_EFFECTS__`
@@ -191,7 +182,7 @@ impl<'a> Binder<'a> for Function<'a> {
 
 impl<'a> Binder<'a> for BindingRestElement<'a> {
     // Binds the FormalParameters's rest of a function or method.
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
         let AstKind::FormalParameters(_) = parent_kind else {
             return;
@@ -201,7 +192,7 @@ impl<'a> Binder<'a> for BindingRestElement<'a> {
         let excludes =
             SymbolFlags::FunctionScopedVariable | SymbolFlags::FunctionScopedVariableExcludes;
         self.bound_names(&mut |ident| {
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+            let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
         });
     }
@@ -209,7 +200,7 @@ impl<'a> Binder<'a> for BindingRestElement<'a> {
 
 impl<'a> Binder<'a> for FormalParameter<'a> {
     // Binds the FormalParameter of a function or method.
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
         let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
 
@@ -236,7 +227,7 @@ impl<'a> Binder<'a> for FormalParameter<'a> {
         };
 
         self.bound_names(&mut |ident| {
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+            let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
         });
     }
@@ -244,7 +235,7 @@ impl<'a> Binder<'a> for FormalParameter<'a> {
 
 impl<'a> Binder<'a> for FormalParameterRest<'a> {
     // Binds the FormalParameter of a function or method.
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
         let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
 
@@ -271,14 +262,14 @@ impl<'a> Binder<'a> for FormalParameterRest<'a> {
         };
 
         self.rest.argument.bound_names(&mut |ident| {
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+            let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
         });
     }
 }
 
 impl<'a> Binder<'a> for CatchParameter<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let current_scope_id = builder.current_scope_id;
         // https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks
         // It is a Syntax Error if any element of the BoundNames of CatchParameter also occurs in the VarDeclaredNames of Block
@@ -286,13 +277,13 @@ impl<'a> Binder<'a> for CatchParameter<'a> {
         if let BindingPattern::BindingIdentifier(ident) = &self.pattern {
             let includes = SymbolFlags::FunctionScopedVariable | SymbolFlags::CatchVariable;
             let symbol_id =
-                builder.declare_shadow_symbol(&ident.name, ident.span, current_scope_id, includes);
+                builder.declare_shadow_symbol(ident.name, ident.span, current_scope_id, includes);
             ident.symbol_id.set(Some(symbol_id));
         } else {
             self.pattern.bound_names(&mut |ident| {
                 let symbol_id = builder.declare_symbol(
                     ident.span,
-                    &ident.name,
+                    ident.name,
                     SymbolFlags::BlockScopedVariable | SymbolFlags::CatchVariable,
                     SymbolFlags::BlockScopedVariableExcludes,
                 );
@@ -302,10 +293,10 @@ impl<'a> Binder<'a> for CatchParameter<'a> {
     }
 }
 
-fn declare_symbol_for_import_specifier(
-    ident: &BindingIdentifier,
+fn declare_symbol_for_import_specifier<'a>(
+    ident: &BindingIdentifier<'a>,
     is_type: bool,
-    builder: &mut SemanticBuilder,
+    builder: &mut SemanticBuilder<'a>,
 ) {
     let includes = if is_type
         || matches!(builder.nodes.parent_kind(builder.current_node_id), AstKind::ImportDeclaration(decl) if decl.import_kind.is_type(),
@@ -317,7 +308,7 @@ fn declare_symbol_for_import_specifier(
 
     let symbol_id = builder.declare_symbol(
         ident.span,
-        &ident.name,
+        ident.name,
         includes,
         SymbolFlags::ImportBindingExcludes,
     );
@@ -325,31 +316,31 @@ fn declare_symbol_for_import_specifier(
 }
 
 impl<'a> Binder<'a> for ImportSpecifier<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         declare_symbol_for_import_specifier(&self.local, self.import_kind.is_type(), builder);
     }
 }
 
 impl<'a> Binder<'a> for ImportDefaultSpecifier<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         declare_symbol_for_import_specifier(&self.local, false, builder);
     }
 }
 
 impl<'a> Binder<'a> for ImportNamespaceSpecifier<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         declare_symbol_for_import_specifier(&self.local, false, builder);
     }
 }
 
 impl<'a> Binder<'a> for TSImportEqualsDeclaration<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         declare_symbol_for_import_specifier(&self.id, false, builder);
     }
 }
 
 impl<'a> Binder<'a> for TSTypeAliasDeclaration<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let includes = if self.declare {
             SymbolFlags::TypeAlias | SymbolFlags::Ambient
         } else {
@@ -357,7 +348,7 @@ impl<'a> Binder<'a> for TSTypeAliasDeclaration<'a> {
         };
         let symbol_id = builder.declare_symbol(
             self.id.span,
-            &self.id.name,
+            self.id.name,
             includes,
             SymbolFlags::TypeAliasExcludes,
         );
@@ -366,7 +357,7 @@ impl<'a> Binder<'a> for TSTypeAliasDeclaration<'a> {
 }
 
 impl<'a> Binder<'a> for TSInterfaceDeclaration<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let includes = if self.declare {
             SymbolFlags::Interface | SymbolFlags::Ambient
         } else {
@@ -374,7 +365,7 @@ impl<'a> Binder<'a> for TSInterfaceDeclaration<'a> {
         };
         let symbol_id = builder.declare_symbol(
             self.id.span,
-            &self.id.name,
+            self.id.name,
             includes,
             SymbolFlags::InterfaceExcludes,
         );
@@ -383,7 +374,7 @@ impl<'a> Binder<'a> for TSInterfaceDeclaration<'a> {
 }
 
 impl<'a> Binder<'a> for TSEnumDeclaration<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let is_const = self.r#const;
         let includes = if self.declare { SymbolFlags::Ambient } else { SymbolFlags::empty() };
         let (includes, excludes) = if is_const {
@@ -391,16 +382,28 @@ impl<'a> Binder<'a> for TSEnumDeclaration<'a> {
         } else {
             (SymbolFlags::RegularEnum | includes, SymbolFlags::RegularEnumExcludes)
         };
-        let symbol_id = builder.declare_symbol(self.id.span, &self.id.name, includes, excludes);
+        let symbol_id = builder.declare_symbol(self.id.span, self.id.name, includes, excludes);
         self.id.symbol_id.set(Some(symbol_id));
     }
 }
 
 impl<'a> Binder<'a> for TSEnumMember<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
+        let name = match &self.id {
+            TSEnumMemberName::Identifier(ident) => ident.name,
+            TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => {
+                Ident::from(lit.value.as_str())
+            }
+            TSEnumMemberName::ComputedTemplateString(template) => {
+                let quasi = template.single_quasi().expect(
+                    "`TSEnumMemberName::TemplateString` should have no substitution and at least one quasi",
+                );
+                Ident::from(quasi.as_str())
+            }
+        };
         builder.declare_symbol(
             self.span,
-            self.id.static_name().as_str(),
+            name,
             SymbolFlags::EnumMember,
             SymbolFlags::EnumMemberExcludes,
         );
@@ -421,7 +424,7 @@ impl<'a> Binder<'a> for TSModuleDeclaration<'a> {
         if self.declare {
             includes |= SymbolFlags::Ambient;
         }
-        let symbol_id = builder.declare_symbol(id.span, &id.name, includes, excludes);
+        let symbol_id = builder.declare_symbol(id.span, id.name, includes, excludes);
 
         id.set_symbol_id(symbol_id);
     }
@@ -685,7 +688,7 @@ fn get_module_instance_state_for_alias_target<'a>(
 }
 
 impl<'a> Binder<'a> for TSTypeParameter<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let scope_id = if matches!(
             builder.nodes.parent_kind(builder.current_node_id),
             AstKind::TSInferType(_)
@@ -700,7 +703,7 @@ impl<'a> Binder<'a> for TSTypeParameter<'a> {
 
         let symbol_id = builder.declare_symbol_on_scope(
             self.name.span,
-            &self.name.name,
+            self.name.name,
             scope_id.unwrap_or(builder.current_scope_id),
             SymbolFlags::TypeParameter,
             SymbolFlags::TypeParameterExcludes,
@@ -710,10 +713,10 @@ impl<'a> Binder<'a> for TSTypeParameter<'a> {
 }
 
 impl<'a> Binder<'a> for TSMappedType<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let symbol_id = builder.declare_symbol_on_scope(
             self.key.span,
-            &self.key.name,
+            self.key.name,
             builder.current_scope_id,
             SymbolFlags::TypeParameter,
             SymbolFlags::TypeParameterExcludes,

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -411,13 +411,8 @@ impl<'a> SemanticBuilder<'a> {
             return symbol_id;
         }
 
-        let symbol_id = self.scoping.create_symbol(
-            span,
-            name.as_str(),
-            includes,
-            scope_id,
-            self.current_node_id,
-        );
+        let symbol_id =
+            self.scoping.create_symbol(span, name, includes, scope_id, self.current_node_id);
 
         self.scoping.add_binding(scope_id, name, symbol_id);
         symbol_id
@@ -501,7 +496,7 @@ impl<'a> SemanticBuilder<'a> {
     ) -> SymbolId {
         let symbol_id = self.scoping.create_symbol(
             span,
-            name.as_str(),
+            name,
             includes,
             self.current_scope_id,
             self.current_node_id,

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
-use rustc_hash::FxHashMap;
 
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::BoundNames;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, IdentHashMap, Span};
 
 use crate::{builder::SemanticBuilder, diagnostics};
 
@@ -91,9 +90,9 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
 }
 
 fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
-    let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
+    let mut idents: IdentHashMap<'a, Span> = IdentHashMap::default();
     bound_names.bound_names(&mut |ident| {
-        if let Some(old_span) = idents.insert(ident.name.into(), ident.span) {
+        if let Some(old_span) = idents.insert(ident.name, ident.span) {
             ctx.error(diagnostics::redeclaration(&ident.name, old_span, ident.span));
         }
     });

--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_span::Ident;
 
 use crate::{ReferenceId, Scoping};
 
@@ -26,7 +27,7 @@ use crate::{ReferenceId, Scoping};
 /// See: <https://github.com/oxc-project/oxc/issues/8365>
 pub trait IsGlobalReference {
     fn is_global_reference(&self, scoping: &Scoping) -> bool;
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool;
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool;
 }
 
 impl IsGlobalReference for ReferenceId {
@@ -34,7 +35,7 @@ impl IsGlobalReference for ReferenceId {
         scoping.references[*self].symbol_id().is_none()
     }
 
-    fn is_global_reference_name(&self, _name: &str, _scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, _name: &Ident<'_>, _scoping: &Scoping) -> bool {
         panic!("This function is pointless to be called.");
     }
 }
@@ -46,8 +47,8 @@ impl IsGlobalReference for IdentifierReference<'_> {
             .is_some_and(|reference_id| reference_id.is_global_reference(scoping))
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
-        self.name == name && self.is_global_reference(scoping)
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool {
+        self.name == *name && self.is_global_reference(scoping)
     }
 }
 
@@ -59,7 +60,7 @@ impl IsGlobalReference for Expression<'_> {
         false
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, name: &Ident<'_>, scoping: &Scoping) -> bool {
         if let Expression::Identifier(ident) = self {
             return ident.is_global_reference_name(name, scoping);
         }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -215,7 +215,7 @@ impl<'a> Semantic<'a> {
         let AstKind::IdentifierReference(id) = reference_node.kind() else {
             return false;
         };
-        self.scoping.root_unresolved_references().contains_key(id.name.as_str())
+        self.scoping.root_unresolved_references().contains_key(&id.name)
     }
 
     /// Find which scope a symbol is declared in
@@ -236,7 +236,7 @@ impl<'a> Semantic<'a> {
     }
 
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
-        self.scoping.root_unresolved_references().contains_key(ident.name.as_str())
+        self.scoping.root_unresolved_references().contains_key(&ident.name)
     }
 
     pub fn reference_name(&self, reference: &Reference) -> &str {
@@ -285,8 +285,10 @@ mod tests {
         let allocator = Allocator::default();
         let semantic = get_semantic(&allocator, source, SourceType::default());
 
-        let top_level_a =
-            semantic.scoping().get_binding(semantic.scoping().root_scope_id(), "a").unwrap();
+        let top_level_a = semantic
+            .scoping()
+            .get_binding_by_name(semantic.scoping().root_scope_id(), "a")
+            .unwrap();
 
         let decl = semantic.symbol_declaration(top_level_a);
         match decl.kind() {
@@ -307,7 +309,7 @@ mod tests {
         let semantic = get_semantic(&allocator, source, SourceType::default());
         let scopes = semantic.scoping();
 
-        assert!(scopes.get_binding(scopes.root_scope_id(), "Fn").is_some());
+        assert!(scopes.get_binding_by_name(scopes.root_scope_id(), "Fn").is_some());
     }
 
     #[test]
@@ -448,8 +450,10 @@ mod tests {
 
         for (source_type, source, flags) in sources {
             let semantic = get_semantic(&alloc, source, source_type);
-            let a_id =
-                semantic.scoping().get_root_binding(&target_symbol_name).unwrap_or_else(|| {
+            let a_id = semantic
+                .scoping()
+                .get_root_binding_by_name(target_symbol_name.as_str())
+                .unwrap_or_else(|| {
                     panic!("no references for '{target_symbol_name}' found");
                 });
             let a_refs: Vec<_> = semantic.symbol_references(a_id).collect();

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,8 +1,7 @@
-use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use oxc_data_structures::assert_unchecked;
-use oxc_span::Atom;
+use oxc_span::IdentHashMap;
 use oxc_syntax::reference::ReferenceId;
 
 /// Stores reference IDs for a single identifier name within a scope.
@@ -10,9 +9,9 @@ use oxc_syntax::reference::ReferenceId;
 /// is referenced only a few times within a given scope.
 pub type ReferenceIds = SmallVec<[ReferenceId; 8]>;
 
-/// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Atom` as the key,
+/// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Ident` as the key,
 /// and uses a heap-allocated hashmap (not arena-allocated)
-type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, ReferenceIds>;
+type TempUnresolvedReferences<'a> = IdentHashMap<'a, ReferenceIds>;
 
 // Stack used to accumulate unresolved refs while traversing scopes.
 // Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -45,7 +45,8 @@ impl<'a> SymbolTester<'a> {
         semantic: Semantic<'a>,
         target: &str,
     ) -> Self {
-        let decl = semantic.scoping().get_binding(semantic.scoping().root_scope_id(), target);
+        let decl =
+            semantic.scoping().get_binding_by_name(semantic.scoping().root_scope_id(), target);
         let data = decl.map_or_else(
             || Err(OxcDiagnostic::error(format!("Could not find declaration for {target}"))),
             Ok,
@@ -67,7 +68,9 @@ impl<'a> SymbolTester<'a> {
         let mut symbols_with_target_name: Vec<SymbolId> = semantic
             .scoping()
             .iter_bindings()
-            .filter_map(|(_, bindings)| bindings.get(target).copied())
+            .filter_map(|(_, bindings)| {
+                bindings.iter().find(|(k, _)| k.as_str() == target).map(|(_, &v)| v)
+            })
             .collect();
 
         let data = match symbols_with_target_name.len() {

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -11,7 +11,8 @@ mod span;
 pub use cmp::ContentEq;
 pub use oxc_str::{
     ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet, IdentHasher,
-    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
+    IncrementalIdentHasher, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str,
+    format_ident,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -10,8 +10,8 @@ mod span;
 
 pub use cmp::ContentEq;
 pub use oxc_str::{
-    Atom, CompactStr, Ident, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom,
-    format_compact_str, format_ident,
+    ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet, IdentHasher,
+    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -10,9 +10,11 @@ mod span;
 
 pub use cmp::ContentEq;
 pub use oxc_str::{
-    ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet, IdentHasher,
-    IncrementalIdentHasher, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str,
-    format_ident,
+    ArenaIdentHashMap, Atom, CompactStr, IDENT_AGGREGATE_ERROR, IDENT_ARRAY, IDENT_DATE,
+    IDENT_ERROR, IDENT_EXPORTS, IDENT_FUNCTION, IDENT_GLOBAL_THIS, IDENT_MATH, IDENT_MODULE,
+    IDENT_NUMBER, IDENT_PROCESS, IDENT_REGEXP, IDENT_REQUIRE, IDENT_STRING, IDENT_TYPE_ERROR,
+    Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
+    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -24,6 +24,7 @@ oxc_allocator = { workspace = true }
 oxc_estree = { workspace = true }
 
 compact_str = { workspace = true }
+rustc-hash = { workspace = true }
 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -18,7 +18,8 @@ use serde::{Serialize, Serializer as SerdeSerializer};
 use crate::{Atom, CompactStr};
 
 /// Multiplier constant for incremental hashing.
-const K: usize = 0xf135_7aea_2e62_a9c5;
+/// Uses u64 to ensure consistent behavior on 32-bit and 64-bit platforms.
+const K: u64 = 0xf135_7aea_2e62_a9c5;
 
 /// Incremental hasher for computing Ident hashes byte-by-byte.
 ///
@@ -26,7 +27,7 @@ const K: usize = 0xf135_7aea_2e62_a9c5;
 /// avoiding a second pass over the data.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct IncrementalIdentHasher {
-    state: usize,
+    state: u64,
 }
 
 impl IncrementalIdentHasher {
@@ -39,7 +40,7 @@ impl IncrementalIdentHasher {
     /// Add a byte to the hash.
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
-        self.state = self.state.wrapping_add(byte as usize).wrapping_mul(K);
+        self.state = self.state.wrapping_add(byte as u64).wrapping_mul(K);
     }
 
     /// Add multiple bytes to the hash.
@@ -64,10 +65,10 @@ impl IncrementalIdentHasher {
 /// This is a const-compatible version for `Ident::new_const`.
 const fn compute_hash(s: &str) -> u32 {
     let bytes = s.as_bytes();
-    let mut state: usize = 0;
+    let mut state: u64 = 0;
     let mut i = 0;
     while i < bytes.len() {
-        state = state.wrapping_add(bytes[i] as usize).wrapping_mul(K);
+        state = state.wrapping_add(bytes[i] as u64).wrapping_mul(K);
         i += 1;
     }
     // 0xff marker

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -1,33 +1,155 @@
 //! Identifier string type.
 
-use std::{
-    borrow::{Borrow, Cow},
-    fmt, hash,
-    ops::Deref,
-};
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::len_without_is_empty,
+    clippy::undocumented_unsafe_blocks,
+    clippy::cast_lossless
+)]
+
+use std::{borrow::Cow, fmt, hash, hash::Hasher, marker::PhantomData, ops::Deref, ptr::NonNull};
 
 use oxc_allocator::{Allocator, CloneIn, Dummy, FromIn, StringBuilder as ArenaStringBuilder};
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
+use rustc_hash::FxHasher;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
 use crate::{Atom, CompactStr};
 
+/// Compute FxHash of a string at compile time.
+///
+/// This matches what `hash::Hash::hash(&s, &mut FxHasher)` produces at runtime
+/// with rustc-hash v2.x, which uses a wyhash-inspired algorithm.
+///
+/// The `str` Hash impl: writes bytes, then 0xff marker, then length.
+const fn const_fx_hash_str(s: &str) -> u64 {
+    // rustc-hash v2.x constants
+    const SEED1: u64 = 0x243f_6a88_85a3_08d3;
+    const SEED2: u64 = 0x1319_8a2e_0370_7344;
+    const PREVENT_TRIVIAL_ZERO_COLLAPSE: u64 = 0xa409_3822_299f_31d0;
+    const K: u64 = 0xf135_7aea_2e62_a9c5;
+
+    // Folded multiplication: (x * y) XOR'd with its high bits
+    const fn multiply_mix(x: u64, y: u64) -> u64 {
+        let full = (x as u128) * (y as u128);
+        (full as u64) ^ ((full >> 64) as u64)
+    }
+
+    // Read u64 from bytes in little-endian
+    const fn read_u64_le(bytes: &[u8], offset: usize) -> u64 {
+        u64::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+            bytes[offset + 4],
+            bytes[offset + 5],
+            bytes[offset + 6],
+            bytes[offset + 7],
+        ])
+    }
+
+    // Read u32 from bytes in little-endian
+    const fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes([bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]])
+    }
+
+    // Hash bytes using rustc-hash v2.x algorithm (wyhash-inspired)
+    const fn hash_bytes(bytes: &[u8]) -> u64 {
+        let len = bytes.len();
+        let mut s0 = SEED1;
+        let mut s1 = SEED2;
+
+        if len <= 16 {
+            if len >= 8 {
+                s0 ^= read_u64_le(bytes, 0);
+                s1 ^= read_u64_le(bytes, len - 8);
+            } else if len >= 4 {
+                s0 ^= read_u32_le(bytes, 0) as u64;
+                s1 ^= read_u32_le(bytes, len - 4) as u64;
+            } else if len > 0 {
+                let lo = bytes[0];
+                let mid = bytes[len / 2];
+                let hi = bytes[len - 1];
+                s0 ^= lo as u64;
+                s1 ^= ((hi as u64) << 8) | mid as u64;
+            }
+        } else {
+            // Handle bulk (can partially overlap with suffix)
+            let mut off = 0;
+            while off < len - 16 {
+                let x = read_u64_le(bytes, off);
+                let y = read_u64_le(bytes, off + 8);
+                let t = multiply_mix(s0 ^ x, PREVENT_TRIVIAL_ZERO_COLLAPSE ^ y);
+                s0 = s1;
+                s1 = t;
+                off += 16;
+            }
+            // Process suffix
+            s0 ^= read_u64_le(bytes, len - 16);
+            s1 ^= read_u64_le(bytes, len - 8);
+        }
+
+        multiply_mix(s0, s1) ^ (len as u64)
+    }
+
+    // add_to_hash in rustc-hash v2.x: hash = (hash + i).wrapping_mul(K)
+    const fn add_to_hash(hash: u64, i: u64) -> u64 {
+        hash.wrapping_add(i).wrapping_mul(K)
+    }
+
+    let bytes = s.as_bytes();
+
+    // str's Hash impl:
+    // 1. write(bytes) -> write_u64(hash_bytes(bytes)) -> add_to_hash(hash_bytes_result)
+    let mut state: u64 = 0;
+    state = add_to_hash(state, hash_bytes(bytes));
+
+    // 2. write_u8(0xff) -> add_to_hash(0xff)
+    state = add_to_hash(state, 0xff);
+
+    // Note: str's Hash impl does NOT call write_usize(len) anymore
+    // (changed in recent Rust versions)
+
+    state
+}
+
+/// Compute the hash of a string, taking top 32 bits which have highest entropy with FxHasher.
+/// This matches what `Ident::new` computes at runtime.
+const fn compute_hash(s: &str) -> u32 {
+    // const_fx_hash_str computes the internal state, but FxHasher::finish()
+    // rotates left by 26 bits before returning.
+    let internal_state = const_fx_hash_str(s);
+    let finished = internal_state.rotate_left(26);
+    (finished >> 32) as u32
+}
+
 /// An identifier string for oxc_allocator.
+///
+/// This type stores a string reference with a precomputed hash for fast equality
+/// checks and efficient hash map operations.
 ///
 /// Use [CompactStr] with [Ident::to_compact_str] or [Ident::into_compact_str] for
 /// the lifetimeless form.
-#[repr(transparent)]
 #[derive(Clone, Copy, Eq)]
-pub struct Ident<'a>(&'a str);
+pub struct Ident<'a> {
+    ptr: NonNull<u8>,
+    len: u32,
+    hash: u32,
+    _marker: PhantomData<&'a str>,
+}
 
 impl Ident<'static> {
     /// Get an [`Ident`] containing a static string.
     #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline(always)]
     pub const fn new_const(s: &'static str) -> Self {
-        Ident(s)
+        let ptr = unsafe { NonNull::new_unchecked(s.as_ptr().cast_mut()) };
+        let len = s.len() as u32;
+        let hash = compute_hash(s);
+        Self { ptr, len, hash, _marker: PhantomData }
     }
 
     /// Get an [`Ident`] containing the empty string (`""`).
@@ -38,18 +160,43 @@ impl Ident<'static> {
 }
 
 impl<'a> Ident<'a> {
+    /// Create a new [`Ident`] from a string slice.
+    #[inline]
+    pub fn new(s: &'a str) -> Self {
+        let ptr = NonNull::from(s).cast::<u8>();
+        let len = s.len() as u32;
+
+        // Produce a hash of the string
+        let hash = {
+            let mut hasher = FxHasher::default();
+            hash::Hash::hash(&s, &mut hasher);
+            // Take top 32 bits which have highest entropy with FxHasher
+            (hasher.finish() >> 32) as u32
+        };
+
+        Self { ptr, len, hash, _marker: PhantomData }
+    }
+
+    /// Get the length of this identifier.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
     /// Borrow a string slice.
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline]
     pub fn as_str(&self) -> &'a str {
-        self.0
+        unsafe {
+            let slice = std::slice::from_raw_parts(self.ptr.as_ptr(), self.len());
+            std::str::from_utf8_unchecked(slice)
+        }
     }
 
     /// Convert this [`Ident`] into an [`Atom`].
     #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline(always)]
     pub fn as_atom(&self) -> Atom<'a> {
-        Atom::from(self.0)
+        Atom::from(self.as_str())
     }
 
     /// Convert this [`Ident`] into a [`String`].
@@ -111,7 +258,9 @@ impl<'new_alloc> CloneIn<'new_alloc> for Ident<'_> {
 
     #[inline]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Ident::from_in(self.as_str(), allocator)
+        let s = allocator.alloc_str(self.as_str());
+        let ptr = NonNull::from(s).cast::<u8>();
+        Ident { ptr, len: self.len, hash: self.hash, _marker: PhantomData }
     }
 }
 
@@ -142,14 +291,14 @@ impl<'alloc> FromIn<'alloc, &str> for Ident<'alloc> {
 impl<'alloc> FromIn<'alloc, String> for Ident<'alloc> {
     #[inline]
     fn from_in(s: String, allocator: &'alloc Allocator) -> Self {
-        Self::from_in(s.as_str(), allocator)
+        Self::from(allocator.alloc_str(&s))
     }
 }
 
 impl<'alloc> FromIn<'alloc, &String> for Ident<'alloc> {
     #[inline]
     fn from_in(s: &String, allocator: &'alloc Allocator) -> Self {
-        Self::from_in(s.as_str(), allocator)
+        Self::from(allocator.alloc_str(s))
     }
 }
 
@@ -161,10 +310,9 @@ impl<'alloc> FromIn<'alloc, Cow<'_, str>> for Ident<'alloc> {
 }
 
 impl<'a> From<&'a str> for Ident<'a> {
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline]
     fn from(s: &'a str) -> Self {
-        Self(s)
+        Self::new(s)
     }
 }
 
@@ -177,25 +325,23 @@ impl<'alloc> From<ArenaStringBuilder<'alloc>> for Ident<'alloc> {
 
 impl<'a> From<Ident<'a>> for &'a str {
     #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline(always)]
     fn from(s: Ident<'a>) -> Self {
         s.as_str()
     }
 }
 
 impl<'a> From<Ident<'a>> for Atom<'a> {
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline]
     fn from(s: Ident<'a>) -> Self {
         s.as_atom()
     }
 }
 
 impl<'a> From<Atom<'a>> for Ident<'a> {
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline]
     fn from(s: Atom<'a>) -> Self {
-        Self(s.as_str())
+        Self::new(s.as_str())
     }
 }
 
@@ -224,7 +370,7 @@ impl Deref for Ident<'_> {
     type Target = str;
 
     #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         self.as_str()
     }
@@ -232,31 +378,25 @@ impl Deref for Ident<'_> {
 
 impl AsRef<str> for Ident<'_> {
     #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
+    #[inline(always)]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Borrow<str> for Ident<'_> {
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl<T: AsRef<str>> PartialEq<T> for Ident<'_> {
-    #[inline]
-    fn eq(&self, other: &T) -> bool {
-        self.as_str() == other.as_ref()
-    }
-}
-
-impl PartialEq<Ident<'_>> for &str {
+impl PartialEq for Ident<'_> {
     #[inline]
     fn eq(&self, other: &Ident<'_>) -> bool {
-        *self == other.as_str()
+        // First compare len and hash for fast rejection (single 64-bit compare),
+        // then fall back to string comparison for potential hash collisions.
+        self.len == other.len && self.hash == other.hash && self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<&Ident<'_>> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &&Ident<'_>) -> bool {
+        self == *other
     }
 }
 
@@ -264,6 +404,41 @@ impl PartialEq<str> for Ident<'_> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<String> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<Atom<'_>> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &Atom<'_>) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<&Atom<'_>> for Ident<'_> {
+    #[inline]
+    fn eq(&self, other: &&Atom<'_>) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<Ident<'_>> for &str {
+    #[inline]
+    fn eq(&self, other: &Ident<'_>) -> bool {
+        *self == other.as_str()
     }
 }
 
@@ -277,7 +452,15 @@ impl PartialEq<Ident<'_>> for Cow<'_, str> {
 impl hash::Hash for Ident<'_> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
-        self.as_str().hash(hasher);
+        // Use precomputed hash.
+        // `hashbrown` only uses top 7 bits and bottom N bits of hash,
+        // where N is the exponent of number of buckets in the hash table.
+        // Rotate by 57 bits (= 64 - 7) so that:
+        // - Original bits 0-6 end up in u64 bits 57-63 (top 7 bits for group matching)
+        // - Original bits 7-31 end up in u64 bits 0-24 (bottom 25 bits for bucket selection)
+        // This gives good entropy as long as HashMap contains less than 33 million entries.
+        let hash = (self.hash as u64).rotate_left(64 - 7);
+        hasher.write_u64(hash);
     }
 }
 
@@ -344,4 +527,164 @@ macro_rules! format_ident {
         write!(s, $($arg)*).unwrap();
         Ident::from(s)
     }}
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ident_eq() {
+        let foo = Ident::new("foo");
+        let foo2 = Ident::new("foo");
+        let bar = Ident::new("bar");
+        assert_eq!(foo, foo2);
+        assert_ne!(foo, bar);
+    }
+
+    #[test]
+    fn ident_as_str() {
+        let s = "hello_world";
+        let ident = Ident::new(s);
+        assert_eq!(ident.as_str(), s);
+    }
+
+    #[test]
+    fn ident_len() {
+        let ident = Ident::new("hello");
+        assert_eq!(ident.len(), 5);
+    }
+
+    #[test]
+    fn ident_empty() {
+        let ident = Ident::empty();
+        assert_eq!(ident.len(), 0);
+        assert_eq!(ident.as_str(), "");
+    }
+
+    #[test]
+    fn ident_hashset_lookup() {
+        use rustc_hash::FxHashSet;
+
+        let mut set: FxHashSet<Ident<'_>> = FxHashSet::default();
+
+        // Insert Idents
+        set.insert(Ident::new("foo"));
+        set.insert(Ident::new("bar"));
+
+        // Look up with new Idents - should find them
+        assert!(set.contains(&Ident::new("foo")));
+        assert!(set.contains(&Ident::new("bar")));
+
+        // Verify that a different key is not found
+        assert!(!set.contains(&Ident::new("baz")));
+    }
+
+    #[test]
+    fn ident_hash_compatible_with_str() {
+        use rustc_hash::FxHashSet;
+
+        // This test verifies that Ident's Hash impl is compatible with str lookups
+        // which is required for correct behavior in mixed hash containers
+        let mut set: FxHashSet<Ident<'_>> = FxHashSet::default();
+        set.insert(Ident::new("foo"));
+
+        // The hash of Ident("foo") should allow finding it via another Ident("foo")
+        let lookup = Ident::new("foo");
+        assert!(set.contains(&lookup));
+    }
+
+    #[test]
+    fn new_const_equals_new() {
+        // Test that Ident::new_const and Ident::new produce equal Idents
+        // for the same string content.
+
+        // Test various string lengths to exercise different code paths in const_fx_hash_str
+        let test_cases: &[&str] = &[
+            "",                                    // empty
+            "a",                                   // 1 byte
+            "ab",                                  // 2 bytes
+            "abc",                                 // 3 bytes
+            "abcd",                                // 4 bytes
+            "abcde",                               // 5 bytes
+            "abcdef",                              // 6 bytes
+            "abcdefg",                             // 7 bytes
+            "abcdefgh",                            // 8 bytes (exactly one chunk)
+            "abcdefghi",                           // 9 bytes (one chunk + 1 remaining)
+            "0123456789abcdef",                    // 16 bytes (two chunks)
+            "0123456789abcdefghij",                // 20 bytes (two chunks + 4 remaining)
+            "hello_world_this_is_a_longer_string", // longer string
+        ];
+
+        for s in test_cases {
+            let runtime = Ident::new(s);
+            let compile_time = Ident::new_const(s);
+
+            // Check that the string content is the same
+            assert_eq!(runtime.as_str(), compile_time.as_str(), "String content differs for {s:?}");
+
+            // Check that len is the same
+            assert_eq!(runtime.len, compile_time.len, "len differs for {s:?}");
+
+            // Check that hash is the same - this is the critical test!
+            assert_eq!(
+                runtime.hash, compile_time.hash,
+                "hash differs for {s:?}: new={:#x}, new_const={:#x}",
+                runtime.hash, compile_time.hash
+            );
+
+            // Check that they compare equal (uses both len and hash)
+            assert_eq!(runtime, compile_time, "Idents not equal for {s:?}");
+        }
+    }
+
+    #[test]
+    fn new_const_in_hashset() {
+        use rustc_hash::FxHashSet;
+
+        // Verify that Ident::new_const works correctly with hash sets
+        let mut set: FxHashSet<Ident<'_>> = FxHashSet::default();
+
+        // Insert using new_const
+        set.insert(Ident::new_const("foo"));
+        set.insert(Ident::new_const("bar"));
+
+        // Look up using new - should find them
+        assert!(set.contains(&Ident::new("foo")), "Failed to find 'foo' inserted with new_const");
+        assert!(set.contains(&Ident::new("bar")), "Failed to find 'bar' inserted with new_const");
+
+        // Look up using new_const - should also find them
+        assert!(
+            set.contains(&Ident::new_const("foo")),
+            "Failed to find 'foo' with new_const lookup"
+        );
+
+        // Insert using new, look up using new_const
+        set.insert(Ident::new("baz"));
+        assert!(set.contains(&Ident::new_const("baz")), "Failed to find 'baz' inserted with new");
+    }
+
+    #[test]
+    fn const_fx_hash_matches_runtime() {
+        // Directly test the const_fx_hash_str function against runtime FxHasher
+        // const_fx_hash_str returns internal state (before rotation)
+        // FxHasher::finish() returns state.rotate_left(26)
+        let test_cases: &[&str] = &["", "a", "ab", "abc", "abcdefgh", "hello_world"];
+
+        for s in test_cases {
+            // const_fx_hash_str returns internal state, apply rotation to match finish()
+            let const_hash = const_fx_hash_str(s).rotate_left(26);
+
+            let runtime_hash = {
+                let mut hasher = FxHasher::default();
+                hash::Hash::hash(&s, &mut hasher);
+                hasher.finish()
+            };
+
+            assert_eq!(
+                const_hash, runtime_hash,
+                "Hash mismatch for {s:?}: const={const_hash:#x}, runtime={runtime_hash:#x}"
+            );
+        }
+    }
 }

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -92,6 +92,11 @@ pub struct Ident<'a> {
     _marker: PhantomData<&'a str>,
 }
 
+// SAFETY: `Ident` only contains a pointer to immutable string data,
+// which is safe to share across threads.
+unsafe impl Sync for Ident<'_> {}
+unsafe impl Send for Ident<'_> {}
+
 impl Ident<'static> {
     /// Get an [`Ident`] containing a static string.
     #[expect(clippy::inline_always)]
@@ -420,6 +425,13 @@ impl hash::Hash for Ident<'_> {
         // This gives good entropy as long as HashMap contains less than 33 million entries.
         let hash = (self.hash as u64).rotate_left(64 - 7);
         hasher.write_u64(hash);
+    }
+}
+
+impl std::borrow::Borrow<str> for Ident<'_> {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/crates/oxc_str/src/ident_consts.rs
+++ b/crates/oxc_str/src/ident_consts.rs
@@ -1,0 +1,29 @@
+//! Compile-time identifier constants with precomputed hashes.
+//!
+//! These constants use `Ident::new_const` to compute hashes at compile time,
+//! enabling fast hash-based comparisons for commonly used identifier names.
+
+use crate::Ident;
+
+// === General ===
+pub const IDENT_EXPORTS: Ident<'static> = Ident::new_const("exports");
+pub const IDENT_MODULE: Ident<'static> = Ident::new_const("module");
+pub const IDENT_REQUIRE: Ident<'static> = Ident::new_const("require");
+
+// === Global Objects ===
+pub const IDENT_GLOBAL_THIS: Ident<'static> = Ident::new_const("globalThis");
+pub const IDENT_PROCESS: Ident<'static> = Ident::new_const("process");
+
+// === Built-in Constructors ===
+pub const IDENT_ARRAY: Ident<'static> = Ident::new_const("Array");
+pub const IDENT_DATE: Ident<'static> = Ident::new_const("Date");
+pub const IDENT_FUNCTION: Ident<'static> = Ident::new_const("Function");
+pub const IDENT_MATH: Ident<'static> = Ident::new_const("Math");
+pub const IDENT_NUMBER: Ident<'static> = Ident::new_const("Number");
+pub const IDENT_REGEXP: Ident<'static> = Ident::new_const("RegExp");
+pub const IDENT_STRING: Ident<'static> = Ident::new_const("String");
+
+// === Error Types ===
+pub const IDENT_AGGREGATE_ERROR: Ident<'static> = Ident::new_const("AggregateError");
+pub const IDENT_ERROR: Ident<'static> = Ident::new_const("Error");
+pub const IDENT_TYPE_ERROR: Ident<'static> = Ident::new_const("TypeError");

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -10,7 +10,7 @@ mod ident;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
-pub use ident::Ident;
+pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher};
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -10,7 +10,9 @@ mod ident;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
-pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher};
+pub use ident::{
+    ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
+};
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -7,12 +7,15 @@
 mod atom;
 mod compact_str;
 mod ident;
+#[expect(missing_docs)]
+mod ident_consts;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{
     ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet, IdentHasher, IncrementalIdentHasher,
 };
+pub use ident_consts::*;
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1027,7 +1027,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name.as_str()));
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name));
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -96,7 +96,7 @@ use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
@@ -879,7 +879,11 @@ impl<'a> ArrowFunctionConverter<'a> {
         let original_scope_id = ctx.scoping().symbol_scope_id(binding.symbol_id);
         if target_scope_id != original_scope_id {
             ctx.scoping_mut().set_symbol_scope_id(binding.symbol_id, target_scope_id);
-            ctx.scoping_mut().move_binding(original_scope_id, target_scope_id, &binding.name);
+            ctx.scoping_mut().move_binding(
+                original_scope_id,
+                target_scope_id,
+                Ident::from(binding.name.as_str()),
+            );
         }
     }
 
@@ -1023,7 +1027,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, name.as_str());
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name.as_str()));
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.
@@ -1062,7 +1066,8 @@ impl<'a> ArrowFunctionConverter<'a> {
         if symbol_id.is_none() {
             let reference = ctx.scoping_mut().get_reference_mut(reference_id);
             reference.set_symbol_id(binding.symbol_id);
-            ctx.scoping_mut().delete_root_unresolved_reference(&ident.name, reference_id);
+            ctx.scoping_mut()
+                .delete_root_unresolved_reference(Ident::from(ident.name.as_str()), reference_id);
             ctx.scoping_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }
 

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -323,7 +323,7 @@ impl<'a> HelperLoaderStore<'a> {
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), HELPER_VAR);
+        let symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), HELPER_VAR);
         let object =
             ctx.create_ident_expr(SPAN, Atom::from(HELPER_VAR), symbol_id, ReferenceFlags::Read);
         let property = ctx.ast.identifier_name(SPAN, Atom::from(helper.name()));

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -182,7 +182,7 @@ impl<'a> ModuleImportsStore<'a> {
             return;
         }
 
-        let require_symbol_id = ctx.scoping().get_root_binding("require");
+        let require_symbol_id = ctx.scoping().get_root_binding_by_name("require");
         let stmts = imports
             .drain(..)
             .map(|(source, names)| Self::get_require(source, names, require_symbol_id, ctx));

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -537,7 +537,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
         right: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Math");
+        let math_symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "Math");
         let object =
             ctx.create_ident_expr(SPAN, Atom::from("Math"), math_symbol_id, ReferenceFlags::Read);
         let property = ctx.ast.identifier_name(SPAN, "pow");

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -57,7 +57,7 @@ use oxc_allocator::{Box as ArenaBox, StringBuilder as ArenaStringBuilder, TakeIn
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{Atom, GetSpan, Ident, SPAN};
 use oxc_syntax::{
     identifier::{is_identifier_name, is_identifier_part, is_identifier_start},
     keyword::is_reserved_keyword,
@@ -651,7 +651,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         bound_ident: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "arguments");
+        let symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "arguments");
         let arguments_ident = Argument::from(ctx.create_ident_expr(
             SPAN,
             Atom::from("arguments"),
@@ -889,7 +889,11 @@ impl<'a> Visit<'a> for BindingMover<'a, '_> {
         let symbol_id = ident.symbol_id();
         let current_scope_id = symbols.symbol_scope_id(symbol_id);
         let scopes = self.ctx.scoping_mut();
-        scopes.move_binding(current_scope_id, self.target_scope_id, ident.name.as_str());
+        scopes.move_binding(
+            current_scope_id,
+            self.target_scope_id,
+            Ident::from(ident.name.as_str()),
+        );
         let symbols = self.ctx.scoping_mut();
         symbols.set_symbol_scope_id(symbol_id, self.target_scope_id);
     }

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -635,7 +635,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 // Move the bindings from the for init scope to scope of the loop body.
                 for ident in bound_names {
                     ctx.scoping_mut().set_symbol_scope_id(ident.symbol_id(), new_scope_id);
-                    ctx.scoping_mut().move_binding(scope_id, new_scope_id, ident.name.into());
+                    ctx.scoping_mut().move_binding(scope_id, new_scope_id, ident.name);
                 }
             }
         }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -888,15 +888,16 @@ fn create_new_weakmap<'a>(
     symbol_id: &mut Option<Option<SymbolId>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let symbol_id = *symbol_id
-        .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), "WeakMap"));
+    let symbol_id = *symbol_id.get_or_insert_with(|| {
+        ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "WeakMap")
+    });
     let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakMap"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }
 
 /// Create `new WeakSet()` expression.
 fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-    let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "WeakSet");
+    let symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "WeakSet");
     let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakSet"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -106,7 +106,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::{
     node::NodeId,
     scope::{ScopeFlags, ScopeId},
@@ -430,7 +430,11 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, new_name.as_str());
+            ctx.scoping_mut().rename_symbol(
+                symbol_id,
+                constructor_scope_id,
+                Ident::from(new_name.as_str()),
+            );
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -430,11 +430,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.scoping_mut().rename_symbol(
-                symbol_id,
-                constructor_scope_id,
-                Ident::from(new_name.as_str()),
-            );
+            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, Ident::from(new_name));
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -341,7 +341,7 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // `Object.defineProperty`
-        let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Object");
+        let object_symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "Object");
         let object = ctx.create_ident_expr(
             SPAN,
             Atom::from("Object"),

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -41,7 +41,7 @@ use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVe
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Atom, SPAN};
+use oxc_span::{Atom, Ident, SPAN};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
 use crate::{
@@ -127,7 +127,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
             ),
         };
         ctx.scoping_mut().set_symbol_scope_id(for_of_init_symbol_id, scope_id);
-        ctx.scoping_mut().move_binding(for_of_stmt_scope_id, scope_id, &for_of_init_name);
+        ctx.scoping_mut().move_binding(for_of_stmt_scope_id, scope_id, for_of_init_name);
 
         if let Statement::BlockStatement(body) = &mut for_of_stmt.body {
             // `for (const _x of y) { x(); }` -> `for (const _x of y) { using x = _x; x(); }`
@@ -173,7 +173,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
             );
 
             ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, static_block_new_scope_id);
-            ctx.scoping_mut().move_binding(scope_id, static_block_new_scope_id, &using_ctx.name);
+            ctx.scoping_mut().move_binding(
+                scope_id,
+                static_block_new_scope_id,
+                Ident::from(using_ctx.name.as_str()),
+            );
             *ctx.scoping_mut().scope_flags_mut(scope_id) = ScopeFlags::StrictMode;
 
             block.set_scope_id(static_block_new_scope_id);
@@ -288,7 +292,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
             let current_hoist_scope_id = ctx.current_hoist_scope_id();
             node.block.set_scope_id(block_stmt_scope_id);
             ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, current_hoist_scope_id);
-            ctx.scoping_mut().move_binding(scope_id, current_hoist_scope_id, &using_ctx.name);
+            ctx.scoping_mut().move_binding(
+                scope_id,
+                current_hoist_scope_id,
+                Ident::from(using_ctx.name.as_str()),
+            );
 
             ctx.scoping_mut().change_scope_parent_id(scope_id, Some(block_stmt_scope_id));
         }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -93,7 +93,7 @@ use oxc_allocator::{
 };
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     identifier::is_white_space_single_line, line_terminator::is_line_terminator,
     reference::ReferenceFlags, symbol::SymbolFlags, xml_entities::XML_ENTITIES,
@@ -1197,7 +1197,8 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let reference_id = ctx.create_reference_in_current_scope(name.as_str(), ReferenceFlags::Read);
+    let reference_id =
+        ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
     let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
     Expression::Identifier(ident)
 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -351,7 +351,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a, '_> {
             if let Some(binding_name) = binding_name {
                 self.non_builtin_hooks_callee.entry(current_scope_id).or_default().push(
                     ctx.scoping()
-                        .find_binding(
+                        .find_binding_by_name(
                             ctx.scoping().scope_parent_id(ctx.current_scope_id()).unwrap(),
                             binding_name.as_str(),
                         )

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -78,7 +78,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
     pub fn to_expression(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         match self {
             Self::Identifier(ident) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,
@@ -86,7 +86,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 )
             }
             Self::Member((ident, property)) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 let ident = ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -163,7 +163,7 @@ impl<'a> RegExp<'a, '_> {
         }
 
         let callee = {
-            let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "RegExp");
+            let symbol_id = ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "RegExp");
             ctx.create_ident_expr(SPAN, Atom::from("RegExp"), symbol_id, ReferenceFlags::read())
         };
 

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -328,7 +328,8 @@ impl<'a> TypeScriptEnum<'a> {
 
         // Infinity
         let expr = if value.is_infinite() {
-            let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Infinity");
+            let infinity_symbol_id =
+                ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "Infinity");
             ctx.create_ident_expr(
                 SPAN,
                 Atom::from("Infinity"),

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -109,7 +109,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         {
             // No value reference, we will remove this declaration in `TypeScriptAnnotations`
             let scope_id = ctx.current_scope_id();
-            ctx.scoping_mut().remove_binding(scope_id, &decl.id.name);
+            ctx.scoping_mut().remove_binding(scope_id, decl.id.name);
             return None;
         }
 
@@ -136,7 +136,7 @@ impl<'a> TypeScriptModule<'a, '_> {
                 }
 
                 let require_symbol_id =
-                    ctx.scoping().find_binding(ctx.current_scope_id(), "require");
+                    ctx.scoping().find_binding_by_name(ctx.current_scope_id(), "require");
                 let callee = ctx.create_ident_expr(
                     SPAN,
                     Atom::from("require"),

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,8 +1,10 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::reference::ReferenceFlags;
+
+const IDENT_MODULE: Ident<'static> = Ident::new_const("module");
 use oxc_traverse::Traverse;
 
 use super::diagnostics;
@@ -73,7 +75,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         // module.exports
         let module_exports = {
             let reference_id =
-                ctx.create_reference_in_current_scope("module", ReferenceFlags::Read);
+                ctx.create_reference_in_current_scope(IDENT_MODULE, ReferenceFlags::Read);
             let reference =
                 ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, "module", reference_id);
             let object = Expression::Identifier(reference);

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -190,9 +190,9 @@ impl<'a> InjectGlobalVariables<'a> {
                         if self.replaced_dot_defines.iter().any(|d| d.0 == i.specifier.local()) {
                             false
                         } else {
-                            scoping
-                                .root_unresolved_references()
-                                .contains_key(i.specifier.local().as_str())
+                            scoping.root_unresolved_references_contains_by_name(
+                                i.specifier.local().as_str(),
+                            )
                         }
                     }
                 }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -624,7 +624,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let BindingIdentifier { name, symbol_id, .. } = ident;
 
         let scopes = ctx.scoping_mut();
-        scopes.remove_binding(scopes.root_scope_id(), &name);
+        scopes.remove_binding(scopes.root_scope_id(), name);
 
         let symbol_id = symbol_id.get().unwrap();
         // Do not need to insert if there no identifiers that point to this symbol

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -54,7 +54,7 @@ use oxc_allocator::{Allocator, Box as ArenaBox, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::identifier::is_identifier_name;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, traverse_mut};
 
@@ -329,7 +329,8 @@ impl<'a> ModuleRunnerTransform<'a> {
                 let mut local = specifier.unbox().local;
                 local.name = self.generate_import_binding_name(ctx).into();
                 let binding = BoundIdentifier::from_binding_ident(&local);
-                ctx.scoping_mut().set_symbol_name(binding.symbol_id, &binding.name);
+                ctx.scoping_mut()
+                    .set_symbol_name(binding.symbol_id, Ident::from(binding.name.as_str()));
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
                 BindingPattern::BindingIdentifier(ctx.alloc(local))

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -766,7 +766,7 @@ struct UpdateReplacedExpression<'a, 'b> {
 impl VisitMut<'_> for UpdateReplacedExpression<'_, '_> {
     fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'_>) {
         let reference_id =
-            self.ctx.create_reference_in_current_scope(ident.name.as_str(), ReferenceFlags::Read);
+            self.ctx.create_reference_in_current_scope(ident.name, ReferenceFlags::Read);
         ident.set_reference_id(reference_id);
         walk_mut::walk_identifier_reference(self, ident);
     }

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     ast::{Expression, IdentifierReference, Statement},
 };
 use oxc_semantic::Scoping;
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, Ident, Span};
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -414,7 +414,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ) -> BoundIdentifier<'a> {
         // Get name for UID
         let name = self.generate_uid_name(name);
-        let symbol_id = self.scoping.add_binding(&name, scope_id, flags);
+        let symbol_id = self.scoping.add_binding(Ident::from(name), scope_id, flags);
         BoundIdentifier::new(name, symbol_id)
     }
 
@@ -536,7 +536,11 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
     #[inline]
-    pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flags)
     }
 
@@ -547,7 +551,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         name: Atom<'a>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_unbound_reference(name.as_str(), flags);
+        let reference_id = self.create_unbound_reference(Ident::from(name), flags);
         self.ast.identifier_reference_with_reference_id(span, name, reference_id)
     }
 
@@ -571,7 +575,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
@@ -620,7 +624,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference_in_current_scope(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_reference_in_current_scope(name, flags)
@@ -631,7 +635,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// Provided `name` must match `reference_id`.
     ///
     /// This is a shortcut for `ctx.scoping.delete_reference`.
-    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
         self.scoping.delete_reference(reference_id, name);
     }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -4,7 +4,7 @@ use oxc_allocator::{Allocator, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -237,7 +237,7 @@ impl<'a> TraverseScoping<'a> {
         flags: SymbolFlags,
     ) -> SymbolId {
         let symbol_id = self.scoping.create_symbol(SPAN, name, flags, scope_id, NodeId::DUMMY);
-        self.scoping.add_binding(scope_id, name, symbol_id);
+        self.scoping.add_binding(scope_id, Ident::from(name), symbol_id);
 
         symbol_id
     }
@@ -300,7 +300,7 @@ impl<'a> TraverseScoping<'a> {
     pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
         let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
-        self.scoping.add_root_unresolved_reference(name, reference_id);
+        self.scoping.add_root_unresolved_reference(Ident::from(name), reference_id);
         reference_id
     }
 
@@ -327,7 +327,7 @@ impl<'a> TraverseScoping<'a> {
         name: &str,
         flags: ReferenceFlags,
     ) -> ReferenceId {
-        let symbol_id = self.scoping.find_binding(self.current_scope_id, name);
+        let symbol_id = self.scoping.find_binding_by_name(self.current_scope_id, name);
         self.create_reference(name, symbol_id, flags)
     }
 
@@ -339,7 +339,7 @@ impl<'a> TraverseScoping<'a> {
         if let Some(symbol_id) = symbol_id {
             self.scoping.delete_resolved_reference(symbol_id, reference_id);
         } else {
-            self.scoping.delete_root_unresolved_reference(name, reference_id);
+            self.scoping.delete_root_unresolved_reference(Ident::from(name), reference_id);
         }
     }
 

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -143,8 +143,8 @@ impl<'a> UidGenerator<'a> {
         for name in scoping.symbol_names() {
             generator.add(name);
         }
-        for &name in scoping.root_unresolved_references().keys() {
-            generator.add(name);
+        for name in scoping.root_unresolved_references().keys() {
+            generator.add(name.as_str());
         }
 
         generator

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -91,12 +91,12 @@ rebuilt        : SymbolId(164): Span { start: 0, end: 0 }
 Symbol span mismatch for "Inner4":
 after transform: SymbolId(195): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(165): Span { start: 12166, end: 12172 }
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(165), ReferenceId(181), ReferenceId(183), ReferenceId(195), ReferenceId(199), ReferenceId(215), ReferenceId(217), ReferenceId(229), ReferenceId(233), ReferenceId(249), ReferenceId(251), ReferenceId(263), ReferenceId(267), ReferenceId(283), ReferenceId(285), ReferenceId(394), ReferenceId(398), ReferenceId(414), ReferenceId(418), ReferenceId(422), ReferenceId(426)]
-rebuilt        : [ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(80), ReferenceId(118), ReferenceId(122), ReferenceId(144), ReferenceId(148), ReferenceId(170), ReferenceId(174), ReferenceId(263), ReferenceId(270), ReferenceId(336), ReferenceId(340), ReferenceId(356), ReferenceId(360), ReferenceId(364), ReferenceId(368)]
 Unresolved reference IDs mismatch for "Function":
 after transform: [ReferenceId(83), ReferenceId(89), ReferenceId(109), ReferenceId(123), ReferenceId(137), ReferenceId(151), ReferenceId(169), ReferenceId(185), ReferenceId(203), ReferenceId(219), ReferenceId(237), ReferenceId(253), ReferenceId(271), ReferenceId(287), ReferenceId(402), ReferenceId(430), ReferenceId(436), ReferenceId(444), ReferenceId(448), ReferenceId(452), ReferenceId(458), ReferenceId(462), ReferenceId(466), ReferenceId(472), ReferenceId(476), ReferenceId(480)]
 rebuilt        : [ReferenceId(84), ReferenceId(90), ReferenceId(126), ReferenceId(152), ReferenceId(178), ReferenceId(277), ReferenceId(344), ReferenceId(372), ReferenceId(378), ReferenceId(385), ReferenceId(391), ReferenceId(398)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(165), ReferenceId(181), ReferenceId(183), ReferenceId(195), ReferenceId(199), ReferenceId(215), ReferenceId(217), ReferenceId(229), ReferenceId(233), ReferenceId(249), ReferenceId(251), ReferenceId(263), ReferenceId(267), ReferenceId(283), ReferenceId(285), ReferenceId(394), ReferenceId(398), ReferenceId(414), ReferenceId(418), ReferenceId(422), ReferenceId(426)]
+rebuilt        : [ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(80), ReferenceId(118), ReferenceId(122), ReferenceId(144), ReferenceId(148), ReferenceId(170), ReferenceId(174), ReferenceId(263), ReferenceId(270), ReferenceId(336), ReferenceId(340), ReferenceId(356), ReferenceId(360), ReferenceId(364), ReferenceId(368)]
 
 semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -4569,12 +4569,12 @@ rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
 rebuilt        : [ReferenceId(30), ReferenceId(34)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(1), ReferenceId(20)]
-rebuilt        : [ReferenceId(13)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
+Unresolved reference IDs mismatch for "Promise":
+after transform: [ReferenceId(1), ReferenceId(20)]
+rebuilt        : [ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -10610,9 +10610,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_It
 Unresolved references mismatch:
 after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
-Unresolved reference IDs mismatch for "WeakRef":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(26)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
 rebuilt        : [ReferenceId(81), ReferenceId(84)]
@@ -10622,6 +10619,9 @@ rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(1), ReferenceId(14)]
 rebuilt        : [ReferenceId(10)]
+Unresolved reference IDs mismatch for "WeakRef":
+after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
+rebuilt        : [ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
 Unresolved references mismatch:
@@ -15713,12 +15713,12 @@ rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(39), ReferenceId(40)
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
-Unresolved reference IDs mismatch for "Boolean":
-after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Object":
 after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(51), ReferenceId(55), ReferenceId(63)]
 rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(42), ReferenceId(47), ReferenceId(57)]
+Unresolved reference IDs mismatch for "Boolean":
+after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
 Symbol reference IDs mismatch for "A":
@@ -23829,21 +23829,21 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
-Unresolved reference IDs mismatch for "Number":
-after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
-rebuilt        : [ReferenceId(4), ReferenceId(22)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
 rebuilt        : [ReferenceId(13), ReferenceId(28)]
-Unresolved reference IDs mismatch for "BigInt":
-after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
-rebuilt        : [ReferenceId(16), ReferenceId(31)]
+Unresolved reference IDs mismatch for "Number":
+after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
+rebuilt        : [ReferenceId(4), ReferenceId(22)]
 Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(7), ReferenceId(20), ReferenceId(30)]
 rebuilt        : [ReferenceId(7), ReferenceId(25)]
 Unresolved reference IDs mismatch for "String":
 after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
 rebuilt        : [ReferenceId(1), ReferenceId(19)]
+Unresolved reference IDs mismatch for "BigInt":
+after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
+rebuilt        : [ReferenceId(16), ReferenceId(31)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 Bindings mismatch:
@@ -24772,12 +24772,12 @@ after transform: SymbolId(3): [ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(2)]
 Unresolved reference IDs mismatch for "Uint8Array":
 after transform: [ReferenceId(7), ReferenceId(9), ReferenceId(13)]
 rebuilt        : [ReferenceId(4)]
+Unresolved reference IDs mismatch for "Int32Array":
+after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
+rebuilt        : [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
 Symbol reference IDs mismatch for "FOO_SYMBOL":
@@ -24938,36 +24938,36 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Unresolved reference IDs mismatch for "Int16Array":
-after transform: [ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(2)]
+Unresolved reference IDs mismatch for "Float32Array":
+after transform: [ReferenceId(12), ReferenceId(13)]
+rebuilt        : [ReferenceId(6)]
 Unresolved reference IDs mismatch for "Int8Array":
 after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "Float64Array":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "BigInt64Array":
-after transform: [ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(8)]
+Unresolved reference IDs mismatch for "Uint8Array":
+after transform: [ReferenceId(2), ReferenceId(3)]
+rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "Int32Array":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(4)]
 Unresolved reference IDs mismatch for "Uint32Array":
 after transform: [ReferenceId(10), ReferenceId(11)]
 rebuilt        : [ReferenceId(5)]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
+Unresolved reference IDs mismatch for "Int16Array":
+after transform: [ReferenceId(4), ReferenceId(5)]
+rebuilt        : [ReferenceId(2)]
+Unresolved reference IDs mismatch for "Uint16Array":
+after transform: [ReferenceId(6), ReferenceId(7)]
+rebuilt        : [ReferenceId(3)]
+Unresolved reference IDs mismatch for "Float64Array":
+after transform: [ReferenceId(14), ReferenceId(15)]
+rebuilt        : [ReferenceId(7)]
 Unresolved reference IDs mismatch for "BigUint64Array":
 after transform: [ReferenceId(18), ReferenceId(19)]
 rebuilt        : [ReferenceId(9)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
+Unresolved reference IDs mismatch for "BigInt64Array":
+after transform: [ReferenceId(16), ReferenceId(17)]
+rebuilt        : [ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -38155,12 +38155,12 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "M":
 after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(13)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
 Scope flags mismatch:
@@ -38487,12 +38487,12 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "M":
 after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(13)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
 Symbol reference IDs mismatch for "p":

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -10613,15 +10613,15 @@ rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", 
 Unresolved reference IDs mismatch for "WeakRef":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
 rebuilt        : [ReferenceId(26)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(1), ReferenceId(14)]
-rebuilt        : [ReferenceId(10)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
 rebuilt        : [ReferenceId(81), ReferenceId(84)]
 Unresolved reference IDs mismatch for "WeakMap":
 after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(108), ReferenceId(109), ReferenceId(110)]
 rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
+Unresolved reference IDs mismatch for "Set":
+after transform: [ReferenceId(1), ReferenceId(14)]
+rebuilt        : [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
 Unresolved references mismatch:
@@ -23829,21 +23829,21 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
-Unresolved reference IDs mismatch for "BigInt":
-after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
-rebuilt        : [ReferenceId(16), ReferenceId(31)]
 Unresolved reference IDs mismatch for "Number":
 after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
 rebuilt        : [ReferenceId(4), ReferenceId(22)]
-Unresolved reference IDs mismatch for "String":
-after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
-rebuilt        : [ReferenceId(1), ReferenceId(19)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
 rebuilt        : [ReferenceId(13), ReferenceId(28)]
+Unresolved reference IDs mismatch for "BigInt":
+after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
+rebuilt        : [ReferenceId(16), ReferenceId(31)]
 Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(7), ReferenceId(20), ReferenceId(30)]
 rebuilt        : [ReferenceId(7), ReferenceId(25)]
+Unresolved reference IDs mismatch for "String":
+after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
+rebuilt        : [ReferenceId(1), ReferenceId(19)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 Bindings mismatch:
@@ -24938,36 +24938,36 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "BigInt64Array":
-after transform: [ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(8)]
-Unresolved reference IDs mismatch for "Int8Array":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "Int16Array":
 after transform: [ReferenceId(4), ReferenceId(5)]
 rebuilt        : [ReferenceId(2)]
+Unresolved reference IDs mismatch for "Int8Array":
+after transform: [ReferenceId(0), ReferenceId(1)]
+rebuilt        : [ReferenceId(0)]
+Unresolved reference IDs mismatch for "Uint16Array":
+after transform: [ReferenceId(6), ReferenceId(7)]
+rebuilt        : [ReferenceId(3)]
 Unresolved reference IDs mismatch for "Float64Array":
 after transform: [ReferenceId(14), ReferenceId(15)]
 rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "BigUint64Array":
-after transform: [ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(9)]
+Unresolved reference IDs mismatch for "BigInt64Array":
+after transform: [ReferenceId(16), ReferenceId(17)]
+rebuilt        : [ReferenceId(8)]
 Unresolved reference IDs mismatch for "Int32Array":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(4)]
 Unresolved reference IDs mismatch for "Uint32Array":
 after transform: [ReferenceId(10), ReferenceId(11)]
 rebuilt        : [ReferenceId(5)]
+Unresolved reference IDs mismatch for "Float32Array":
+after transform: [ReferenceId(12), ReferenceId(13)]
+rebuilt        : [ReferenceId(6)]
+Unresolved reference IDs mismatch for "BigUint64Array":
+after transform: [ReferenceId(18), ReferenceId(19)]
+rebuilt        : [ReferenceId(9)]
+Unresolved reference IDs mismatch for "Uint8Array":
+after transform: [ReferenceId(2), ReferenceId(3)]
+rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -6,7 +6,7 @@ cal.com.tsx                | 1.06 MB        ||          21098 |            474 |
 
 RadixUIAdoptionSection.jsx | 2.52 kB        ||             58 |              3 ||             30 |              6
 
-pdf.mjs                    | 567.30 kB      ||           4691 |            569 ||          47464 |           7730
+pdf.mjs                    | 567.30 kB      ||           4692 |            569 ||          47464 |           7730
 
 antd.js                    | 6.69 MB        ||          10728 |           2514 ||         331644 |          69358
 


### PR DESCRIPTION
```
group                                  main                                   pr
-----                                  ----                                   --
pipeline/RadixUIAdoptionSection.jsx    1.01     29.6±0.63µs        ? ?/sec    1.00     29.4±4.17µs        ? ?/sec
pipeline/binder.ts                     1.04      2.8±0.14ms        ? ?/sec    1.00      2.6±0.06ms        ? ?/sec
pipeline/cal.com.tsx                   1.00     23.6±0.85ms        ? ?/sec    1.04     24.4±1.47ms        ? ?/sec
pipeline/react.development.js          1.03  1252.5±36.66µs        ? ?/sec    1.00  1216.7±31.09µs        ? ?/sec
```