### PR TITLE
docs(npm): update package homepage URLs and add keywords

### DIFF
--- a/napi/minify/README.md
+++ b/napi/minify/README.md
@@ -1,5 +1,7 @@
 # Oxc Minify
 
+See [usage instructions](https://oxc.rs/docs/guide/usage/minifier).
+
 This is alpha software and may yield incorrect results, feel free to [submit a bug report](https://github.com/oxc-project/oxc/issues/new?assignees=&labels=C-bug&projects=&template=bug_report.md).
 
 ### Performance and Compression Size

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -3,10 +3,15 @@
   "version": "0.110.0",
   "description": "Oxc Minifier Node API",
   "keywords": [
+    "javascript",
+    "minifier",
     "minify",
-    "oxc"
+    "oxc",
+    "terser",
+    "typescript",
+    "uglify"
   ],
-  "homepage": "https://oxc.rs",
+  "homepage": "https://oxc.rs/docs/guide/usage/minifier",
   "bugs": "https://github.com/oxc-project/oxc/issues",
   "license": "MIT",
   "author": "Boshen and oxc contributors",

--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -1,5 +1,7 @@
 # Oxc Parser
 
+See [usage instructions](https://oxc.rs/docs/guide/usage/parser).
+
 ## Features
 
 ### Supports WASM

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -3,10 +3,14 @@
   "version": "0.110.0",
   "description": "Oxc Parser Node API",
   "keywords": [
+    "ast",
+    "estree",
+    "javascript",
     "oxc",
-    "parser"
+    "parser",
+    "typescript"
   ],
-  "homepage": "https://oxc.rs",
+  "homepage": "https://oxc.rs/docs/guide/usage/parser",
   "bugs": "https://github.com/oxc-project/oxc/issues",
   "license": "MIT",
   "author": "Boshen and oxc contributors",

--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -1,5 +1,7 @@
 # Oxc Transform
 
+See [usage instructions](https://oxc.rs/docs/guide/usage/transformer).
+
 ## TypeScript and React JSX Transform
 
 ```javascript

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -3,10 +3,16 @@
   "version": "0.110.0",
   "description": "Oxc Transformer Node API",
   "keywords": [
+    "babel",
+    "javascript",
+    "jsx",
     "oxc",
-    "transform"
+    "transform",
+    "transformer",
+    "tsx",
+    "typescript"
   ],
-  "homepage": "https://oxc.rs",
+  "homepage": "https://oxc.rs/docs/guide/usage/transformer",
   "bugs": "https://github.com/oxc-project/oxc/issues",
   "license": "MIT",
   "author": "Boshen and oxc contributors",

--- a/npm/oxfmt/README.md
+++ b/npm/oxfmt/README.md
@@ -50,7 +50,7 @@ The Oxidation Compiler is creating a suite of high-performance tools for JavaScr
 
 This is the formatter for oxc.
 
-See [usage instructions](https://oxc.rs/docs/guide/usage/formatter.html).
+See [usage instructions](https://oxc.rs/docs/guide/usage/formatter).
 
 Run
 

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -2,8 +2,15 @@
   "name": "oxfmt",
   "version": "0.26.0",
   "description": "Formatter for the JavaScript Oxidation Compiler",
-  "keywords": [],
-  "homepage": "https://oxc.rs",
+  "keywords": [
+    "formatter",
+    "javascript",
+    "oxc",
+    "oxfmt",
+    "prettier",
+    "typescript"
+  ],
+  "homepage": "https://oxc.rs/docs/guide/usage/formatter",
   "bugs": "https://github.com/oxc-project/oxc/issues",
   "license": "MIT",
   "author": "Boshen and oxc contributors",

--- a/npm/oxlint/README.md
+++ b/npm/oxlint/README.md
@@ -50,7 +50,7 @@ The Oxidation Compiler is creating a suite of high-performance tools for JavaScr
 
 This is the linter for oxc.
 
-See [usage instructions](https://oxc.rs/docs/guide/usage/linter.html).
+See [usage instructions](https://oxc.rs/docs/guide/usage/linter).
 
 Run
 

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -2,8 +2,15 @@
   "name": "oxlint",
   "version": "1.41.0",
   "description": "Linter for the JavaScript Oxidation Compiler",
-  "keywords": [],
-  "homepage": "https://oxc.rs",
+  "keywords": [
+    "eslint",
+    "javascript",
+    "linter",
+    "oxc",
+    "oxlint",
+    "typescript"
+  ],
+  "homepage": "https://oxc.rs/docs/guide/usage/linter",
   "bugs": "https://github.com/oxc-project/oxc/issues",
   "license": "MIT",
   "author": "Boshen and oxc contributors",


### PR DESCRIPTION
## Summary

- Update homepage links to point to specific documentation pages (e.g., `https://oxc.rs/docs/guide/usage/linter`)
- Add usage instruction links to napi package READMEs
- Add relevant keywords for better npm discoverability

🤖 Generated with [Claude Code](https://claude.com/claude-code)