### PR TITLE
refactor(linter): Implement the proper config system for `react/forbid-elements`

### DIFF
--- a/crates/oxc_linter/src/rules/react/forbid_elements.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_elements.rs
@@ -3,43 +3,76 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 use rustc_hash::FxHashMap;
-use serde_json::Value;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_type, is_react_function_call},
 };
 
 fn forbid_elements_diagnostic(
     element: &str,
-    help: Option<CompactStr>,
+    help: Option<&CompactStr>,
     span: Span,
 ) -> OxcDiagnostic {
     if let Some(help) = help {
         return OxcDiagnostic::warn(format!("<{element}> is forbidden."))
-            .with_help(help)
+            .with_help(help.to_string())
             .with_label(span);
     }
 
     OxcDiagnostic::warn(format!("<{element}> is forbidden.")).with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ForbidElements(Box<ForbidElementsConfig>);
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(from = "ForbidElementsConfig")]
+pub struct ForbidElements {
+    // Map from element name to optional message for diagnostics.
+    forbid: Box<FxHashMap<CompactStr, Option<CompactStr>>>,
+}
 
-impl std::ops::Deref for ForbidElements {
-    type Target = ForbidElementsConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl From<ForbidElementsConfig> for ForbidElements {
+    fn from(config: ForbidElementsConfig) -> Self {
+        // Convert Vec to FxHashMap.
+        // Later entries will override earlier ones for duplicates.
+        let mut forbid = FxHashMap::default();
+        for item in config.forbid {
+            match item {
+                ForbidItem::ElementName(element) => {
+                    forbid.insert(element, None);
+                }
+                ForbidItem::ElementWithMessage { element, message } => {
+                    forbid.insert(element, message);
+                }
+            }
+        }
+        Self { forbid: Box::new(forbid) }
     }
 }
 
-#[derive(Debug, Default, Clone)]
+/// A forbidden element, either as a plain element name or with a custom message.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ForbidItem {
+    ElementName(CompactStr),
+    ElementWithMessage { element: CompactStr, message: Option<CompactStr> },
+}
+
+// Raw config for deserialization.
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ForbidElementsConfig {
-    forbid_elements: FxHashMap<CompactStr, Option<CompactStr>>,
+    /// List of forbidden elements, with optional messages for display with lint violations.
+    ///
+    /// Examples:
+    ///
+    /// - `["error, { "forbid": ["button"] }]`
+    /// - `["error, { "forbid": [{ "element": "button", "message": "Use <Button> instead." }] }]`
+    /// - `["error, { "forbid": [{ "element": "input" }] }]`
+    forbid: Vec<ForbidItem>,
 }
 
 declare_oxc_lint!(
@@ -49,53 +82,55 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// You may want to forbid usage of certain elements in favor of others, (e.g. forbid all <div /> and use <Box /> instead)
+    /// You may want to forbid usage of certain elements in favor of others, e.g.
+    /// forbid all `<div />` and use `<Box />` instead.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// // [1, { "forbid": ["button"] }]
+    /// // ["error", { "forbid": ["button"] }]
     /// <button />
     /// React.createElement('button');
     ///
-    /// // [1, { "forbid": ["Modal"] }]
+    /// // ["error", { "forbid": ["Modal"] }]
     /// <Modal />
     /// React.createElement(Modal);
     ///
-    /// // [1, { "forbid": ["Namespaced.Element"] }]
+    /// // ["error", { "forbid": ["Namespaced.Element"] }]
     /// <Namespaced.Element />
     /// React.createElement(Namespaced.Element);
     ///
-    /// // [1, { "forbid": [{ "element": "button", "message": "use <Button> instead" }, "input"] }]
+    /// // ["error", { "forbid": [{ "element": "button", "message": "use <Button> instead" }, "input"] }]
     /// <div><button /><input /></div>
     /// React.createElement('div', {}, React.createElement('button', {}, React.createElement('input')));
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
-    /// // [1, { "forbid": ["button"] }]
+    /// // ["error", { "forbid": ["button"] }]
     /// <Button />
     ///
-    /// // [1, { "forbid": [{ "element": "button" }] }]
+    /// // ["error", { "forbid": [{ "element": "button" }] }]
     /// <Button />
     /// ```
     ForbidElements,
     react,
     restriction,
+    config = ForbidElementsConfig,
 );
 
 impl Rule for ForbidElements {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
                 let name = &get_element_type(ctx, jsx_el);
 
-                self.add_diagnostic_if_invalid_element(
-                    ctx,
-                    &CompactStr::new(name),
-                    jsx_el.name.span(),
-                );
+                self.add_diagnostic_if_invalid_element(ctx, name, jsx_el.name.span());
             }
             AstKind::CallExpression(call_expr) => {
                 if !is_react_function_call(call_expr, r"createElement") {
@@ -111,33 +146,20 @@ impl Rule for ForbidElements {
                         if !is_valid_identifier(&it.name) {
                             return;
                         }
-                        self.add_diagnostic_if_invalid_element(
-                            ctx,
-                            &CompactStr::new(it.name.as_str()),
-                            it.span,
-                        );
+                        self.add_diagnostic_if_invalid_element(ctx, it.name.as_str(), it.span);
                     }
                     Argument::StringLiteral(str) => {
                         if !is_valid_literal(&str.value) {
                             return;
                         }
-                        self.add_diagnostic_if_invalid_element(
-                            ctx,
-                            &CompactStr::new(str.value.as_str()),
-                            str.span,
-                        );
+                        self.add_diagnostic_if_invalid_element(ctx, str.value.as_str(), str.span);
                     }
                     Argument::StaticMemberExpression(member_expression) => {
                         let Some(it) = member_expression.object.get_identifier_reference() else {
                             return;
                         };
-                        self.add_diagnostic_if_invalid_element(
-                            ctx,
-                            &CompactStr::new(
-                                format!("{}.{}", it.name, member_expression.property.name).as_str(),
-                            ),
-                            member_expression.span,
-                        );
+                        let name = format!("{}.{}", it.name, member_expression.property.name);
+                        self.add_diagnostic_if_invalid_element(ctx, &name, member_expression.span);
                     }
                     _ => {}
                 }
@@ -146,65 +168,15 @@ impl Rule for ForbidElements {
         }
     }
 
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut forbid_elements: FxHashMap<CompactStr, Option<CompactStr>> = FxHashMap::default();
-
-        match &value {
-            Value::Array(configs) => {
-                for config in configs {
-                    if let Value::Object(obj) = config
-                        && let Some(forbid_value) = obj.get("forbid")
-                    {
-                        add_configuration_forbid_from_object(&mut forbid_elements, forbid_value);
-                    }
-                }
-            }
-            Value::Object(obj) => {
-                if let Some(forbid_value) = obj.get("forbid") {
-                    add_configuration_forbid_from_object(&mut forbid_elements, forbid_value);
-                }
-            }
-            _ => {}
-        }
-
-        Ok(Self(Box::new(ForbidElementsConfig { forbid_elements })))
-    }
-
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx() && !self.forbid_elements.is_empty()
+        ctx.source_type().is_jsx() && !self.forbid.is_empty()
     }
 }
 
 impl ForbidElements {
-    fn add_diagnostic_if_invalid_element(&self, ctx: &LintContext, name: &CompactStr, span: Span) {
-        if let Some(forbid_element) = self.forbid_elements.get(name.as_str()) {
-            ctx.diagnostic(forbid_elements_diagnostic(name.as_str(), forbid_element.clone(), span));
-        }
-    }
-}
-
-fn add_configuration_forbid_from_object(
-    forbid_elements: &mut FxHashMap<CompactStr, Option<CompactStr>>,
-    forbid_value: &serde_json::Value,
-) {
-    let Some(forbid_array) = forbid_value.as_array() else {
-        return;
-    };
-
-    for forbid_value in forbid_array {
-        match forbid_value {
-            Value::String(element_name) => {
-                forbid_elements.insert(CompactStr::new(element_name), None);
-            }
-            Value::Object(object) => {
-                if let Some(element_name) = object.get("element").and_then(|el| el.as_str()) {
-                    forbid_elements.insert(
-                        CompactStr::new(element_name),
-                        object.get("message").and_then(|el| el.as_str()).map(CompactStr::new),
-                    );
-                }
-            }
-            _ => (),
+    fn add_diagnostic_if_invalid_element(&self, ctx: &LintContext, name: &str, span: Span) {
+        if let Some(message) = self.forbid.get(name) {
+            ctx.diagnostic(forbid_elements_diagnostic(name, message.as_ref(), span));
         }
     }
 }

--- a/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
+++ b/crates/oxc_linter/tests/rule_configuration_documentation_test.rs
@@ -37,7 +37,6 @@ fn test_rules_with_custom_configuration_have_schema() {
         "jest/valid-title",
         // react
         "react/forbid-dom-props",
-        "react/forbid-elements",
     ];
 
     let exception_set: FxHashSet<&str> = exceptions.iter().copied().collect();


### PR DESCRIPTION
This was missing the `config` attribute in the `declare_oxc_lint!` macro and also had a config struct that didn't quite match the shape of what the rule actually took, so I have fixed that. I've also simplified the `from_configuration` method now that the config struct is actually matching the accepted shape.

One rule closer to #14743.

AI Disclosure: Edits made with help from Claude Code and Copilot w/ Raptor mini. Driven and reviewed by me for correctness.

Generated config docs:

````md
## Configuration

This rule accepts a configuration object with the following properties:

### forbid

type: `array`

List of forbidden elements, with optional messages for display with lint violations.

Examples:

- `["error, { "forbid": ["button"] }]`
- `["error, { "forbid": [{ "element": "button", "message": "Use <Button> instead." }] }]`
- `["error, { "forbid": [{ "element": "input" }] }]`

#### forbid[n]

type: `object | string`

A forbidden element, either as a plain element name or with a custom message.

##### forbid[n].element

type: `string`

##### forbid[n].message

type: `string`
```