### PR TITLE
test(linter/plugins): conformance test snapshots include parser details

### DIFF
--- a/apps/oxlint/conformance/src/index.ts
+++ b/apps/oxlint/conformance/src/index.ts
@@ -112,10 +112,15 @@ export interface TestGroup {
    *
    * e.g. `{ specifier: "@typescript-eslint/parser", lang: "ts" }`
    */
-  parsers: {
-    specifier: string;
-    lang: Language;
-  }[];
+  parsers: ParserDetails[];
+}
+
+/**
+ * Custom parser details.
+ */
+export interface ParserDetails {
+  specifier: string;
+  lang: Language;
 }
 
 /**
@@ -245,13 +250,12 @@ function runGroup(group: TestGroup, mocks: Mocks) {
   parserModules.clear();
   parserModulePaths.clear();
 
-  for (const parserProps of group.parsers) {
-    const path = resolveFromTestsDir(parserProps.specifier);
+  for (const parserDetails of group.parsers) {
+    const path = resolveFromTestsDir(parserDetails.specifier);
     const parser = require(path);
 
-    const { lang } = parserProps;
-    parserModules.set(parser, lang);
-    parserModulePaths.set(path, lang);
+    parserModules.set(parser, parserDetails);
+    parserModulePaths.set(path, parserDetails);
   }
 
   // Find test files and run tests

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -9,6 +9,7 @@ import { describe, it, setCurrentTest } from "./capture.ts";
 import { SHOULD_SKIP_CODE } from "./filter.ts";
 
 import type { Rule } from "#oxlint";
+import type { ParserDetails } from "./index.ts";
 import type { LanguageOptionsInternal } from "../../src-js/package/rule_tester.ts";
 
 type DescribeFn = RuleTester.DescribeFn;
@@ -21,15 +22,16 @@ interface TestCaseExtension {
   languageOptions?: LanguageOptionsInternal;
   // Parser was specified as `test.parser` (path string) in old ESLint versions
   parser?: string;
+  _parser?: ParserDetails;
 }
 
 export type ValidTestCase = RuleTester.ValidTestCase & TestCaseExtension;
 export type InvalidTestCase = RuleTester.InvalidTestCase & TestCaseExtension;
 export type TestCase = ValidTestCase | InvalidTestCase;
 
-// Maps of parser modules and parser paths to languages those parsers parse as
-export const parserModules: Map<unknown, Language> = new Map();
-export const parserModulePaths: Map<string, Language> = new Map();
+// Maps of parser modules and parser paths to parser details (language + specifier)
+export const parserModules: Map<unknown, ParserDetails> = new Map();
+export const parserModulePaths: Map<string, ParserDetails> = new Map();
 
 // Set up `RuleTester` to use our hooks
 RuleTester.describe = describe;
@@ -135,11 +137,11 @@ function modifyTestCase(test: TestCase): void {
   // Record current test case.
   // Clone it to avoid including the changes to the original test case made below.
   // Replace `languageOptions.parser` with `{}` to avoid verbose output in snapshots.
-  const clonedTest = { ...test };
+  const storedTest = { ...test };
   if (languageOptions?.parser != null) {
-    clonedTest.languageOptions = { ...languageOptions, parser: {} };
+    storedTest.languageOptions = { ...languageOptions, parser: {} };
   }
-  setCurrentTest(clonedTest);
+  setCurrentTest(storedTest);
 
   // Enable ESLint compat mode.
   // This makes `RuleTester` adjust column indexes in diagnostics to match ESLint's behavior.
@@ -165,24 +167,29 @@ function modifyTestCase(test: TestCase): void {
   // Parser can be specified as:
   // - Current ESLint: `test.languageOptions.parser` (parser object)
   // - Old ESLint versions: `test.parser` (absolute path to parser)
-  let lang: Language | null = null;
+  let parserDetails: ParserDetails | null = null;
 
   if (languageOptions.parser != null) {
-    lang = parserModules.get(languageOptions.parser) ?? null;
-    if (lang !== null) delete languageOptions.parser;
+    parserDetails = parserModules.get(languageOptions.parser) ?? null;
+    if (parserDetails !== null) delete languageOptions.parser;
   }
 
   if (test.parser != null) {
-    lang = parserModulePaths.get(test.parser) ?? null;
-    if (lang === null) {
-      // Set `languageOptions.parser` so an error is thrown
-      languageOptions.parser = {};
-    } else {
-      delete test.parser;
+    if (parserDetails !== null) {
+      throw new Error("Both `test.parser` and `test.languageOptions.parser` specified");
     }
+    parserDetails = parserModulePaths.get(test.parser) ?? null;
+    if (parserDetails === null) {
+      // Set `languageOptions.parser` so an error is thrown.
+      // Store in stored test case so appears in snapshot.
+      (languageOptions as any).parser = { specifier: "__unknownParser", path: test.parser };
+      (storedTest as any)._parser = { specifier: "__unknownParser", path: test.parser };
+    }
+    delete test.parser;
   }
 
-  if (lang !== null) {
+  if (parserDetails !== null) {
+    let { lang } = parserDetails;
     if (parserOptions.ecmaFeatures?.jsx === true) {
       if (lang === "ts") {
         lang = "tsx";
@@ -191,6 +198,11 @@ function modifyTestCase(test: TestCase): void {
       }
     }
     parserOptions.lang = lang;
+
+    // Store parser details in test case so tests using different parsers don't get detected as duplicates.
+    // Store in stored test case so they appear in snapshot.
+    (test as any)._parser = parserDetails;
+    storedTest._parser = parserDetails;
   }
 }
 


### PR DESCRIPTION
Include details of what parser test cases are parsed with in conformance test snapshots, to make it easier to reproduce bugs.