### PR TITLE
fix(vscode): support json5 for oxfmt

### DIFF
--- a/editors/vscode/client/tools/formatter.ts
+++ b/editors/vscode/client/tools/formatter.ts
@@ -134,6 +134,7 @@ export default class FormatterTool implements ToolInterface {
       "yyp",
       // JSONC
       "jsonc",
+      "json5",
       "code-snippets",
       "code-workspace",
       "sublime-build",


### PR DESCRIPTION
oxfmt supports json5:
https://github.com/oxc-project/oxc/blob/42ce1b4640529f2e2a5fde2d1969fdd01c8528da/apps/oxfmt/src/core/support.rs#L151-L153

closes #18488