### PR TITLE
fix(parser): detect `import x = require()` as module indicator

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1539,7 +1539,7 @@ impl<'a> ParserImpl<'a> {
 
             if self.ctx.has_top_level() {
                 // At top level - upgrade to ESM immediately (like Babel's `sawUnambiguousESM`)
-                self.module_record_builder.found_unambiguous_await();
+                self.module_record_builder.set_module_syntax();
                 // Defer error - will be discarded when we upgrade to ESM
                 self.error_on_script(diagnostics::await_expression(self.cur_token().span()));
             } else {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -402,7 +402,7 @@ impl<'a> ParserImpl<'a> {
         let expression = self.parse_assignment_expression_or_higher();
         self.asi();
         if self.ctx.has_top_level() {
-            self.module_record_builder.found_ts_export();
+            self.module_record_builder.set_module_syntax();
         }
         self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression)
     }
@@ -416,7 +416,7 @@ impl<'a> ParserImpl<'a> {
         let id = self.parse_identifier_name();
         self.asi();
         if self.ctx.has_top_level() {
-            self.module_record_builder.found_ts_export();
+            self.module_record_builder.set_module_syntax();
         }
         self.ast.alloc_ts_namespace_export_declaration(self.end_span(start_span), id)
     }

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -384,13 +384,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record.has_module_syntax = true;
     }
 
-    pub fn found_ts_export(&mut self) {
-        self.module_record.has_module_syntax = true;
-    }
-
-    /// Mark the file as ESM when unambiguous top-level await is detected.
-    /// This is similar to Babel's `sawUnambiguousESM` flag.
-    pub fn found_unambiguous_await(&mut self) {
+    pub fn set_module_syntax(&mut self) {
         self.module_record.has_module_syntax = true;
     }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -568,6 +568,9 @@ impl<'a> ParserImpl<'a> {
             self.expect(Kind::LParen);
             let expression = self.parse_literal_string();
             self.expect(Kind::RParen);
+            if self.ctx.has_top_level() {
+                self.module_record_builder.set_module_syntax();
+            }
             self.ast.ts_module_reference_external_module_reference(
                 self.end_span(reference_span),
                 expression,

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: 7f6a8467
 
 parser_typescript Summary:
 AST Parsed     : 9842/9843 (99.99%)
-Positive Passed: 9837/9843 (99.94%)
+Positive Passed: 9838/9843 (99.95%)
 Negative Passed: 1500/2555 (58.71%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
@@ -2137,15 +2137,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asy
      ·             ╰── It can not be redeclared here
  132 │     }
      ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
-
-  × Cannot assign to 'arguments' in strict mode
-   ╭─[typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts:2:10]
- 1 │ var p1 = import("./0");
- 2 │ function arguments() { } // this is allow as the file doesn't have implicit "use strict"
-   ·          ─────────
-   ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 
@@ -19719,13 +19710,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·                   ─────
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts:3:8]
- 2 │ declare var require: any;
- 3 │ import await = require("./other");
-   ·        ─────
-   ╰────
-
   × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts:3:8]
  2 │ declare var require: any;
@@ -19805,25 +19789,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.7.ts:2:13]
- 1 │ // await disallowed in namespace import
- 2 │ import * as await from "./other";
-   ·             ─────
-   ╰────
-
   × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.7.ts:2:13]
  1 │ // await disallowed in namespace import
  2 │ import * as await from "./other";
    ·             ─────
-   ╰────
-
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.8.ts:2:8]
- 1 │ // await disallowed in default import
- 2 │ import await from "./other";
-   ·        ─────
    ╰────
 
   × The keyword 'await' is reserved
@@ -21043,36 +21013,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │     }
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.classMethods.es2018.ts:2:15]
- 1 │ class C4 {
- 2 │     async * f(await) {
-   ·               ─────
- 3 │     }
-   ╰────
-
   × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:18]
- 1 │ async function * await() {
-   ·                  ─────
- 2 │ }
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:18]
- 1 │ async function * await() {
-   ·                  ─────
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:21]
+ 1 │ async function * f4(await) {
+   ·                     ─────
  2 │ }
    ╰────
 
   × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionExpressions.es2018.ts:1:29]
- 1 │ const f2 = async function * await() {
-   ·                             ─────
- 2 │ };
-   ╰────
-
-  × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionExpressions.es2018.ts:1:29]
  1 │ const f2 = async function * await() {
    ·                             ─────
@@ -21087,21 +21035,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │     }
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.objectLiteralMethods.es2018.ts:2:15]
- 1 │ const o4 = {
- 2 │     async * f(await) {
-   ·               ─────
- 3 │     }
-   ╰────
-
-  × await can only be used in conjunction with `for...of` statements
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/forAwait/parser.forAwait.es2018.ts:1:1]
- 1 │ for await (const x in y) {
-   · ────────────────────────
+  × `await` is only allowed within async functions and at the top levels of modules
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/forAwait/parser.forAwait.es2018.ts:1:5]
+ 1 │ for await (const x of y) {
+   ·     ─────
  2 │ }
    ╰────
-  help: Did you mean to use a for...of statement?
+  help: Either remove this `await` or add the `async` keyword to the enclosing function
 
   × Invalid Character `
   │ `
@@ -24342,13 +24282,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerUnicodeEscapeInKeyword1.ts:1:1]
  1 │ \u0076ar x = "hello";
    · ────────
-   ╰────
-
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerUnicodeEscapeInKeyword2.ts:1:5]
- 1 │ var \u0061wait = 12; // ok
-   ·     ──────────
- 2 │ async function main() {
    ╰────
 
   × Keywords cannot contain escape characters

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7f6a8467
 
 semantic_typescript Summary:
 AST Parsed     : 6126/6126 (100.00%)
-Positive Passed: 3339/6126 (54.51%)
+Positive Passed: 3340/6126 (54.52%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -287,6 +287,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientClassDecla
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "d"]
 rebuilt        : ScopeId(0): ["D", "d"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "D":
 after transform: SymbolId(3): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -1506,8 +1509,8 @@ Reference symbol mismatch for "Err":
 after transform: SymbolId(0) "Err"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Err"]
+after transform: ["require"]
+rebuilt        : ["Err", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
 Scope flags mismatch:
@@ -4545,7 +4548,7 @@ after transform: ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "ctor", "f1
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "f1", "f2", "f3", "f4", "foo", "goo"]
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(8): [ReferenceId(36), ReferenceId(37), ReferenceId(38)]
-rebuilt        : SymbolId(9): [ReferenceId(29), ReferenceId(32)]
+rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(33)]
 Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
@@ -4556,11 +4559,11 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Promise", "Set"]
-rebuilt        : ["Promise", "Set", "ctor", "x"]
+after transform: ["Function", "Promise", "Set", "require"]
+rebuilt        : ["Promise", "Set", "ctor", "require", "x"]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(33)]
-rebuilt        : [ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(18), ReferenceId(22), ReferenceId(25)]
+rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 Symbol reference IDs mismatch for "A":
@@ -12430,8 +12433,8 @@ rebuilt        : ["expect", "fooFn"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Unresolved references mismatch:
-after transform: ["CallableExtention"]
-rebuilt        : []
+after transform: ["CallableExtention", "require"]
+rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/generics3.ts
 Symbol reference IDs mismatch for "C":
@@ -12686,12 +12689,18 @@ after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "WhichThing"]
 rebuilt        : ScopeId(4): ["WhichThing"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "My":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -23366,6 +23375,9 @@ after transform: ["TemplateStringsArray"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "n":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -24027,14 +24039,14 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["T", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["T", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Reference symbol mismatch for "T":
 after transform: SymbolId(6) "T"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["T", "require"]
+after transform: ["JSX"]
+rebuilt        : ["T"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
 Bindings mismatch:
@@ -28494,8 +28506,8 @@ Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["arguments"]
-rebuilt        : ["arguments", "console"]
+after transform: ["arguments", "require"]
+rebuilt        : ["arguments", "console", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
 Bindings mismatch:
@@ -28536,8 +28548,8 @@ rebuilt        : ["getPath"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
 Unresolved references mismatch:
-after transform: ["Promise", "arguments"]
-rebuilt        : ["arguments"]
+after transform: ["Promise", "arguments", "require"]
+rebuilt        : ["arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
 Unresolved references mismatch:
@@ -28569,9 +28581,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["arguments"]
 rebuilt        : ["arguments", "console"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
-Cannot assign to 'arguments' in strict mode
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 Bindings mismatch:
@@ -30976,8 +30985,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "Object"]
-rebuilt        : ["Function", "Number", "Object", "dec"]
+after transform: ["Function", "Number", "Object", "require"]
+rebuilt        : ["Function", "Number", "Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 Bindings mismatch:
@@ -36373,6 +36382,9 @@ after transform: ["Object", "require"]
 rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36471,6 +36483,9 @@ after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36593,6 +36608,15 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Root":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36613,6 +36637,12 @@ after transform: SymbolId(3): Span { start: 157, end: 162 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36915,8 +36945,8 @@ rebuilt        : ScopeId(0): ["a", "b", "c"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
+after transform: ["JSX"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 Bindings mismatch:
@@ -37336,8 +37366,8 @@ rebuilt        : ["React"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["Component", "_jsxFileName", "_objectSpread", "_reactJsxRuntime", "decorator", "decorator1"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_objectSpread", "_reactJsxRuntime", "decorator", "decorator1"]
+after transform: ScopeId(0): ["Component", "_jsx", "_jsxFileName", "_objectSpread", "decorator", "decorator1"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_objectSpread", "decorator", "decorator1"]
 Reference symbol mismatch for "Component":
 after transform: SymbolId(1) "Component"
 rebuilt        : <None>
@@ -37345,13 +37375,13 @@ Reference symbol mismatch for "Component":
 after transform: SymbolId(1) "Component"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["Component", "require"]
+after transform: ["JSX"]
+rebuilt        : ["Component"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["Component", "_jsxFileName", "_objectSpread", "_reactJsxRuntime", "decorator", "decorator1"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_objectSpread", "_reactJsxRuntime", "decorator", "decorator1"]
+after transform: ScopeId(0): ["Component", "_jsx", "_jsxFileName", "_objectSpread", "decorator", "decorator1"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_objectSpread", "decorator", "decorator1"]
 Reference symbol mismatch for "Component":
 after transform: SymbolId(1) "Component"
 rebuilt        : <None>
@@ -37359,8 +37389,8 @@ Reference symbol mismatch for "Component":
 after transform: SymbolId(1) "Component"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["Component", "require"]
+after transform: ["JSX"]
+rebuilt        : ["Component"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 Symbol reference IDs mismatch for "React":
@@ -37412,8 +37442,8 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["MyComp", "React", "_jsxFileName", "_reactJsxRuntime", "x"]
-rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["MyComp", "React", "_jsx", "_jsxFileName", "x"]
+rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x"]
 Symbol reference IDs mismatch for "React":
 after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(2): []
@@ -37426,8 +37456,8 @@ rebuilt        : ["MyComp", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 Bindings mismatch:
-after transform: ScopeId(0): ["MyComp", "React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
-rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
+after transform: ScopeId(0): ["MyComp", "React", "_jsx", "_jsxFileName", "x", "x1"]
+rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x", "x1"]
 Symbol reference IDs mismatch for "React":
 after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(2): []

--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -167,7 +167,6 @@ impl TestCaseContent {
 
         let settings = CompilerSettings::new(&current_file_options);
 
-        let is_module = test_unit_data.len() > 1;
         let test_unit_data = test_unit_data
             .into_iter()
             // Some snapshot units contain an invalid file with just a message, not even a comment!
@@ -191,11 +190,7 @@ impl TestCaseContent {
                 !unit.content.lines().any(is_invalid_line)
             })
             .filter_map(|mut unit| {
-                let mut source_type = Self::get_source_type(Path::new(&unit.name), &settings)?;
-                if is_module {
-                    source_type = source_type.with_module(true);
-                }
-                unit.source_type = source_type;
+                unit.source_type = Self::get_source_type(Path::new(&unit.name), &settings)?;
 
                 // Collect spans of @ts-ignore or @ts-expect-error comments
                 unit.ts_ignore_spans = TS_IGNORE_PATTERN
@@ -222,10 +217,12 @@ impl TestCaseContent {
     }
 
     fn get_source_type(path: &Path, options: &CompilerSettings) -> Option<SourceType> {
-        let source_type = SourceType::from_path(path)
-            .ok()?
-            .with_jsx(!options.jsx.is_empty())
-            .with_unambiguous(true);
+        let mut source_type = SourceType::from_path(path).ok()?.with_jsx(!options.jsx.is_empty());
+        // TypeScript accepts ES imports in CommonJS files by default
+        // (only rejects them with verbatimModuleSyntax or module:preserve, which we don't support)
+        if source_type.is_commonjs() {
+            source_type = source_type.with_module(true);
+        }
         Some(source_type)
     }
 


### PR DESCRIPTION
## Summary

- Mark `import x = require('...')` with external module reference as ESM indicator (matching TypeScript's `isFileProbablyExternalModule` behavior)
- Treat CommonJS files as modules in TypeScript coverage tests (TypeScript accepts ES imports in `.cjs` by default, only rejecting with `verbatimModuleSyntax` or `module:preserve`)
- Unify `found_ts_export` and `found_unambiguous_await` into single `set_module_syntax` method

🤖 Generated with [Claude Code](https://claude.ai/code)