### PR TITLE
fix(coverage): add `explicit-resource-management` test262 flag

### DIFF
--- a/tasks/coverage/src/test262/meta.rs
+++ b/tasks/coverage/src/test262/meta.rs
@@ -26,6 +26,7 @@ pub enum TestFlag {
     CanBlockIsFalse,
     CanBlockIsTrue,
     NonDeterministic,
+    ExplicitResourceManagement,
 }
 
 impl TestFlag {
@@ -40,6 +41,7 @@ impl TestFlag {
             "CanBlockIsFalse" => Self::CanBlockIsFalse,
             "CanBlockIsTrue" => Self::CanBlockIsTrue,
             "non-deterministic" => Self::NonDeterministic,
+            "explicit-resource-management" => Self::ExplicitResourceManagement,
             _ => panic!("{s} not supported for TestFlag"),
         }
     }


### PR DESCRIPTION
## Summary
- Add support for the new `explicit-resource-management` test flag in test262 metadata parser
- Fixes CI panic: "explicit-resource-management not supported for TestFlag"
- The test262 suite recently added this flag for explicit resource management tests (`using` and `await using` declarations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)