### PR TITLE
fix(oxlint/cli): report error when nested config could not be parsed

### DIFF
--- a/apps/oxlint/fixtures/invalid_config_nested/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_nested/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  // valid config
+}

--- a/apps/oxlint/fixtures/invalid_config_nested/invalid/.oxlintrc.json
+++ b/apps/oxlint/fixtures/invalid_config_nested/invalid/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../invalid/plugin.ts"],
+}

--- a/apps/oxlint/fixtures/invalid_config_nested/invalid/foo.ts
+++ b/apps/oxlint/fixtures/invalid_config_nested/invalid/foo.ts
@@ -1,0 +1,1 @@
+// .oxlintrc.json should be reported as invalid

--- a/apps/oxlint/src/snapshots/fixtures__invalid_config_nested_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__invalid_config_nested_@oxlint.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/invalid_config_nested
+----------
+Failed to parse oxlint configuration file at <cwd>/fixtures/invalid_config_nested/invalid/.oxlintrc.json.
+
+  x Failed to parse config with error Error("Unknown plugin: '../invalid/plugin.ts'.", line: 0, column: 0)
+
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
fixed the TODO where we skipped reporting the error when the oxlintrc config could not be created from a file.
Refactored the code a bit so we searched only for the file paths first and then creating the `Oxlintrc` directly and passing it to the store builder.
The refactoring should us allow creating a helper function and combining it with LSP, where it knows already the config paths from a walker.
https://github.com/oxc-project/oxc/blob/94a9973ba810129118d92e085c579a3f20c82dc6/apps/oxlint/src/lsp/server_linter.rs#L271-L312
