### PR TITLE
test(oxlint): fix `nested_config_duplicate` fixture

### DIFF
--- a/apps/oxlint/test/fixtures/nested_config_duplicate/files/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/files/.oxlintrc.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["../plugin.ts"],
+  "jsPlugins": ["../plugin.ts"],
   "extends": ["../.oxlintrc.json"]
 }

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
@@ -10,7 +10,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file using X threads.
 ```
 
 # stderr


### PR DESCRIPTION
found via failed test from https://github.com/oxc-project/oxc/pull/18504