### PR TITLE
fix(oxfmt): Canonicalize `..` component in config path

### DIFF
--- a/apps/oxfmt/test/cli/config_ignore_patterns/__snapshots__/config_ignore_patterns.test.ts.snap
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/__snapshots__/config_ignore_patterns.test.ts.snap
@@ -1,5 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`config_ignore_patterns > explicit --config with parent-relative path resolves ignorePatterns correctly 1`] = `
+"--------------------
+arguments: --check --config ../.oxfmtrc.json .
+working directory: config_ignore_patterns/fixtures/nested_cwd/sub
+exit code: 1
+--- STDOUT ---------
+Checking formatting...
+
+src/test.js (<variable>ms)
+
+Format issues found in above 1 files. Run without \`--check\` to fix.
+Finished in <variable>ms on 1 files using 1 threads.
+--- STDERR ---------
+
+--------------------"
+`;
+
 exports[`config_ignore_patterns > nested cwd - ignorePatterns resolved relative to .oxfmtrc.json location 1`] = `
 "--------------------
 arguments: --check .

--- a/apps/oxfmt/test/cli/config_ignore_patterns/config_ignore_patterns.test.ts
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/config_ignore_patterns.test.ts
@@ -34,4 +34,20 @@ describe("config_ignore_patterns", () => {
     const snapshot = await runAndSnapshot(nestedCwd, [["--check", "."]]);
     expect(snapshot).toMatchSnapshot();
   });
+
+  // Same structure as above, but explicitly specifying `--config ../.oxfmtrc.json`
+  // instead of relying on automatic upward config search.
+  //
+  // When `--config` contains `..`, `normalize_relative_path` joins
+  // cwd + `../.oxfmtrc.json` without resolving `..`, leaving the path as
+  // `.../sub/../.oxfmtrc.json`. This causes `GitignoreBuilder`'s root
+  // to be `.../sub/..` which doesn't match file paths via `strip_prefix`,
+  // making `ignorePatterns` ineffective.
+  it("explicit --config with parent-relative path resolves ignorePatterns correctly", async () => {
+    const nestedCwd = join(import.meta.dirname, "fixtures", "nested_cwd", "sub");
+    const snapshot = await runAndSnapshot(nestedCwd, [
+      ["--check", "--config", "../.oxfmtrc.json", "."],
+    ]);
+    expect(snapshot).toMatchSnapshot();
+  });
 });

--- a/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/generated/error.html
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/generated/error.html
@@ -1,0 +1,1 @@
+<link rel=stylesheet href=/styles.css />

--- a/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/generated/ignored.js
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/generated/ignored.js
@@ -1,2 +1,0 @@
-// This file should be ignored
-const x=1

--- a/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/sub/generated/error.html
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/sub/generated/error.html
@@ -1,0 +1,1 @@
+<link rel=stylesheet href=/styles.css />

--- a/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/sub/generated/ignored.js
+++ b/apps/oxfmt/test/cli/config_ignore_patterns/fixtures/nested_cwd/sub/generated/ignored.js
@@ -1,2 +1,0 @@
-// This file should be ignored
-const x=1


### PR DESCRIPTION
Fixes `ignorePatterns` not working when `--config` is specified with a `..` path (e.g., `--config ../../.oxfmtrc.json`)

Canonicalize the joined path via `fs::canonicalize()` in `normalize_relative_path()`.

