### PR TITLE
refactor(linter): Add an `is_inside` convenience method

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -4,7 +4,7 @@ use std::{ffi::OsStr, ops::Deref, path::Path, rc::Rc};
 
 use javascript_globals::GLOBALS;
 
-use oxc_ast::{AstType, ast::IdentifierReference};
+use oxc_ast::ast::IdentifierReference;
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::{AstNode, NodeId, Semantic};
@@ -548,7 +548,7 @@ impl<'a> LintContext<'a> {
 
     /* AST traversal helpers */
 
-    /// Returns `true` if any ancestor of the given node matches any of the provided AST types.
+    /// Returns `true` if any ancestor of the given node satisfies the predicate.
     ///
     /// This is a convenience method for the common pattern of checking if a node is inside
     /// a particular kind of AST node.
@@ -556,35 +556,24 @@ impl<'a> LintContext<'a> {
     /// # Example
     ///
     /// ```ignore
-    /// use oxc_ast::AstType;
+    /// use oxc_ast::AstKind;
     ///
     /// // Check if we're inside a yield or await expression
-    /// if ctx.is_inside(node.id(), &[AstType::YieldExpression, AstType::AwaitExpression]) {
+    /// if ctx.is_inside(node.id(), |ancestor| {
+    ///     matches!(ancestor.kind(), AstKind::YieldExpression(_) | AstKind::AwaitExpression(_))
+    /// }) {
     ///     return;
     /// }
-    /// ```
-    #[inline]
-    pub fn is_inside(&self, node_id: NodeId, types: &[AstType]) -> bool {
-        self.nodes().ancestors(node_id).any(|node| types.contains(&node.kind().ty()))
-    }
-
-    /// Returns `true` if any ancestor of the given node satisfies the predicate.
     ///
-    /// This is a convenience method for the common pattern of checking if a node is inside
-    /// a particular kind of AST node, with custom matching logic.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
     /// // Check if we're inside a declared TypeScript module
-    /// if ctx.is_inside_where(node.id(), |ancestor| {
+    /// if ctx.is_inside(node.id(), |ancestor| {
     ///     matches!(ancestor.kind(), AstKind::TSModuleDeclaration(decl) if decl.declare)
     /// }) {
     ///     return;
     /// }
     /// ```
     #[inline]
-    pub fn is_inside_where<F>(&self, node_id: NodeId, predicate: F) -> bool
+    pub fn is_inside<F>(&self, node_id: NodeId, predicate: F) -> bool
     where
         F: FnMut(&AstNode<'a>) -> bool,
     {

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -258,12 +258,8 @@ fn is_recursive_function(func: &Function, func_name: &str, ctx: &LintContext) ->
                 if call_expr.callee.span()
                     == ctx.nodes().get_node(reference.node_id()).kind().span()
                 {
-                    return ctx.nodes().ancestors(reference.node_id()).any(|ancestor| {
-                        if let AstKind::Function(f) = ancestor.kind() {
-                            f.scope_id.get() == Some(func_scope_id)
-                        } else {
-                            false
-                        }
+                    return ctx.is_inside_where(reference.node_id(), |ancestor| {
+                        matches!(ancestor.kind(), AstKind::Function(f) if f.scope_id.get() == Some(func_scope_id))
                     });
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -258,7 +258,7 @@ fn is_recursive_function(func: &Function, func_name: &str, ctx: &LintContext) ->
                 if call_expr.callee.span()
                     == ctx.nodes().get_node(reference.node_id()).kind().span()
                 {
-                    return ctx.is_inside_where(reference.node_id(), |ancestor| {
+                    return ctx.is_inside(reference.node_id(), |ancestor| {
                         matches!(ancestor.kind(), AstKind::Function(f) if f.scope_id.get() == Some(func_scope_id))
                     });
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, ast::BindingPattern};
+use oxc_ast::{AstKind, AstType, ast::BindingPattern};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -74,12 +74,10 @@ impl Rule for NoUnassignedVars {
         ) {
             return;
         }
-        if ctx.nodes().ancestors(node.id()).skip(1).any(|ancestor| {
-            matches!(
-                ancestor.kind(),
-                AstKind::TSModuleDeclaration(_) | AstKind::TSGlobalDeclaration(_)
-            )
-        }) {
+        if ctx.is_inside(
+            ctx.nodes().parent_id(node.id()),
+            &[AstType::TSModuleDeclaration, AstType::TSGlobalDeclaration],
+        ) {
             return;
         }
         let BindingPattern::BindingIdentifier(ident) = &declarator.id else {

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, AstType, ast::BindingPattern};
+use oxc_ast::{AstKind, ast::BindingPattern};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -74,10 +74,12 @@ impl Rule for NoUnassignedVars {
         ) {
             return;
         }
-        if ctx.is_inside(
-            ctx.nodes().parent_id(node.id()),
-            &[AstType::TSModuleDeclaration, AstType::TSGlobalDeclaration],
-        ) {
+        if ctx.is_inside(ctx.nodes().parent_id(node.id()), |ancestor| {
+            matches!(
+                ancestor.kind(),
+                AstKind::TSModuleDeclaration(_) | AstKind::TSGlobalDeclaration(_)
+            )
+        }) {
             return;
         }
         let BindingPattern::BindingIdentifier(ident) = &declarator.id else {

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -58,7 +58,7 @@ impl Rule for NoVar {
             && dec.kind == VariableDeclarationKind::Var
         {
             // Skip TypeScript ambient declarations (declare global/module/namespace)
-            if ctx.nodes().ancestors(node.id()).any(|ancestor| match ancestor.kind() {
+            if ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
                 AstKind::TSModuleDeclaration(module) => module.declare,
                 AstKind::TSGlobalDeclaration(_) => true,
                 _ => false,

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -58,7 +58,7 @@ impl Rule for NoVar {
             && dec.kind == VariableDeclarationKind::Var
         {
             // Skip TypeScript ambient declarations (declare global/module/namespace)
-            if ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
+            if ctx.is_inside(node.id(), |ancestor| match ancestor.kind() {
                 AstKind::TSModuleDeclaration(module) => module.declare,
                 AstKind::TSGlobalDeclaration(_) => true,
                 _ => false,

--- a/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
+++ b/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
@@ -226,7 +226,7 @@ fn check_var_on_top_in_function_scope(
 }
 
 fn is_in_ambient_typescript_context(node: &AstNode, ctx: &LintContext) -> bool {
-    ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
+    ctx.is_inside(node.id(), |ancestor| match ancestor.kind() {
         AstKind::TSModuleDeclaration(module) => module.declare,
         // No need to check `declare` field, as `global` is only valid in ambient context
         AstKind::TSGlobalDeclaration(_) => true,

--- a/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
+++ b/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
@@ -226,7 +226,7 @@ fn check_var_on_top_in_function_scope(
 }
 
 fn is_in_ambient_typescript_context(node: &AstNode, ctx: &LintContext) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|ancestor| match ancestor.kind() {
+    ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
         AstKind::TSModuleDeclaration(module) => module.declare,
         // No need to check `declare` field, as `global` is only valid in ambient context
         AstKind::TSGlobalDeclaration(_) => true,

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -118,9 +118,9 @@ impl Rule for NoConditionalInTest {
             _ => return,
         }
 
-        let is_if_statement_in_test = ctx.nodes().ancestors(node.id()).any(|node| {
-            let AstKind::CallExpression(call_expr) = node.kind() else { return false };
-            let vitest_node = PossibleJestNode { node, original: None };
+        let is_if_statement_in_test = ctx.is_inside_where(node.id(), |ancestor| {
+            let AstKind::CallExpression(call_expr) = ancestor.kind() else { return false };
+            let vitest_node = PossibleJestNode { node: ancestor, original: None };
 
             is_type_of_jest_fn_call(
                 call_expr,

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -118,7 +118,7 @@ impl Rule for NoConditionalInTest {
             _ => return,
         }
 
-        let is_if_statement_in_test = ctx.is_inside_where(node.id(), |ancestor| {
+        let is_if_statement_in_test = ctx.is_inside(node.id(), |ancestor| {
             let AstKind::CallExpression(call_expr) = ancestor.kind() else { return false };
             let vitest_node = PossibleJestNode { node: ancestor, original: None };
 

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -19,7 +19,7 @@ fn use_prefer_each(span: Span, fn_name: &str) -> OxcDiagnostic {
 
 #[inline]
 fn is_in_test(ctx: &LintContext<'_>, id: NodeId) -> bool {
-    ctx.is_inside_where(id, |ancestor| {
+    ctx.is_inside(id, |ancestor| {
         let AstKind::CallExpression(ancestor_call_expr) = ancestor.kind() else { return false };
         let Some(ancestor_member_expr) = ancestor_call_expr.callee.as_member_expression() else {
             return false;

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -19,8 +19,8 @@ fn use_prefer_each(span: Span, fn_name: &str) -> OxcDiagnostic {
 
 #[inline]
 fn is_in_test(ctx: &LintContext<'_>, id: NodeId) -> bool {
-    ctx.nodes().ancestors(id).any(|node| {
-        let AstKind::CallExpression(ancestor_call_expr) = node.kind() else { return false };
+    ctx.is_inside_where(id, |ancestor| {
+        let AstKind::CallExpression(ancestor_call_expr) = ancestor.kind() else { return false };
         let Some(ancestor_member_expr) = ancestor_call_expr.callee.as_member_expression() else {
             return false;
         };

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -203,8 +203,7 @@ impl Rule for NoNesting {
             return;
         }
 
-        let mut ancestors = ctx.nodes().ancestors(node.id());
-        if ancestors.any(|node| is_inside_promise(node, ctx)) {
+        if ctx.is_inside_where(node.id(), |ancestor| is_inside_promise(ancestor, ctx)) {
             match closest_promise_cb(node, ctx) {
                 Some(closest) => {
                     if can_safely_unnest(call_expr, closest, ctx) {

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -203,7 +203,7 @@ impl Rule for NoNesting {
             return;
         }
 
-        if ctx.is_inside_where(node.id(), |ancestor| is_inside_promise(ancestor, ctx)) {
+        if ctx.is_inside(node.id(), |ancestor| is_inside_promise(ancestor, ctx)) {
             match closest_promise_cb(node, ctx) {
                 Some(closest) => {
                     if can_safely_unnest(call_expr, closest, ctx) {

--- a/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
+++ b/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
@@ -65,8 +65,7 @@ impl Rule for NoPromiseInCallback {
             return;
         }
 
-        let mut ancestors = ctx.nodes().ancestors(node.id());
-        if ancestors.any(|node| is_callback_function(node, ctx)) {
+        if ctx.is_inside_where(node.id(), |ancestor| is_callback_function(ancestor, ctx)) {
             ctx.diagnostic(no_promise_in_callback_diagnostic(call_expr.callee.span()));
         }
     }

--- a/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
+++ b/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
@@ -65,7 +65,7 @@ impl Rule for NoPromiseInCallback {
             return;
         }
 
-        if ctx.is_inside_where(node.id(), |ancestor| is_callback_function(ancestor, ctx)) {
+        if ctx.is_inside(node.id(), |ancestor| is_callback_function(ancestor, ctx)) {
             ctx.diagnostic(no_promise_in_callback_diagnostic(call_expr.callee.span()));
         }
     }

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -335,8 +335,11 @@ fn check_for_resolve_reject(ctx: &LintContext, allow_reject: bool, call_expr: &C
 
 /// Return true if this node is inside a `then` or `catch` or `finally` promise callback.
 fn inside_promise_cb<'a, 'b>(node: &'a AstNode<'b>, ctx: &'a LintContext<'b>) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|node| {
-        node.kind().as_call_expression().is_some_and(|call_expr| is_promise(call_expr).is_some())
+    ctx.is_inside_where(node.id(), |ancestor| {
+        ancestor
+            .kind()
+            .as_call_expression()
+            .is_some_and(|call_expr| is_promise(call_expr).is_some())
     })
 }
 

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -335,7 +335,7 @@ fn check_for_resolve_reject(ctx: &LintContext, allow_reject: bool, call_expr: &C
 
 /// Return true if this node is inside a `then` or `catch` or `finally` promise callback.
 fn inside_promise_cb<'a, 'b>(node: &'a AstNode<'b>, ctx: &'a LintContext<'b>) -> bool {
-    ctx.is_inside_where(node.id(), |ancestor| {
+    ctx.is_inside(node.id(), |ancestor| {
         ancestor
             .kind()
             .as_call_expression()

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{
-    AstKind, AstType,
+    AstKind,
     ast::{Argument, Expression, FormalParameters, MemberExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -105,9 +105,12 @@ impl Rule for PreferAwaitToCallbacks {
                     if matches!(
                         param.pattern.get_identifier_name().as_deref(),
                         Some("err" | "error")
-                    ) && !ctx
-                        .is_inside(node.id(), &[AstType::YieldExpression, AstType::AwaitExpression])
-                    {
+                    ) && !ctx.is_inside(node.id(), |ancestor| {
+                        matches!(
+                            ancestor.kind(),
+                            AstKind::YieldExpression(_) | AstKind::AwaitExpression(_)
+                        )
+                    }) {
                         ctx.diagnostic(prefer_await_to_callbacks(last_arg.span()));
                     }
                 }

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -68,10 +68,6 @@ declare_oxc_lint!(
     config = PreferAwaitToThenConfig,
 );
 
-fn is_inside_yield_or_await(node: &AstNode) -> bool {
-    matches!(node.kind(), AstKind::YieldExpression(_) | AstKind::AwaitExpression(_))
-}
-
 impl Rule for PreferAwaitToThen {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
         serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
@@ -92,7 +88,7 @@ impl Rule for PreferAwaitToThen {
 
         if !self.strict {
             // Already inside a yield or await
-            if ctx.nodes().ancestors(node.id()).any(is_inside_yield_or_await) {
+            if ctx.is_inside(node.id(), &[AstType::YieldExpression, AstType::AwaitExpression]) {
                 return;
             }
         }

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, AstType};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -88,7 +88,9 @@ impl Rule for PreferAwaitToThen {
 
         if !self.strict {
             // Already inside a yield or await
-            if ctx.is_inside(node.id(), &[AstType::YieldExpression, AstType::AwaitExpression]) {
+            if ctx.is_inside(node.id(), |ancestor| {
+                matches!(ancestor.kind(), AstKind::YieldExpression(_) | AstKind::AwaitExpression(_))
+            }) {
                 return;
             }
         }

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -232,7 +232,7 @@ pub fn is_children<'a, 'b>(call: &'b CallExpression<'a>, ctx: &'b LintContext<'a
     is_import(ctx, ident.name.as_str(), REACT, REACT) && local_name == CHILDREN
 }
 fn is_within_children_to_array<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
-    ctx.is_inside_where(ctx.nodes().parent_id(node.id()), |ancestor| {
+    ctx.is_inside(ctx.nodes().parent_id(node.id()), |ancestor| {
         ancestor
             .kind()
             .as_call_expression()

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -232,10 +232,12 @@ pub fn is_children<'a, 'b>(call: &'b CallExpression<'a>, ctx: &'b LintContext<'a
     is_import(ctx, ident.name.as_str(), REACT, REACT) && local_name == CHILDREN
 }
 fn is_within_children_to_array<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
-    let parents_iter = ctx.nodes().ancestors(node.id()).skip(1);
-    parents_iter
-        .filter_map(|parent_node| parent_node.kind().as_call_expression())
-        .any(|parent_call| is_children(parent_call, ctx) && is_to_array(parent_call))
+    ctx.is_inside_where(ctx.nodes().parent_id(node.id()), |ancestor| {
+        ancestor
+            .kind()
+            .as_call_expression()
+            .is_some_and(|call| is_children(call, ctx) && is_to_array(call))
+    })
 }
 
 enum InsideArrayOrIterator {

--- a/crates/oxc_linter/src/rules/react/no_unsafe.rs
+++ b/crates/oxc_linter/src/rules/react/no_unsafe.rs
@@ -107,16 +107,9 @@ impl Rule for NoUnsafe {
             AstKind::ObjectProperty(obj_prop) => {
                 if let Some(name) = obj_prop.key.static_name()
                     && is_unsafe_method(name.as_ref(), self.0.check_aliases, ctx)
+                    && ctx.is_inside_where(node.id(), is_es5_component)
                 {
-                    for ancestor in ctx.nodes().ancestors(node.id()) {
-                        if is_es5_component(ancestor) {
-                            ctx.diagnostic(no_unsafe_diagnostic(
-                                name.as_ref(),
-                                obj_prop.key.span(),
-                            ));
-                            break;
-                        }
-                    }
+                    ctx.diagnostic(no_unsafe_diagnostic(name.as_ref(), obj_prop.key.span()));
                 }
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/react/no_unsafe.rs
+++ b/crates/oxc_linter/src/rules/react/no_unsafe.rs
@@ -107,7 +107,7 @@ impl Rule for NoUnsafe {
             AstKind::ObjectProperty(obj_prop) => {
                 if let Some(name) = obj_prop.key.static_name()
                     && is_unsafe_method(name.as_ref(), self.0.check_aliases, ctx)
-                    && ctx.is_inside_where(node.id(), is_es5_component)
+                    && ctx.is_inside(node.id(), is_es5_component)
                 {
                     ctx.diagnostic(no_unsafe_diagnostic(name.as_ref(), obj_prop.key.span()));
                 }

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -160,7 +160,7 @@ impl Rule for StateInConstructor {
 }
 
 fn has_parent_es6_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
-    ctx.is_inside_where(node.id(), is_es6_component)
+    ctx.is_inside(node.id(), is_es6_component)
 }
 
 /// Checks if a node is inside a constructor method.

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -160,7 +160,7 @@ impl Rule for StateInConstructor {
 }
 
 fn has_parent_es6_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|node| is_es6_component(node))
+    ctx.is_inside_where(node.id(), is_es6_component)
 }
 
 /// Checks if a node is inside a constructor method.

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
-    AstKind,
+    AstKind, AstType,
     ast::{ExportDefaultDeclarationKind, TSType},
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -243,9 +243,7 @@ impl Rule for ConsistentTypeDefinitions {
 }
 
 fn is_within_declare_global_block(ctx: &LintContext, node_id: NodeId) -> bool {
-    ctx.nodes()
-        .ancestors(node_id)
-        .any(|node| matches!(node.kind(), AstKind::TSGlobalDeclaration(_)))
+    ctx.is_inside(node_id, &[AstType::TSGlobalDeclaration])
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
-    AstKind, AstType,
+    AstKind,
     ast::{ExportDefaultDeclarationKind, TSType},
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -243,7 +243,7 @@ impl Rule for ConsistentTypeDefinitions {
 }
 
 fn is_within_declare_global_block(ctx: &LintContext, node_id: NodeId) -> bool {
-    ctx.is_inside(node_id, &[AstType::TSGlobalDeclaration])
+    ctx.is_inside(node_id, |ancestor| matches!(ancestor.kind(), AstKind::TSGlobalDeclaration(_)))
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, AstType};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -106,7 +106,7 @@ impl Rule for NoExplicitAny {
 impl NoExplicitAny {
     fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
         debug_assert!(matches!(node.kind(), AstKind::TSAnyKeyword(_)));
-        ctx.is_inside(node.id(), &[AstType::FormalParameterRest])
+        ctx.is_inside(node.id(), |ancestor| matches!(ancestor.kind(), AstKind::FormalParameterRest(_)))
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -106,7 +106,9 @@ impl Rule for NoExplicitAny {
 impl NoExplicitAny {
     fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
         debug_assert!(matches!(node.kind(), AstKind::TSAnyKeyword(_)));
-        ctx.is_inside(node.id(), |ancestor| matches!(ancestor.kind(), AstKind::FormalParameterRest(_)))
+        ctx.is_inside(node.id(), |ancestor| {
+            matches!(ancestor.kind(), AstKind::FormalParameterRest(_))
+        })
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -106,9 +106,7 @@ impl Rule for NoExplicitAny {
 impl NoExplicitAny {
     fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
         debug_assert!(matches!(node.kind(), AstKind::TSAnyKeyword(_)));
-        ctx.nodes()
-            .ancestors(node.id())
-            .any(|parent| matches!(parent.kind(), AstKind::FormalParameterRest(_)))
+        ctx.is_inside(node.id(), &[AstType::FormalParameterRest])
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -157,7 +157,7 @@ impl Rule for NoNamespace {
 }
 
 fn is_any_ancestor_declaration(node: &AstNode, ctx: &LintContext) -> bool {
-    ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
+    ctx.is_inside(node.id(), |ancestor| match ancestor.kind() {
         AstKind::TSModuleDeclaration(decl) => decl.declare,
         // No need to check `declare` field, as `global` is only valid in ambient context
         AstKind::TSGlobalDeclaration(_) => true,

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -157,7 +157,7 @@ impl Rule for NoNamespace {
 }
 
 fn is_any_ancestor_declaration(node: &AstNode, ctx: &LintContext) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|node| match node.kind() {
+    ctx.is_inside_where(node.id(), |ancestor| match ancestor.kind() {
         AstKind::TSModuleDeclaration(decl) => decl.declare,
         // No need to check `declare` field, as `global` is only valid in ambient context
         AstKind::TSGlobalDeclaration(_) => true,

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -67,15 +67,12 @@ fn has_hashbang(ctx: &LintContext) -> bool {
 }
 
 fn is_inside_process_event_handler(ctx: &LintContext, node: &AstNode) -> bool {
-    for parent in ctx.nodes().ancestors(node.id()) {
-        if let AstKind::CallExpression(expr) = parent.kind()
-            && is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None)
-        {
-            return true;
-        }
-    }
-
-    false
+    ctx.is_inside_where(node.id(), |ancestor| {
+        ancestor
+            .kind()
+            .as_call_expression()
+            .is_some_and(|expr| is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None))
+    })
 }
 
 fn is_worker_threads_imported(ctx: &LintContext) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -68,10 +68,9 @@ fn has_hashbang(ctx: &LintContext) -> bool {
 
 fn is_inside_process_event_handler(ctx: &LintContext, node: &AstNode) -> bool {
     ctx.is_inside_where(node.id(), |ancestor| {
-        ancestor
-            .kind()
-            .as_call_expression()
-            .is_some_and(|expr| is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None))
+        ancestor.kind().as_call_expression().is_some_and(|expr| {
+            is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None)
+        })
     })
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -67,7 +67,7 @@ fn has_hashbang(ctx: &LintContext) -> bool {
 }
 
 fn is_inside_process_event_handler(ctx: &LintContext, node: &AstNode) -> bool {
-    ctx.is_inside_where(node.id(), |ancestor| {
+    ctx.is_inside(node.id(), |ancestor| {
         ancestor.kind().as_call_expression().is_some_and(|expr| {
             is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None)
         })

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -115,7 +115,7 @@ impl RequireLocalTestContextForConcurrentSnapshots {
             }
 
             let test_or_describe_node_found =
-                ctx.is_inside_where(possible_jest_node.node.id(), |ancestor| {
+                ctx.is_inside(possible_jest_node.node.id(), |ancestor| {
                     ancestor
                         .kind()
                         .as_call_expression()

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -115,8 +115,9 @@ impl RequireLocalTestContextForConcurrentSnapshots {
             }
 
             let test_or_describe_node_found =
-                ctx.nodes().ancestors(possible_jest_node.node.id()).any(|node| {
-                    node.kind()
+                ctx.is_inside_where(possible_jest_node.node.id(), |ancestor| {
+                    ancestor
+                        .kind()
                         .as_call_expression()
                         .and_then(|call_expr| call_expr.callee.as_member_expression())
                         .is_some_and(|member_expr| is_test_or_describe_node(member_expr))


### PR DESCRIPTION
This started as an exploration of adding an `is_inside` method using Claude Code to see how much simpler it makes some of the linter code.

`is_inside` takes an AST node ID and a closure and then returns true or false based on the closure. The goal is to simplify a common pattern across the linter codebase for checking the ancestors of a given AST node.

I think there are still more places where we could apply this pattern, but I had Claude go through a decent number of iterations already.

cc: @Boshen 

AI Disclosure: Most of the exploration was done using Claude Code, obviously :) Then cleaned up by me afterward.