### PR TITLE
refactor(oxlint): use one constant for default oxlintrc filename

### DIFF
--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -45,6 +45,8 @@ mod js_plugins;
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
+const DEFAULT_OXLINTRC: &str = ".oxlintrc.json";
+
 /// Return a JSON blob containing metadata for all available oxlint rules.
 ///
 /// This uses the internal JSON output formatter to generate the full list.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -21,6 +21,7 @@ use oxc_linter::{
 };
 
 use crate::{
+    DEFAULT_OXLINTRC,
     cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
     output_formatter::{LintCommandInfo, OutputFormat, OutputFormatter},
     walk::Walk,
@@ -271,7 +272,7 @@ impl CliRunner {
                     config_file
                 };
 
-                if fs::write(Self::DEFAULT_OXLINTRC, configuration).is_ok() {
+                if fs::write(DEFAULT_OXLINTRC, configuration).is_ok() {
                     print_and_flush_stdout(stdout, "Configuration file created\n");
                     return CliRunResult::ConfigFileInitSucceeded;
                 }
@@ -464,8 +465,6 @@ impl CliRunner {
 }
 
 impl CliRunner {
-    const DEFAULT_OXLINTRC: &'static str = ".oxlintrc.json";
-
     #[must_use]
     pub fn with_cwd(mut self, cwd: PathBuf) -> Self {
         self.cwd = cwd;
@@ -624,7 +623,7 @@ impl CliRunner {
     // when no config is provided, it will search for the default file names in the current working directory
     // when no file is found, the default configuration is returned
     fn find_oxlint_config(cwd: &Path, config: Option<&PathBuf>) -> Result<Oxlintrc, OxcDiagnostic> {
-        let path: &Path = config.map_or(Self::DEFAULT_OXLINTRC.as_ref(), PathBuf::as_ref);
+        let path: &Path = config.map_or(DEFAULT_OXLINTRC.as_ref(), PathBuf::as_ref);
         let full_path = cwd.join(path);
 
         if config.is_some() || full_path.exists() {
@@ -637,7 +636,7 @@ impl CliRunner {
     /// and returns `Err` if none exists or the file is invalid. Does not apply the default
     /// config file.
     fn find_oxlint_config_in_directory(dir: &Path) -> Result<Option<Oxlintrc>, OxcDiagnostic> {
-        let possible_config_path = dir.join(Self::DEFAULT_OXLINTRC);
+        let possible_config_path = dir.join(DEFAULT_OXLINTRC);
         if possible_config_path.is_file() {
             Oxlintrc::from_file(&possible_config_path).map(Some)
         } else {
@@ -671,7 +670,7 @@ mod test {
     use std::{fs, path::PathBuf};
 
     use super::CliRunner;
-    use crate::tester::Tester;
+    use crate::{DEFAULT_OXLINTRC, tester::Tester};
 
     // lints the full directory of fixtures,
     // so do not snapshot it, test only
@@ -1046,14 +1045,14 @@ mod test {
 
     #[test]
     fn test_init_config() {
-        assert!(!fs::exists(CliRunner::DEFAULT_OXLINTRC).unwrap());
+        assert!(!fs::exists(DEFAULT_OXLINTRC).unwrap());
 
         let args = &["--init"];
         Tester::new().with_cwd("fixtures".into()).test(args);
 
-        assert!(fs::exists(CliRunner::DEFAULT_OXLINTRC).unwrap());
+        assert!(fs::exists(DEFAULT_OXLINTRC).unwrap());
 
-        fs::remove_file(CliRunner::DEFAULT_OXLINTRC).unwrap();
+        fs::remove_file(DEFAULT_OXLINTRC).unwrap();
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/config_walker.rs
+++ b/apps/oxlint/src/lsp/config_walker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ignore::DirEntry;
 
-use crate::lsp::LINT_CONFIG_FILE;
+use crate::DEFAULT_OXLINTRC;
 
 pub struct ConfigWalker {
     inner: ignore::WalkParallel,
@@ -56,7 +56,7 @@ impl WalkCollector {
         }
         let Some(file_name) = entry.path().file_name() else { return false };
 
-        file_name == LINT_CONFIG_FILE
+        file_name == DEFAULT_OXLINTRC
     }
 }
 

--- a/apps/oxlint/src/lsp/mod.rs
+++ b/apps/oxlint/src/lsp/mod.rs
@@ -9,8 +9,6 @@ mod server_linter;
 mod tester;
 mod utils;
 
-const LINT_CONFIG_FILE: &str = ".oxlintrc.json";
-
 /// Run the language server
 pub async fn run_lsp() {
     oxc_language_server::run_server(

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -24,18 +24,20 @@ use oxc_language_server::{
     ToolRestartChanges,
 };
 
-use crate::lsp::{
-    LINT_CONFIG_FILE,
-    code_actions::{
-        CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, apply_all_fix_code_action, apply_fix_code_actions,
-        fix_all_text_edit,
+use crate::{
+    DEFAULT_OXLINTRC,
+    lsp::{
+        code_actions::{
+            CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, apply_all_fix_code_action, apply_fix_code_actions,
+            fix_all_text_edit,
+        },
+        commands::{FIX_ALL_COMMAND_ID, FixAllCommandArgs},
+        config_walker::ConfigWalker,
+        error_with_position::LinterCodeAction,
+        isolated_lint_handler::{IsolatedLintHandler, IsolatedLintHandlerOptions},
+        options::{LintOptions as LSPLintOptions, Run, UnusedDisableDirectives},
+        utils::normalize_path,
     },
-    commands::{FIX_ALL_COMMAND_ID, FixAllCommandArgs},
-    config_walker::ConfigWalker,
-    error_with_position::LinterCodeAction,
-    isolated_lint_handler::{IsolatedLintHandler, IsolatedLintHandlerOptions},
-    options::{LintOptions as LSPLintOptions, Run, UnusedDisableDirectives},
-    utils::normalize_path,
 };
 
 #[derive(Default)]
@@ -67,7 +69,7 @@ impl ServerLinterBuilder {
             &mut nested_ignore_patterns,
         );
         let config_path = match options.config_path.as_deref() {
-            Some("") | None => LINT_CONFIG_FILE,
+            Some("") | None => DEFAULT_OXLINTRC,
             Some(v) => v,
         };
         let config = normalize_path(root_path.join(config_path));


### PR DESCRIPTION
> Refactors oxlint to use a single shared constant for the default .oxlintrc.json filename across the CLI and LSP code paths.