### PR TITLE
docs(linter): Improve diagnostic message in `valid_typeof` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -14,7 +14,7 @@ use crate::{
 
 fn not_string(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
     let mut d =
-        OxcDiagnostic::warn("Typeof comparisons should be to string literals.").with_label(span);
+        OxcDiagnostic::warn("`typeof` comparisons should be to string literals.").with_label(span);
     if let Some(x) = help {
         d = d.with_help(x);
     }
@@ -22,7 +22,7 @@ fn not_string(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
 }
 
 fn invalid_value(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn("Invalid typeof comparison value.").with_label(span);
+    let mut d = OxcDiagnostic::warn("Invalid `typeof` comparison value.").with_label(span);
     if let Some(x) = help {
         d = d.with_help(x);
     }
@@ -93,6 +93,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for ValidTypeof {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // match on `typeof` unary expression for better performance
         let _unary_expr = match node.kind() {
@@ -156,10 +160,6 @@ impl Rule for ValidTypeof {
         {
             ctx.diagnostic(not_string(None, sibling.span()));
         }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/eslint_valid_typeof.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_valid_typeof.snap
@@ -1,131 +1,131 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:16]
  1 │ typeof foo === 'strnig'
    ·                ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:1]
  1 │ 'strnig' === typeof foo
    · ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:20]
  1 │ if (typeof bar === 'umdefined') {}
    ·                    ───────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:16]
  1 │ typeof foo !== 'strnig'
    ·                ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:1]
  1 │ 'strnig' !== typeof foo
    · ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:20]
  1 │ if (typeof bar !== 'umdefined') {}
    ·                    ───────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:15]
  1 │ typeof foo != 'strnig'
    ·               ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:1]
  1 │ 'strnig' != typeof foo
    · ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:19]
  1 │ if (typeof bar != 'umdefined') {}
    ·                   ───────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:15]
  1 │ typeof foo == 'strnig'
    ·               ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:1]
  1 │ 'strnig' == typeof foo
    · ────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:19]
  1 │ if (typeof bar == 'umdefined') {}
    ·                   ───────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:20]
  1 │ if (typeof bar === `umdefined`) {}
    ·                    ───────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:15]
  1 │ typeof foo == 'invalid string'
    ·               ────────────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Invalid typeof comparison value.
+  ⚠ eslint(valid-typeof): Invalid `typeof` comparison value.
    ╭─[valid_typeof.tsx:1:20]
  1 │ if (typeof bar !== undefined) {}
    ·                    ─────────
    ╰────
   help: Use `"undefined"` instead of `undefined`.
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:15]
  1 │ typeof foo == Object
    ·               ──────
    ╰────
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:16]
  1 │ typeof foo === undefined
    ·                ─────────
    ╰────
   help: Use `"undefined"` instead of `undefined`.
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:1]
  1 │ undefined === typeof foo
    · ─────────
    ╰────
   help: Use `"undefined"` instead of `undefined`.
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:1]
  1 │ undefined == typeof foo
    · ─────────
    ╰────
   help: Use `"undefined"` instead of `undefined`.
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:16]
  1 │ typeof foo === `undefined${foo}`
    ·                ─────────────────
    ╰────
 
-  ⚠ eslint(valid-typeof): Typeof comparisons should be to string literals.
+  ⚠ eslint(valid-typeof): `typeof` comparisons should be to string literals.
    ╭─[valid_typeof.tsx:1:16]
  1 │ typeof foo === `${string}`
    ·                ───────────


### PR DESCRIPTION
Simple improvement.