### PR TITLE
refactor(linter): Add deny_unknown_fields to `only-export-components` and  `text-encoding-identifier-case` rules.

### DIFF
--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -56,7 +56,7 @@ impl std::ops::Deref for OnlyExportComponents {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct OnlyExportComponentsConfig {
     /// Treat specific named exports as HMR-safe (useful for frameworks that hot-replace
     /// certain exports). For example, in Remix:
@@ -169,9 +169,7 @@ static DEFAULT_REACT_HOCS: &[&str] = &["memo", "forwardRef"];
 
 impl Rule for OnlyExportComponents {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -22,7 +22,7 @@ fn text_encoding_identifier_case_diagnostic(
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct TextEncodingIdentifierCase {
     /// If `true`, prefer `utf-8` over `utf8`.
     with_dash: bool,


### PR DESCRIPTION
Ensures that if the user provides any other fields to these rules, the CLI will error.

These two were missed because they changed to use the new from_configuration pattern only just recently.