### PR TITLE
fix(vscode): use built-in `getWorkspaceFolder` for detecting the right workspace of a given uri

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -102,14 +102,13 @@ export class ConfigService implements IDisposable {
       return false;
     }
 
-    const textDocumentPath = textDocumentUri.path;
-
-    for (const [workspaceUri, workspaceConfig] of this.workspaceConfigs.entries()) {
-      if (textDocumentPath.startsWith(workspaceUri)) {
-        return workspaceConfig.shouldRequestDiagnostics(diagnosticPullMode);
-      }
+    const ws = workspace.getWorkspaceFolder(textDocumentUri);
+    if (!ws) {
+      return false;
     }
-    return false;
+    const workspaceConfig = this.getWorkspaceConfig(ws.uri);
+
+    return workspaceConfig?.shouldRequestDiagnostics(diagnosticPullMode) ?? false;
   }
 
   private async searchBinaryPath(


### PR DESCRIPTION
> This PR improves workspace folder detection by using VS Code's built-in getWorkspaceFolder API instead of manual string path comparison.