### PR TITLE
chore(linter): Bump minimum tsgolint to 0.11.2.

### DIFF
--- a/npm/oxlint/scripts/generate-packages.js
+++ b/npm/oxlint/scripts/generate-packages.js
@@ -90,7 +90,7 @@ function writeManifest() {
   // Do not automatically install 'oxlint-tsgolint'.
   // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta
   manifestData.peerDependencies = {
-    "oxlint-tsgolint": ">=0.11.1",
+    "oxlint-tsgolint": ">=0.11.2",
   };
   manifestData.peerDependenciesMeta = {
     "oxlint-tsgolint": {


### PR DESCRIPTION
Ensure that the fix for the `prefer-optional-chain` rule gets included for any users upgrading oxlint.

https://github.com/oxc-project/tsgolint/releases/tag/v0.11.2