### PR TITLE
perf(linter/plugins): replace ESLint Traverser with lightweight traverseNode

### DIFF
--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -252,20 +252,7 @@ function prepareSteps(ast: Program) {
  * @param enter - Callback for entering a node
  * @param leave - Callback for leaving a node
  */
-function traverseNode(
-  node: Node | (Node | null)[],
-  enter: (node: Node) => void,
-  leave: (node: Node) => void,
-): void {
-  if (Array.isArray(node)) {
-    const len = node.length;
-    for (let i = 0; i < len; i++) {
-      const child = node[i];
-      if (child !== null) traverseNode(child, enter, leave);
-    }
-    return;
-  }
-
+function traverseNode(node: Node, enter: (node: Node) => void, leave: (node: Node) => void): void {
   // Enter the node
   enter(node);
 
@@ -274,7 +261,16 @@ function traverseNode(
   const keysLen = keys.length;
   for (let i = 0; i < keysLen; i++) {
     const child = (node as any)[keys[i]] as Node | (Node | null)[] | null;
-    if (child !== null) {
+
+    if (child === null) continue;
+
+    if (Array.isArray(child)) {
+      const len = child.length;
+      for (let i = 0; i < len; i++) {
+        const element = child[i];
+        if (element !== null) traverseNode(element, enter, leave);
+      }
+    } else {
       traverseNode(child, enter, leave);
     }
   }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -55,9 +55,6 @@ const stepTypeIds: number[] = [];
  */
 const stepData: (Node | unknown[])[] = [];
 
-// Pre-computed for performance
-const { isArray } = Array;
-
 /**
  * Reset state for walking AST with CFG.
  *
@@ -262,7 +259,7 @@ function traverseNode(
 ): void {
   if (node == null) return;
 
-  if (isArray(node)) {
+  if (Array.isArray(node)) {
     const len = node.length;
     for (let i = 0; i < len; i++) {
       traverseNode(node[i], enter, leave);

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -155,49 +155,6 @@ export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): vo
 }
 
 /**
- * Lightweight AST traverser for CFG building.
- * This is a simplified version that only calls enter/leave callbacks,
- * without building ancestors array or other overhead that ESLint's Traverser has.
- *
- * @param node - AST node to traverse
- * @param enter - Callback for entering a node
- * @param leave - Callback for leaving a node
- */
-function traverseNode(
-  node: Node | null | undefined,
-  enter: (node: Node) => void,
-  leave: (node: Node) => void,
-): void {
-  if (node == null) return;
-
-  if (isArray(node)) {
-    const len = node.length;
-    for (let i = 0; i < len; i++) {
-      traverseNode(node[i], enter, leave);
-    }
-    return;
-  }
-
-  // Enter the node
-  enter(node);
-
-  // Traverse children using visitorKeys
-  const keys = visitorKeys[node.type as keyof typeof visitorKeys];
-  if (keys != null) {
-    const keysLen = keys.length;
-    for (let i = 0; i < keysLen; i++) {
-      const child = (node as any)[keys[i]];
-      if (child != null) {
-        traverseNode(child, enter, leave);
-      }
-    }
-  }
-
-  // Leave the node
-  leave(node);
-}
-
-/**
  * Walk AST and put a list of all steps to walk AST into the SoA arrays.
  * @param ast - AST
  */
@@ -287,4 +244,47 @@ function prepareSteps(ast: Program) {
     stepTypeIds.length === stepData.length,
     "`stepTypeIds` and `stepData` should have the same length",
   );
+}
+
+/**
+ * Lightweight AST traverser for CFG building.
+ * This is a simplified version that only calls enter/leave callbacks,
+ * without building ancestors array or other overhead that ESLint's `Traverser` has.
+ *
+ * @param node - AST node to traverse
+ * @param enter - Callback for entering a node
+ * @param leave - Callback for leaving a node
+ */
+function traverseNode(
+  node: Node | null | undefined,
+  enter: (node: Node) => void,
+  leave: (node: Node) => void,
+): void {
+  if (node == null) return;
+
+  if (isArray(node)) {
+    const len = node.length;
+    for (let i = 0; i < len; i++) {
+      traverseNode(node[i], enter, leave);
+    }
+    return;
+  }
+
+  // Enter the node
+  enter(node);
+
+  // Traverse children using visitorKeys
+  const keys = visitorKeys[node.type as keyof typeof visitorKeys];
+  if (keys != null) {
+    const keysLen = keys.length;
+    for (let i = 0; i < keysLen; i++) {
+      const child = (node as any)[keys[i]];
+      if (child != null) {
+        traverseNode(child, enter, leave);
+      }
+    }
+  }
+
+  // Leave the node
+  leave(node);
 }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -253,10 +253,8 @@ function prepareSteps(ast: Program) {
  * @param leave - Callback for leaving a node
  */
 function traverseNode(node: Node, enter: (node: Node) => void, leave: (node: Node) => void): void {
-  // Enter the node
   enter(node);
 
-  // Traverse children using visitorKeys
   const keys = visitorKeys[node.type as keyof typeof visitorKeys];
   const keysLen = keys.length;
   for (let i = 0; i < keysLen; i++) {
@@ -275,6 +273,5 @@ function traverseNode(node: Node, enter: (node: Node) => void, leave: (node: Nod
     }
   }
 
-  // Leave the node
   leave(node);
 }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -253,16 +253,15 @@ function prepareSteps(ast: Program) {
  * @param leave - Callback for leaving a node
  */
 function traverseNode(
-  node: Node | (Node | null)[] | null,
+  node: Node | (Node | null)[],
   enter: (node: Node) => void,
   leave: (node: Node) => void,
 ): void {
-  if (node == null) return;
-
   if (Array.isArray(node)) {
     const len = node.length;
     for (let i = 0; i < len; i++) {
-      traverseNode(node[i], enter, leave);
+      const child = node[i];
+      if (child !== null) traverseNode(child, enter, leave);
     }
     return;
   }
@@ -275,7 +274,7 @@ function traverseNode(
   const keysLen = keys.length;
   for (let i = 0; i < keysLen; i++) {
     const child = (node as any)[keys[i]] as Node | (Node | null)[] | null;
-    if (child != null) {
+    if (child !== null) {
       traverseNode(child, enter, leave);
     }
   }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -253,7 +253,7 @@ function prepareSteps(ast: Program) {
  * @param leave - Callback for leaving a node
  */
 function traverseNode(
-  node: Node | null | undefined,
+  node: Node | (Node | null)[] | null,
   enter: (node: Node) => void,
   leave: (node: Node) => void,
 ): void {
@@ -274,7 +274,7 @@ function traverseNode(
   const keys = visitorKeys[node.type as keyof typeof visitorKeys];
   const keysLen = keys.length;
   for (let i = 0; i < keysLen; i++) {
-    const child = (node as any)[keys[i]];
+    const child = (node as any)[keys[i]] as Node | (Node | null)[] | null;
     if (child != null) {
       traverseNode(child, enter, leave);
     }

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -272,13 +272,11 @@ function traverseNode(
 
   // Traverse children using visitorKeys
   const keys = visitorKeys[node.type as keyof typeof visitorKeys];
-  if (keys != null) {
-    const keysLen = keys.length;
-    for (let i = 0; i < keysLen; i++) {
-      const child = (node as any)[keys[i]];
-      if (child != null) {
-        traverseNode(child, enter, leave);
-      }
+  const keysLen = keys.length;
+  for (let i = 0; i < keysLen; i++) {
+    const child = (node as any)[keys[i]];
+    if (child != null) {
+      traverseNode(child, enter, leave);
     }
   }
 

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -230,12 +230,8 @@ function prepareSteps(ast: Program) {
     },
   });
 
-  // Walk AST using our lightweight traverser instead of ESLint's Traverser
-  traverseNode(
-    ast,
-    (node) => analyzer.enterNode(node),
-    (node) => analyzer.leaveNode(node),
-  );
+  // Walk AST, calling `analyzer` methods for each node
+  traverseNode(ast, analyzer.enterNode.bind(analyzer), analyzer.leaveNode.bind(analyzer));
 
   debugAssert(
     stepTypeIds.length === stepData.length,


### PR DESCRIPTION
Part 3 of #17232, continuing after #18527 and #18528 - CFG walker optimization.

- Remove ESLint's `Traverser`
- Add lightweight `traverseNode` function that walks AST using visitor keys
- Simplify traversal by only calling enter/leave callbacks without extra overhead

Benefits:

- Eliminates ESLint Traverser overhead (ancestors tracking, etc.)
- Uses pre-generated visitor keys for child property lookup
- Reduces bundle size by removing unused ESLint internal module (~1.7KB smaller)