### PR TITLE
test(linter/plugins): conformance tester set default export on parser modules

### DIFF
--- a/apps/oxlint/conformance/src/index.ts
+++ b/apps/oxlint/conformance/src/index.ts
@@ -254,6 +254,9 @@ function runGroup(group: TestGroup, mocks: Mocks) {
     const path = resolveFromTestsDir(parserDetails.specifier);
     const parser = require(path);
 
+    // Set `default` export on parser module to work around apparent bug in `tsx`
+    if (parser && parser.default === undefined) parser.default = parser;
+
     parserModules.set(parser, parserDetails);
     parserModulePaths.set(path, parserDetails);
   }


### PR DESCRIPTION
Conformance tester is run with `tsx` to support test files written in TS. `tsx` seems to sometimes malfunction where ESM code `import`s CommonJS modules (like parsers e.g. `@typescript-eslint/parser`. Add a `default` property to parser modules, to solve this problem.