### PR TITLE
fix(ci): replace Docker action with shell command for ubuntu-slim compatibility

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -169,13 +169,10 @@ jobs:
 
       - run: ls
 
-      - name: Unzip from windows builds
-        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
-        with:
-          args: unzip -qq *.zip -d .
-
-      - name: Untar from non-windows builds
-        run: ls *.gz | xargs -i tar xf {}
+      - name: Unzip and untar
+        run: |
+          unzip -qq '*.zip' -d .
+          ls *.gz | xargs -i tar xf {}
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
@@ -335,13 +332,10 @@ jobs:
 
       - run: ls
 
-      - name: Unzip from windows builds
-        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
-        with:
-          args: unzip -qq *.zip -d .
-
-      - name: Untar from non-windows builds
-        run: ls *.gz | xargs -i tar xf {}
+      - name: Unzip and untar
+        run: |
+          unzip -qq '*.zip' -d .
+          ls *.gz | xargs -i tar xf {}
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 


### PR DESCRIPTION
## Summary

- Replace `montudor/action-zip` Docker action with native `unzip` shell command
- Docker actions don't work on `ubuntu-slim` runners (they run in containers without Docker support)
- `unzip` is pre-installed on `ubuntu-slim` runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)