### PR TITLE
test(linter/plugins): add filter for test group to conformance tests

### DIFF
--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -1,13 +1,36 @@
 /*
  * Test filtering.
+ *
+ * Alter the constants below (`FILTER_ONLY_GROUP` etc) to apply a filter to tests.
+ * These should only be used temporarily for debugging a certain test case.
+ * In committed code, these should all be `null`.
  */
 
 type Filter = string | string[];
+type ShouldSkipFn = (name: string) => boolean;
 
-// Options to filter tests to a specific rule or specific code.
+// Options to filter tests to a specific group, rule, or specific code.
 // Useful for debugging a particular test case.
-export const FILTER_ONLY_RULE: Filter | null = null;
-export const FILTER_ONLY_CODE: Filter | null = null;
+const FILTER_ONLY_GROUP: Filter | null = null;
+const FILTER_ONLY_RULE: Filter | null = null;
+const FILTER_ONLY_CODE: Filter | null = null;
 
-// Filter out rules where test failures are expected
-export const FILTER_EXCLUDE_RULE: Filter | null = null;
+// Filtering functions, generated from the above constants
+export const SHOULD_SKIP_GROUP = createShouldSkipFn(FILTER_ONLY_GROUP);
+export const SHOULD_SKIP_RULE = createShouldSkipFn(FILTER_ONLY_RULE);
+export const SHOULD_SKIP_CODE = createShouldSkipFn(FILTER_ONLY_CODE);
+
+/**
+ * Create a function which determines if should skip based on a filter.
+ * @param filter - Filter
+ * @returns Filter function
+ */
+function createShouldSkipFn(filter: Filter | null): ShouldSkipFn {
+  if (filter === null) return returnFalse;
+  if (Array.isArray(filter)) return (name) => !filter.includes(name);
+  return (name) => name !== filter;
+}
+
+function returnFalse(): boolean {
+  return false;
+}

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -6,7 +6,7 @@
 import eslintGlobals from "../submodules/eslint/conf/globals.js";
 import { RuleTester } from "#oxlint";
 import { describe, it, setCurrentTest } from "./capture.ts";
-import { FILTER_ONLY_CODE } from "./filter.ts";
+import { SHOULD_SKIP_CODE } from "./filter.ts";
 
 import type { Rule } from "#oxlint";
 import type { LanguageOptionsInternal } from "../../src-js/package/rule_tester.ts";
@@ -68,19 +68,13 @@ class RuleTesterShim extends RuleTester {
 
   // Apply filter to test cases.
   run(ruleName: string, rule: Rule, tests: TestCases): void {
-    if (FILTER_ONLY_CODE !== null) {
-      const codeMatchesFilter = Array.isArray(FILTER_ONLY_CODE)
-        ? (code: string) => FILTER_ONLY_CODE!.includes(code)
-        : (code: string) => code === FILTER_ONLY_CODE;
-
-      tests = {
-        valid: tests.valid.filter((test) => {
-          const code = typeof test === "string" ? test : test.code;
-          return codeMatchesFilter(code);
-        }),
-        invalid: tests.invalid.filter((test) => codeMatchesFilter(test.code)),
-      };
-    }
+    tests = {
+      valid: tests.valid.filter((test) => {
+        const code = typeof test === "string" ? test : test.code;
+        return !SHOULD_SKIP_CODE(code);
+      }),
+      invalid: tests.invalid.filter((test) => !SHOULD_SKIP_CODE(test.code)),
+    };
 
     super.run(ruleName, rule, tests);
   }


### PR DESCRIPTION
Add ability to filter by group (i.e. just `react-hooks` tests) in conformance tester.