### PR TITLE
docs(linter): Clarify the `no-find-dom-node` rule with a note that the method was removed in React 19.

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -21,13 +21,16 @@ pub struct NoFindDomNode;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule disallows the use of `findDOMNode`.
+    /// This rule disallows the use of `findDOMNode`, which was deprecated in 2018 and removed in React 19.
     ///
     /// ### Why is this bad?
     ///
     /// `findDOMNode` is an escape hatch used to access the underlying DOM node.
     /// In most cases, use of this escape hatch is discouraged because it pierces the component abstraction.
-    /// [It has been deprecated in `StrictMode`.](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)
+    /// It has been deprecated for years, and was
+    /// [removed from React entirely in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-reactdom-finddomnode).
+    ///
+    /// It should not be used.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
And so this rule is important to enforce for codebases on 17/18, to make the upgrade easier later.