### PR TITLE
fix(ast): remove `ThisExpression` from `TSModuleReference`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -5558,13 +5558,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1617,7 +1617,7 @@ export interface TSImportEqualsDeclaration extends Span {
   parent: Node;
 }
 
-export type TSModuleReference = TSExternalModuleReference | TSTypeName;
+export type TSModuleReference = TSExternalModuleReference | IdentifierReference | TSQualifiedName;
 
 export interface TSExternalModuleReference extends Span {
   type: "TSExternalModuleReference";

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1628,20 +1628,24 @@ pub struct TSImportEqualsDeclaration<'a> {
     pub import_kind: ImportOrExportKind,
 }
 
-inherit_variants! {
 /// TS Module Reference
 ///
-/// Inherits variants from [`TSTypeName`]. See [`ast` module docs] for explanation of inheritance.
+/// The right-hand side of an `import x = ...` declaration.
 ///
-/// [`ast` module docs]: `super`
+/// ## Examples
+///
+/// ```ts
+/// import x = foo;           // IdentifierReference
+/// import x = foo.bar;       // QualifiedName
+/// import x = require("x");  // ExternalModuleReference
+/// ```
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSModuleReference<'a> {
-    ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>) = 3,
-    // `TSTypeName` variants added here by `inherit_variants!` macro
-    @inherit TSTypeName
-}
+    ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>) = 0,
+    IdentifierReference(Box<'a, IdentifierReference<'a>>) = 1,
+    QualifiedName(Box<'a, TSQualifiedName<'a>>) = 2,
 }
 
 #[ast(visit)]

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -14857,6 +14857,68 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`TSModuleReference::IdentifierReference`].
+    ///
+    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    /// * `name`: The name of the identifier being referenced.
+    #[inline]
+    pub fn ts_module_reference_identifier_reference<A1>(
+        self,
+        span: Span,
+        name: A1,
+    ) -> TSModuleReference<'a>
+    where
+        A1: Into<Ident<'a>>,
+    {
+        TSModuleReference::IdentifierReference(self.alloc_identifier_reference(span, name))
+    }
+
+    /// Build a [`TSModuleReference::IdentifierReference`] with `reference_id`.
+    ///
+    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    /// * `name`: The name of the identifier being referenced.
+    /// * `reference_id`: Reference ID
+    #[inline]
+    pub fn ts_module_reference_identifier_reference_with_reference_id<A1>(
+        self,
+        span: Span,
+        name: A1,
+        reference_id: ReferenceId,
+    ) -> TSModuleReference<'a>
+    where
+        A1: Into<Ident<'a>>,
+    {
+        TSModuleReference::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
+            span,
+            name,
+            reference_id,
+        ))
+    }
+
+    /// Build a [`TSModuleReference::QualifiedName`].
+    ///
+    /// This node contains a [`TSQualifiedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    /// * `left`
+    /// * `right`
+    #[inline]
+    pub fn ts_module_reference_qualified_name(
+        self,
+        span: Span,
+        left: TSTypeName<'a>,
+        right: IdentifierName<'a>,
+    ) -> TSModuleReference<'a> {
+        TSModuleReference::QualifiedName(self.alloc_ts_qualified_name(span, left, right))
+    }
+
     /// Build a [`TSExternalModuleReference`].
     ///
     /// If you want the built node to be allocated in the memory arena,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7757,9 +7757,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'_> {
             Self::QualifiedName(it) => {
                 TSModuleReference::QualifiedName(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => {
-                TSModuleReference::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
         }
     }
 
@@ -7774,9 +7771,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'_> {
             Self::QualifiedName(it) => {
                 TSModuleReference::QualifiedName(CloneIn::clone_in_with_semantic_ids(it, allocator))
             }
-            Self::ThisExpression(it) => TSModuleReference::ThisExpression(
-                CloneIn::clone_in_with_semantic_ids(it, allocator),
-            ),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2434,7 +2434,6 @@ impl ContentEq for TSModuleReference<'_> {
             (Self::ExternalModuleReference(a), Self::ExternalModuleReference(b)) => a.content_eq(b),
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
             (Self::QualifiedName(a), Self::QualifiedName(b)) => a.content_eq(b),
-            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
             _ => false,
         }
     }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2798,7 +2798,7 @@ impl<'a> Dummy<'a> for TSTypeAssertion<'a> {
 impl<'a> Dummy<'a> for TSImportEqualsDeclaration<'a> {
     /// Create a dummy [`TSImportEqualsDeclaration`].
     ///
-    /// Has cost of making 1 allocation (8 bytes).
+    /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -2812,9 +2812,9 @@ impl<'a> Dummy<'a> for TSImportEqualsDeclaration<'a> {
 impl<'a> Dummy<'a> for TSModuleReference<'a> {
     /// Create a dummy [`TSModuleReference`].
     ///
-    /// Has cost of making 1 allocation (8 bytes).
+    /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::ThisExpression(Dummy::dummy(allocator))
+        Self::IdentifierReference(Dummy::dummy(allocator))
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3111,7 +3111,6 @@ impl ESTree for TSModuleReference<'_> {
             Self::ExternalModuleReference(it) => it.serialize(serializer),
             Self::IdentifierReference(it) => it.serialize(serializer),
             Self::QualifiedName(it) => it.serialize(serializer),
-            Self::ThisExpression(it) => it.serialize(serializer),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -791,7 +791,6 @@ impl GetAddress for TSModuleReference<'_> {
             Self::ExternalModuleReference(it) => GetAddress::address(it),
             Self::IdentifierReference(it) => GetAddress::address(it),
             Self::QualifiedName(it) => GetAddress::address(it),
-            Self::ThisExpression(it) => GetAddress::address(it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -2113,7 +2113,6 @@ impl GetSpan for TSModuleReference<'_> {
             Self::ExternalModuleReference(it) => GetSpan::span(&**it),
             Self::IdentifierReference(it) => GetSpan::span(&**it),
             Self::QualifiedName(it) => GetSpan::span(&**it),
-            Self::ThisExpression(it) => GetSpan::span(&**it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -2113,7 +2113,6 @@ impl GetSpanMut for TSModuleReference<'_> {
             Self::ExternalModuleReference(it) => GetSpanMut::span_mut(&mut **it),
             Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
             Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4127,9 +4127,8 @@ pub mod walk {
             TSModuleReference::ExternalModuleReference(it) => {
                 visitor.visit_ts_external_module_reference(it)
             }
-            match_ts_type_name!(TSModuleReference) => {
-                visitor.visit_ts_type_name(it.to_ts_type_name())
-            }
+            TSModuleReference::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            TSModuleReference::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
         }
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4351,9 +4351,8 @@ pub mod walk_mut {
             TSModuleReference::ExternalModuleReference(it) => {
                 visitor.visit_ts_external_module_reference(it)
             }
-            match_ts_type_name!(TSModuleReference) => {
-                visitor.visit_ts_type_name(it.to_ts_type_name_mut())
-            }
+            TSModuleReference::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            TSModuleReference::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
         }
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3844,7 +3844,8 @@ impl Gen for TSModuleReference<'_> {
                 p.print_string_literal(&decl.expression, false);
                 p.print_ascii_byte(b')');
             }
-            match_ts_type_name!(Self) => self.to_ts_type_name().print(p, ctx),
+            Self::IdentifierReference(ident) => ident.print(p, ctx),
+            Self::QualifiedName(qualified) => qualified.print(p, ctx),
         }
     }
 }

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -9433,16 +9433,21 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                     following_span_start: self.following_span_start,
                 }))
             }
-            it @ match_ts_type_name!(TSModuleReference) => {
-                return self
-                    .allocator
-                    .alloc(AstNode {
-                        inner: it.to_ts_type_name(),
-                        parent,
-                        allocator: self.allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .as_ast_nodes();
+            TSModuleReference::IdentifierReference(s) => {
+                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSModuleReference::QualifiedName(s) => {
+                AstNodes::TSQualifiedName(self.allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
             }
         };
         self.allocator.alloc(node)

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -5519,10 +5519,19 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
                     })
                     .fmt(f);
             }
-            it @ match_ts_type_name!(TSModuleReference) => {
-                let inner = it.to_ts_type_name();
+            TSModuleReference::IdentifierReference(inner) => {
                 allocator
-                    .alloc(AstNode::<'a, TSTypeName> {
+                    .alloc(AstNode::<IdentifierReference> {
+                        inner,
+                        parent,
+                        allocator,
+                        following_span_start: self.following_span_start,
+                    })
+                    .fmt(f);
+            }
+            TSModuleReference::QualifiedName(inner) => {
+                allocator
+                    .alloc(AstNode::<TSQualifiedName> {
                         inner,
                         parent,
                         allocator,

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -116,8 +116,7 @@ impl Rule for First {
                         }
                     }
                     TSModuleReference::IdentifierReference(_)
-                    | TSModuleReference::QualifiedName(_)
-                    | TSModuleReference::ThisExpression(_) => {}
+                    | TSModuleReference::QualifiedName(_) => {}
                 },
                 Statement::ImportDeclaration(decl) => {
                     if matches!(self.0, AbsoluteFirst::AbsoluteFirst) {

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -192,9 +192,8 @@ impl Rule for NoRequireImports {
 
                     ctx.diagnostic(no_require_imports_diagnostic(decl.span));
                 }
-                TSModuleReference::IdentifierReference(_)
-                | TSModuleReference::QualifiedName(_)
-                | TSModuleReference::ThisExpression(_) => {}
+                TSModuleReference::IdentifierReference(_) | TSModuleReference::QualifiedName(_) => {
+                }
             },
             _ => {}
         }

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -143,8 +143,7 @@ impl Rule for TripleSlashReference {
                             }
                         }
                         TSModuleReference::IdentifierReference(_)
-                        | TSModuleReference::QualifiedName(_)
-                        | TSModuleReference::ThisExpression(_) => {}
+                        | TSModuleReference::QualifiedName(_) => {}
                     },
                     Statement::ImportDeclaration(decl) => {
                         if let Some(v) = refs_for_import.get(decl.source.value.as_str()) {

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5548,9 +5548,12 @@ unsafe fn walk_ts_module_reference<'a, State, Tr: Traverse<'a, State>>(
         TSModuleReference::ExternalModuleReference(node) => {
             walk_ts_external_module_reference(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSModuleReference::IdentifierReference(_)
-        | TSModuleReference::QualifiedName(_)
-        | TSModuleReference::ThisExpression(_) => walk_ts_type_name(traverser, node as *mut _, ctx),
+        TSModuleReference::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSModuleReference::QualifiedName(node) => {
+            walk_ts_qualified_name(traverser, (&mut **node) as *mut _, ctx)
+        }
     }
     traverser.exit_ts_module_reference(&mut *node, ctx);
 }

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -3978,13 +3978,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -4489,13 +4489,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -4474,13 +4474,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -4988,13 +4988,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -4285,13 +4285,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -4822,13 +4822,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -4815,13 +4815,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -5352,13 +5352,11 @@ function deserializeTSImportEqualsDeclaration(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
-    case 1:
-      return deserializeBoxTSQualifiedName(pos + 8);
-    case 2:
-      return deserializeBoxThisExpression(pos + 8);
-    case 3:
       return deserializeBoxTSExternalModuleReference(pos + 8);
+    case 1:
+      return deserializeBoxIdentifierReference(pos + 8);
+    case 2:
+      return deserializeBoxTSQualifiedName(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -11274,13 +11274,11 @@ const DebugTSImportEqualsDeclaration = class TSImportEqualsDeclaration {};
 function constructTSModuleReference(pos, ast) {
   switch (ast.buffer[pos]) {
     case 0:
-      return constructBoxIdentifierReference(pos + 8, ast);
-    case 1:
-      return constructBoxTSQualifiedName(pos + 8, ast);
-    case 2:
-      return constructBoxThisExpression(pos + 8, ast);
-    case 3:
       return constructBoxTSExternalModuleReference(pos + 8, ast);
+    case 1:
+      return constructBoxIdentifierReference(pos + 8, ast);
+    case 2:
+      return constructBoxTSQualifiedName(pos + 8, ast);
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for TSModuleReference`);
   }

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -4572,16 +4572,13 @@ function walkTSImportEqualsDeclaration(pos, ast, visitors) {
 function walkTSModuleReference(pos, ast, visitors) {
   switch (ast.buffer[pos]) {
     case 0:
-      walkBoxIdentifierReference(pos + 8, ast, visitors);
+      walkBoxTSExternalModuleReference(pos + 8, ast, visitors);
       return;
     case 1:
-      walkBoxTSQualifiedName(pos + 8, ast, visitors);
+      walkBoxIdentifierReference(pos + 8, ast, visitors);
       return;
     case 2:
-      walkBoxThisExpression(pos + 8, ast, visitors);
-      return;
-    case 3:
-      walkBoxTSExternalModuleReference(pos + 8, ast, visitors);
+      walkBoxTSQualifiedName(pos + 8, ast, visitors);
       return;
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for TSModuleReference`);

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1610,7 +1610,7 @@ export interface TSImportEqualsDeclaration extends Span {
   parent?: Node;
 }
 
-export type TSModuleReference = TSExternalModuleReference | TSTypeName;
+export type TSModuleReference = TSExternalModuleReference | IdentifierReference | TSQualifiedName;
 
 export interface TSExternalModuleReference extends Span {
   type: "TSExternalModuleReference";

--- a/tasks/coverage/misc/fail/import-equals-this.ts
+++ b/tasks/coverage/misc/fail/import-equals-this.ts
@@ -1,0 +1,2 @@
+// `this` is not valid in import equals declaration
+import x = this;

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 6ef16ca4
 parser_babel Summary:
 AST Parsed     : 2217/2221 (99.82%)
 Positive Passed: 2204/2221 (99.23%)
-Negative Passed: 1654/1689 (97.93%)
+Negative Passed: 1655/1689 (97.99%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
@@ -59,8 +59,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/module-identifier-invalid/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts
 
@@ -13630,6 +13628,21 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
   help: Either remove this `await` or add the `async` keyword to the enclosing function
+
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts:2:12]
+ 1 │ import X = Y.if;
+ 2 │ import A = this.A;
+   ·            ────
+   ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-disallowed/input.ts:2:16]
+ 1 │ import X = Y.if;
+ 2 │ import A = this.A;
+   ·                ▲
+   ╰────
+  help: Try inserting a semicolon here
 
   × Identifier `A` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-class/input.ts:1:7]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 64/64 (100.00%)
 Positive Passed: 64/64 (100.00%)
-Negative Passed: 133/133 (100.00%)
+Negative Passed: 134/134 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -252,6 +252,13 @@ Negative Passed: 133/133 (100.00%)
  1 │ import defer 'module';
    ·              ────┬───
    ·                  ╰── `from` expected
+   ╰────
+
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
+   ╭─[misc/fail/import-equals-this.ts:2:12]
+ 1 │ // `this` is not valid in import equals declaration
+ 2 │ import x = this;
+   ·            ────
    ╰────
 
   × Expected `from` but found `string`


### PR DESCRIPTION
## Summary

- Removes `ThisExpression` variant from `TSModuleReference` since `import x = this` is invalid TypeScript (error TS1359)
- Adds parser error when `this` is used in import equals declaration
- Updates codegen, transformer, and linter rules to handle the new enum structure

Closes #16841

🤖 Generated with [Claude Code](https://claude.com/claude-code)