### PR TITLE
perf(linter/plugins): replace ESLint step classes with plain objects

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
-    "@eslint/plugin-kit": "^0.5.0",
     "@napi-rs/cli": "catalog:",
     "@types/esquery": "^1.5.4",
     "@types/estree": "^1.0.8",

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -93,7 +93,7 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
 
     if (stepType === STEP_TYPE_ENTER) {
       // Enter node - can be leaf or non-leaf node
-      const node = step.target as Node;
+      const node = step.target;
       const typeId = NODE_TYPE_IDS_MAP.get(node.type)!;
       const visit = visitors[typeId];
 
@@ -116,7 +116,7 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
       }
     } else if (stepType === STEP_TYPE_EXIT) {
       // Exit non-leaf node
-      const node = step.target as Node;
+      const node = step.target;
       ancestors.shift();
 
       const typeId = NODE_TYPE_IDS_MAP.get(node.type)!;

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -26,20 +26,34 @@ const STEP_TYPE_EXIT = 1;
 const STEP_TYPE_CALL = 2;
 
 /**
- * Step to walk AST - using plain objects instead of ESLint's class instances.
+ * Step to walk AST.
  */
-interface VisitStep {
-  type: typeof STEP_TYPE_ENTER | typeof STEP_TYPE_EXIT;
+type Step = EnterStep | ExitStep | CallStep;
+
+/**
+ * Step for entering AST node.
+ */
+interface EnterStep {
+  type: typeof STEP_TYPE_ENTER;
   target: Node;
 }
 
+/**
+ * Step for exiting AST node.
+ */
+interface ExitStep {
+  type: typeof STEP_TYPE_EXIT;
+  target: Node;
+}
+
+/**
+ * Step for calling a CFG event handler.
+ */
 interface CallStep {
   type: typeof STEP_TYPE_CALL;
   eventName: string;
   args: unknown[];
 }
-
-type Step = VisitStep | CallStep;
 
 // Array of steps to walk AST.
 // Singleton array which is re-used for each walk, and emptied after each walk.
@@ -128,7 +142,7 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
       }
     } else {
       // Call method (CFG event)
-      const callStep = step as CallStep;
+      const callStep = step;
       const eventId = NODE_TYPE_IDS_MAP.get(callStep.eventName)!;
       const visit = visitors[eventId];
       if (visit !== null) {

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -142,11 +142,10 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
       }
     } else {
       // Call method (CFG event)
-      const callStep = step;
-      const eventId = NODE_TYPE_IDS_MAP.get(callStep.eventName)!;
+      const eventId = NODE_TYPE_IDS_MAP.get(step.eventName)!;
       const visit = visitors[eventId];
       if (visit !== null) {
-        (visit as any).apply(undefined, callStep.args);
+        (visit as any).apply(undefined, step.args);
       }
     }
   }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -18,9 +18,8 @@ import type { EnterExit, VisitFn } from "./visitor.ts";
 import type { Node, Program } from "../generated/types.d.ts";
 import type { CompiledVisitors } from "../generated/walk.js";
 
-/**
- * Step type constants (merged kind + phase into single type).
- */
+// Step type constants.
+// Equivalent to an enum, but minifies better.
 const STEP_TYPE_ENTER = 0;
 const STEP_TYPE_EXIT = 1;
 const STEP_TYPE_CALL = 2;

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -35,7 +35,7 @@ type VisitStep = {
 
 type CallStep = {
   type: typeof STEP_TYPE_CALL;
-  target: string;
+  eventName: string;
   args: unknown[];
 };
 
@@ -129,7 +129,7 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
     } else {
       // Call method (CFG event)
       const callStep = step as CallStep;
-      const eventId = NODE_TYPE_IDS_MAP.get(callStep.target)!;
+      const eventId = NODE_TYPE_IDS_MAP.get(callStep.eventName)!;
       const visit = visitors[eventId];
       if (visit !== null) {
         (visit as any).apply(undefined, callStep.args);
@@ -201,7 +201,7 @@ function prepareSteps(ast: Program) {
           const eventNames = steps
             .slice(stepsLenAfterEnter)
             .filter((step): step is CallStep => step.type === STEP_TYPE_CALL)
-            .map((step) => step.target);
+            .map((step) => step.eventName);
           throw new Error(
             `CFG events emitted during visiting leaf node \`${node.type}\`: ${eventNames.join(", ")}`,
           );
@@ -212,7 +212,7 @@ function prepareSteps(ast: Program) {
     emit(eventName: string, args: unknown[]) {
       steps.push({
         type: STEP_TYPE_CALL,
-        target: eventName,
+        eventName,
         args,
       });
     },

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -198,10 +198,10 @@ function prepareSteps(ast: Program) {
         // visit functions are called in would be wrong.
         // `exit` visit fn would be called before the CFG event handlers, instead of after.
         if (DEBUG && steps.length !== stepsLenAfterEnter) {
-          const eventNames = steps
-            .slice(stepsLenAfterEnter)
-            .filter((step): step is CallStep => step.type === STEP_TYPE_CALL)
-            .map((step) => step.eventName);
+          const eventNames = steps.slice(stepsLenAfterEnter).map((step) => {
+            if (step.type === STEP_TYPE_CALL) return step.eventName;
+            return `${step.type === STEP_TYPE_ENTER ? "enter" : "exit"} ${node.type}`;
+          });
           throw new Error(
             `CFG events emitted during visiting leaf node \`${node.type}\`: ${eventNames.join(", ")}`,
           );

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -28,16 +28,16 @@ const STEP_TYPE_CALL = 2;
 /**
  * Step to walk AST - using plain objects instead of ESLint's class instances.
  */
-type VisitStep = {
+interface VisitStep {
   type: typeof STEP_TYPE_ENTER | typeof STEP_TYPE_EXIT;
   target: Node;
-};
+}
 
-type CallStep = {
+interface CallStep {
   type: typeof STEP_TYPE_CALL;
   eventName: string;
   args: unknown[];
-};
+}
 
 type Step = VisitStep | CallStep;
 

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -99,17 +99,17 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
 
       if (typeId < LEAF_NODE_TYPES_COUNT) {
         // Leaf node
-        if (visit != null) {
+        if (visit !== null) {
           typeAssertIs<VisitFn>(visit);
           visit(node);
         }
         // Don't add node to `ancestors`, because we don't visit them on exit
       } else {
         // Non-leaf node
-        if (visit != null) {
+        if (visit !== null) {
           typeAssertIs<EnterExit>(visit);
           const { enter } = visit;
-          if (enter != null) enter(node);
+          if (enter !== null) enter(node);
         }
 
         ancestors.unshift(node);
@@ -121,17 +121,17 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
 
       const typeId = NODE_TYPE_IDS_MAP.get(node.type)!;
       const enterExit = visitors[typeId];
-      if (enterExit != null) {
+      if (enterExit !== null) {
         typeAssertIs<EnterExit>(enterExit);
         const { exit } = enterExit;
-        if (exit != null) exit(node);
+        if (exit !== null) exit(node);
       }
     } else {
       // Call method (CFG event)
       const callStep = step as CallStep;
       const eventId = NODE_TYPE_IDS_MAP.get(callStep.target)!;
       const visit = visitors[eventId];
-      if (visit != null) {
+      if (visit !== null) {
         (visit as any).apply(undefined, callStep.args);
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,6 @@ importers:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
         version: 0.18.2
-      '@eslint/plugin-kit':
-        specifier: ^0.5.0
-        version: 0.5.0
       '@napi-rs/cli':
         specifier: 'catalog:'
         version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.1.0)
@@ -1044,10 +1041,6 @@ packages:
     resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@1.0.0':
-    resolution: {integrity: sha512-PRfWP+8FOldvbApr6xL7mNCw4cJcSTq4GA7tYbgq15mRb0kWKO/wEB2jr+uwjFH3sZvEZneZyCUGTxsv4Sahyw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
   '@eslint/eslintrc@3.3.3':
     resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1063,10 +1056,6 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.5.0':
-    resolution: {integrity: sha512-rSXBsAcmx80jI9OUevyNBU0f5pZRQJkNmk4bLX6hCbm1qKe5Z/TcU7vwXc2nR8814mhRlgbZIHL1+HSiYS0VkQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -6269,10 +6258,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/core@1.0.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
@@ -6294,11 +6279,6 @@ snapshots:
   '@eslint/plugin-kit@0.3.5':
     dependencies:
       '@eslint/core': 0.15.2
-      levn: 0.4.1
-
-  '@eslint/plugin-kit@0.5.0':
-    dependencies:
-      '@eslint/core': 1.0.0
       levn: 0.4.1
 
   '@humanfs/core@0.19.1': {}


### PR DESCRIPTION
Part 1 of #17232 - CFG walker optimization.

- Remove `@eslint/plugin-kit` dependency (no longer needed)
- Replace `VisitNodeStep` and `CallMethodStep` classes with plain objects
- Merge `kind` and `phase` into a single `type` property:
  - 0 = enter visit
  - 1 = exit visit
  - 2 = call method (CFG event)

This reduces object creation overhead and improves memory efficiency by using simpler data structures.